### PR TITLE
Sift tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ This provides access to your Grafana instance and the surrounding ecosystem.
   - [x] List Investigations with a limit parameter
   - [x] Get Investigation
   - [x] Get Analyses
-  - [x] Create an Investigation only running ErrorPatternLogs Check
-  - [x] Create an Investigation only running SlowRequests Check
+  - [x] Find error patterns in logs using Sift
+  - [x] Find slow requests using Sift
   - [ ] Add tools on the other Sift Checks
 - [ ] Alerting
   - [x] List and fetch alert rule information
@@ -77,15 +77,15 @@ the OnCall tools, use `--disable-oncall`.
 | `list_alert_rules`                | Alerting    | List alert rules                                                   |
 | `get_alert_rule_by_uid`           | Alerting    | Get alert rule by UID                                              |
 | `list_oncall_schedules`           | OnCall      | List schedules from Grafana OnCall                                 |
-| `get_oncall_shift`                | OnCall      | Get details for a specific OnCall shift                           |
+| `get_oncall_shift`                | OnCall      | Get details for a specific OnCall shift                            |
 | `get_current_oncall_users`        | OnCall      | Get users currently on-call for a specific schedule                |
 | `list_oncall_teams`               | OnCall      | List teams from Grafana OnCall                                     |
 | `list_oncall_users`               | OnCall      | List users from Grafana OnCall                                     |
-| `get_investigation`               | Sift        | Retrieve an existing Sift investigation by its UUID                     |
-| `get_analysis`                    | Sift        | Retrieve a specific analysis from a Sift investigation                 |
-| `list_investigations`             | Sift        | Retrieve a list of Sift investigations with an optional limit           |
-| `run_error_pattern_logs`          | Sift        | Create a Sift investigation with ErrorPatternLogs check and get results |
-| `run_slow_requests_check`         | Sift        | Create a Sift investigation with SlowRequests check and get results    |
+| `get_investigation`               | Sift        | Retrieve an existing Sift investigation by its UUID                |
+| `get_analysis`                    | Sift        | Retrieve a specific analysis from a Sift investigation             |
+| `list_investigations`             | Sift        | Retrieve a list of Sift investigations with an optional limit      |
+| `find_error_pattern_logs`         | Sift        | Finds elevated error patterns in Loki logs.                        |
+| `find_slow_requests`              | Sift        | Finds slow requests from the relevant tempo datasources.           |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ the OnCall tools, use `--disable-oncall`.
 | `get_current_oncall_users`        | OnCall      | Get users currently on-call for a specific schedule                |
 | `list_oncall_teams`               | OnCall      | List teams from Grafana OnCall                                     |
 | `list_oncall_users`               | OnCall      | List users from Grafana OnCall                                     |
-| `create_investigation`            | Sift        | Create a new Sift investigation to analyze data from different datasources |
 | `get_investigation`               | Sift        | Retrieve an existing Sift investigation by its UUID                     |
 | `get_analysis`                    | Sift        | Retrieve a specific analysis from a Sift investigation                 |
 | `list_investigations`             | Sift        | Retrieve a list of Sift investigations with an optional limit           |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ This provides access to your Grafana instance and the surrounding ecosystem.
   - [x] Label values
   - [x] Stats
 - [x] Search, create, update and close incidents
-- [ ] Start Sift investigations and view the results
+- [x] Start Sift investigations and view the results
+  - [x] Create Investigations
+  - [x] List Investigations with a limit parameter
+  - [x] Get Investigation
+  - [x] Get Analyses
+  - [x] Create an Investigation only running ErrorPatternLogs Check
+  - [x] Create an Investigation only running SlowRequests Check
+  - [ ] Add tools on the other Sift Checks
 - [ ] Alerting
   - [x] List and fetch alert rule information
   - [x] Get alert rule statuses (firing/normal/error/etc.)
@@ -74,6 +81,12 @@ the OnCall tools, use `--disable-oncall`.
 | `get_current_oncall_users`        | OnCall      | Get users currently on-call for a specific schedule                |
 | `list_oncall_teams`               | OnCall      | List teams from Grafana OnCall                                     |
 | `list_oncall_users`               | OnCall      | List users from Grafana OnCall                                     |
+| `create_investigation`            | Sift        | Create a new Sift investigation to analyze data from different datasources |
+| `get_investigation`               | Sift        | Retrieve an existing Sift investigation by its UUID                     |
+| `get_analysis`                    | Sift        | Retrieve a specific analysis from a Sift investigation                 |
+| `list_investigations`             | Sift        | Retrieve a list of Sift investigations with an optional limit           |
+| `run_error_pattern_logs`          | Sift        | Create a Sift investigation with ErrorPatternLogs check and get results |
+| `run_slow_requests_check`         | Sift        | Create a Sift investigation with SlowRequests check and get results    |
 
 ## Usage
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -34,7 +34,7 @@ type disabledTools struct {
 
 	search, datasource, incident,
 	prometheus, loki, alerting,
-	dashboard, oncall bool
+	dashboard, oncall, sift bool
 }
 
 // Configuration for the Grafana client.
@@ -54,6 +54,7 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.alerting, "disable-alerting", false, "Disable alerting tools")
 	flag.BoolVar(&dt.dashboard, "disable-dashboard", false, "Disable dashboard tools")
 	flag.BoolVar(&dt.oncall, "disable-oncall", false, "Disable oncall tools")
+	flag.BoolVar(&dt.sift, "disable-sift", false, "Disable sift tools")
 }
 
 func (gc *grafanaConfig) addFlags() {
@@ -70,6 +71,7 @@ func (dt *disabledTools) addTools(s *server.MCPServer) {
 	maybeAddTools(s, tools.AddAlertingTools, enabledTools, dt.alerting, "alerting")
 	maybeAddTools(s, tools.AddDashboardTools, enabledTools, dt.dashboard, "dashboard")
 	maybeAddTools(s, tools.AddOnCallTools, enabledTools, dt.oncall, "oncall")
+	maybeAddTools(s, tools.AddSiftTools, enabledTools, dt.sift, "sift")
 }
 
 func newServer(dt disabledTools) *server.MCPServer {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/go-openapi/strfmt v0.23.0
+	github.com/google/uuid v1.6.0
 	github.com/grafana/amixr-api-go-client v0.0.21
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65
 	github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43
@@ -34,7 +35,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -24,6 +24,7 @@ const (
 
 	grafanaURLHeader    = "X-Grafana-URL"
 	grafanaAPIKeyHeader = "X-Grafana-API-Key"
+	grafanaOrgIDHeader  = "X-Scope-OrgID"
 )
 
 func urlAndAPIKeyFromEnv() (string, string) {
@@ -40,6 +41,7 @@ func urlAndAPIKeyFromHeaders(req *http.Request) (string, string) {
 
 type grafanaURLKey struct{}
 type grafanaAPIKeyKey struct{}
+type grafanaOrgIDKey struct{}
 
 // grafanaDebugKey is the context key for the Grafana transport's debug flag.
 type grafanaDebugKey struct{}
@@ -90,7 +92,8 @@ var ExtractGrafanaInfoFromHeaders server.SSEContextFunc = func(ctx context.Conte
 	if apiKey == "" {
 		apiKey = apiKeyEnv
 	}
-	return WithGrafanaURL(WithGrafanaAPIKey(ctx, apiKey), u)
+	orgID := req.Header.Get(grafanaOrgIDHeader)
+	return WithGrafanaOrgID(WithGrafanaURL(WithGrafanaAPIKey(ctx, apiKey), u), orgID)
 }
 
 // WithGrafanaURL adds the Grafana URL to the context.
@@ -101,6 +104,11 @@ func WithGrafanaURL(ctx context.Context, url string) context.Context {
 // WithGrafanaAPIKey adds the Grafana API key to the context.
 func WithGrafanaAPIKey(ctx context.Context, apiKey string) context.Context {
 	return context.WithValue(ctx, grafanaAPIKeyKey{}, apiKey)
+}
+
+// WithGrafanaOrgID adds the Grafana organization ID to the context.
+func WithGrafanaOrgID(ctx context.Context, orgID string) context.Context {
+	return context.WithValue(ctx, grafanaOrgIDKey{}, orgID)
 }
 
 // GrafanaURLFromContext extracts the Grafana URL from the context.
@@ -115,6 +123,15 @@ func GrafanaURLFromContext(ctx context.Context) string {
 func GrafanaAPIKeyFromContext(ctx context.Context) string {
 	if k, ok := ctx.Value(grafanaAPIKeyKey{}).(string); ok {
 		return k
+	}
+	return ""
+}
+
+// GrafanaOrgIDFromContext extracts the Grafana organization ID from the context.
+// TODO: To be discovered
+func GrafanaOrgIDFromContext(ctx context.Context) string {
+	if orgID, ok := ctx.Value(grafanaOrgIDKey{}).(string); ok {
+		return orgID
 	}
 	return ""
 }

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -24,7 +24,6 @@ const (
 
 	grafanaURLHeader    = "X-Grafana-URL"
 	grafanaAPIKeyHeader = "X-Grafana-API-Key"
-	grafanaOrgIDHeader  = "X-Scope-OrgID"
 )
 
 func urlAndAPIKeyFromEnv() (string, string) {
@@ -41,7 +40,6 @@ func urlAndAPIKeyFromHeaders(req *http.Request) (string, string) {
 
 type grafanaURLKey struct{}
 type grafanaAPIKeyKey struct{}
-type grafanaOrgIDKey struct{}
 
 // grafanaDebugKey is the context key for the Grafana transport's debug flag.
 type grafanaDebugKey struct{}
@@ -92,8 +90,7 @@ var ExtractGrafanaInfoFromHeaders server.SSEContextFunc = func(ctx context.Conte
 	if apiKey == "" {
 		apiKey = apiKeyEnv
 	}
-	orgID := req.Header.Get(grafanaOrgIDHeader)
-	return WithGrafanaOrgID(WithGrafanaURL(WithGrafanaAPIKey(ctx, apiKey), u), orgID)
+	return WithGrafanaURL(WithGrafanaAPIKey(ctx, apiKey), u)
 }
 
 // WithGrafanaURL adds the Grafana URL to the context.
@@ -104,11 +101,6 @@ func WithGrafanaURL(ctx context.Context, url string) context.Context {
 // WithGrafanaAPIKey adds the Grafana API key to the context.
 func WithGrafanaAPIKey(ctx context.Context, apiKey string) context.Context {
 	return context.WithValue(ctx, grafanaAPIKeyKey{}, apiKey)
-}
-
-// WithGrafanaOrgID adds the Grafana organization ID to the context.
-func WithGrafanaOrgID(ctx context.Context, orgID string) context.Context {
-	return context.WithValue(ctx, grafanaOrgIDKey{}, orgID)
 }
 
 // GrafanaURLFromContext extracts the Grafana URL from the context.
@@ -123,15 +115,6 @@ func GrafanaURLFromContext(ctx context.Context) string {
 func GrafanaAPIKeyFromContext(ctx context.Context) string {
 	if k, ok := ctx.Value(grafanaAPIKeyKey{}).(string); ok {
 		return k
-	}
-	return ""
-}
-
-// GrafanaOrgIDFromContext extracts the Grafana organization ID from the context.
-// TODO: To be discovered
-func GrafanaOrgIDFromContext(ctx context.Context) string {
-	if orgID, ok := ctx.Value(grafanaOrgIDKey{}).(string); ok {
-		return orgID
 	}
 	return ""
 }

--- a/tools/cloud_testing_utils.go
+++ b/tools/cloud_testing_utils.go
@@ -1,0 +1,33 @@
+//go:build cloud
+// +build cloud
+
+package tools
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+// createCloudTestContext creates a context with Grafana URL and API key for cloud integration tests.
+// The test will be skipped if required environment variables are not set.
+// testName is used to customize the skip message (e.g. "OnCall", "Sift", "Incident")
+func createCloudTestContext(t *testing.T, testName string) context.Context {
+	grafanaURL := os.Getenv("GRAFANA_URL")
+	if grafanaURL == "" {
+		t.Skipf("GRAFANA_URL environment variable not set, skipping cloud %s integration tests", testName)
+	}
+
+	grafanaApiKey := os.Getenv("GRAFANA_API_KEY")
+	if grafanaApiKey == "" {
+		t.Skipf("GRAFANA_API_KEY environment variable not set, skipping cloud %s integration tests", testName)
+	}
+
+	ctx := context.Background()
+	ctx = mcpgrafana.WithGrafanaURL(ctx, grafanaURL)
+	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, grafanaApiKey)
+
+	return ctx
+}

--- a/tools/incident_integration_test.go
+++ b/tools/incident_integration_test.go
@@ -3,11 +3,15 @@
 //go:build cloud
 // +build cloud
 
+// This file contains cloud integration tests that run against a dedicated test instance
+// at mcptests.grafana-dev.net. This instance is configured with a minimal setup on the Incident side
+// with two incidents created, one minor and one major, and both of them resolved.
+// These tests expect this configuration to exist and will skip if the required
+// environment variables (GRAFANA_URL, GRAFANA_API_KEY) are not set.
+
 package tools
 
 import (
-	"context"
-	"os"
 	"testing"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
@@ -15,33 +19,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This file contains cloud integration tests that run against a dedicated test instance
-// at mcptests.grafana-dev.net. This instance is configured with a minimal setup on the Incident side
-// with two incidents created, one minor and one major, and both of them resolved.
-// These tests expect this configuration to exist and will skip if the required
-// environment variables (GRAFANA_URL, GRAFANA_API_KEY) are not set.
-
-func createCloudTestContext(t *testing.T) context.Context {
-	grafanaURL := os.Getenv("GRAFANA_URL")
-	if grafanaURL == "" {
-		t.Skip("GRAFANA_URL environment variable not set, skipping cloud Incident integration tests")
-	}
-
-	grafanaApiKey := os.Getenv("GRAFANA_API_KEY")
-	if grafanaApiKey == "" {
-		t.Skip("GRAFANA_API_KEY environment variable not set, skipping cloud Incident integration tests")
-	}
-
-	ctx := context.Background()
-	ctx = mcpgrafana.WithGrafanaURL(ctx, grafanaURL)
-	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, grafanaApiKey)
-	ctx = mcpgrafana.ExtractIncidentClientFromEnv(ctx)
-	return ctx
-}
-
 func TestCloudIncidentTools(t *testing.T) {
 	t.Run("list incidents", func(t *testing.T) {
-		ctx := createCloudTestContext(t)
+		ctx := createCloudTestContext(t, "Incident")
+		ctx = mcpgrafana.ExtractIncidentClientFromEnv(ctx)
+
 		result, err := listIncidents(ctx, ListIncidentsParams{
 			Limit: 1,
 		})

--- a/tools/incident_integration_test.go
+++ b/tools/incident_integration_test.go
@@ -35,6 +35,7 @@ func TestCloudIncidentTools(t *testing.T) {
 
 	t.Run("get incident by ID", func(t *testing.T) {
 		ctx := createCloudTestContext(t, "Incident")
+		ctx = mcpgrafana.ExtractIncidentClientFromEnv(ctx)
 		result, err := getIncident(ctx, GetIncidentParams{
 			ID: "1",
 		})

--- a/tools/incident_integration_test.go
+++ b/tools/incident_integration_test.go
@@ -34,7 +34,7 @@ func TestCloudIncidentTools(t *testing.T) {
 	})
 
 	t.Run("get incident by ID", func(t *testing.T) {
-		ctx := createCloudTestContext(t)
+		ctx := createCloudTestContext(t, "Incident")
 		result, err := getIncident(ctx, GetIncidentParams{
 			ID: "1",
 		})

--- a/tools/oncall_cloud_test.go
+++ b/tools/oncall_cloud_test.go
@@ -13,35 +13,14 @@
 package tools
 
 import (
-	"context"
-	"os"
 	"testing"
 
-	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func createOnCallCloudTestContext(t *testing.T) context.Context {
-	grafanaURL := os.Getenv("GRAFANA_URL")
-	if grafanaURL == "" {
-		t.Skip("GRAFANA_URL environment variable not set, skipping cloud OnCall integration tests")
-	}
-
-	grafanaApiKey := os.Getenv("GRAFANA_API_KEY")
-	if grafanaApiKey == "" {
-		t.Skip("GRAFANA_API_KEY environment variable not set, skipping cloud OnCall integration tests")
-	}
-
-	ctx := context.Background()
-	ctx = mcpgrafana.WithGrafanaURL(ctx, grafanaURL)
-	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, grafanaApiKey)
-
-	return ctx
-}
-
 func TestCloudOnCallSchedules(t *testing.T) {
-	ctx := createOnCallCloudTestContext(t)
+	ctx := createCloudTestContext(t, "OnCall")
 
 	// Test listing all schedules
 	t.Run("list all schedules", func(t *testing.T) {
@@ -104,7 +83,7 @@ func TestCloudOnCallSchedules(t *testing.T) {
 }
 
 func TestCloudOnCallShift(t *testing.T) {
-	ctx := createOnCallCloudTestContext(t)
+	ctx := createCloudTestContext(t, "OnCall")
 
 	// First get a schedule to find a valid shift
 	schedules, err := listOnCallSchedules(ctx, ListOnCallSchedulesParams{})
@@ -134,7 +113,7 @@ func TestCloudOnCallShift(t *testing.T) {
 }
 
 func TestCloudGetCurrentOnCallUsers(t *testing.T) {
-	ctx := createOnCallCloudTestContext(t)
+	ctx := createCloudTestContext(t, "OnCall")
 
 	// First get a schedule to use for testing
 	schedules, err := listOnCallSchedules(ctx, ListOnCallSchedulesParams{})
@@ -171,7 +150,7 @@ func TestCloudGetCurrentOnCallUsers(t *testing.T) {
 }
 
 func TestCloudOnCallTeams(t *testing.T) {
-	ctx := createOnCallCloudTestContext(t)
+	ctx := createCloudTestContext(t, "OnCall")
 
 	t.Run("list teams", func(t *testing.T) {
 		result, err := listOnCallTeams(ctx, ListOnCallTeamsParams{})
@@ -200,7 +179,7 @@ func TestCloudOnCallTeams(t *testing.T) {
 }
 
 func TestCloudOnCallUsers(t *testing.T) {
-	ctx := createOnCallCloudTestContext(t)
+	ctx := createCloudTestContext(t, "OnCall")
 
 	t.Run("list all users", func(t *testing.T) {
 		result, err := listOnCallUsers(ctx, ListOnCallUsersParams{})

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -233,11 +233,10 @@ var ListSiftInvestigations = mcpgrafana.MustTool(
 
 // FindErrorPatternLogsParams defines the parameters for running an ErrorPatternLogs check
 type FindErrorPatternLogsParams struct {
-	Name     string            `json:"name" jsonschema:"required,description=The name of the investigation"`
-	Labels   map[string]string `json:"labels" jsonschema:"required,description=Labels to scope the analysis"`
-	Start    time.Time         `json:"start,omitempty" jsonschema:"description=Start time for the investigation. Defaults to 30 minutes ago if not specified."`
-	End      time.Time         `json:"end,omitempty" jsonschema:"description=End time for the investigation. Defaults to now if not specified."`
-	QueryURL string            `json:"queryUrl,omitempty" jsonschema:"description=Optional query URL for the investigation"`
+	Name   string            `json:"name" jsonschema:"required,description=The name of the investigation"`
+	Labels map[string]string `json:"labels" jsonschema:"required,description=Labels to scope the analysis"`
+	Start  time.Time         `json:"start,omitempty" jsonschema:"description=Start time for the investigation. Defaults to 30 minutes ago if not specified."`
+	End    time.Time         `json:"end,omitempty" jsonschema:"description=End time for the investigation. Defaults to now if not specified."`
 }
 
 // findErrorPatternLogs creates an investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis
@@ -249,11 +248,10 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 
 	// Create the investigation request with ErrorPatternLogs check
 	requestData := investigationRequest{
-		Labels:   args.Labels,
-		Start:    args.Start,
-		End:      args.End,
-		QueryURL: args.QueryURL,
-		Checks:   []string{string(checkTypeErrorPatternLogs)},
+		Labels: args.Labels,
+		Start:  args.Start,
+		End:    args.End,
+		Checks: []string{string(checkTypeErrorPatternLogs)},
 	}
 
 	investigation := &Investigation{
@@ -299,11 +297,10 @@ var FindErrorPatternLogs = mcpgrafana.MustTool(
 
 // FindSlowRequestsParams defines the parameters for running an SlowRequests check
 type FindSlowRequestsParams struct {
-	Name     string            `json:"name" jsonschema:"required,description=The name of the investigation"`
-	Labels   map[string]string `json:"labels" jsonschema:"required,description=Labels to scope the analysis"`
-	Start    time.Time         `json:"start,omitempty" jsonschema:"description=Start time for the investigation. Defaults to 30 minutes ago if not specified."`
-	End      time.Time         `json:"end,omitempty" jsonschema:"description=End time for the investigation. Defaults to now if not specified."`
-	QueryURL string            `json:"queryUrl,omitempty" jsonschema:"description=Optional query URL for the investigation"`
+	Name   string            `json:"name" jsonschema:"required,description=The name of the investigation"`
+	Labels map[string]string `json:"labels" jsonschema:"required,description=Labels to scope the analysis"`
+	Start  time.Time         `json:"start,omitempty" jsonschema:"description=Start time for the investigation. Defaults to 30 minutes ago if not specified."`
+	End    time.Time         `json:"end,omitempty" jsonschema:"description=End time for the investigation. Defaults to now if not specified."`
 }
 
 // findSlowRequests creates an investigation with SlowRequests check, waits for it to complete, and returns the analysis
@@ -315,11 +312,10 @@ func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*analys
 
 	// Create the investigation request with SlowRequests check
 	requestData := investigationRequest{
-		Labels:   args.Labels,
-		Start:    args.Start,
-		End:      args.End,
-		QueryURL: args.QueryURL,
-		Checks:   []string{string(checkTypeSlowRequests)},
+		Labels: args.Labels,
+		Start:  args.Start,
+		End:    args.End,
+		Checks: []string{string(checkTypeSlowRequests)},
 	}
 
 	investigation := &Investigation{

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -162,7 +162,6 @@ type RequestData struct {
 type SiftClient struct {
 	client *http.Client
 	url    string
-	orgID  string
 }
 
 func NewSiftClient(url, apiKey string) *SiftClient {
@@ -181,13 +180,8 @@ func NewSiftClient(url, apiKey string) *SiftClient {
 func siftClientFromContext(ctx context.Context) (*SiftClient, error) {
 	// Get the standard Grafana URL and API key
 	grafanaURL, grafanaAPIKey := mcpgrafana.GrafanaURLFromContext(ctx), mcpgrafana.GrafanaAPIKeyFromContext(ctx)
-	orgID := mcpgrafana.GrafanaOrgIDFromContext(ctx)
-	if orgID == "" {
-		return nil, fmt.Errorf("organization ID not set in context")
-	}
 
 	client := NewSiftClient(grafanaURL, grafanaAPIKey)
-	client.orgID = orgID
 
 	return client, nil
 }
@@ -250,7 +244,6 @@ func (c *SiftClient) createInvestigation(ctx context.Context, investigation *Inv
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Scope-OrgID", c.orgID)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -397,7 +397,7 @@ func runErrorPatternLogs(ctx context.Context, args RunErrorPatternLogsParams) (*
 // RunErrorPatternLogs is a tool for running an ErrorPatternLogs check
 var RunErrorPatternLogs = mcpgrafana.MustTool(
 	"run_error_pattern_logs",
-	"Creates an investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis results. This tool simplifies the process of running an ErrorPatternLogs check by handling the creation, waiting, and retrieval of results in a single operation.",
+	"Creates an investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis results. This tool triggers an investigation with the ErrorPatternLogs check in the relevant Loki datasource. It investigates if the there are elevated errors rates in the logs compared to the last day's average and returns the error pattern found, if any.",
 	runErrorPatternLogs,
 )
 
@@ -464,7 +464,7 @@ func runSlowRequests(ctx context.Context, args RunSlowRequestsCheckParams) (*Ana
 // RunSlowRequestsCheck is a tool for running an SlowRequests check
 var RunSlowRequestsCheck = mcpgrafana.MustTool(
 	"run_slow_requests_check",
-	"Creates an investigation with SlowRequests check, waits for it to complete, and returns the analysis results. This tool simplifies the process of running an SlowRequests check by handling the creation, waiting, and retrieval of results in a single operation.",
+	"Creates an investigation with SlowRequests check in the relevant Tempo datasources, waits for it to complete, and returns the analysis results.",
 	runSlowRequests,
 )
 

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -226,7 +226,7 @@ func createInvestigation(ctx context.Context, args CreateInvestigationParams) (*
 // CreateInvestigation is a tool for creating new investigations
 var CreateInvestigation = mcpgrafana.MustTool(
 	"create_investigation",
-	"Create a new investigation. An investigation analyzes data from different datasource types. It takes a set of labels and values to scope the analysis, optionally accepts a time range (defaults to last hour if not specified) and the title can be infered by the labels used. The investigation will automatically explore relevant data sources and provide insights about potential causes.",
+	"Create a new Sift investigation. An investigation analyzes data from different datasource types. It takes a set of labels and values to scope the analysis, optionally accepts a time range (defaults to last hour if not specified) and the title can be infered by the labels used. The investigation will automatically explore relevant data sources and provide insights about potential causes.",
 	createInvestigation,
 )
 
@@ -259,7 +259,7 @@ func getInvestigation(ctx context.Context, args GetInvestigationParams) (*Invest
 // GetInvestigation is a tool for retrieving an existing investigation
 var GetInvestigation = mcpgrafana.MustTool(
 	"get_investigation",
-	"Retrieves an existing investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').",
+	"Retrieves an existing Sift investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').",
 	getInvestigation,
 )
 
@@ -298,7 +298,7 @@ func getAnalysis(ctx context.Context, args GetAnalysisParams) (*Analysis, error)
 // GetAnalysis is a tool for retrieving a specific analysis from an investigation
 var GetAnalysis = mcpgrafana.MustTool(
 	"get_analysis",
-	"Retrieves a specific analysis from an investigation by their UUIDs. Both the investigation ID and analysis ID should be provided as strings in UUID format.",
+	"Retrieves a specific analysis from a Sift investigation by their UUIDs. Both the investigation ID and analysis ID should be provided as strings in UUID format.",
 	getAnalysis,
 )
 
@@ -330,7 +330,7 @@ func listInvestigations(ctx context.Context, args ListInvestigationsParams) ([]I
 // ListInvestigations is a tool for retrieving a list of investigations
 var ListInvestigations = mcpgrafana.MustTool(
 	"list_investigations",
-	"Retrieves a list of investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",
+	"Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",
 	listInvestigations,
 )
 
@@ -397,7 +397,7 @@ func runErrorPatternLogs(ctx context.Context, args RunErrorPatternLogsParams) (*
 // RunErrorPatternLogs is a tool for running an ErrorPatternLogs check
 var RunErrorPatternLogs = mcpgrafana.MustTool(
 	"run_error_pattern_logs",
-	"Creates an investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis results. This tool triggers an investigation with the ErrorPatternLogs check in the relevant Loki datasource. It investigates if the there are elevated errors rates in the logs compared to the last day's average and returns the error pattern found, if any.",
+	"Creates a Sift investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis results. This tool triggers an investigation with the ErrorPatternLogs check in the relevant Loki datasource. It investigates if the there are elevated errors rates in the logs compared to the last day's average and returns the error pattern found, if any.",
 	runErrorPatternLogs,
 )
 
@@ -464,7 +464,7 @@ func runSlowRequests(ctx context.Context, args RunSlowRequestsCheckParams) (*Ana
 // RunSlowRequestsCheck is a tool for running an SlowRequests check
 var RunSlowRequestsCheck = mcpgrafana.MustTool(
 	"run_slow_requests_check",
-	"Creates an investigation with SlowRequests check in the relevant Tempo datasources, waits for it to complete, and returns the analysis results.",
+	"Creates a Sift investigation with SlowRequests check in the relevant Tempo datasources, waits for it to complete, and returns the analysis results.",
 	runSlowRequests,
 )
 

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -38,20 +38,20 @@ type investigationRequest struct {
 }
 
 // Interesting: The analysis complete with results that indicate a probable cause for failure.
-type AnalysisResult struct {
+type analysisResult struct {
 	Successful  bool                   `json:"successful"`
 	Interesting bool                   `json:"interesting"`
 	Message     string                 `json:"message"`
 	Details     map[string]interface{} `json:"details"`
 }
 
-type AnalysisMeta struct {
-	Items []Analysis `json:"items"`
+type analysisMeta struct {
+	Items []analysis `json:"items"`
 }
 
-// An Analysis struct provides the status and results
+// An analysis struct provides the status and results
 // of running a specific type of check.
-type Analysis struct {
+type analysis struct {
 	ID        uuid.UUID `json:"id"`
 	CreatedAt time.Time `json:"created"`
 	UpdatedAt time.Time `json:"modified"`
@@ -65,7 +65,7 @@ type Analysis struct {
 	// Name is the name of the check that this analysis represents.
 	Name   string         `json:"name"`
 	Title  string         `json:"title"`
-	Result AnalysisResult `json:"result"`
+	Result analysisResult `json:"result"`
 }
 
 type Investigation struct {
@@ -88,7 +88,7 @@ type Investigation struct {
 	// investigation failed.
 	FailureReason string `json:"failureReason,omitempty"`
 
-	Analyses AnalysisMeta `json:"analyses"`
+	Analyses analysisMeta `json:"analyses"`
 }
 
 // siftClient represents a client for interacting with the Sift API.
@@ -167,7 +167,7 @@ type GetSiftAnalysisParams struct {
 }
 
 // getSiftAnalysis retrieves a specific analysis from an investigation
-func getSiftAnalysis(ctx context.Context, args GetSiftAnalysisParams) (*Analysis, error) {
+func getSiftAnalysis(ctx context.Context, args GetSiftAnalysisParams) (*analysis, error) {
 	client, err := siftClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating Sift client: %w", err)
@@ -241,7 +241,7 @@ type FindErrorPatternLogsParams struct {
 }
 
 // findErrorPatternLogs creates an investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis
-func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) (*Analysis, error) {
+func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) (*analysis, error) {
 	client, err := siftClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating Sift client: %w", err)
@@ -275,7 +275,7 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 	}
 
 	// Find the ErrorPatternLogs analysis
-	var errorPatternLogsAnalysis *Analysis
+	var errorPatternLogsAnalysis *analysis
 	for i := range analyses {
 		if analyses[i].Name == string(checkTypeErrorPatternLogs) {
 			errorPatternLogsAnalysis = &analyses[i]
@@ -307,7 +307,7 @@ type FindSlowRequestsParams struct {
 }
 
 // findSlowRequests creates an investigation with SlowRequests check, waits for it to complete, and returns the analysis
-func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*Analysis, error) {
+func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*analysis, error) {
 	client, err := siftClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating Sift client: %w", err)
@@ -341,7 +341,7 @@ func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*Analys
 	}
 
 	// Find the SlowRequests analysis
-	var slowRequestsAnalysis *Analysis
+	var slowRequestsAnalysis *analysis
 	for i := range analyses {
 		if analyses[i].Name == string(checkTypeSlowRequests) {
 			slowRequestsAnalysis = &analyses[i]
@@ -492,7 +492,7 @@ func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation 
 }
 
 // getSiftAnalyses is a helper method to get all analyses from an investigation
-func (c *siftClient) getSiftAnalyses(ctx context.Context, investigationID uuid.UUID) ([]Analysis, error) {
+func (c *siftClient) getSiftAnalyses(ctx context.Context, investigationID uuid.UUID) ([]analysis, error) {
 	path := fmt.Sprintf("/api/plugins/grafana-ml-app/resources/sift/api/v1/investigations/%s/analyses", investigationID)
 	buf, err := c.makeRequest(ctx, "GET", path, nil)
 	if err != nil {
@@ -501,7 +501,7 @@ func (c *siftClient) getSiftAnalyses(ctx context.Context, investigationID uuid.U
 
 	var response struct {
 		Status string     `json:"status"`
-		Data   []Analysis `json:"data"`
+		Data   []analysis `json:"data"`
 	}
 
 	if err := json.Unmarshal(buf, &response); err != nil {
@@ -512,7 +512,7 @@ func (c *siftClient) getSiftAnalyses(ctx context.Context, investigationID uuid.U
 }
 
 // getSiftAnalysis is a helper method to get a specific analysis from an investigation
-func (c *siftClient) getSiftAnalysis(ctx context.Context, investigationID, analysisID uuid.UUID) (*Analysis, error) {
+func (c *siftClient) getSiftAnalysis(ctx context.Context, investigationID, analysisID uuid.UUID) (*analysis, error) {
 	// First get all analyses to verify the analysis exists
 	analyses, err := c.getSiftAnalyses(ctx, investigationID)
 	if err != nil {
@@ -520,7 +520,7 @@ func (c *siftClient) getSiftAnalysis(ctx context.Context, investigationID, analy
 	}
 
 	// Find the specific analysis
-	var targetAnalysis *Analysis
+	var targetAnalysis *analysis
 	for _, analysis := range analyses {
 		if analysis.ID == analysisID {
 			targetAnalysis = &analysis

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -1,0 +1,272 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+type InvestigationStatus string
+
+const (
+	InvestigationStatusPending  InvestigationStatus = "pending"
+	InvestigationStatusRunning  InvestigationStatus = "running"
+	InvestigationStatusFinished InvestigationStatus = "finished"
+	InvestigationStatusFailed   InvestigationStatus = "failed"
+)
+
+type AnalysisStatus string
+
+const (
+	AnalysisStatusPending       AnalysisStatus = "pending"
+	AnalysisStatusSkipped       AnalysisStatus = "skipped"
+	AnalysisStatusRunning       AnalysisStatus = "running"
+	AnalysisStatusFinished      AnalysisStatus = "finished"
+	AnalysisRunningStuckMessage string         = "Analysis was stuck in a running state for too long."
+	AnalysisPendingStuckMessage string         = "Analysis was stuck in a pending state for too long."
+)
+
+type InvestigationRequest struct {
+	AlertLabels map[string]string `json:"alertLabels,omitempty" gorm:"-"`
+	Labels      map[string]string `json:"labels"`
+
+	Start time.Time `json:"start" gorm:"not null"`
+	End   time.Time `json:"end" gorm:"not null"`
+
+	// TODO: Add this when we have a new investigation source field InvestigationSourceTypeMCP.
+	// InvestigationSource InvestigationSource `json:"investigationSource" gorm:"embedded;embeddedPrefix:investigation_source_"`
+
+	// This field holds metric query input for oncall integration investigations.
+	// To be removed after migrating to a new more explicit field.
+	QueryURL string `json:"queryUrl"`
+
+	Checks []string `json:"checks" gorm:"serializer:json"`
+}
+
+// AnalysisStep represents a single step in the analysis process.
+type AnalysisStep struct {
+	CreatedAt time.Time `json:"created" validate:"isdefault"`
+	// State that the Analysis is entering.
+	State string `json:"state"`
+	// The exit message of the step. Can be empty if the step was successful.
+	ExitMessage string `json:"exitMessage"`
+	// Runtime statistics for this step, stored as JSON in the database
+	Stats map[string]interface{} `json:"stats,omitempty"`
+}
+
+type AnalysisEvent struct {
+	StartTime   time.Time              `json:"startTime"`
+	EndTime     time.Time              `json:"endTime"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Details     map[string]interface{} `json:"details"`
+}
+
+// Interesting: The analysis complete with results that indicate a probable cause for failure.
+type AnalysisResult struct {
+	Successful  bool   `json:"successful"`
+	Interesting bool   `json:"interesting"`
+	Message     string `json:"message"`
+	// Do not put these into the database while we are testing it out. Just used for sending to OnCall.
+	MarkdownSummary string                 `json:"-" gorm:"-"`
+	Details         map[string]interface{} `json:"details"`
+	Events          []AnalysisEvent        `json:"events,omitempty" gorm:"serializer:json"`
+}
+
+// An Analysis struct provides the status and results
+// of running a specific type of check.
+// The information is stored in the database.
+type Analysis struct {
+	ID        uuid.UUID `json:"id" gorm:"primarykey;type:char(36)" validate:"isdefault"`
+	CreatedAt time.Time `json:"created" validate:"isdefault"`
+	UpdatedAt time.Time `json:"modified" validate:"isdefault"`
+
+	Status    AnalysisStatus `json:"status" gorm:"default:pending;index:idx_analyses_stats,priority:100"`
+	StartedAt *time.Time     `json:"started" validate:"isdefault"`
+
+	// Foreign key to the Investigation that created this Analysis.
+	InvestigationID uuid.UUID `json:"investigationId" gorm:"index:idx_analyses_stats,priority:10"`
+
+	// Name is the name of the check that this analysis represents.
+	Name   string         `json:"name"`
+	Title  string         `json:"title"`
+	Steps  []AnalysisStep `json:"steps" gorm:"foreignKey:AnalysisID;constraint:OnDelete:CASCADE"`
+	Result AnalysisResult `json:"result" gorm:"embedded;embeddedPrefix:result_"`
+
+	// CreateWithID is used to indicate that the analysis should be created with the
+	// ID in the ID field, rather than generating a new one. This is used by the
+	// copy command of the mlapi CLI.
+	CreateWithID bool `json:"-" gorm:"-"`
+}
+
+type Investigation struct {
+	ID        uuid.UUID `json:"id" gorm:"primarykey;type:char(36)" validate:"isdefault"`
+	CreatedAt time.Time `json:"created" gorm:"index" validate:"isdefault"`
+	UpdatedAt time.Time `json:"modified" validate:"isdefault"`
+
+	TenantID string `json:"tenantId" gorm:"index;not null;size:256"`
+
+	// TODO: To be added.
+	// Datasources DatasourceConfig `json:"datasources" gorm:"embedded;embeddedPrefix:datasources_"`
+
+	Name        string               `json:"name"`
+	RequestData InvestigationRequest `json:"requestData" gorm:"not null;embedded;embeddedPrefix:request_"`
+
+	// TODO: Add this when we want to extract discovered inputs for later usage
+	// Inputs      Inputs               `json:"inputs" gorm:"serializer:json"`
+
+	// GrafanaURL is the Grafana URL to be used for datasource queries
+	// for this investigation.
+	// If missing from a request then the `X-Grafana-URL` header is used.
+	GrafanaURL string `json:"grafanaUrl"`
+
+	// Verbose allows the client to write extra details in the results of each analysis.
+	Verbose bool `json:"verbose" gorm:"-"`
+
+	// Status describes the state of the investigation (pending, running, failed, or finished).
+	// This is stored in the db along with the failure reason if the investigation failed.
+	// It is computed in the AfterUpdate hook on Analyses.
+	//
+	// Note this is not tagged as validate:"isdefault" because we want users to be able
+	// to take an existing investigation, update a field or two, and just POST it to
+	// create a new investigation. If we included that tag we'd return a 400 here even
+	// though we just ignore the field, which just adds a slightly annoying step for users.
+	Status InvestigationStatus `json:"status"`
+
+	// FailureReason is a short human-friendly string that explains the reason that the
+	// investigation failed.
+	FailureReason string `json:"failureReason,omitempty"`
+
+	// TODO: Add this when we want to extract quicker analysis results for later usage
+	// // AnalysisMeta contains high level metadata about the investigation's analyses.
+	// // It is computed on the fly in the AfterFind hook on Investigations.
+	// AnalysisMeta analysisMeta `json:"analyses" gorm:"-"`
+
+	Analyses []Analysis `json:"-"`
+}
+
+type RequestData struct {
+	Labels map[string]string `json:"labels"`
+	Checks []string          `json:"checks"`
+}
+
+// SiftClient represents a client for interacting with the Sift API
+type SiftClient struct {
+	client *http.Client
+	url    string
+	orgID  string
+}
+
+func NewSiftClient(url, apiKey string) *SiftClient {
+	client := &http.Client{
+		Transport: &authRoundTripper{
+			apiKey:     apiKey,
+			underlying: http.DefaultTransport,
+		},
+	}
+	return &SiftClient{
+		client: client,
+		url:    url,
+	}
+}
+
+func siftClientFromContext(ctx context.Context) (*SiftClient, error) {
+	// Get the standard Grafana URL and API key
+	grafanaURL, grafanaAPIKey := mcpgrafana.GrafanaURLFromContext(ctx), mcpgrafana.GrafanaAPIKeyFromContext(ctx)
+	orgID := mcpgrafana.GrafanaOrgIDFromContext(ctx)
+	if orgID == "" {
+		return nil, fmt.Errorf("organization ID not set in context")
+	}
+
+	client := NewSiftClient(grafanaURL, grafanaAPIKey)
+	client.orgID = orgID
+
+	return client, nil
+}
+
+// CreateInvestigationParams defines the parameters for creating a new investigation
+type CreateInvestigationParams struct {
+	Name        string               `json:"name" jsonschema:"required,description=The name of the investigation"`
+	RequestData InvestigationRequest `json:"requestData" jsonschema:"required,description=The request data for the investigation"`
+	GrafanaURL  string               `json:"grafanaUrl,omitempty" jsonschema:"description=The Grafana URL to be used for datasource queries"`
+	Verbose     bool                 `json:"verbose,omitempty" jsonschema:"description=Whether to include extra details in the results of each analysis"`
+}
+
+// createInvestigation creates a new investigation
+func createInvestigation(ctx context.Context, args CreateInvestigationParams) (*Investigation, error) {
+	client, err := siftClientFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating Sift client: %w", err)
+	}
+
+	// Set default time range to last hour if not provided
+	if args.RequestData.Start.IsZero() {
+		args.RequestData.Start = time.Now().Add(-1 * time.Hour)
+	}
+	if args.RequestData.End.IsZero() {
+		args.RequestData.End = time.Now()
+	}
+
+	investigation := &Investigation{
+		Name:        args.Name,
+		RequestData: args.RequestData,
+		GrafanaURL:  args.GrafanaURL,
+		Verbose:     args.Verbose,
+		Status:      InvestigationStatusPending,
+	}
+
+	return client.createInvestigation(ctx, investigation)
+}
+
+// CreateInvestigation is a tool for creating new investigations
+var CreateInvestigation = mcpgrafana.MustTool(
+	"create_investigation",
+	"Create a new investigation with the specified parameters. The investigation will be created in a pending state and will be processed asynchronously. If time is not provided, the default time range will be last hour and the title can be infered by the labels used. User can provide labels to run the investigation on.",
+	createInvestigation,
+)
+
+// AddSiftTools registers all Sift tools with the MCP server
+func AddSiftTools(mcp *server.MCPServer) {
+	CreateInvestigation.Register(mcp)
+}
+
+// TODO: this needs to be refactored so it waits for the investigation to be finished
+func (c *SiftClient) createInvestigation(ctx context.Context, investigation *Investigation) (*Investigation, error) {
+	jsonData, err := json.Marshal(investigation)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling investigation: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.url+"/api/plugins/grafana-ml-app/resources/sift/api/v1/investigations", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scope-OrgID", c.orgID)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result Investigation
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -226,7 +226,7 @@ func createInvestigation(ctx context.Context, args CreateInvestigationParams) (*
 // CreateInvestigation is a tool for creating new investigations
 var CreateInvestigation = mcpgrafana.MustTool(
 	"create_investigation",
-	"Create a new investigation. An investigation analyzes data from different datasource types. It takes a set of labels and values to scope the analysis, optionally accepts a time range (defaults to last hour if not specified) and the title can be infered by the labels used. The investigation will automatically explore relevant data sources and provide insights about potential causes. Optionally pass ErrorPatternLogs or SlowRequests as check types to run specific checks.",
+	"Create a new investigation. An investigation analyzes data from different datasource types. It takes a set of labels and values to scope the analysis, optionally accepts a time range (defaults to last hour if not specified) and the title can be infered by the labels used. The investigation will automatically explore relevant data sources and provide insights about potential causes.",
 	createInvestigation,
 )
 

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -224,7 +224,7 @@ func listSiftInvestigations(ctx context.Context, args ListSiftInvestigationsPara
 	return investigations, nil
 }
 
-// ListInvestigations is a tool for retrieving a list of investigations
+// ListSiftInvestigations is a tool for retrieving a list of investigations
 var ListSiftInvestigations = mcpgrafana.MustTool(
 	"list_sift_investigations",
 	"Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -192,7 +192,7 @@ func getSiftAnalysis(ctx context.Context, args GetSiftAnalysisParams) (*analysis
 	return analysis, nil
 }
 
-// GetAnalysis is a tool for retrieving a specific analysis from an investigation
+// GetSiftAnalysis is a tool for retrieving a specific analysis from an investigation
 var GetSiftAnalysis = mcpgrafana.MustTool(
 	"get_sift_analysis",
 	"Retrieves a specific analysis from an investigation by its UUID. The investigation ID and analysis ID should be provided as strings in UUID format.",

--- a/tools/sift_cloud_test.go
+++ b/tools/sift_cloud_test.go
@@ -10,35 +10,14 @@
 package tools
 
 import (
-	"context"
-	"os"
 	"testing"
 
-	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func createSiftCloudTestContext(t *testing.T) context.Context {
-	grafanaURL := os.Getenv("GRAFANA_URL")
-	if grafanaURL == "" {
-		t.Skip("GRAFANA_URL environment variable not set, skipping cloud Sift integration tests")
-	}
-
-	grafanaApiKey := os.Getenv("GRAFANA_API_KEY")
-	if grafanaApiKey == "" {
-		t.Skip("GRAFANA_API_KEY environment variable not set, skipping cloud Sift integration tests")
-	}
-
-	ctx := context.Background()
-	ctx = mcpgrafana.WithGrafanaURL(ctx, grafanaURL)
-	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, grafanaApiKey)
-
-	return ctx
-}
-
 func TestCloudSiftInvestigations(t *testing.T) {
-	ctx := createSiftCloudTestContext(t)
+	ctx := createCloudTestContext(t, "Sift")
 
 	// Test listing all investigations
 	t.Run("list all investigations", func(t *testing.T) {

--- a/tools/sift_cloud_test.go
+++ b/tools/sift_cloud_test.go
@@ -21,7 +21,7 @@ func TestCloudSiftInvestigations(t *testing.T) {
 
 	// Test listing all investigations
 	t.Run("list all investigations", func(t *testing.T) {
-		result, err := listInvestigations(ctx, ListInvestigationsParams{})
+		result, err := listSiftInvestigations(ctx, ListSiftInvestigationsParams{})
 		require.NoError(t, err, "Should not error when listing investigations")
 		assert.NotNil(t, result, "Result should not be nil")
 		assert.GreaterOrEqual(t, len(result), 1, "Should have at least one investigation")
@@ -34,7 +34,7 @@ func TestCloudSiftInvestigations(t *testing.T) {
 		require.NoError(t, err, "Should not error when getting Sift client")
 
 		// List investigations with a limit of 1
-		investigations, err := client.listInvestigations(ctx, 1)
+		investigations, err := client.listSiftInvestigations(ctx, 1)
 		require.NoError(t, err, "Should not error when listing investigations with limit")
 		assert.NotNil(t, investigations, "Investigations should not be nil")
 		assert.LessOrEqual(t, len(investigations), 1, "Should have at most one investigation")
@@ -49,7 +49,7 @@ func TestCloudSiftInvestigations(t *testing.T) {
 	})
 
 	// Get an investigation ID from the list to test getting a specific investigation
-	investigations, err := listInvestigations(ctx, ListInvestigationsParams{Limit: 1})
+	investigations, err := listSiftInvestigations(ctx, ListSiftInvestigationsParams{Limit: 1})
 	require.NoError(t, err, "Should not error when listing investigations")
 	require.NotEmpty(t, investigations, "Should have at least one investigation to test with")
 
@@ -57,7 +57,7 @@ func TestCloudSiftInvestigations(t *testing.T) {
 
 	// Test getting a specific investigation
 	t.Run("get specific investigation", func(t *testing.T) {
-		result, err := getInvestigation(ctx, GetInvestigationParams{
+		result, err := getSiftInvestigation(ctx, GetSiftInvestigationParams{
 			ID: investigationID,
 		})
 		require.NoError(t, err, "Should not error when getting specific investigation")
@@ -74,7 +74,7 @@ func TestCloudSiftInvestigations(t *testing.T) {
 
 	// Test getting a non-existent investigation
 	t.Run("get non-existent investigation", func(t *testing.T) {
-		_, err := getInvestigation(ctx, GetInvestigationParams{
+		_, err := getSiftInvestigation(ctx, GetSiftInvestigationParams{
 			ID: "00000000-0000-0000-0000-000000000000",
 		})
 		assert.NoError(t, err, "Should not error when getting non-existent investigation")
@@ -83,7 +83,7 @@ func TestCloudSiftInvestigations(t *testing.T) {
 	// Test getting analyses for an investigation
 	t.Run("get analyses for investigation", func(t *testing.T) {
 		// Get the investigation
-		result, err := getInvestigation(ctx, GetInvestigationParams{
+		result, err := getSiftInvestigation(ctx, GetSiftInvestigationParams{
 			ID: investigationID,
 		})
 		require.NoError(t, err, "Should not error when getting specific investigation")
@@ -93,7 +93,7 @@ func TestCloudSiftInvestigations(t *testing.T) {
 		analysisID := result.Analyses.Items[0].ID
 
 		// Get the analysis
-		analysis, err := getAnalysis(ctx, GetAnalysisParams{
+		analysis, err := getSiftAnalysis(ctx, GetSiftAnalysisParams{
 			InvestigationID: investigationID,
 			AnalysisID:      analysisID.String(),
 		})

--- a/tools/sift_cloud_test.go
+++ b/tools/sift_cloud_test.go
@@ -67,9 +67,9 @@ func TestCloudSiftInvestigations(t *testing.T) {
 		// Verify all required fields are present
 		assert.NotEmpty(t, result.Name, "Investigation should have a name")
 		assert.NotEmpty(t, result.TenantID, "Investigation should have a tenant ID")
-		assert.NotNil(t, result.Datasources, "Investigation should have datasources")
-		assert.NotNil(t, result.RequestData, "Investigation should have request data")
-		assert.NotNil(t, result.Analyses, "Investigation should have analyses")
+		assert.NotNil(t, result.GrafanaURL, "Investigation should have a Grafana URL")
+		assert.NotNil(t, result.Status, "Investigation should have a status")
+		assert.NotNil(t, result.FailureReason, "Investigation should have a failure reason")
 	})
 
 	// Test getting a non-existent investigation

--- a/tools/sift_cloud_test.go
+++ b/tools/sift_cloud_test.go
@@ -3,7 +3,7 @@
 
 // This file contains cloud integration tests that run against a dedicated test instance
 // at mcptests.grafana-dev.net. This instance is configured with a minimal setup on the Sift side:
-//   - 1 test investigation
+//   - 2 test investigations
 // These tests expect this configuration to exist and will skip if the required
 // environment variables (GRAFANA_URL, GRAFANA_API_KEY) are not set.
 
@@ -25,6 +25,27 @@ func TestCloudSiftInvestigations(t *testing.T) {
 		require.NoError(t, err, "Should not error when listing investigations")
 		assert.NotNil(t, result, "Result should not be nil")
 		assert.GreaterOrEqual(t, len(result), 1, "Should have at least one investigation")
+	})
+
+	// Test listing investigations with a limit
+	t.Run("list investigations with limit", func(t *testing.T) {
+		// Get the client
+		client, err := siftClientFromContext(ctx)
+		require.NoError(t, err, "Should not error when getting Sift client")
+
+		// List investigations with a limit of 1
+		investigations, err := client.listInvestigations(ctx, 1)
+		require.NoError(t, err, "Should not error when listing investigations with limit")
+		assert.NotNil(t, investigations, "Investigations should not be nil")
+		assert.LessOrEqual(t, len(investigations), 1, "Should have at most one investigation")
+
+		// If there are investigations, verify their structure
+		if len(investigations) > 0 {
+			investigation := investigations[0]
+			assert.NotEmpty(t, investigation.ID, "Investigation should have an ID")
+			assert.NotEmpty(t, investigation.Name, "Investigation should have a name")
+			assert.NotEmpty(t, investigation.TenantID, "Investigation should have a tenant ID")
+		}
 	})
 
 	// Get an investigation ID from the list to test getting a specific investigation
@@ -57,5 +78,31 @@ func TestCloudSiftInvestigations(t *testing.T) {
 			ID: "00000000-0000-0000-0000-000000000000",
 		})
 		assert.NoError(t, err, "Should not error when getting non-existent investigation")
+	})
+
+	// Test getting analyses for an investigation
+	t.Run("get analyses for investigation", func(t *testing.T) {
+		// Get the investigation
+		result, err := getInvestigation(ctx, GetInvestigationParams{
+			ID: investigationID,
+		})
+		require.NoError(t, err, "Should not error when getting specific investigation")
+		assert.NotNil(t, result, "Result should not be nil")
+
+		// Get an analysis ID
+		analysisID := result.Analyses.Items[0].ID
+
+		// Get the analysis
+		analysis, err := getAnalysis(ctx, GetAnalysisParams{
+			InvestigationID: investigationID,
+			AnalysisID:      analysisID.String(),
+		})
+		require.NoError(t, err, "Should not error when getting specific analysis")
+		assert.NotNil(t, analysis, "Analysis should not be nil")
+
+		// Verify all required fields are present
+		assert.NotEmpty(t, analysis.Name, "Analysis should have a name")
+		assert.NotEmpty(t, analysis.InvestigationID, "Analysis should have an investigation ID")
+		assert.NotNil(t, analysis.Result, "Analysis should have a result")
 	})
 }

--- a/tools/sift_cloud_test.go
+++ b/tools/sift_cloud_test.go
@@ -1,0 +1,82 @@
+//go:build cloud
+// +build cloud
+
+// This file contains cloud integration tests that run against a dedicated test instance
+// at mcptests.grafana-dev.net. This instance is configured with a minimal setup on the Sift side:
+//   - 1 test investigation
+// These tests expect this configuration to exist and will skip if the required
+// environment variables (GRAFANA_URL, GRAFANA_API_KEY) are not set.
+
+package tools
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createSiftCloudTestContext(t *testing.T) context.Context {
+	grafanaURL := os.Getenv("GRAFANA_URL")
+	if grafanaURL == "" {
+		t.Skip("GRAFANA_URL environment variable not set, skipping cloud Sift integration tests")
+	}
+
+	grafanaApiKey := os.Getenv("GRAFANA_API_KEY")
+	if grafanaApiKey == "" {
+		t.Skip("GRAFANA_API_KEY environment variable not set, skipping cloud Sift integration tests")
+	}
+
+	ctx := context.Background()
+	ctx = mcpgrafana.WithGrafanaURL(ctx, grafanaURL)
+	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, grafanaApiKey)
+
+	return ctx
+}
+
+func TestCloudSiftInvestigations(t *testing.T) {
+	ctx := createSiftCloudTestContext(t)
+
+	// Test listing all investigations
+	t.Run("list all investigations", func(t *testing.T) {
+		result, err := listInvestigations(ctx, ListInvestigationsParams{})
+		require.NoError(t, err, "Should not error when listing investigations")
+		assert.NotNil(t, result, "Result should not be nil")
+		assert.GreaterOrEqual(t, len(result), 1, "Should have at least one investigation")
+	})
+
+	// Get an investigation ID from the list to test getting a specific investigation
+	investigations, err := listInvestigations(ctx, ListInvestigationsParams{Limit: 1})
+	require.NoError(t, err, "Should not error when listing investigations")
+	require.NotEmpty(t, investigations, "Should have at least one investigation to test with")
+
+	investigationID := investigations[0].ID.String()
+
+	// Test getting a specific investigation
+	t.Run("get specific investigation", func(t *testing.T) {
+		result, err := getInvestigation(ctx, GetInvestigationParams{
+			ID: investigationID,
+		})
+		require.NoError(t, err, "Should not error when getting specific investigation")
+		assert.NotNil(t, result, "Result should not be nil")
+		assert.Equal(t, investigationID, result.ID.String(), "Should return the correct investigation")
+
+		// Verify all required fields are present
+		assert.NotEmpty(t, result.Name, "Investigation should have a name")
+		assert.NotEmpty(t, result.TenantID, "Investigation should have a tenant ID")
+		assert.NotNil(t, result.Datasources, "Investigation should have datasources")
+		assert.NotNil(t, result.RequestData, "Investigation should have request data")
+		assert.NotNil(t, result.Analyses, "Investigation should have analyses")
+	})
+
+	// Test getting a non-existent investigation
+	t.Run("get non-existent investigation", func(t *testing.T) {
+		_, err := getInvestigation(ctx, GetInvestigationParams{
+			ID: "00000000-0000-0000-0000-000000000000",
+		})
+		assert.NoError(t, err, "Should not error when getting non-existent investigation")
+	})
+}


### PR DESCRIPTION
Adding Sift tools for 

* Create Investigation 
* List investigations with a limit parameter
* Get investigation 
* Get analyses
* Run ErrorPatternLogs Sift Check
* Run SlowRequests Sift Check

Also there is cloud test added checking the get tools for sift. 

## Implementation Approach:
I initially created separate tools for basic Sift API operations (create/get investigations) to reduce code duplication. However, for specific checks like ErrorPatternLogs and SlowRequests, I created dedicated tools that handle the entire workflow internally.

## Current Workflow Example:
When running ErrorPatternLogs in Sift, the process involves:
1. Creating an investigation with specific tags to limit checks (eg: ErrorPatternLogs)
2. Getting investigation details when complete
3. Retrieving the ErrorPatternLog analysis using the analysis ID from investigation data

This can be done through:
- Three separate tool calls when using the basic API tools
- A single tool call with our dedicated `run_error_pattern_logs` tool (which makes three API calls internally)

## Questions for Discussion:
Should we provide:
1. Basic API wrappers and let the model chain them together?
2. Higher-level tools that handle complete workflows?
3. A combination of both approaches? This maybe gives a bit more freedom to the LLM to provide more info if needed. 

**I'm leaning toward removing the createInvestigation tool and keeping just the specialized Sift workflow tools, but I'm open to suggestions.**

*Note: I've also refactored cloud tests into a utils file for better organization.*
