### PR TITLE
Add tool get incident

### DIFF
--- a/tools/incident.go
+++ b/tools/incident.go
@@ -103,7 +103,7 @@ func addActivityToIncident(ctx context.Context, args AddActivityToIncidentParams
 
 var AddActivityToIncident = mcpgrafana.MustTool(
 	"add_activity_to_incident",
-	"Add an activity to an incident",
+	"Add a note to an incident's timeline. The note will appear in the incident's activity feed. Use this if there is a request to add context to an incident with a note.",
 	addActivityToIncident,
 )
 
@@ -111,4 +111,29 @@ func AddIncidentTools(mcp *server.MCPServer) {
 	ListIncidents.Register(mcp)
 	CreateIncident.Register(mcp)
 	AddActivityToIncident.Register(mcp)
+	GetIncident.Register(mcp)
 }
+
+type GetIncidentParams struct {
+	ID string `json:"id" jsonschema:"description=The ID of the incident to retrieve"`
+}
+
+func getIncident(ctx context.Context, args GetIncidentParams) (*incident.Incident, error) {
+	c := mcpgrafana.IncidentClientFromContext(ctx)
+	is := incident.NewIncidentsService(c)
+
+	incidentResp, err := is.GetIncident(ctx, incident.GetIncidentRequest{
+		IncidentID: args.ID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get incident by ID: %w", err)
+	}
+
+	return &incidentResp.Incident, nil
+}
+
+var GetIncident = mcpgrafana.MustTool(
+	"get_incident",
+	"Get a single incident by ID. Returns the full incident details including title, status, severity, and other metadata.",
+	getIncident,
+)

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -18,6 +18,13 @@ type ListIncidentsParams struct {
 func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.QueryIncidentPreviewsResponse, error) {
 	c := mcpgrafana.IncidentClientFromContext(ctx)
 	is := incident.NewIncidentsService(c)
+
+	// Set default limit to 10 if not specified
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+
 	query := ""
 	if !args.Drill {
 		query = "isdrill:false"
@@ -29,7 +36,7 @@ func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.Que
 		Query: incident.IncidentPreviewsQuery{
 			QueryString:    query,
 			OrderDirection: "DESC",
-			Limit:          args.Limit,
+			Limit:          limit,
 		},
 	})
 	if err != nil {

--- a/tools/incident_integration_test.go
+++ b/tools/incident_integration_test.go
@@ -50,4 +50,16 @@ func TestCloudIncidentTools(t *testing.T) {
 		assert.NotNil(t, result.IncidentPreviews, "IncidentPreviews should not be nil")
 		assert.LessOrEqual(t, len(result.IncidentPreviews), 1, "Should not return more incidents than the limit")
 	})
+
+	t.Run("get incident by ID", func(t *testing.T) {
+		ctx := createCloudTestContext(t)
+		result, err := getIncident(ctx, GetIncidentParams{
+			ID: "1",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Result should not be nil")
+		assert.Equal(t, "1", result.IncidentID, "Should return the requested incident ID")
+		assert.NotEmpty(t, result.Title, "Incident should have a title")
+		assert.NotEmpty(t, result.Status, "Incident should have a status")
+	})
 }


### PR DESCRIPTION
Adds tool to get one incident if an ID is provided. 
Also iterates a bit on the incident prompts as the model was always very keen to add an activity item to the incident 🙄 without having a request for it. 