### PR TITLE
Add loki tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is useful if you don't use certain functionality or if you don't want to ta
 | `create_incident` | Incident | Create an incident in Grafana Incident |
 | `add_activity_to_incident` | Incident | Add an activity item to an incident in Grafana Incident |
 | `resolve_incident` | Incident | Resolve an incident in Grafana Incident |
-| `query_loki_logs` | Loki | Query and retrieve log entries using LogQL |
+| `query_loki_logs` | Loki | Query and retrieve logs using LogQL (either log or metric queries) |
 | `list_loki_label_names` | Loki | List all available label names in logs |
 | `list_loki_label_values` | Loki | List values for a specific log label |
 | `query_loki_stats` | Loki | Get statistics about log streams |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This provides access to your Grafana instance and the surrounding ecosystem.
   - [x] Prometheus
   - [x] Loki
     - [x] Log queries
-    - [ ] Metric queries
+    - [x] Metric queries
   - [ ] Tempo
   - [ ] Pyroscope
 - [x] Query Prometheus metadata

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This provides access to your Grafana instance and the surrounding ecosystem.
 - [x] List and fetch datasource information
 - [ ] Query datasources
   - [x] Prometheus
-  - [ ] Loki (log queries, metric queries)
+  - [x] Loki
+    - [x] Log queries
+    - [ ] Metric queries
   - [ ] Tempo
   - [ ] Pyroscope
 - [x] Query Prometheus metadata
@@ -18,6 +20,11 @@ This provides access to your Grafana instance and the surrounding ecosystem.
   - [x] Metric names
   - [x] Label names
   - [x] Label values
+- [x] Query Loki
+  - [x] Label names
+  - [x] Label values
+  - [x] Stats
+  - [x] Logs
 - [x] Search, create, update and close incidents
 - [ ] Start Sift investigations and view the results
 
@@ -41,6 +48,10 @@ This is useful if you don't use certain functionality or if you don't want to ta
 | `create_incident` | Incident | Create an incident in Grafana Incident |
 | `add_activity_to_incident` | Incident | Add an activity item to an incident in Grafana Incident |
 | `resolve_incident` | Incident | Resolve an incident in Grafana Incident |
+| `query_loki_logs` | Loki | Query and retrieve log entries using LogQL |
+| `list_loki_label_names` | Loki | List all available label names in logs |
+| `list_loki_label_values` | Loki | List values for a specific log label |
+| `query_loki_stats` | Loki | Get statistics about log streams |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@ This provides access to your Grafana instance and the surrounding ecosystem.
   - [x] Metric names
   - [x] Label names
   - [x] Label values
-- [x] Query Loki
+- [x] Query Loki metadata
   - [x] Label names
   - [x] Label values
   - [x] Stats
-  - [x] Logs
 - [x] Search, create, update and close incidents
 - [ ] Start Sift investigations and view the results
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -22,6 +22,7 @@ func newServer() *server.MCPServer {
 	tools.AddDatasourceTools(s)
 	tools.AddIncidentTools(s)
 	tools.AddPrometheusTools(s)
+	tools.AddLokiTools(s)
 	return s
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,44 @@ services:
     image: grafana/loki:2.6.0
     ports:
       - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./tests/loki-config.yml:/etc/loki/loki-config.yml
+      - loki-data:/loki
+
+  promtail:
+    image: grafana/promtail:2.6.0
+    volumes:
+      - ./tests/promtail-config.yml:/etc/promtail/config.yml
+      - /var/log:/var/log
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+  
+  log-generator:
+    image: alpine:latest
+    platform: linux/arm64
+    command: >
+      /bin/sh -c "while true; do
+        echo '{\"level\":\"info\",\"message\":\"Test log message\",\"timestamp\":\"'$$(date -Iseconds)'\",\"service\":\"test-service\"}';
+        sleep 5;
+      done"
+    depends_on:
+      - loki
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://loki:3100/loki/api/v1/push"
+        loki-retries: "5"
+        loki-batch-size: "400"
 
 volumes:
   var-lib-grafana:
+  loki-data:
+  docker-sock:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /var/run/docker.sock

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,5 +19,11 @@ services:
     command:
       - --config.file=/etc/prometheus/prometheus.yml
 
+  loki:
+    image: grafana/loki:2.6.0
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
 volumes:
   var-lib-grafana:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,6 @@ services:
     command: -config.file=/etc/loki/loki-config.yml
     volumes:
       - ./tests/loki-config.yml:/etc/loki/loki-config.yml
-      - loki-data:/loki
 
   promtail:
     image: grafana/promtail:2.6.0
@@ -37,30 +36,3 @@ services:
     command: -config.file=/etc/promtail/config.yml
     depends_on:
       - loki
-  
-  log-generator:
-    image: alpine:latest
-    platform: linux/arm64
-    command: >
-      /bin/sh -c "while true; do
-        echo '{\"level\":\"info\",\"message\":\"Test log message\",\"timestamp\":\"'$$(date -Iseconds)'\",\"service\":\"test-service\"}';
-        sleep 5;
-      done"
-    depends_on:
-      - loki
-    logging:
-      driver: loki
-      options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
-        loki-retries: "5"
-        loki-batch-size: "400"
-
-volumes:
-  var-lib-grafana:
-  loki-data:
-  docker-sock:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: /var/run/docker.sock

--- a/tests/loki-config.yml
+++ b/tests/loki-config.yml
@@ -38,8 +38,3 @@ storage_config:
     shared_store: filesystem
   filesystem:
     directory: /loki/chunks
-
-limits_config:
-  enforce_metric_name: false
-  reject_old_samples: true
-  reject_old_samples_max_age: 168h

--- a/tests/loki-config.yml
+++ b/tests/loki-config.yml
@@ -1,0 +1,45 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+  wal:
+    enabled: true
+    dir: /loki/wal
+
+compactor:
+  working_directory: /loki/compactor
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/boltdb-shipper-active
+    cache_location: /loki/boltdb-shipper-cache
+    cache_ttl: 24h
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h

--- a/tests/promtail-config.yml
+++ b/tests/promtail-config.yml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'

--- a/tests/provisioning/datasources/datasources.yaml
+++ b/tests/provisioning/datasources/datasources.yaml
@@ -14,3 +14,10 @@ datasources:
     type: prometheus
     access: proxy
     url: https://prometheus.demo.prometheus.io
+  - name: Loki
+    id: 3
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false

--- a/tools/datasources_test.go
+++ b/tools/datasources_test.go
@@ -53,7 +53,8 @@ func TestDatasourcesTools(t *testing.T) {
 		ctx := newTestContext()
 		result, err := listDatasources(ctx, ListDatasourcesParams{})
 		require.NoError(t, err)
-		assert.Greater(t, len(result), 0)
+		// Three datasources are provisioned in the test environment (Prometheus and Loki).
+		assert.Len(t, result, 3)
 	})
 
 	t.Run("get datasource by uid", func(t *testing.T) {

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -1,0 +1,271 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// lokiClientFromContext creates a simple HTTP client for Loki API requests
+// We're using a simple HTTP client approach since the Loki client libraries
+// are not as standardized as Prometheus ones
+func lokiClientFromContext(ctx context.Context, uid string) (*http.Client, string, error) {
+	grafanaURL, apiKey := mcpgrafana.GrafanaURLFromContext(ctx), mcpgrafana.GrafanaAPIKeyFromContext(ctx)
+	url := fmt.Sprintf("%s/api/datasources/proxy/uid/%s", strings.TrimRight(grafanaURL, "/"), uid)
+
+	client := &http.Client{}
+
+	// We'll use the apiKey when making requests, not when creating the client
+	_ = apiKey
+
+	return client, url, nil
+}
+
+// QueryLokiParams defines the parameters for querying Loki
+type QueryLokiParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
+	Query         string `json:"query" jsonschema:"required,description=The LogQL query to execute"`
+	StartRFC3339  string `json:"startRfc3339" jsonschema:"required,description=The start time in RFC3339 format"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=The end time in RFC3339 format"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"description=The maximum number of log lines to return"`
+	Direction     string `json:"direction,omitempty" jsonschema:"description=The direction of the query, either 'forward' or 'backward'"`
+}
+
+// queryLoki executes a LogQL query against a Loki datasource
+func queryLoki(ctx context.Context, args QueryLokiParams) (map[string]interface{}, error) {
+	client, baseURL, err := lokiClientFromContext(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("getting Loki client: %w", err)
+	}
+
+	// Parse time parameters
+	startTime, err := time.Parse(time.RFC3339, args.StartRFC3339)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
+	}
+
+	var endTime time.Time
+	if args.EndRFC3339 != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
+		if err != nil {
+			return nil, fmt.Errorf("parsing end time: %w", err)
+		}
+	} else {
+		endTime = time.Now()
+	}
+
+	// Set default limit if not provided
+	limit := args.Limit
+	if limit == 0 {
+		limit = 100
+	}
+
+	// Set default direction if not provided
+	direction := args.Direction
+	if direction == "" {
+		direction = "backward"
+	}
+
+	// Build the query URL
+	queryURL := fmt.Sprintf("%s/loki/api/v1/query_range", baseURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", queryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Add query parameters
+	q := req.URL.Query()
+	q.Add("query", args.Query)
+	q.Add("start", fmt.Sprintf("%d", startTime.UnixNano()))
+	q.Add("end", fmt.Sprintf("%d", endTime.UnixNano()))
+	q.Add("limit", fmt.Sprintf("%d", limit))
+	q.Add("direction", direction)
+	req.URL.RawQuery = q.Encode()
+
+	// Add authorization header if API key is available
+	apiKey := mcpgrafana.GrafanaAPIKeyFromContext(ctx)
+	if apiKey != "" {
+		req.Header.Add("Authorization", "Bearer "+apiKey)
+	}
+
+	// Execute the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing Loki query: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// For simplicity, we'll return a placeholder response
+	// In a real implementation, you would parse the JSON response
+	return map[string]interface{}{
+		"status": "success",
+		"data": map[string]interface{}{
+			"resultType": "streams",
+			"result":     []interface{}{},
+		},
+	}, nil
+}
+
+// QueryLoki is a tool for querying Loki
+var QueryLoki = mcpgrafana.MustTool(
+	"query_loki",
+	"Query Loki using LogQL",
+	queryLoki,
+)
+
+// ListLokiLabelNamesParams defines the parameters for listing Loki label names
+type ListLokiLabelNamesParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the time range to filter the results by"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the time range to filter the results by"`
+}
+
+// listLokiLabelNames lists all label names in a Loki datasource
+func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]string, error) {
+	client, baseURL, err := lokiClientFromContext(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("getting Loki client: %w", err)
+	}
+
+	// Parse time parameters if provided
+	var startTime, endTime time.Time
+	if args.StartRFC3339 != "" {
+		startTime, err = time.Parse(time.RFC3339, args.StartRFC3339)
+		if err != nil {
+			return nil, fmt.Errorf("parsing start time: %w", err)
+		}
+	} else {
+		startTime = time.Now().Add(-1 * time.Hour)
+	}
+
+	if args.EndRFC3339 != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
+		if err != nil {
+			return nil, fmt.Errorf("parsing end time: %w", err)
+		}
+	} else {
+		endTime = time.Now()
+	}
+
+	// Build the query URL
+	queryURL := fmt.Sprintf("%s/loki/api/v1/labels", baseURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", queryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Add query parameters
+	q := req.URL.Query()
+	q.Add("start", fmt.Sprintf("%d", startTime.UnixNano()))
+	q.Add("end", fmt.Sprintf("%d", endTime.UnixNano()))
+	req.URL.RawQuery = q.Encode()
+
+	// Add authorization header if API key is available
+	apiKey := mcpgrafana.GrafanaAPIKeyFromContext(ctx)
+	if apiKey != "" {
+		req.Header.Add("Authorization", "Bearer "+apiKey)
+	}
+
+	// Execute the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("listing Loki label names: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// For simplicity, we'll return a placeholder response
+	// In a real implementation, you would parse the JSON response
+	return []string{"app", "container", "filename", "host", "job", "level", "namespace", "pod"}, nil
+}
+
+// ListLokiLabelNames is a tool for listing Loki label names
+var ListLokiLabelNames = mcpgrafana.MustTool(
+	"list_loki_label_names",
+	"List the label names in a Loki datasource",
+	listLokiLabelNames,
+)
+
+// ListLokiLabelValuesParams defines the parameters for listing Loki label values
+type ListLokiLabelValuesParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
+	LabelName     string `json:"labelName" jsonschema:"required,description=The name of the label to query"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query"`
+}
+
+// listLokiLabelValues lists all values for a specific label in a Loki datasource
+func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([]string, error) {
+	client, baseURL, err := lokiClientFromContext(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("getting Loki client: %w", err)
+	}
+
+	// Parse time parameters if provided
+	var startTime, endTime time.Time
+	if args.StartRFC3339 != "" {
+		startTime, err = time.Parse(time.RFC3339, args.StartRFC3339)
+		if err != nil {
+			return nil, fmt.Errorf("parsing start time: %w", err)
+		}
+	} else {
+		startTime = time.Now().Add(-1 * time.Hour)
+	}
+
+	if args.EndRFC3339 != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
+		if err != nil {
+			return nil, fmt.Errorf("parsing end time: %w", err)
+		}
+	} else {
+		endTime = time.Now()
+	}
+
+	// Build the query URL
+	queryURL := fmt.Sprintf("%s/loki/api/v1/label/%s/values", baseURL, args.LabelName)
+	req, err := http.NewRequestWithContext(ctx, "GET", queryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Add query parameters
+	q := req.URL.Query()
+	q.Add("start", fmt.Sprintf("%d", startTime.UnixNano()))
+	q.Add("end", fmt.Sprintf("%d", endTime.UnixNano()))
+	req.URL.RawQuery = q.Encode()
+
+	// Add authorization header if API key is available
+	apiKey := mcpgrafana.GrafanaAPIKeyFromContext(ctx)
+	if apiKey != "" {
+		req.Header.Add("Authorization", "Bearer "+apiKey)
+	}
+
+	// Execute the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("listing Loki label values: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// For simplicity, we'll return a placeholder response
+	// In a real implementation, you would parse the JSON response
+	return []string{"value1", "value2", "value3"}, nil
+}
+
+// ListLokiLabelValues is a tool for listing Loki label values
+var ListLokiLabelValues = mcpgrafana.MustTool(
+	"list_loki_label_values",
+	"Get the values of a label in Loki",
+	listLokiLabelValues,
+)
+
+// AddLokiTools registers all Loki tools with the MCP server
+func AddLokiTools(mcp *server.MCPServer) {
+	QueryLoki.Register(mcp)
+	ListLokiLabelNames.Register(mcp)
+	ListLokiLabelValues.Register(mcp)
+}

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/server"
@@ -23,6 +24,14 @@ type Client struct {
 type LabelResponse struct {
 	Status string   `json:"status"`
 	Data   []string `json:"data,omitempty"`
+}
+
+// Stats represents the statistics returned by Loki's index/stats endpoint
+type Stats struct {
+	Streams int `json:"streams"`
+	Chunks  int `json:"chunks"`
+	Entries int `json:"entries"`
+	Bytes   int `json:"bytes"`
 }
 
 func newLokiClient(ctx context.Context, uid string) (*Client, error) {
@@ -216,8 +225,132 @@ var ListLokiLabelValues = mcpgrafana.MustTool(
 	listLokiLabelValues,
 )
 
+// fetchStats is a method to fetch stats data from Loki API
+func (c *Client) fetchStats(ctx context.Context, query, startRFC3339, endRFC3339 string) (*Stats, error) {
+	fullURL := c.baseURL
+	urlPath := "/loki/api/v1/index/stats"
+
+	if !strings.HasSuffix(fullURL, "/") && !strings.HasPrefix(urlPath, "/") {
+		fullURL += "/"
+	} else if strings.HasSuffix(fullURL, "/") && strings.HasPrefix(urlPath, "/") {
+		// Remove the leading slash from urlPath to avoid double slash
+		urlPath = strings.TrimPrefix(urlPath, "/")
+	}
+	fullURL += urlPath
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing URL: %w", err)
+	}
+
+	params := url.Values{}
+	params.Add("query", query)
+
+	// Convert RFC3339 timestamps to Unix nanoseconds if provided
+	if startRFC3339 != "" {
+		startTime, err := time.Parse(time.RFC3339, startRFC3339)
+		if err != nil {
+			return nil, fmt.Errorf("parsing start time: %w", err)
+		}
+		params.Add("start", fmt.Sprintf("%d", startTime.UnixNano()))
+	}
+
+	if endRFC3339 != "" {
+		endTime, err := time.Parse(time.RFC3339, endRFC3339)
+		if err != nil {
+			return nil, fmt.Errorf("parsing end time: %w", err)
+		}
+		params.Add("end", fmt.Sprintf("%d", endTime.UnixNano()))
+	}
+
+	u.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for non-200 status code
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Loki API returned status code %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	// Read the response body with a limit to prevent memory issues
+	body := io.LimitReader(resp.Body, 1024*1024*48)
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	// Check if the response is empty
+	if len(bodyBytes) == 0 {
+		return nil, fmt.Errorf("empty response from Loki API")
+	}
+
+	// Trim any whitespace that might cause JSON parsing issues
+	trimmedBody := bytes.TrimSpace(bodyBytes)
+
+	var stats Stats
+	err = json.Unmarshal(trimmedBody, &stats)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling response (content: %s): %w", string(trimmedBody), err)
+	}
+
+	return &stats, nil
+}
+
+// QueryLokiStatsParams defines the parameters for querying Loki stats
+type QueryLokiStatsParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
+	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL query to execute"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query in RFC3339 format"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query in RFC3339 format"`
+}
+
+// queryLokiStats queries stats from a Loki datasource using LogQL
+func queryLokiStats(ctx context.Context, args QueryLokiStatsParams) (*Stats, error) {
+	client, err := newLokiClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating Loki client: %w", err)
+	}
+
+	// Set default time range if not provided
+	startTime := args.StartRFC3339
+	endTime := args.EndRFC3339
+	if startTime == "" {
+		// Default to 1 hour ago if not specified
+		startTime = time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+	}
+	if endTime == "" {
+		// Default to now if not specified
+		endTime = time.Now().Format(time.RFC3339)
+	}
+
+	stats, err := client.fetchStats(ctx, args.LogQL, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+// QueryLokiStats is a tool for querying stats from Loki
+var QueryLokiStats = mcpgrafana.MustTool(
+	"query_loki_stats",
+	"Query statistics about logs in a Loki datasource using LogQL",
+	queryLokiStats,
+)
+
 // AddLokiTools registers all Loki tools with the MCP server
 func AddLokiTools(mcp *server.MCPServer) {
 	ListLokiLabelNames.Register(mcp)
 	ListLokiLabelValues.Register(mcp)
+	QueryLokiStats.Register(mcp)
 }

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -41,8 +41,8 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 type QueryLokiParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	Query         string `json:"query" jsonschema:"required,description=The LogQL query to execute"`
-	StartTime     string `json:"startTime" jsonschema:"required,description=The start time"`
-	EndTime       string `json:"endTime,omitempty" jsonschema:"description=The end time"`
+	StartRFC3339  string `json:"startRfc3339" jsonschema:"required,description=The start time in RFC3339 format"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=The end time in RFC3339 format."`
 	Limit         int    `json:"limit,omitempty" jsonschema:"description=The maximum number of log lines to return"`
 	Direction     string `json:"direction,omitempty" jsonschema:"description=The direction of the query, either 'forward' or 'backward'"`
 }
@@ -55,14 +55,14 @@ func queryLoki(ctx context.Context, args QueryLokiParams) (map[string]interface{
 	}
 
 	// Parse time parameters
-	startTime, err := time.Parse(time.RFC3339, args.StartTime)
+	startTime, err := time.Parse(time.RFC3339, args.StartRFC3339)
 	if err != nil {
 		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
 
 	var endTime time.Time
-	if args.EndTime != "" {
-		endTime, err = time.Parse(time.RFC3339, args.EndTime)
+	if args.EndRFC3339 != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
 		if err != nil {
 			return nil, fmt.Errorf("parsing end time: %w", err)
 		}
@@ -126,8 +126,8 @@ var QueryLoki = mcpgrafana.MustTool(
 // ListLokiLabelNamesParams defines the parameters for listing Loki label names
 type ListLokiLabelNamesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	StartTime     string `json:"startTime,omitempty" jsonschema:"description=Optionally, the start time of the time range to filter the results by"`
-	EndTime       string `json:"endTime,omitempty" jsonschema:"description=Optionally, the end time of the time range to filter the results by"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the time range to filter the results by"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the time range to filter the results by"`
 }
 
 // listLokiLabelNames lists all label names in a Loki datasource
@@ -139,8 +139,8 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 
 	// Parse time parameters if provided
 	var startTime, endTime time.Time
-	if args.StartTime != "" {
-		startTime, err = time.Parse(time.RFC3339, args.StartTime)
+	if args.StartRFC3339 != "" {
+		startTime, err = time.Parse(time.RFC3339, args.StartRFC3339)
 		if err != nil {
 			return nil, fmt.Errorf("parsing start time: %w", err)
 		}
@@ -148,8 +148,8 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 		startTime = time.Now().Add(-1 * time.Hour)
 	}
 
-	if args.EndTime != "" {
-		endTime, err = time.Parse(time.RFC3339, args.EndTime)
+	if args.EndRFC3339 != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
 		if err != nil {
 			return nil, fmt.Errorf("parsing end time: %w", err)
 		}
@@ -193,8 +193,8 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 type ListLokiLabelValuesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LabelName     string `json:"labelName" jsonschema:"required,description=The name of the label to query"`
-	StartTime     string `json:"startTime,omitempty" jsonschema:"description=Optionally, the start time of the query"`
-	EndTime       string `json:"endTime,omitempty" jsonschema:"description=Optionally, the end time of the query"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query"`
 }
 
 // listLokiLabelValues lists all values for a specific label in a Loki datasource
@@ -206,8 +206,8 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 
 	// Parse time parameters if provided
 	var startTime, endTime time.Time
-	if args.StartTime != "" {
-		startTime, err = time.Parse(time.RFC3339, args.StartTime)
+	if args.StartRFC3339 != "" {
+		startTime, err = time.Parse(time.RFC3339, args.StartRFC3339)
 		if err != nil {
 			return nil, fmt.Errorf("parsing start time: %w", err)
 		}
@@ -215,8 +215,8 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 		startTime = time.Now().Add(-1 * time.Hour)
 	}
 
-	if args.EndTime != "" {
-		endTime, err = time.Parse(time.RFC3339, args.EndTime)
+	if args.EndRFC3339 != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
 		if err != nil {
 			return nil, fmt.Errorf("parsing end time: %w", err)
 		}

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -448,7 +448,7 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) ([]LogEntry, e
 // QueryLokiLogs is a tool for querying logs from Loki
 var QueryLokiLogs = mcpgrafana.MustTool(
 	"query_loki_logs",
-	"Query and retrieve log entries or metric values from a Loki datasource using LogQL. Returns either log lines or numeric values with timestamps and labels. Use query_loki_stats first to check stream size, then list_loki_label_names/values to verify labels exist. Supports full LogQL syntax including both log queries and metric queries (e.g., rate, count_over_time).",
+	"Query and retrieve log entries or metric values from a Loki datasource using LogQL. Returns either log lines or numeric values with timestamps and labels. Use `query_loki_stats` first to check stream size, then `list_loki_label_names` and `list_loki_label_values` to verify labels exist. Supports full LogQL syntax including both log queries and metric queries (e.g., rate, count_over_time).",
 	queryLokiLogs,
 )
 

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -41,8 +41,8 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 type QueryLokiParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	Query         string `json:"query" jsonschema:"required,description=The LogQL query to execute"`
-	StartRFC3339  string `json:"startRfc3339" jsonschema:"required,description=The start time in RFC3339 format"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=The end time in RFC3339 format"`
+	StartTime     string `json:"startTime" jsonschema:"required,description=The start time"`
+	EndTime       string `json:"endTime,omitempty" jsonschema:"description=The end time"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"description=The maximum number of log lines to return"`
 	Direction     string `json:"direction,omitempty" jsonschema:"description=The direction of the query, either 'forward' or 'backward'"`
 }
@@ -55,14 +55,14 @@ func queryLoki(ctx context.Context, args QueryLokiParams) (map[string]interface{
 	}
 
 	// Parse time parameters
-	startTime, err := time.Parse(time.RFC3339, args.StartRFC3339)
+	startTime, err := time.Parse(time.RFC3339, args.StartTime)
 	if err != nil {
 		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
 
 	var endTime time.Time
-	if args.EndRFC3339 != "" {
-		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
+	if args.EndTime != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndTime)
 		if err != nil {
 			return nil, fmt.Errorf("parsing end time: %w", err)
 		}
@@ -126,8 +126,8 @@ var QueryLoki = mcpgrafana.MustTool(
 // ListLokiLabelNamesParams defines the parameters for listing Loki label names
 type ListLokiLabelNamesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the time range to filter the results by"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the time range to filter the results by"`
+	StartTime     string `json:"startTime,omitempty" jsonschema:"description=Optionally, the start time of the time range to filter the results by"`
+	EndTime       string `json:"endTime,omitempty" jsonschema:"description=Optionally, the end time of the time range to filter the results by"`
 }
 
 // listLokiLabelNames lists all label names in a Loki datasource
@@ -139,8 +139,8 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 
 	// Parse time parameters if provided
 	var startTime, endTime time.Time
-	if args.StartRFC3339 != "" {
-		startTime, err = time.Parse(time.RFC3339, args.StartRFC3339)
+	if args.StartTime != "" {
+		startTime, err = time.Parse(time.RFC3339, args.StartTime)
 		if err != nil {
 			return nil, fmt.Errorf("parsing start time: %w", err)
 		}
@@ -148,8 +148,8 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 		startTime = time.Now().Add(-1 * time.Hour)
 	}
 
-	if args.EndRFC3339 != "" {
-		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
+	if args.EndTime != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndTime)
 		if err != nil {
 			return nil, fmt.Errorf("parsing end time: %w", err)
 		}
@@ -193,8 +193,8 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 type ListLokiLabelValuesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LabelName     string `json:"labelName" jsonschema:"required,description=The name of the label to query"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query"`
+	StartTime     string `json:"startTime,omitempty" jsonschema:"description=Optionally, the start time of the query"`
+	EndTime       string `json:"endTime,omitempty" jsonschema:"description=Optionally, the end time of the query"`
 }
 
 // listLokiLabelValues lists all values for a specific label in a Loki datasource
@@ -206,8 +206,8 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 
 	// Parse time parameters if provided
 	var startTime, endTime time.Time
-	if args.StartRFC3339 != "" {
-		startTime, err = time.Parse(time.RFC3339, args.StartRFC3339)
+	if args.StartTime != "" {
+		startTime, err = time.Parse(time.RFC3339, args.StartTime)
 		if err != nil {
 			return nil, fmt.Errorf("parsing start time: %w", err)
 		}
@@ -215,8 +215,8 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 		startTime = time.Now().Add(-1 * time.Hour)
 	}
 
-	if args.EndRFC3339 != "" {
-		endTime, err = time.Parse(time.RFC3339, args.EndRFC3339)
+	if args.EndTime != "" {
+		endTime, err = time.Parse(time.RFC3339, args.EndTime)
 		if err != nil {
 			return nil, fmt.Errorf("parsing end time: %w", err)
 		}

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -471,7 +471,7 @@ func queryLokiStats(ctx context.Context, args QueryLokiStatsParams) (*Stats, err
 // QueryLokiStats is a tool for querying stats from Loki
 var QueryLokiStats = mcpgrafana.MustTool(
 	"query_loki_stats",
-	"Query statistics about logs in a Loki datasource using LogQL",
+	"Query statistics about log streams in a Loki datasource, using LogQL selectors to select streams",
 	queryLokiStats,
 )
 

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLokiClientFromContext(t *testing.T) {
+	ctx := context.Background()
+	client, url, err := lokiClientFromContext(ctx, "loki")
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Contains(t, url, "/api/datasources/proxy/uid/loki")
+}
+
+func TestQueryLoki(t *testing.T) {
+	// This is a mock test since we can't actually query Loki in unit tests
+	ctx := context.Background()
+	result, err := queryLoki(ctx, QueryLokiParams{
+		DatasourceUID: "loki",
+		Query:         `{app="test"}`,
+		StartRFC3339:  "2023-01-01T00:00:00Z",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "success", result["status"])
+}
+
+func TestListLokiLabelNames(t *testing.T) {
+	// This is a mock test since we can't actually query Loki in unit tests
+	ctx := context.Background()
+	result, err := listLokiLabelNames(ctx, ListLokiLabelNamesParams{
+		DatasourceUID: "loki",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Contains(t, result, "app")
+	assert.Contains(t, result, "job")
+}
+
+func TestListLokiLabelValues(t *testing.T) {
+	// This is a mock test since we can't actually query Loki in unit tests
+	ctx := context.Background()
+	result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
+		DatasourceUID: "loki",
+		LabelName:     "app",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Contains(t, result, "value1")
+}
+
+// TestLokiTools tests all Loki tools together in a single test function
+// This follows the structure of TestPrometheusTools
+func TestLokiTools(t *testing.T) {
+	t.Run("query loki", func(t *testing.T) {
+		// This is a mock test since we can't actually query Loki in unit tests
+		ctx := context.Background()
+		result, err := queryLoki(ctx, QueryLokiParams{
+			DatasourceUID: "loki",
+			Query:         `{app="test"}`,
+			StartRFC3339:  "2023-01-01T00:00:00Z",
+			EndRFC3339:    "2023-01-02T00:00:00Z",
+			Limit:         100,
+			Direction:     "backward",
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "success", result["status"])
+
+		data, ok := result["data"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "streams", data["resultType"])
+	})
+
+	t.Run("list loki label names", func(t *testing.T) {
+		// This is a mock test since we can't actually query Loki in unit tests
+		ctx := context.Background()
+		result, err := listLokiLabelNames(ctx, ListLokiLabelNamesParams{
+			DatasourceUID: "loki",
+			StartRFC3339:  "2023-01-01T00:00:00Z",
+			EndRFC3339:    "2023-01-02T00:00:00Z",
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result, "app")
+		assert.Contains(t, result, "job")
+		assert.Contains(t, result, "level")
+		assert.Contains(t, result, "container")
+	})
+
+	t.Run("list loki label values", func(t *testing.T) {
+		// This is a mock test since we can't actually query Loki in unit tests
+		ctx := context.Background()
+		result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
+			DatasourceUID: "loki",
+			LabelName:     "app",
+			StartRFC3339:  "2023-01-01T00:00:00Z",
+			EndRFC3339:    "2023-01-02T00:00:00Z",
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Contains(t, result, "value1")
+		assert.Contains(t, result, "value2")
+		assert.Contains(t, result, "value3")
+	})
+}

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -1,7 +1,8 @@
+//go:build integration
+
 package tools
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,59 +10,16 @@ import (
 )
 
 func TestLokiClientFromContext(t *testing.T) {
-	ctx := context.Background()
+	ctx := newTestContext()
 	client, url, err := lokiClientFromContext(ctx, "loki")
 	require.NoError(t, err)
 	assert.NotNil(t, client)
 	assert.Contains(t, url, "/api/datasources/proxy/uid/loki")
 }
 
-func TestQueryLoki(t *testing.T) {
-	// This is a mock test since we can't actually query Loki in unit tests
-	ctx := context.Background()
-	result, err := queryLoki(ctx, QueryLokiParams{
-		DatasourceUID: "loki",
-		Query:         `{app="test"}`,
-		StartRFC3339:  "2023-01-01T00:00:00Z",
-	})
-
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Equal(t, "success", result["status"])
-}
-
-func TestListLokiLabelNames(t *testing.T) {
-	// This is a mock test since we can't actually query Loki in unit tests
-	ctx := context.Background()
-	result, err := listLokiLabelNames(ctx, ListLokiLabelNamesParams{
-		DatasourceUID: "loki",
-	})
-
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Contains(t, result, "app")
-	assert.Contains(t, result, "job")
-}
-
-func TestListLokiLabelValues(t *testing.T) {
-	// This is a mock test since we can't actually query Loki in unit tests
-	ctx := context.Background()
-	result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
-		DatasourceUID: "loki",
-		LabelName:     "app",
-	})
-
-	require.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Contains(t, result, "value1")
-}
-
-// TestLokiTools tests all Loki tools together in a single test function
-// This follows the structure of TestPrometheusTools
 func TestLokiTools(t *testing.T) {
 	t.Run("query loki", func(t *testing.T) {
-		// This is a mock test since we can't actually query Loki in unit tests
-		ctx := context.Background()
+		ctx := newTestContext()
 		result, err := queryLoki(ctx, QueryLokiParams{
 			DatasourceUID: "loki",
 			Query:         `{app="test"}`,
@@ -82,7 +40,7 @@ func TestLokiTools(t *testing.T) {
 
 	t.Run("list loki label names", func(t *testing.T) {
 		// This is a mock test since we can't actually query Loki in unit tests
-		ctx := context.Background()
+		ctx := newTestContext()
 		result, err := listLokiLabelNames(ctx, ListLokiLabelNamesParams{
 			DatasourceUID: "loki",
 			StartRFC3339:  "2023-01-01T00:00:00Z",
@@ -99,7 +57,7 @@ func TestLokiTools(t *testing.T) {
 
 	t.Run("list loki label values", func(t *testing.T) {
 		// This is a mock test since we can't actually query Loki in unit tests
-		ctx := context.Background()
+		ctx := newTestContext()
 		result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
 			DatasourceUID: "loki",
 			LabelName:     "app",

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -18,4 +18,14 @@ func TestLokiTools(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 	})
+
+	t.Run("get loki label values", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
+			DatasourceUID: "loki",
+			LabelName:     "container",
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result, "Should have at least one container label value")
+	})
 }

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -18,26 +18,6 @@ func TestLokiClientFromContext(t *testing.T) {
 }
 
 func TestLokiTools(t *testing.T) {
-	t.Run("query loki", func(t *testing.T) {
-		ctx := newTestContext()
-		result, err := queryLoki(ctx, QueryLokiParams{
-			DatasourceUID: "loki",
-			Query:         `{app="test"}`,
-			StartRFC3339:  "2023-01-01T00:00:00Z",
-			EndRFC3339:    "2023-01-02T00:00:00Z",
-			Limit:         100,
-			Direction:     "backward",
-		})
-
-		require.NoError(t, err)
-		assert.NotNil(t, result)
-		assert.Equal(t, "success", result["status"])
-
-		data, ok := result["data"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, "streams", data["resultType"])
-	})
-
 	t.Run("list loki label names", func(t *testing.T) {
 		// This is a mock test since we can't actually query Loki in unit tests
 		ctx := newTestContext()

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -9,46 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLokiClientFromContext(t *testing.T) {
-	ctx := newTestContext()
-	client, url, err := lokiClientFromContext(ctx, "loki")
-	require.NoError(t, err)
-	assert.NotNil(t, client)
-	assert.Contains(t, url, "/api/datasources/proxy/uid/loki")
-}
-
 func TestLokiTools(t *testing.T) {
 	t.Run("list loki label names", func(t *testing.T) {
-		// This is a mock test since we can't actually query Loki in unit tests
 		ctx := newTestContext()
 		result, err := listLokiLabelNames(ctx, ListLokiLabelNamesParams{
 			DatasourceUID: "loki",
-			StartRFC3339:  "2023-01-01T00:00:00Z",
-			EndRFC3339:    "2023-01-02T00:00:00Z",
 		})
-
 		require.NoError(t, err)
-		assert.NotNil(t, result)
-		assert.Contains(t, result, "app")
-		assert.Contains(t, result, "job")
-		assert.Contains(t, result, "level")
-		assert.Contains(t, result, "container")
-	})
-
-	t.Run("list loki label values", func(t *testing.T) {
-		// This is a mock test since we can't actually query Loki in unit tests
-		ctx := newTestContext()
-		result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
-			DatasourceUID: "loki",
-			LabelName:     "app",
-			StartRFC3339:  "2023-01-01T00:00:00Z",
-			EndRFC3339:    "2023-01-02T00:00:00Z",
-		})
-
-		require.NoError(t, err)
-		assert.NotNil(t, result)
-		assert.Contains(t, result, "value1")
-		assert.Contains(t, result, "value2")
-		assert.Contains(t, result, "value3")
+		assert.Len(t, result, 1)
 	})
 }

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -28,4 +28,21 @@ func TestLokiTools(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, result, "Should have at least one container label value")
 	})
+
+	t.Run("query loki stats", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryLokiStats(ctx, QueryLokiStatsParams{
+			DatasourceUID: "loki",
+			LogQL:         `{container="grafana"}`,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Should return a result")
+
+		// We can't assert on specific values as they will vary,
+		// but we can check that the structure is correct
+		assert.GreaterOrEqual(t, result.Streams, 0, "Should have a valid streams count")
+		assert.GreaterOrEqual(t, result.Chunks, 0, "Should have a valid chunks count")
+		assert.GreaterOrEqual(t, result.Entries, 0, "Should have a valid entries count")
+		assert.GreaterOrEqual(t, result.Bytes, 0, "Should have a valid bytes count")
+	})
 }


### PR DESCRIPTION
Related to [this issue](https://github.com/grafana/mcp-grafana/issues/33)

In this PR we are adding tools to:
- get label names
- get label values
- get stats
- run queries (either metric or log queries)
from Loki datasources. 

TODO: 
- [x] Update README.md