### PR TITLE
Add listing all contact points with pagination

### DIFF
--- a/testdata/provisioning/alerting/contact_points.yaml
+++ b/testdata/provisioning/alerting/contact_points.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+contactPoints:
+  - name: Email1
+    receivers:
+      - uid: email1
+        type: email
+        settings:
+          addresses: test1@example.com
+          singleEmail: false
+          message: my optional message1 to include
+  - name: Email2
+    receivers:
+      - uid: email2
+        type: email
+        settings:
+          addresses: test2@example.com
+          singleEmail: false
+          message: my optional message2 to include

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultListAlertRulesLimit = 100
+	DefaultListAlertRulesLimit    = 100
 	DefaultListContactPointsLimit = 100
 )
 
@@ -216,7 +216,7 @@ func listContactPoints(ctx context.Context, args ListContactPointsParams) ([]con
 		return nil, fmt.Errorf("list contact points: %w", err)
 	}
 
-	pagedContactPoints, err := applyContactPointPagination(response.Payload, args.Limit)
+	pagedContactPoints, err := applyLimitToContactPoints(response.Payload, args.Limit)
 	if err != nil {
 		return nil, fmt.Errorf("list contact points: %w", err)
 	}

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -216,12 +216,12 @@ func listContactPoints(ctx context.Context, args ListContactPointsParams) ([]con
 		return nil, fmt.Errorf("list contact points: %w", err)
 	}
 
-	pagedContactPoints, err := applyLimitToContactPoints(response.Payload, args.Limit)
+	filteredContactPoints, err := applyLimitToContactPoints(response.Payload, args.Limit)
 	if err != nil {
 		return nil, fmt.Errorf("list contact points: %w", err)
 	}
 
-	return summarizeContactPoints(pagedContactPoints), nil
+	return summarizeContactPoints(filteredContactPoints), nil
 }
 
 func summarizeContactPoints(contactPoints []*models.EmbeddedContactPoint) []contactPointSummary {

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -236,16 +236,16 @@ func summarizeContactPoints(contactPoints []*models.EmbeddedContactPoint) []cont
 	return result
 }
 
-func applyContactPointPagination(items []*models.EmbeddedContactPoint, limit int) ([]*models.EmbeddedContactPoint, error) {
-    if limit == 0 {
-        limit = DefaultListContactPointsLimit
-    }
+func applyLimitToContactPoints(items []*models.EmbeddedContactPoint, limit int) ([]*models.EmbeddedContactPoint, error) {
+	if limit == 0 {
+		limit = DefaultListContactPointsLimit
+	}
 
-    if limit > len(items) {
-        return items, nil
-    }
+	if limit > len(items) {
+		return items, nil
+	}
 
-    return items[:limit], nil
+	return items[:limit], nil
 }
 
 var ListContactPoints = mcpgrafana.MustTool(

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/prometheus/prometheus/model/labels"
@@ -13,6 +14,7 @@ import (
 
 const (
 	DefaultListAlertRulesLimit = 100
+	DefaultListContactPointsLimit = 100
 )
 
 type ListAlertRulesParams struct {
@@ -179,7 +181,93 @@ var GetAlertRuleByUID = mcpgrafana.MustTool(
 	getAlertRuleByUID,
 )
 
+type ListContactPointsParams struct {
+	Limit int     `json:"limit,omitempty" jsonschema:"description=The maximum number of results to return. Default is 100."`
+	Page  int     `json:"page,omitempty" jsonschema:"description=The page number to return."`
+	Name  *string `json:"name,omitempty" jsonschema:"description=Filter contact points by name"`
+}
+
+func (p ListContactPointsParams) validate() error {
+	if p.Limit < 0 {
+		return fmt.Errorf("invalid limit: %d, must be greater than 0", p.Limit)
+	}
+	if p.Page < 0 {
+		return fmt.Errorf("invalid page: %d, must be greater than 0", p.Page)
+	}
+	return nil
+}
+
+type contactPointSummary struct {
+	UID  string  `json:"uid"`
+	Name string  `json:"name"`
+	Type *string `json:"type,omitempty"`
+}
+
+func listContactPoints(ctx context.Context, args ListContactPointsParams) ([]contactPointSummary, error) {
+	if err := args.validate(); err != nil {
+		return nil, fmt.Errorf("list contact points: %w", err)
+	}
+
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+
+	params := provisioning.NewGetContactpointsParams().WithContext(ctx)
+	if args.Name != nil {
+		params.Name = args.Name
+	}
+
+	response, err := c.Provisioning.GetContactpoints(params)
+	if err != nil {
+		return nil, fmt.Errorf("list contact points: %w", err)
+	}
+
+	pagedContactPoints, err := applyContactPointPagination(response.Payload, args.Limit, args.Page)
+	if err != nil {
+		return nil, fmt.Errorf("list contact points: %w", err)
+	}
+
+	return summarizeContactPoints(pagedContactPoints), nil
+}
+
+func summarizeContactPoints(contactPoints []*models.EmbeddedContactPoint) []contactPointSummary {
+	result := make([]contactPointSummary, 0, len(contactPoints))
+	for _, cp := range contactPoints {
+		result = append(result, contactPointSummary{
+			UID:  cp.UID,
+			Name: cp.Name,
+			Type: cp.Type,
+		})
+	}
+	return result
+}
+
+func applyContactPointPagination(items []*models.EmbeddedContactPoint, limit, page int) ([]*models.EmbeddedContactPoint, error) {
+	if limit == 0 {
+		limit = DefaultListContactPointsLimit
+	}
+	if page == 0 {
+		page = 1
+	}
+
+	start := (page - 1) * limit
+	end := start + limit
+
+	if start >= len(items) {
+		return []*models.EmbeddedContactPoint{}, nil
+	} else if end > len(items) {
+		return items[start:], nil
+	}
+
+	return items[start:end], nil
+}
+
+var ListContactPoints = mcpgrafana.MustTool(
+	"list_contact_points",
+	"List contact points",
+	listContactPoints,
+)
+
 func AddAlertingTools(mcp *server.MCPServer) {
 	ListAlertRules.Register(mcp)
 	GetAlertRuleByUID.Register(mcp)
+	ListContactPoints.Register(mcp)
 }

--- a/tools/alerting_test.go
+++ b/tools/alerting_test.go
@@ -429,24 +429,15 @@ func TestAlertingTools_ListContactPoints(t *testing.T) {
 		require.ElementsMatch(t, allExpectedContactPoints, result)
 	})
 
-	t.Run("list contact points with pagination", func(t *testing.T) {
+	t.Run("list one contact point", func(t *testing.T) {
 		ctx := newTestContext()
 
 		// Get the first page with limit 1
 		result1, err := listContactPoints(ctx, ListContactPointsParams{
 			Limit: 1,
-			Page:  1,
 		})
 		require.NoError(t, err)
 		require.Len(t, result1, 1)
-
-		// The next page should be empty
-		result2, err := listContactPoints(ctx, ListContactPointsParams{
-			Limit: 1,
-			Page:  4,
-		})
-		require.NoError(t, err)
-		require.Empty(t, result2)
 	})
 
 	t.Run("list contact points with name filter", func(t *testing.T) {
@@ -459,15 +450,6 @@ func TestAlertingTools_ListContactPoints(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		require.Equal(t, "Email1", result[0].Name)
-	})
-
-	t.Run("list contact points with invalid page parameter", func(t *testing.T) {
-		ctx := newTestContext()
-		result, err := listContactPoints(ctx, ListContactPointsParams{
-			Page: -1,
-		})
-		require.Error(t, err)
-		require.Empty(t, result)
 	})
 
 	t.Run("list contact points with invalid limit parameter", func(t *testing.T) {
@@ -483,7 +465,6 @@ func TestAlertingTools_ListContactPoints(t *testing.T) {
 		ctx := newTestContext()
 		result, err := listContactPoints(ctx, ListContactPointsParams{
 			Limit: 1000,
-			Page:  1,
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, result)

--- a/tools/alerting_test.go
+++ b/tools/alerting_test.go
@@ -432,7 +432,7 @@ func TestAlertingTools_ListContactPoints(t *testing.T) {
 	t.Run("list one contact point", func(t *testing.T) {
 		ctx := newTestContext()
 
-		// Get the first page with limit 1
+		// Get the contact points with limit 1
 		result1, err := listContactPoints(ctx, ListContactPointsParams{
 			Limit: 1,
 		})

--- a/tools/alerting_test.go
+++ b/tools/alerting_test.go
@@ -399,3 +399,104 @@ func TestAlertingTools_GetAlertRuleByUID(t *testing.T) {
 		require.Contains(t, err.Error(), "getAlertRuleNotFound")
 	})
 }
+
+var (
+	emailType = "email"
+
+	contactPoint1 = contactPointSummary{
+		UID:  "email1",
+		Name: "Email1",
+		Type: &emailType,
+	}
+	contactPoint2 = contactPointSummary{
+		UID:  "email2",
+		Name: "Email2",
+		Type: &emailType,
+	}
+	contactPoint3 = contactPointSummary{
+		UID:  "",
+		Name: "email receiver",
+		Type: &emailType,
+	}
+	allExpectedContactPoints = []contactPointSummary{contactPoint1, contactPoint2, contactPoint3}
+)
+
+func TestAlertingTools_ListContactPoints(t *testing.T) {
+	t.Run("list contact points", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listContactPoints(ctx, ListContactPointsParams{})
+		require.NoError(t, err)
+		require.ElementsMatch(t, allExpectedContactPoints, result)
+	})
+
+	t.Run("list contact points with pagination", func(t *testing.T) {
+		ctx := newTestContext()
+
+		// Get the first page with limit 1
+		result1, err := listContactPoints(ctx, ListContactPointsParams{
+			Limit: 1,
+			Page:  1,
+		})
+		require.NoError(t, err)
+		require.Len(t, result1, 1)
+
+		// The next page should be empty
+		result2, err := listContactPoints(ctx, ListContactPointsParams{
+			Limit: 1,
+			Page:  4,
+		})
+		require.NoError(t, err)
+		require.Empty(t, result2)
+	})
+
+	t.Run("list contact points with name filter", func(t *testing.T) {
+		ctx := newTestContext()
+		name := "Email1"
+
+		result, err := listContactPoints(ctx, ListContactPointsParams{
+			Name: &name,
+		})
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, "Email1", result[0].Name)
+	})
+
+	t.Run("list contact points with invalid page parameter", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listContactPoints(ctx, ListContactPointsParams{
+			Page: -1,
+		})
+		require.Error(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("list contact points with invalid limit parameter", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listContactPoints(ctx, ListContactPointsParams{
+			Limit: -1,
+		})
+		require.Error(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("list contact points with large limit", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listContactPoints(ctx, ListContactPointsParams{
+			Limit: 1000,
+			Page:  1,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+	})
+
+	t.Run("list contact points with non-existent name filter", func(t *testing.T) {
+		ctx := newTestContext()
+		name := "NonExistentAlert"
+
+		result, err := listContactPoints(ctx, ListContactPointsParams{
+			Name: &name,
+		})
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
+}


### PR DESCRIPTION
Added listContactPoints function to fetch and paginate contact points from Grafana. 
Supports filtering by name and returns summarized data (UID, Name, Type). 
Tests included for pagination, filtering, and invalid parameters.