### PR TITLE
Allow filtering of datasources by type

### DIFF
--- a/tools/datasources_test.go
+++ b/tools/datasources_test.go
@@ -57,6 +57,14 @@ func TestDatasourcesTools(t *testing.T) {
 		assert.Len(t, result, 3)
 	})
 
+	t.Run("list datasources for type", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listDatasources(ctx, ListDatasourcesParams{Type: "Prometheus"})
+		require.NoError(t, err)
+		// Only two Prometheus datasources are provisioned in the test environment.
+		assert.Len(t, result, 2)
+	})
+
 	t.Run("get datasource by uid", func(t *testing.T) {
 		ctx := newTestContext()
 		result, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{


### PR DESCRIPTION
To reduce the amount of context passed back to the agent it is now possible to do client-side filtering of all datasources to just the type desired. This is implemented using case insensitive Contains so that the type does not have to be perfect.

Closes: #52 