### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners is the Machine Learning team.
+* @grafana/machine-learning
+


### PR DESCRIPTION
Adds @grafana/machine-learning as CODEOWNERS so we get assigned to review
PRs.
