### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ make build-image
 And to run the image, use:
 
 ```
-docker run -it --rm mcp-grafana:latest --port-forward 8000:8000
+docker run -it --rm -p 8000:8000 mcp-grafana:latest
 ```
 
 ### Testing


### PR DESCRIPTION
Fix docker instructions to move the port forwarding to before the container name and switch to short syntax. I tried with `--port-forward` locally and received `--port-forward`. I did test the updated version locally.