### PR TITLE
Add specific dashboard type in the params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 dist/
 wheels/
 *.egg-info
+.DS_Store
+.vscode/
 
 # Virtual environments
 .venv

--- a/tools/search.go
+++ b/tools/search.go
@@ -11,6 +11,8 @@ import (
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
+var dashboardTypeStr = "dash-db"
+
 type SearchDashboardsParams struct {
 	Query string `json:"query" jsonschema:"description=The query to search for"`
 }
@@ -20,6 +22,7 @@ func searchDashboards(ctx context.Context, args SearchDashboardsParams) (models.
 	params := search.NewSearchParamsWithContext(ctx)
 	if args.Query != "" {
 		params.SetQuery(&args.Query)
+		params.SetType(&dashboardTypeStr)
 	}
 	search, err := c.Search.Search(params)
 	if err != nil {

--- a/tools/search_test.go
+++ b/tools/search_test.go
@@ -8,6 +8,7 @@ package tools
 import (
 	"testing"
 
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,5 +21,6 @@ func TestSearchTools(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
+		assert.Equal(t, models.HitType("dash-db"), result[0].Type)
 	})
 }


### PR DESCRIPTION
Without this type the search will return related folders as well, which in some cases are even empty. 