### PR TITLE
feat: add middleware to accept auth in http transport

### DIFF
--- a/src/mcp_grafana/__init__.py
+++ b/src/mcp_grafana/__init__.py
@@ -5,6 +5,8 @@ import anyio
 import uvicorn
 from mcp.server import FastMCP
 
+from mcp_grafana.transports.http import GrafanaAuthMiddleware
+
 from .tools import add_tools
 
 
@@ -17,6 +19,7 @@ class Transport(enum.StrEnum):
 class GrafanaMCP(FastMCP):
     async def run_http_async(self) -> None:
         from starlette.applications import Starlette
+        from starlette.middleware import Middleware
         from starlette.routing import Mount
 
         from .transports.http import handle_message
@@ -36,6 +39,7 @@ class GrafanaMCP(FastMCP):
 
         starlette_app = Starlette(
             debug=self.settings.debug,
+            middleware=[Middleware(GrafanaAuthMiddleware)],
             routes=[Mount("/", app=handle_http)],
         )
 

--- a/src/mcp_grafana/grafana_types.py
+++ b/src/mcp_grafana/grafana_types.py
@@ -87,7 +87,7 @@ class SearchDashboardsArguments(BaseModel):
     )
     starred: bool = Field(default=False, description="Only include starred dashboards")
     limit: int = Field(
-        default=grafana_settings.tools.search.limit,
+        default=grafana_settings.get().tools.search.limit,
         description="Limit the number of returned results",
     )
     page: int = Field(default=1)

--- a/src/mcp_grafana/settings.py
+++ b/src/mcp_grafana/settings.py
@@ -1,3 +1,5 @@
+import contextvars
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -66,7 +68,23 @@ class GrafanaSettings(BaseSettings):
         description="A Grafana API key or service account token with the necessary permissions to use the tools.",
     )
 
+    access_token: str | None = Field(
+        default=None,
+        description="A Grafana Cloud Access Token, provided in and passed to Grafana using the X-Access-Token header.",
+    )
+    id_token: str | None = Field(
+        default=None,
+        description="A Grafana ID Token, provided by Grafana to identify the user, and passed to Grafana in the X-Grafana-Id header.",
+    )
+
     tools: ToolSettings = Field(default_factory=ToolSettings)
 
 
-grafana_settings = GrafanaSettings()
+# This contextvar can be updated by middleware to reflect the Grafana settings
+# for the current request.
+
+# If the middleware is not used, the default settings will be used.
+grafana_settings: contextvars.ContextVar[GrafanaSettings] = contextvars.ContextVar(
+    "grafana_settings"
+)
+grafana_settings.set(GrafanaSettings())

--- a/src/mcp_grafana/tools/__init__.py
+++ b/src/mcp_grafana/tools/__init__.py
@@ -8,11 +8,12 @@ def add_tools(mcp: FastMCP):
     """
     Add all enabled tools to the MCP server.
     """
-    if grafana_settings.tools.search.enabled:
+    settings = grafana_settings.get()
+    if settings.tools.search.enabled:
         search.add_tools(mcp)
-    if grafana_settings.tools.datasources.enabled:
+    if settings.tools.datasources.enabled:
         datasources.add_tools(mcp)
-    if grafana_settings.tools.incident.enabled:
+    if settings.tools.incident.enabled:
         incident.add_tools(mcp)
-    if grafana_settings.tools.prometheus.enabled:
+    if settings.tools.prometheus.enabled:
         prometheus.add_tools(mcp)

--- a/src/mcp_grafana/tools/datasources.py
+++ b/src/mcp_grafana/tools/datasources.py
@@ -7,21 +7,21 @@ async def list_datasources() -> bytes:
     """
     List datasources in the Grafana instance.
     """
-    return await grafana_client.list_datasources()
+    return await grafana_client.get().list_datasources()
 
 
 async def get_datasource_by_uid(uid: str) -> bytes:
     """
     Get a datasource by uid.
     """
-    return await grafana_client.get_datasource(uid=uid)
+    return await grafana_client.get().get_datasource(uid=uid)
 
 
 async def get_datasource_by_name(name: str) -> bytes:
     """
     Get a datasource by name.
     """
-    return await grafana_client.get_datasource(name=name)
+    return await grafana_client.get().get_datasource(name=name)
 
 
 def add_tools(mcp: FastMCP):

--- a/src/mcp_grafana/tools/incident.py
+++ b/src/mcp_grafana/tools/incident.py
@@ -5,9 +5,9 @@ from mcp.server import FastMCP
 from pydantic import BaseModel, Field
 
 from ..client import (
-    grafana_client,
     AddActivityToIncidentArguments,
     CreateIncidentArguments,
+    grafana_client,
 )
 from ..grafana_types import QueryIncidentPreviewsRequest, IncidentPreviewsQuery
 
@@ -49,14 +49,14 @@ async def list_incidents(arguments: ListIncidentsArguments) -> bytes:
         ),
         includeCustomFieldValues=True,
     )
-    return await grafana_client.list_incidents(body)
+    return await grafana_client.get().list_incidents(body)
 
 
 async def create_incident(arguments: CreateIncidentArguments) -> bytes:
     """
     Create an incident in the Grafana Incident incident management tool.
     """
-    return await grafana_client.create_incident(arguments)
+    return await grafana_client.get().create_incident(arguments)
 
 
 async def add_activity_to_incident(
@@ -70,7 +70,7 @@ async def add_activity_to_incident(
     :param event_time: The time that the activity occurred. If not provided, the current time will be used.
                        If provided, it must be in RFC3339 format.
     """
-    return await grafana_client.add_activity_to_incident(
+    return await grafana_client.get().add_activity_to_incident(
         AddActivityToIncidentArguments(
             incidentId=incident_id,
             body=body,
@@ -89,7 +89,7 @@ async def resolve_incident(incident_id: str, summary: str) -> bytes:
                     This should be succint but thorough and informative,
                     enough to serve as a mini post-incident-report.
     """
-    return await grafana_client.close_incident(incident_id, summary)
+    return await grafana_client.get().close_incident(incident_id, summary)
 
 
 def add_tools(mcp: FastMCP):

--- a/src/mcp_grafana/tools/prometheus.py
+++ b/src/mcp_grafana/tools/prometheus.py
@@ -56,7 +56,7 @@ async def query_prometheus(
         expr=expr,  # type: ignore
         intervalMs=interval_ms,
     )
-    response = await grafana_client.query(start, end, [query])
+    response = await grafana_client.get().query(start, end, [query])
     return DSQueryResponse.model_validate_json(response)
 
 
@@ -81,7 +81,7 @@ async def list_prometheus_metric_metadata(
 
     A mapping from metric name to all available metadata for that metric.
     """
-    response = await grafana_client.list_prometheus_metric_metadata(
+    response = await grafana_client.get().list_prometheus_metric_metadata(
         datasource_uid,
         limit=limit,
         limit_per_metric=limit_per_metric,
@@ -144,7 +144,7 @@ async def list_prometheus_label_names(
     end: Optionally, the end time of the time range to filter the results by.
     limit: Optionally, the maximum number of results to return. Defaults to 100.
     """
-    response = await grafana_client.list_prometheus_label_names(
+    response = await grafana_client.get().list_prometheus_label_names(
         datasource_uid,
         matches=matches,
         start=start,
@@ -174,7 +174,7 @@ async def list_prometheus_label_values(
     end: Optionally, the end time of the query.
     limit: Optionally, the maximum number of results to return. Defaults to 100.
     """
-    response = await grafana_client.list_prometheus_label_values(
+    response = await grafana_client.get().list_prometheus_label_values(
         datasource_uid,
         label_name,
         matches=matches,

--- a/src/mcp_grafana/tools/search.py
+++ b/src/mcp_grafana/tools/search.py
@@ -7,7 +7,7 @@ async def search_dashboards(arguments: SearchDashboardsArguments) -> bytes:
     """
     Search dashboards in the Grafana instance.
     """
-    return await grafana_client.search_dashboards(arguments)
+    return await grafana_client.get().search_dashboards(arguments)
 
 
 def add_tools(mcp: FastMCP):

--- a/src/mcp_grafana/transports/http.py
+++ b/src/mcp_grafana/transports/http.py
@@ -139,15 +139,6 @@ async def handle_message(scope: Scope, receive: Receive, send: Send):
             try:
                 client_message = types.JSONRPCMessage.model_validate(json)
                 logger.debug(f"Validated client message: {client_message}")
-                # The server does this internally but we don't get nice error
-                # handling; do it ourselves here and return a correct status
-                # code.
-                types.ClientRequest.model_validate(
-                    client_message.root.model_dump(
-                        by_alias=True, mode="json", exclude_none=True
-                    )
-                )
-                logger.debug("Validated client request")
             except ValidationError as err:
                 logger.error(f"Failed to validate message: {err}")
                 response = Response(f"Invalid message: {err}", status_code=400)


### PR DESCRIPTION
This commit adds an ASGI middleware which extracts Grafana URL and auth headers from the incoming request to the MCP server:

- `X-Grafana-Url`
- `X-Grafana-Api-Key`
- `X-Access-Token`
- `X-Grafana-Id`

and updates the current task's Grafana settings & client to use the appropriate authorization scheme depending on the headers present.

It's the equivalent of #21 but for the simpler HTTP transport.