### PR TITLE
chore: bump version 0.1.1 -> 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-grafana"
-version = "0.1.1"
+version = "0.1.2"
 description = "MCP server for Grafana and the ecosystem"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ cli = [
 
 [[package]]
 name = "mcp-grafana"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The only change is a bump of the mcp dependency.
