### PR TITLE
fix: don't set base URL of SSE server

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -34,9 +34,7 @@ func run(transport, addr string) error {
 		srv.SetContextFunc(mcpgrafana.ComposedStdioContextFunc)
 		return srv.Listen(context.Background(), os.Stdin, os.Stdout)
 	case "sse":
-		url := "http://" + addr
 		srv := server.NewSSEServer(s,
-			server.WithBaseURL(url),
 			server.WithSSEContextFunc(mcpgrafana.ComposedSSEContextFunc),
 		)
 		log.Printf("SSE server listening on %s", addr)


### PR DESCRIPTION
Prior to this we would set the base URL of the SSE server to the
address of the HTTP server. This isn't quite right because the
address on which the server listens isn't always the same as the
one which the client connects to; for example, in Docker we might
set the address to 0.0.0.0 but the client will connect to localhost.

Since most clients will verify that the endpoint sent by the initial
SSE handshake matches the address of the server they connect to, they
raise an error when they see that `localhost` doesn't match `0.0.0.0`.

This commit fixes that by just not setting the base URL at all. This
results in the initial message just looking like this:

```
event: endpoint
data: /message?sessionId=c96d5796-92f3-42f3-aa51-555aa21e1c8f
```

which matches what the Python SDK does (see [here][python1], [here][python2],
and [here][python3]), and fixes things for me when testing with Cursor.

Fixes #40.

[python1]: https://github.com/sd2k/python-sdk/blob/400dcda2eba67776f708d3dce6eaac3a9db97b92/src/mcp/server/sse.py#L98
[python2]: https://github.com/sd2k/python-sdk/blob/400dcda2eba67776f708d3dce6eaac3a9db97b92/src/mcp/server/sse.py#L77
[python3]: https://github.com/sd2k/python-sdk/blob/400dcda2eba67776f708d3dce6eaac3a9db97b92/src/mcp/server/fastmcp/server.py#L466
