### PR TITLE
ci: use --locked flag in uv sync in CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ jobs:
           python-version-file: "pyproject.toml"
           
       - name: Install the project
-        run: uv sync --all-extras --all-groups
+        run: uv sync --all-extras --all-groups --locked
 
       - name: Run ruff
         run: uv run ruff check .


### PR DESCRIPTION
This makes sure the lock file is up-to-date.
