### PR TITLE
chore: remove 'version' from docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   grafana:
     image: grafana/grafana


### PR DESCRIPTION
Gets rid of the annoying warning about the version field being
deprecated.
