### PR TITLE
Alerting: Add support for getting alert rule information

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,31 +26,39 @@ This provides access to your Grafana instance and the surrounding ecosystem.
   - [x] Stats
 - [x] Search, create, update and close incidents
 - [ ] Start Sift investigations and view the results
+- [ ] Alerting
+  - [x] List and fetch alert rule information
+  - [ ] Get alert rule statuses (firing/normal/error/etc.)
+  - [ ] Create and change alert rules
+  - [ ] List contact points
+  - [ ] Create and change contact points
 
 The list of tools is configurable, so you can choose which tools you want to make available to the MCP client.
 This is useful if you don't use certain functionality or if you don't want to take up too much of the context window.
 
 ### Tools
 
-| Tool | Category | Description |
-| --- | --- | --- |
-| `search_dashboards` | Search | Search for dashboards |
-| `list_datasources` | Datasources | List datasources |
-| `get_datasource_by_uid` | Datasources | Get a datasource by uid |
-| `get_datasource_by_name` | Datasources | Get a datasource by name |
-| `query_prometheus` | Prometheus | Execute a query against a Prometheus datasource |
-| `list_prometheus_metric_metadata` | Prometheus | List metric metadata |
-| `list_prometheus_metric_names` | Prometheus | List available metric names |
-| `list_prometheus_label_names` | Prometheus | List label names matching a selector |
-| `list_prometheus_label_values` | Prometheus | List values for a specific label |
-| `list_incidents` | Incident | List incidents in Grafana Incident |
-| `create_incident` | Incident | Create an incident in Grafana Incident |
-| `add_activity_to_incident` | Incident | Add an activity item to an incident in Grafana Incident |
-| `resolve_incident` | Incident | Resolve an incident in Grafana Incident |
-| `query_loki_logs` | Loki | Query and retrieve logs using LogQL (either log or metric queries) |
-| `list_loki_label_names` | Loki | List all available label names in logs |
-| `list_loki_label_values` | Loki | List values for a specific log label |
-| `query_loki_stats` | Loki | Get statistics about log streams |
+| Tool                              | Category    | Description                                                        |
+|-----------------------------------|-------------|--------------------------------------------------------------------|
+| `search_dashboards`               | Search      | Search for dashboards                                              |
+| `list_datasources`                | Datasources | List datasources                                                   |
+| `get_datasource_by_uid`           | Datasources | Get a datasource by uid                                            |
+| `get_datasource_by_name`          | Datasources | Get a datasource by name                                           |
+| `query_prometheus`                | Prometheus  | Execute a query against a Prometheus datasource                    |
+| `list_prometheus_metric_metadata` | Prometheus  | List metric metadata                                               |
+| `list_prometheus_metric_names`    | Prometheus  | List available metric names                                        |
+| `list_prometheus_label_names`     | Prometheus  | List label names matching a selector                               |
+| `list_prometheus_label_values`    | Prometheus  | List values for a specific label                                   |
+| `list_incidents`                  | Incident    | List incidents in Grafana Incident                                 |
+| `create_incident`                 | Incident    | Create an incident in Grafana Incident                             |
+| `add_activity_to_incident`        | Incident    | Add an activity item to an incident in Grafana Incident            |
+| `resolve_incident`                | Incident    | Resolve an incident in Grafana Incident                            |
+| `query_loki_logs`                 | Loki        | Query and retrieve logs using LogQL (either log or metric queries) |
+| `list_loki_label_names`           | Loki        | List all available label names in logs                             |
+| `list_loki_label_values`          | Loki        | List values for a specific log label                               |
+| `query_loki_stats`                | Loki        | Get statistics about log streams                                   |
+| `list_alert_rules`                | Alerting    | List alert rules                                                   |
+| `get_alert_rule_by_uid`           | Alerting    | Get alert rule by UID                                              |
 
 ## Usage
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -23,6 +23,7 @@ func newServer() *server.MCPServer {
 	tools.AddIncidentTools(s)
 	tools.AddPrometheusTools(s)
 	tools.AddLokiTools(s)
+	tools.AddAlertingTools(s)
 	return s
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mark3labs/mcp-go v0.15.0
 	github.com/prometheus/client_golang v1.21.0
 	github.com/prometheus/common v0.62.0
+	github.com/prometheus/prometheus v0.302.1
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -32,6 +33,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -52,7 +54,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65 
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65/go.mod h1:hiZnMmXc9KXNUlvkV2BKFsiWuIFF/fF4wGgYWEjBitI=
 github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43 h1:+MCsOKi5BJ1wO3PRj3eDNxCScYwE2IcKNW1t8OcTarE=
 github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43/go.mod h1:3QDfdZOWKRxNhMJFL+0C/+12+jLNHDlt0VKNr/i9Daw=
+github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
+github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -92,6 +94,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/prometheus/prometheus v0.302.1 h1:xqVdrwrB4WNpdgJqxsz5loqFWNUZitsK8myqLuSZ6Ag=
+github.com/prometheus/prometheus v0.302.1/go.mod h1:YcyCoTbUR/TM8rY3Aoeqr0AWTu/pu1Ehh+trpX3eRzg=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/testdata/provisioning/alerting/alert_rules.yaml
+++ b/testdata/provisioning/alerting/alert_rules.yaml
@@ -60,6 +60,7 @@ groups:
         labels:
           severity: info
           type: test
+          rule: first
         isPaused: false
 
       - uid: test_alert_rule_2
@@ -116,6 +117,7 @@ groups:
         labels:
           severity: info
           type: test
+          rule: second
         isPaused: false
 
       - uid: test_alert_rule_paused
@@ -172,4 +174,5 @@ groups:
         labels:
           severity: info
           type: test
+          rule: third
         isPaused: true

--- a/testdata/provisioning/alerting/alert_rules.yaml
+++ b/testdata/provisioning/alerting/alert_rules.yaml
@@ -1,0 +1,175 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: Test Alert Rules
+    folder: Test Alerts
+    interval: 1m
+    rules:
+      - uid: test_alert_rule_1
+        title: Test Alert Rule 1
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: vector(1)
+              hide: false
+              instant: true
+              legendFormat: __auto
+              range: false
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              refId: B
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 1m
+        keepFiringFor: 0s
+        annotations:
+          description: This is a test alert rule that is always firing
+        labels:
+          severity: info
+          type: test
+        isPaused: false
+
+      - uid: test_alert_rule_2
+        title: Test Alert Rule 2
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: vector(0)
+              hide: false
+              instant: true
+              legendFormat: __auto
+              range: false
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              refId: B
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 1m
+        keepFiringFor: 0s
+        annotations:
+          description: This is a test alert rule that is always normal
+        labels:
+          severity: info
+          type: test
+        isPaused: false
+
+      - uid: test_alert_rule_paused
+        title: Test Alert Rule (Paused)
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: vector(1)
+              hide: false
+              instant: true
+              legendFormat: __auto
+              range: false
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              refId: B
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 1m
+        keepFiringFor: 0s
+        annotations:
+          description: This is a paused alert rule
+        labels:
+          severity: info
+          type: test
+        isPaused: true

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+type ListAlertRulesParams struct{}
+
+func listAlertRules(ctx context.Context, args ListAlertRulesParams) (models.ProvisionedAlertRules, error) {
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	alertRules, err := c.Provisioning.GetAlertRules()
+	if err != nil {
+		return nil, fmt.Errorf("list alert rules: %w", err)
+	}
+	return alertRules.Payload, nil
+}
+
+var ListAlertRules = mcpgrafana.MustTool(
+	"list_alert_rules",
+	"List alert rules",
+	listAlertRules,
+)
+
+type GetAlertRuleByUIDParams struct {
+	UID string `json:"uid" jsonschema:"required,description=The uid of the alert rule"`
+}
+
+func getAlertRuleByUID(ctx context.Context, args GetAlertRuleByUIDParams) (*models.ProvisionedAlertRule, error) {
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	alertRule, err := c.Provisioning.GetAlertRule(args.UID)
+	if err != nil {
+		return nil, fmt.Errorf("get alert rule by uid %s: %w", args.UID, err)
+	}
+	return alertRule.Payload, nil
+}
+
+var GetAlertRuleByUID = mcpgrafana.MustTool(
+	"get_alert_rule_by_uid",
+	"Get alert rule by uid",
+	getAlertRuleByUID,
+)
+
+func AddAlertingTools(mcp *server.MCPServer) {
+	ListAlertRules.Register(mcp)
+	GetAlertRuleByUID.Register(mcp)
+}

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -9,15 +9,86 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-type ListAlertRulesParams struct{}
+const (
+	DefaultListAlertRulesLimit = 100
+)
 
-func listAlertRules(ctx context.Context, args ListAlertRulesParams) (models.ProvisionedAlertRules, error) {
+type ListAlertRulesParams struct {
+	Limit int `json:"limit,omitempty" jsonschema:"description=The maximum number of results to return. Default is 100."`
+	Page  int `json:"page,omitempty" jsonschema:"description=The page number to return."`
+}
+
+func (p ListAlertRulesParams) validate() error {
+	if p.Limit < 0 {
+		return fmt.Errorf("invalid limit: %d, must be greater than 0", p.Limit)
+	}
+	if p.Page < 0 {
+		return fmt.Errorf("invalid page: %d, must be greater than 0", p.Page)
+	}
+
+	return nil
+}
+
+type alertRuleSummary struct {
+	UID   string `json:"uid"`
+	Title string `json:"title"`
+}
+
+func listAlertRules(ctx context.Context, args ListAlertRulesParams) ([]alertRuleSummary, error) {
+	if err := args.validate(); err != nil {
+		return nil, fmt.Errorf("list alert rules: %w", err)
+	}
+
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	alertRules, err := c.Provisioning.GetAlertRules()
+	response, err := c.Provisioning.GetAlertRules()
 	if err != nil {
 		return nil, fmt.Errorf("list alert rules: %w", err)
 	}
-	return alertRules.Payload, nil
+
+	alertRules, err := applyPagination(response.Payload, args.Limit, args.Page)
+	if err != nil {
+		return nil, fmt.Errorf("list alert rules: %w", err)
+	}
+
+	return summarizeAlertRules(alertRules), nil
+}
+
+func summarizeAlertRules(alertRules models.ProvisionedAlertRules) []alertRuleSummary {
+	result := make([]alertRuleSummary, 0, len(alertRules))
+	for _, r := range alertRules {
+		title := ""
+		if r.Title != nil {
+			title = *r.Title
+		}
+
+		result = append(result, alertRuleSummary{
+			UID:   r.UID,
+			Title: title,
+		})
+	}
+	return result
+}
+
+// applyPagination applies pagination to the list of alert rules.
+// It doesn't sort the items and relies on the order returned by the API.
+func applyPagination(items models.ProvisionedAlertRules, limit, page int) (models.ProvisionedAlertRules, error) {
+	if limit == 0 {
+		limit = DefaultListAlertRulesLimit
+	}
+	if page == 0 {
+		page = 1
+	}
+
+	start := (page - 1) * limit
+	end := start + limit
+
+	if start >= len(items) {
+		return models.ProvisionedAlertRules{}, nil
+	} else if end > len(items) {
+		return items[start:], nil
+	}
+
+	return items[start:end], nil
 }
 
 var ListAlertRules = mcpgrafana.MustTool(
@@ -30,7 +101,19 @@ type GetAlertRuleByUIDParams struct {
 	UID string `json:"uid" jsonschema:"required,description=The uid of the alert rule"`
 }
 
+func (p GetAlertRuleByUIDParams) validate() error {
+	if p.UID == "" {
+		return fmt.Errorf("uid is required")
+	}
+
+	return nil
+}
+
 func getAlertRuleByUID(ctx context.Context, args GetAlertRuleByUIDParams) (*models.ProvisionedAlertRule, error) {
+	if err := args.validate(); err != nil {
+		return nil, fmt.Errorf("get alert rule by uid: %w", err)
+	}
+
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
 	alertRule, err := c.Provisioning.GetAlertRule(args.UID)
 	if err != nil {

--- a/tools/alerting_test.go
+++ b/tools/alerting_test.go
@@ -1,0 +1,76 @@
+// Requires a Grafana instance running on localhost:3000,
+// with alert rules configured.
+// Run with `go test -tags integration`.
+//go:build integration
+
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertingTools(t *testing.T) {
+	const (
+		rule1UID        = "test_alert_rule_1"
+		rule1Title      = "Test Alert Rule 1"
+		rule2UID        = "test_alert_rule_2"
+		rule2Title      = "Test Alert Rule 2"
+		rulePausedUID   = "test_alert_rule_paused"
+		rulePausedTitle = "Test Alert Rule (Paused)"
+	)
+
+	t.Run("list alert rules", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listAlertRules(ctx, ListAlertRulesParams{})
+		require.NoError(t, err)
+
+		// We should have 3 test alert rules we provisioned
+		require.Equal(t, len(result), 3, "Expected 3 alert rules from provisioning")
+
+		expectedRules := map[string]struct {
+			title    string
+			isPaused bool
+		}{
+			rule1UID:      {rule1Title, false},
+			rule2UID:      {rule2Title, false},
+			rulePausedUID: {rulePausedTitle, true},
+		}
+
+		for _, rule := range result {
+			expected, exists := expectedRules[rule.UID]
+			require.True(t, exists, "Unexpected rule with UID %s", rule.UID)
+			assert.Equal(t, expected.title, *rule.Title, "Unexpected title for %s", rule.UID)
+			assert.Equal(t, expected.isPaused, rule.IsPaused, "Unexpected isPaused value for %s", rule.UID)
+		}
+	})
+
+	t.Run("get running alert rule by uid", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := getAlertRuleByUID(ctx, GetAlertRuleByUIDParams{
+			UID: rule1UID,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, rule1UID, result.UID)
+		require.NotNil(t, result.Title)
+		require.Equal(t, rule1Title, *result.Title)
+		require.False(t, result.IsPaused)
+
+	})
+
+	t.Run("get paused alert rule by uid", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := getAlertRuleByUID(ctx, GetAlertRuleByUIDParams{
+			UID: "test_alert_rule_paused",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, rulePausedUID, result.UID)
+		require.NotNil(t, result.Title)
+		require.Equal(t, rulePausedTitle, *result.Title)
+		require.True(t, result.IsPaused)
+	})
+}

--- a/tools/alerting_test.go
+++ b/tools/alerting_test.go
@@ -8,45 +8,125 @@ package tools
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAlertingTools(t *testing.T) {
-	const (
-		rule1UID        = "test_alert_rule_1"
-		rule1Title      = "Test Alert Rule 1"
-		rule2UID        = "test_alert_rule_2"
-		rule2Title      = "Test Alert Rule 2"
-		rulePausedUID   = "test_alert_rule_paused"
-		rulePausedTitle = "Test Alert Rule (Paused)"
-	)
+const (
+	rule1UID        = "test_alert_rule_1"
+	rule1Title      = "Test Alert Rule 1"
+	rule2UID        = "test_alert_rule_2"
+	rule2Title      = "Test Alert Rule 2"
+	rulePausedUID   = "test_alert_rule_paused"
+	rulePausedTitle = "Test Alert Rule (Paused)"
+)
 
+func TestAlertingTools_ListAlertRules(t *testing.T) {
 	t.Run("list alert rules", func(t *testing.T) {
 		ctx := newTestContext()
 		result, err := listAlertRules(ctx, ListAlertRulesParams{})
 		require.NoError(t, err)
 
-		// We should have 3 test alert rules we provisioned
-		require.Equal(t, len(result), 3, "Expected 3 alert rules from provisioning")
-
-		expectedRules := map[string]struct {
-			title    string
-			isPaused bool
-		}{
-			rule1UID:      {rule1Title, false},
-			rule2UID:      {rule2Title, false},
-			rulePausedUID: {rulePausedTitle, true},
+		expectedRules := []alertRuleSummary{
+			{UID: rule1UID, Title: rule1Title},
+			{UID: rule2UID, Title: rule2Title},
+			{UID: rulePausedUID, Title: rulePausedTitle},
 		}
-
-		for _, rule := range result {
-			expected, exists := expectedRules[rule.UID]
-			require.True(t, exists, "Unexpected rule with UID %s", rule.UID)
-			assert.Equal(t, expected.title, *rule.Title, "Unexpected title for %s", rule.UID)
-			assert.Equal(t, expected.isPaused, rule.IsPaused, "Unexpected isPaused value for %s", rule.UID)
-		}
+		require.ElementsMatch(t, expectedRules, result)
 	})
 
+	t.Run("list alert rules with pagination", func(t *testing.T) {
+		ctx := newTestContext()
+
+		// Get the first page with limit 1
+		result1, err := listAlertRules(ctx, ListAlertRulesParams{
+			Limit: 1,
+			Page:  1,
+		})
+		require.NoError(t, err)
+		require.Len(t, result1, 1)
+
+		// Get the second page with limit 1
+		result2, err := listAlertRules(ctx, ListAlertRulesParams{
+			Limit: 1,
+			Page:  2,
+		})
+		require.NoError(t, err)
+		require.Len(t, result2, 1)
+
+		// Get the third page with limit 1
+		result3, err := listAlertRules(ctx, ListAlertRulesParams{
+			Limit: 1,
+			Page:  3,
+		})
+		require.NoError(t, err)
+		require.Len(t, result3, 1)
+
+		// The next page is empty
+		result4, err := listAlertRules(ctx, ListAlertRulesParams{
+			Limit: 1,
+			Page:  4,
+		})
+		require.NoError(t, err)
+		require.Empty(t, result4)
+	})
+
+	t.Run("list alert rules without the page and limit params", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listAlertRules(ctx, ListAlertRulesParams{})
+		require.NoError(t, err)
+		expectedRules := []alertRuleSummary{
+			{UID: rule1UID, Title: rule1Title},
+			{UID: rule2UID, Title: rule2Title},
+			{UID: rulePausedUID, Title: rulePausedTitle},
+		}
+		require.ElementsMatch(t, expectedRules, result)
+	})
+
+	t.Run("list alert rules with a limit that is larger than the number of rules", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listAlertRules(ctx, ListAlertRulesParams{
+			Limit: 1000,
+			Page:  1,
+		})
+		require.NoError(t, err)
+		expectedRules := []alertRuleSummary{
+			{UID: rule1UID, Title: rule1Title},
+			{UID: rule2UID, Title: rule2Title},
+			{UID: rulePausedUID, Title: rulePausedTitle},
+		}
+		require.ElementsMatch(t, expectedRules, result)
+	})
+
+	t.Run("list alert rules with a page that doesn't exist", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listAlertRules(ctx, ListAlertRulesParams{
+			Limit: 10,
+			Page:  1000,
+		})
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("list alert rules with invalid page parameter", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listAlertRules(ctx, ListAlertRulesParams{
+			Page: -1,
+		})
+		require.Error(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("list alert rules with invalid limit parameter", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listAlertRules(ctx, ListAlertRulesParams{
+			Limit: -1,
+		})
+		require.Error(t, err)
+		require.Empty(t, result)
+	})
+}
+
+func TestAlertingTools_GetAlertRuleByUID(t *testing.T) {
 	t.Run("get running alert rule by uid", func(t *testing.T) {
 		ctx := newTestContext()
 		result, err := getAlertRuleByUID(ctx, GetAlertRuleByUIDParams{
@@ -58,7 +138,6 @@ func TestAlertingTools(t *testing.T) {
 		require.NotNil(t, result.Title)
 		require.Equal(t, rule1Title, *result.Title)
 		require.False(t, result.IsPaused)
-
 	})
 
 	t.Run("get paused alert rule by uid", func(t *testing.T) {
@@ -72,5 +151,26 @@ func TestAlertingTools(t *testing.T) {
 		require.NotNil(t, result.Title)
 		require.Equal(t, rulePausedTitle, *result.Title)
 		require.True(t, result.IsPaused)
+	})
+
+	t.Run("get alert rule with empty UID fails", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := getAlertRuleByUID(ctx, GetAlertRuleByUIDParams{
+			UID: "",
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+	})
+
+	t.Run("get non-existing alert rule by uid", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := getAlertRuleByUID(ctx, GetAlertRuleByUIDParams{
+			UID: "some-non-existing-alert-rule-uid",
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "getAlertRuleNotFound")
 	})
 }


### PR DESCRIPTION
This PR adds new tools to interact with Grafana Alerting:

- `list_alert_rules`: List all alert rules
- `get_alert_rule_by_uid`: Get information about a specific alert rule