### PR TITLE
chore: use published v0.13.0 of mark3labs/mcp-go

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -34,8 +34,11 @@ func run(transport, addr string) error {
 		srv.SetContextFunc(mcpgrafana.ComposedStdioContextFunc)
 		return srv.Listen(context.Background(), os.Stdin, os.Stdout)
 	case "sse":
-		srv := server.NewSSEServer(s, "http://"+addr)
-		srv.SetContextFunc(mcpgrafana.ComposedSSEContextFunc)
+		url := "http://" + addr
+		srv := server.NewSSEServer(s,
+			server.WithBaseURL(url),
+			server.WithSSEContextFunc(mcpgrafana.ComposedSSEContextFunc),
+		)
 		log.Printf("SSE server listening on %s", addr)
 		if err := srv.Start(addr); err != nil {
 			return fmt.Errorf("Server error: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65
 	github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43
 	github.com/invopop/jsonschema v0.13.0
-	github.com/mark3labs/mcp-go v0.8.5
+	github.com/mark3labs/mcp-go v0.13.0
 	github.com/prometheus/client_golang v1.21.0
 	github.com/prometheus/common v0.62.0
 	github.com/stretchr/testify v1.10.0
@@ -62,6 +62,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// Use a fork until https://github.com/mark3labs/mcp-go/pull/32 is merged.
-replace github.com/mark3labs/mcp-go => github.com/grafana/mcp-go v0.8.6-0.20250226194234-5e1fa6f6f8af

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65 
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65/go.mod h1:hiZnMmXc9KXNUlvkV2BKFsiWuIFF/fF4wGgYWEjBitI=
 github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43 h1:+MCsOKi5BJ1wO3PRj3eDNxCScYwE2IcKNW1t8OcTarE=
 github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43/go.mod h1:3QDfdZOWKRxNhMJFL+0C/+12+jLNHDlt0VKNr/i9Daw=
-github.com/grafana/mcp-go v0.8.6-0.20250226194234-5e1fa6f6f8af h1:SwCTIu0dpOapmOc+3HQtC5VM7CUimW0r83u+5fCgQTU=
-github.com/grafana/mcp-go v0.8.6-0.20250226194234-5e1fa6f6f8af/go.mod h1:cjMlBU0cv/cj9kjlgmRhoJ5JREdS7YX83xeIG9Ko/jE=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -64,6 +62,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mark3labs/mcp-go v0.13.0 h1:HP+cJaE9KjWufUF9FxN/XgcXE6LVSebFZLiZYPmFbGU=
+github.com/mark3labs/mcp-go v0.13.0/go.mod h1:cjMlBU0cv/cj9kjlgmRhoJ5JREdS7YX83xeIG9Ko/jE=
 github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
 github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
https://github.com/mark3labs/mcp-go/pull/32 was merged so we can
use the latest release now.
