### PR TITLE
Add state retrieval for alert rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ This provides access to your Grafana instance and the surrounding ecosystem.
 - [ ] Start Sift investigations and view the results
 - [ ] Alerting
   - [x] List and fetch alert rule information
-  - [ ] Get alert rule statuses (firing/normal/error/etc.)
+  - [x] Get alert rule statuses (firing/normal/error/etc.)
   - [ ] Create and change alert rules
-  - [ ] List contact points
+  - [x] List contact points
   - [ ] Create and change contact points
 - [x] Access Grafana OnCall functionality
   - [x] List and manage schedules

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -56,7 +56,7 @@ func listAlertRules(ctx context.Context, args ListAlertRulesParams) ([]alertRule
 		return nil, fmt.Errorf("list alert rules: %w", err)
 	}
 
-	alertRules := []AlertingRule{}
+	alertRules := []alertingRule{}
 	for _, group := range response.Data.RuleGroups {
 		alertRules = append(alertRules, group.Rules...)
 	}
@@ -75,12 +75,12 @@ func listAlertRules(ctx context.Context, args ListAlertRulesParams) ([]alertRule
 }
 
 // filterAlertRules filters a list of alert rules based on label selectors
-func filterAlertRules(rules []AlertingRule, selectors []Selector) ([]AlertingRule, error) {
+func filterAlertRules(rules []alertingRule, selectors []Selector) ([]alertingRule, error) {
 	if len(selectors) == 0 {
 		return rules, nil
 	}
 
-	filteredResult := []AlertingRule{}
+	filteredResult := []alertingRule{}
 	for _, rule := range rules {
 		match, err := matchesSelectors(rule, selectors)
 		if err != nil {
@@ -96,7 +96,7 @@ func filterAlertRules(rules []AlertingRule, selectors []Selector) ([]AlertingRul
 }
 
 // matchesSelectors checks if an alert rule matches all provided selectors
-func matchesSelectors(rule AlertingRule, selectors []Selector) (bool, error) {
+func matchesSelectors(rule alertingRule, selectors []Selector) (bool, error) {
 	for _, selector := range selectors {
 		match, err := selector.Matches(rule.Labels)
 		if err != nil {
@@ -109,7 +109,7 @@ func matchesSelectors(rule AlertingRule, selectors []Selector) (bool, error) {
 	return true, nil
 }
 
-func summarizeAlertRules(alertRules []AlertingRule) []alertRuleSummary {
+func summarizeAlertRules(alertRules []alertingRule) []alertRuleSummary {
 	result := make([]alertRuleSummary, 0, len(alertRules))
 	for _, r := range alertRules {
 		result = append(result, alertRuleSummary{
@@ -124,7 +124,7 @@ func summarizeAlertRules(alertRules []AlertingRule) []alertRuleSummary {
 
 // applyPagination applies pagination to the list of alert rules.
 // It doesn't sort the items and relies on the order returned by the API.
-func applyPagination(items []AlertingRule, limit, page int) ([]AlertingRule, error) {
+func applyPagination(items []alertingRule, limit, page int) ([]alertingRule, error) {
 	if limit == 0 {
 		limit = DefaultListAlertRulesLimit
 	}

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/mark3labs/mcp-go/server"
-	"github.com/prometheus/prometheus/model/labels"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
@@ -35,8 +34,11 @@ func (p ListAlertRulesParams) validate() error {
 }
 
 type alertRuleSummary struct {
-	UID    string            `json:"uid"`
-	Title  string            `json:"title"`
+	UID   string `json:"uid"`
+	Title string `json:"title"`
+	// State can be one of: pending, firing, error, recovering, inactive.
+	// "inactive" means the alert state is normal, not firing.
+	State  string            `json:"state"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
@@ -45,13 +47,21 @@ func listAlertRules(ctx context.Context, args ListAlertRulesParams) ([]alertRule
 		return nil, fmt.Errorf("list alert rules: %w", err)
 	}
 
-	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	response, err := c.Provisioning.GetAlertRules()
+	c, err := newAlertingClientFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list alert rules: %w", err)
+	}
+	response, err := c.GetRules(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list alert rules: %w", err)
 	}
 
-	alertRules, err := filterAlertRules(response.Payload, args.LabelSelectors)
+	alertRules := []AlertingRule{}
+	for _, group := range response.Data.RuleGroups {
+		alertRules = append(alertRules, group.Rules...)
+	}
+
+	alertRules, err = filterAlertRules(alertRules, args.LabelSelectors)
 	if err != nil {
 		return nil, fmt.Errorf("list alert rules: %w", err)
 	}
@@ -65,18 +75,14 @@ func listAlertRules(ctx context.Context, args ListAlertRulesParams) ([]alertRule
 }
 
 // filterAlertRules filters a list of alert rules based on label selectors
-func filterAlertRules(rules models.ProvisionedAlertRules, selectors []Selector) (models.ProvisionedAlertRules, error) {
+func filterAlertRules(rules []AlertingRule, selectors []Selector) ([]AlertingRule, error) {
 	if len(selectors) == 0 {
 		return rules, nil
 	}
 
-	filteredResult := models.ProvisionedAlertRules{}
+	filteredResult := []AlertingRule{}
 	for _, rule := range rules {
-		if rule == nil {
-			continue
-		}
-
-		match, err := matchesSelectors(*rule, selectors)
+		match, err := matchesSelectors(rule, selectors)
 		if err != nil {
 			return nil, fmt.Errorf("filtering alert rules: %w", err)
 		}
@@ -90,11 +96,9 @@ func filterAlertRules(rules models.ProvisionedAlertRules, selectors []Selector) 
 }
 
 // matchesSelectors checks if an alert rule matches all provided selectors
-func matchesSelectors(rule models.ProvisionedAlertRule, selectors []Selector) (bool, error) {
-	promLabels := labels.FromMap(rule.Labels)
-
+func matchesSelectors(rule AlertingRule, selectors []Selector) (bool, error) {
 	for _, selector := range selectors {
-		match, err := selector.Matches(promLabels)
+		match, err := selector.Matches(rule.Labels)
 		if err != nil {
 			return false, err
 		}
@@ -105,18 +109,14 @@ func matchesSelectors(rule models.ProvisionedAlertRule, selectors []Selector) (b
 	return true, nil
 }
 
-func summarizeAlertRules(alertRules models.ProvisionedAlertRules) []alertRuleSummary {
+func summarizeAlertRules(alertRules []AlertingRule) []alertRuleSummary {
 	result := make([]alertRuleSummary, 0, len(alertRules))
 	for _, r := range alertRules {
-		title := ""
-		if r.Title != nil {
-			title = *r.Title
-		}
-
 		result = append(result, alertRuleSummary{
 			UID:    r.UID,
-			Title:  title,
-			Labels: r.Labels,
+			Title:  r.Name,
+			State:  r.State,
+			Labels: r.Labels.Map(),
 		})
 	}
 	return result
@@ -124,7 +124,7 @@ func summarizeAlertRules(alertRules models.ProvisionedAlertRules) []alertRuleSum
 
 // applyPagination applies pagination to the list of alert rules.
 // It doesn't sort the items and relies on the order returned by the API.
-func applyPagination(items models.ProvisionedAlertRules, limit, page int) (models.ProvisionedAlertRules, error) {
+func applyPagination(items []AlertingRule, limit, page int) ([]AlertingRule, error) {
 	if limit == 0 {
 		limit = DefaultListAlertRulesLimit
 	}
@@ -136,7 +136,7 @@ func applyPagination(items models.ProvisionedAlertRules, limit, page int) (model
 	end := start + limit
 
 	if start >= len(items) {
-		return models.ProvisionedAlertRules{}, nil
+		return nil, nil
 	} else if end > len(items) {
 		return items[start:], nil
 	}
@@ -146,7 +146,7 @@ func applyPagination(items models.ProvisionedAlertRules, limit, page int) (model
 
 var ListAlertRules = mcpgrafana.MustTool(
 	"list_alert_rules",
-	"List alert rules",
+	"Lists alert rules with their current states (pending, firing, error, recovering, inactive) and labels. Inactive state means the alert state is normal, not firing.",
 	listAlertRules,
 )
 
@@ -177,7 +177,7 @@ func getAlertRuleByUID(ctx context.Context, args GetAlertRuleByUIDParams) (*mode
 
 var GetAlertRuleByUID = mcpgrafana.MustTool(
 	"get_alert_rule_by_uid",
-	"Get alert rule by uid",
+	"Retrieves detailed information about a specific alert rule by its UID.",
 	getAlertRuleByUID,
 )
 
@@ -250,7 +250,7 @@ func applyLimitToContactPoints(items []*models.EmbeddedContactPoint, limit int) 
 
 var ListContactPoints = mcpgrafana.MustTool(
 	"list_contact_points",
-	"List contact points",
+	"Lists notification contact points with their type, name, and configuration.",
 	listContactPoints,
 )
 

--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -1,0 +1,133 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+const (
+	defaultTimeout    = 30 * time.Second
+	rulesEndpointPath = "/api/prometheus/grafana/api/v1/rules"
+)
+
+type AlertingClient struct {
+	baseURL    *url.URL
+	apiKey     string
+	httpClient *http.Client
+}
+
+func newAlertingClientFromContext(ctx context.Context) (*AlertingClient, error) {
+	baseURL := strings.TrimRight(mcpgrafana.GrafanaURLFromContext(ctx), "/")
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Grafana base URL %q: %w", baseURL, err)
+	}
+
+	return &AlertingClient{
+		baseURL: parsedBaseURL,
+		apiKey:  mcpgrafana.GrafanaAPIKeyFromContext(ctx),
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}, nil
+}
+
+func (c *AlertingClient) makeRequest(ctx context.Context, path string) (*http.Response, error) {
+	p := c.baseURL.JoinPath(path).String()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request to %s: %w", p, err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request to %s: %w", p, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("Grafana API returned status code %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return resp, nil
+}
+
+func (c *AlertingClient) GetRules(ctx context.Context) (*RulesResponse, error) {
+	resp, err := c.makeRequest(ctx, rulesEndpointPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alert rules from Grafana API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var rulesResponse RulesResponse
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&rulesResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode rules response from %s: %w", rulesEndpointPath, err)
+	}
+
+	return &rulesResponse, nil
+}
+
+type RulesResponse struct {
+	Data struct {
+		RuleGroups []RuleGroup      `json:"groups"`
+		NextToken  string           `json:"groupNextToken,omitempty"`
+		Totals     map[string]int64 `json:"totals,omitempty"`
+	} `json:"data"`
+}
+
+type RuleGroup struct {
+	Name           string         `json:"name"`
+	FolderUID      string         `json:"folderUid"`
+	Rules          []AlertingRule `json:"rules"`
+	Interval       float64        `json:"interval"`
+	LastEvaluation time.Time      `json:"lastEvaluation"`
+	EvaluationTime float64        `json:"evaluationTime"`
+}
+
+type AlertingRule struct {
+	State          string           `json:"state,omitempty"`
+	Name           string           `json:"name,omitempty"`
+	Query          string           `json:"query,omitempty"`
+	Duration       float64          `json:"duration,omitempty"`
+	KeepFiringFor  float64          `json:"keepFiringFor,omitempty"`
+	Annotations    labels.Labels    `json:"annotations,omitempty"`
+	ActiveAt       *time.Time       `json:"activeAt,omitempty"`
+	Alerts         []Alert          `json:"alerts,omitempty"`
+	Totals         map[string]int64 `json:"totals,omitempty"`
+	TotalsFiltered map[string]int64 `json:"totalsFiltered,omitempty"`
+	UID            string           `json:"uid"`
+	FolderUID      string           `json:"folderUid"`
+	Labels         labels.Labels    `json:"labels,omitempty"`
+	Health         string           `json:"health"`
+	LastError      string           `json:"lastError,omitempty"`
+	Type           string           `json:"type"`
+	LastEvaluation time.Time        `json:"lastEvaluation"`
+	EvaluationTime float64          `json:"evaluationTime"`
+}
+
+type Alert struct {
+	Labels      labels.Labels `json:"labels"`
+	Annotations labels.Labels `json:"annotations"`
+	State       string        `json:"state"`
+	ActiveAt    *time.Time    `json:"activeAt"`
+	Value       string        `json:"value"`
+}

--- a/tools/alerting_client_test.go
+++ b/tools/alerting_client_test.go
@@ -1,0 +1,114 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+var (
+	fakeRuleGroup = RuleGroup{
+		Name:      "TestGroup",
+		FolderUID: "test-folder",
+		Rules: []AlertingRule{
+			{
+				State:     "firing",
+				Name:      "Test Alert Rule",
+				UID:       "test-rule-uid",
+				FolderUID: "test-folder",
+				Labels:    labels.Labels{{Name: "severity", Value: "critical"}},
+				Alerts: []Alert{
+					{
+						Labels:      labels.Labels{{Name: "instance", Value: "test-instance"}},
+						Annotations: labels.Labels{{Name: "summary", Value: "Test alert firing"}},
+						State:       "firing",
+						Value:       "1",
+					},
+				},
+			},
+		},
+	}
+)
+
+func setupMockServer(handler http.HandlerFunc) (*httptest.Server, *AlertingClient) {
+	server := httptest.NewServer(handler)
+	baseURL, _ := url.Parse(server.URL)
+	client := &AlertingClient{
+		baseURL:    baseURL,
+		apiKey:     "test-api-key",
+		httpClient: &http.Client{},
+	}
+	return server, client
+}
+
+func mockRulesResponse() RulesResponse {
+	resp := RulesResponse{}
+	resp.Data.RuleGroups = []RuleGroup{fakeRuleGroup}
+	return resp
+}
+
+func TestAlertingClient_GetRules(t *testing.T) {
+	server, client := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/prometheus/grafana/api/v1/rules", r.URL.Path)
+		require.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		resp := mockRulesResponse()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(resp)
+		require.NoError(t, err)
+	})
+	defer server.Close()
+
+	rules, err := client.GetRules(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, rules)
+	require.ElementsMatch(t, rules.Data.RuleGroups, []RuleGroup{fakeRuleGroup})
+}
+
+func TestAlertingClient_GetRules_Error(t *testing.T) {
+	t.Run("internal server error", func(t *testing.T) {
+		server, client := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := w.Write([]byte("internal server error"))
+			require.NoError(t, err)
+		})
+		defer server.Close()
+
+		rules, err := client.GetRules(context.Background())
+		require.Error(t, err)
+		require.Nil(t, rules)
+		require.ErrorContains(t, err, "Grafana API returned status code 500: internal server error")
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		server, client := setupMockServer(func(w http.ResponseWriter, r *http.Request) {})
+		server.Close()
+
+		rules, err := client.GetRules(context.Background())
+
+		require.Error(t, err)
+		require.Nil(t, rules)
+		require.ErrorContains(t, err, "failed to execute request")
+	})
+}
+
+func TestNewAlertingClientFromContext(t *testing.T) {
+	ctx := mcpgrafana.WithGrafanaURL(context.Background(), "http://localhost:3000/")
+	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, "test-api-key")
+
+	client, err := newAlertingClientFromContext(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "http://localhost:3000", client.baseURL.String())
+	require.Equal(t, "test-api-key", client.apiKey)
+	require.NotNil(t, client.httpClient)
+}

--- a/tools/alerting_client_test.go
+++ b/tools/alerting_client_test.go
@@ -15,17 +15,17 @@ import (
 )
 
 var (
-	fakeRuleGroup = RuleGroup{
+	fakeruleGroup = ruleGroup{
 		Name:      "TestGroup",
 		FolderUID: "test-folder",
-		Rules: []AlertingRule{
+		Rules: []alertingRule{
 			{
 				State:     "firing",
 				Name:      "Test Alert Rule",
 				UID:       "test-rule-uid",
 				FolderUID: "test-folder",
 				Labels:    labels.Labels{{Name: "severity", Value: "critical"}},
-				Alerts: []Alert{
+				Alerts: []alert{
 					{
 						Labels:      labels.Labels{{Name: "instance", Value: "test-instance"}},
 						Annotations: labels.Labels{{Name: "summary", Value: "Test alert firing"}},
@@ -38,10 +38,10 @@ var (
 	}
 )
 
-func setupMockServer(handler http.HandlerFunc) (*httptest.Server, *AlertingClient) {
+func setupMockServer(handler http.HandlerFunc) (*httptest.Server, *alertingClient) {
 	server := httptest.NewServer(handler)
 	baseURL, _ := url.Parse(server.URL)
-	client := &AlertingClient{
+	client := &alertingClient{
 		baseURL:    baseURL,
 		apiKey:     "test-api-key",
 		httpClient: &http.Client{},
@@ -49,9 +49,9 @@ func setupMockServer(handler http.HandlerFunc) (*httptest.Server, *AlertingClien
 	return server, client
 }
 
-func mockRulesResponse() RulesResponse {
-	resp := RulesResponse{}
-	resp.Data.RuleGroups = []RuleGroup{fakeRuleGroup}
+func mockrulesResponse() rulesResponse {
+	resp := rulesResponse{}
+	resp.Data.RuleGroups = []ruleGroup{fakeruleGroup}
 	return resp
 }
 
@@ -60,7 +60,7 @@ func TestAlertingClient_GetRules(t *testing.T) {
 		require.Equal(t, "/api/prometheus/grafana/api/v1/rules", r.URL.Path)
 		require.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
 
-		resp := mockRulesResponse()
+		resp := mockrulesResponse()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		err := json.NewEncoder(w).Encode(resp)
@@ -71,7 +71,7 @@ func TestAlertingClient_GetRules(t *testing.T) {
 	rules, err := client.GetRules(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, rules)
-	require.ElementsMatch(t, rules.Data.RuleGroups, []RuleGroup{fakeRuleGroup})
+	require.ElementsMatch(t, rules.Data.RuleGroups, []ruleGroup{fakeruleGroup})
 }
 
 func TestAlertingClient_GetRules_Error(t *testing.T) {

--- a/tools/alerting_test.go
+++ b/tools/alerting_test.go
@@ -39,21 +39,35 @@ var (
 
 	rule1 = alertRuleSummary{
 		UID:    rule1UID,
+		State:  "",
 		Title:  rule1Title,
 		Labels: rule1Labels,
 	}
 	rule2 = alertRuleSummary{
 		UID:    rule2UID,
+		State:  "",
 		Title:  rule2Title,
 		Labels: rule2Labels,
 	}
 	rulePaused = alertRuleSummary{
 		UID:    rulePausedUID,
+		State:  "",
 		Title:  rulePausedTitle,
 		Labels: rule3Labels,
 	}
 	allExpectedRules = []alertRuleSummary{rule1, rule2, rulePaused}
 )
+
+// Because the state depends on the evaluation of the alert rules,
+// clear it before comparing the results to avoid waiting for the
+// alerts to start firing or be in the pending state.
+func clearState(rules []alertRuleSummary) []alertRuleSummary {
+	for i := range rules {
+		rules[i].State = ""
+	}
+
+	return rules
+}
 
 func TestAlertingTools_ListAlertRules(t *testing.T) {
 	t.Run("list alert rules", func(t *testing.T) {
@@ -61,7 +75,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 		result, err := listAlertRules(ctx, ListAlertRulesParams{})
 		require.NoError(t, err)
 
-		require.ElementsMatch(t, allExpectedRules, result)
+		require.ElementsMatch(t, allExpectedRules, clearState(result))
 	})
 
 	t.Run("list alert rules with pagination", func(t *testing.T) {
@@ -104,7 +118,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 		ctx := newTestContext()
 		result, err := listAlertRules(ctx, ListAlertRulesParams{})
 		require.NoError(t, err)
-		require.ElementsMatch(t, allExpectedRules, result)
+		require.ElementsMatch(t, allExpectedRules, clearState(result))
 	})
 
 	t.Run("list alert rules with selectors that match", func(t *testing.T) {
@@ -123,7 +137,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, allExpectedRules, result)
+		require.ElementsMatch(t, allExpectedRules, clearState(result))
 	})
 
 	t.Run("list alert rules with selectors that don't match", func(t *testing.T) {
@@ -170,7 +184,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, []alertRuleSummary{rule2}, result)
+		require.ElementsMatch(t, []alertRuleSummary{rule2}, clearState(result))
 	})
 
 	t.Run("list alert rules with regex matcher", func(t *testing.T) {
@@ -189,7 +203,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, []alertRuleSummary{rule1}, result)
+		require.ElementsMatch(t, []alertRuleSummary{rule1}, clearState(result))
 	})
 
 	t.Run("list alert rules with selectors and pagination", func(t *testing.T) {
@@ -211,7 +225,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, result, 1)
-		require.ElementsMatch(t, []alertRuleSummary{rule1}, result)
+		require.ElementsMatch(t, []alertRuleSummary{rule1}, clearState(result))
 
 		// Second page
 		result, err = listAlertRules(ctx, ListAlertRulesParams{
@@ -231,7 +245,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, result, 1)
-		require.ElementsMatch(t, []alertRuleSummary{rule2}, result)
+		require.ElementsMatch(t, []alertRuleSummary{rule2}, clearState(result))
 	})
 
 	t.Run("list alert rules with not equals operator", func(t *testing.T) {
@@ -250,7 +264,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, allExpectedRules, result)
+		require.ElementsMatch(t, allExpectedRules, clearState(result))
 	})
 
 	t.Run("list alert rules with not matches operator", func(t *testing.T) {
@@ -269,7 +283,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, allExpectedRules, result)
+		require.ElementsMatch(t, allExpectedRules, clearState(result))
 	})
 
 	t.Run("list alert rules with non-existent label", func(t *testing.T) {
@@ -309,7 +323,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, allExpectedRules, result)
+		require.ElementsMatch(t, allExpectedRules, clearState(result))
 	})
 
 	t.Run("list alert rules with a limit that is larger than the number of rules", func(t *testing.T) {
@@ -319,7 +333,7 @@ func TestAlertingTools_ListAlertRules(t *testing.T) {
 			Page:  1,
 		})
 		require.NoError(t, err)
-		require.ElementsMatch(t, allExpectedRules, result)
+		require.ElementsMatch(t, allExpectedRules, clearState(result))
 	})
 
 	t.Run("list alert rules with a page that doesn't exist", func(t *testing.T) {


### PR DESCRIPTION
Updates the existing alert tools to retrieve state information (firing, normal, pending, etc.) for alerts.

Since the Alerting provisioning API does not expose this information, I had to add a custom alerting client that uses the same [API](https://github.com/grafana/grafana/blob/87e69e13493899cfa3083ba9327dfeb5a9a4b093/pkg/services/ngalert/api/tooling/definitions/prom.go#L15) used by the UI. This API is not part of the officially stable public APIs, but the client makes it possible to add other endpoints, for example alert state history.

This API supports pagination of the alert rule groups, but I haven't added anything for it yet. Can do a follow-up :)