### PR TITLE
Limit the amount of data returned for list tools

### DIFF
--- a/tools/incident.go
+++ b/tools/incident.go
@@ -15,7 +15,10 @@ type ListIncidentsParams struct {
 	Status string `json:"status" jsonschema:"description=The status of the incidents to include"`
 }
 
-func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.QueryIncidentsResponse, error) {
+type incidentSummary struct {
+}
+
+func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.QueryIncidentPreviewsResponse, error) {
 	c := mcpgrafana.IncidentClientFromContext(ctx)
 	is := incident.NewIncidentsService(c)
 	query := ""
@@ -25,8 +28,8 @@ func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.Que
 	if args.Status != "" {
 		query += fmt.Sprintf(" and status:%s", args.Status)
 	}
-	incidents, err := is.QueryIncidents(ctx, incident.QueryIncidentsRequest{
-		Query: incident.IncidentsQuery{
+	incidents, err := is.QueryIncidentPreviews(ctx, incident.QueryIncidentPreviewsRequest{
+		Query: incident.IncidentPreviewsQuery{
 			QueryString:    query,
 			OrderDirection: "DESC",
 			Limit:          args.Limit,

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -15,9 +15,6 @@ type ListIncidentsParams struct {
 	Status string `json:"status" jsonschema:"description=The status of the incidents to include"`
 }
 
-type incidentSummary struct {
-}
-
 func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.QueryIncidentPreviewsResponse, error) {
 	c := mcpgrafana.IncidentClientFromContext(ctx)
 	is := incident.NewIncidentsService(c)

--- a/tools/incident_integration_test.go
+++ b/tools/incident_integration_test.go
@@ -21,6 +21,6 @@ func TestCloudIncidentTools(t *testing.T) {
 			Limit: 2,
 		})
 		require.NoError(t, err)
-		assert.Len(t, result.Incidents, 2)
+		assert.Len(t, result.IncidentPreviews, 2)
 	})
 }

--- a/tools/incident_test.go
+++ b/tools/incident_test.go
@@ -22,7 +22,7 @@ func TestIncidentTools(t *testing.T) {
 			Limit: 2,
 		})
 		require.NoError(t, err)
-		assert.Len(t, result.Incidents, 2)
+		assert.Len(t, result.IncidentPreviews, 2)
 	})
 
 	t.Run("create incident", func(t *testing.T) {


### PR DESCRIPTION
List incidents and list datasources can use a lot more context than necessary when returning results. For dashboards use a custom struct that only returns a few fields. For incidents use the preview incident endpoint which returns a more concise format.