### PR TITLE
feat: fallback to environment variables in SSE mode

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -44,6 +44,9 @@ type grafanaAPIKeyKey struct{}
 // from environment variables and injects a configured client into the context.
 var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
 	u, apiKey := urlAndAPIKeyFromEnv()
+	if u == "" {
+		u = defaultGrafanaURL
+	}
 	return WithGrafanaURL(WithGrafanaAPIKey(ctx, apiKey), u)
 }
 
@@ -51,6 +54,16 @@ var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context
 // from request headers and injects a configured client into the context.
 var ExtractGrafanaInfoFromHeaders server.SSEContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	u, apiKey := urlAndAPIKeyFromHeaders(req)
+	uEnv, apiKeyEnv := urlAndAPIKeyFromEnv()
+	if u == "" {
+		u = uEnv
+	}
+	if u == "" {
+		u = defaultGrafanaURL
+	}
+	if apiKey == "" {
+		apiKey = apiKeyEnv
+	}
 	return WithGrafanaURL(WithGrafanaAPIKey(ctx, apiKey), u)
 }
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -2,6 +2,7 @@ package mcpgrafana
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,4 +16,57 @@ func TestExtractIncidentClientFromEnv(t *testing.T) {
 	client := IncidentClientFromContext(ctx)
 	require.NotNil(t, client)
 	assert.Equal(t, "http://my-test-url.grafana.com/api/plugins/grafana-incident-app/resources/api/v1/", client.RemoteHost)
+}
+
+func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
+	t.Run("no headers, no env", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
+		url := GrafanaURLFromContext(ctx)
+		assert.Equal(t, defaultGrafanaURL, url)
+		apiKey := GrafanaAPIKeyFromContext(ctx)
+		assert.Equal(t, "", apiKey)
+	})
+
+	t.Run("no headers, with env", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "http://my-test-url.grafana.com")
+		t.Setenv("GRAFANA_API_KEY", "my-test-api-key")
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
+		url := GrafanaURLFromContext(ctx)
+		assert.Equal(t, "http://my-test-url.grafana.com", url)
+		apiKey := GrafanaAPIKeyFromContext(ctx)
+		assert.Equal(t, "my-test-api-key", apiKey)
+	})
+
+	t.Run("with headers, no env", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
+		req.Header.Set(grafanaAPIKeyHeader, "my-test-api-key")
+		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
+		url := GrafanaURLFromContext(ctx)
+		assert.Equal(t, "http://my-test-url.grafana.com", url)
+		apiKey := GrafanaAPIKeyFromContext(ctx)
+		assert.Equal(t, "my-test-api-key", apiKey)
+	})
+
+	t.Run("with headers, with env", func(t *testing.T) {
+		// Env vars should be ignored if headers are present.
+		t.Setenv("GRAFANA_URL", "will-not-be-used")
+		t.Setenv("GRAFANA_API_KEY", "will-not-be-used")
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
+		req.Header.Set(grafanaAPIKeyHeader, "my-test-api-key")
+		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
+		url := GrafanaURLFromContext(ctx)
+		assert.Equal(t, "http://my-test-url.grafana.com", url)
+		apiKey := GrafanaAPIKeyFromContext(ctx)
+		assert.Equal(t, "my-test-api-key", apiKey)
+	})
 }


### PR DESCRIPTION
Prior to this commit, the MCP server wasn't respecting the
`GRAFANA_URL` and `GRAFANA_API_KEY` environment variables when running in
SSE mode, and was expecting them to be passed in via headers
(which is admittedly non-standard).

This commit adds a fallback to the environment variables if the
headers aren't present.

Relates to #40.
