### PR TITLE
Limit the data returned in list operations

### DIFF
--- a/src/mcp_grafana/tools/datasources.py
+++ b/src/mcp_grafana/tools/datasources.py
@@ -1,13 +1,30 @@
+from typing import List
 from mcp.server import FastMCP
+
+from mcp_grafana.grafana_types import Datasource
 
 from ..client import grafana_client
 
 
-async def list_datasources() -> bytes:
+async def list_datasources() -> List[Datasource]:
     """
     List datasources in the Grafana instance.
     """
-    return await grafana_client.list_datasources()
+    datasources = await grafana_client.list_datasources()
+    resp = []
+    # Only push a subset of fields to save on space.
+    for ds in datasources:
+        resp.append(
+            {
+                "id": ds.id,
+                "uid": ds.uid,
+                "name": ds.name,
+                "type": ds.type,
+                "isDefault": ds.is_default,
+            }
+        )
+
+    return resp
 
 
 async def get_datasource_by_uid(uid: str) -> bytes:

--- a/src/mcp_grafana/tools/incident.py
+++ b/src/mcp_grafana/tools/incident.py
@@ -31,7 +31,9 @@ class ListIncidentsArguments(BaseModel):
     )
 
 
-async def list_incidents(arguments: ListIncidentsArguments) -> bytes:
+async def list_incidents(
+    arguments: ListIncidentsArguments = ListIncidentsArguments(),
+) -> bytes:
     """
     List incidents from the Grafana Incident incident management tool.
 


### PR DESCRIPTION
When running list operations against large instances even the default limits were causing things like Cursor or Claude Desktop to bail as the conversation was too large. Using summary types for these calls instead allow them to return with reasonable limits.