### PR TITLE
Fix commas in JSONSchema descriptions and add linter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,14 +19,8 @@ jobs:
           go-version: "1.24"
           cache: true
 
-      # Use the golangci-lint action for improved caching etc.
-      - name: Lint with golangi-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.64
-
-      - name: Lint with custom linters
-        run: make lint-jsonschema
+      - name: Run linters
+        run: make lint
 
   test-unit:
     name: Test Unit

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -16,13 +16,17 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
           cache: true
 
-      - name: Lint
+      # Use the golangci-lint action for improved caching etc.
+      - name: Lint with golangi-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.64
+
+      - name: Lint with custom linters
+        run: make lint-jsonschema
 
   test-unit:
     name: Test Unit
@@ -34,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
           cache: true
 
       - name: Run unit tests
@@ -58,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
           cache: true
 
       - name: Wait for Grafana server and Prometheus server to start and scrape
@@ -77,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
           cache: true
 
       - name: Run cloud tests
@@ -85,4 +89,3 @@ jobs:
           GRAFANA_URL: ${{ vars.CLOUD_GRAFANA_URL }}
           GRAFANA_API_KEY: ${{ secrets.CLOUD_GRAFANA_API_KEY }}
         run: make test-cloud
-

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,15 @@ help: ## Print this help message.
 build-image: ## Build the Docker image.
 	docker build -t mcp-grafana:latest .
 
-.PHONY: lint
-lint: ## Lint the Go code.
+.PHONY: lint lint-jsonschema lint-jsonschema-fix
+lint: lint-jsonschema ## Lint the Go code.
 	go tool -modfile go.tools.mod golangci-lint run
+
+lint-jsonschema: ## Lint for unescaped commas in jsonschema tags.
+	go run ./cmd/linters/jsonschema --path .
+
+lint-jsonschema-fix: ## Automatically fix unescaped commas in jsonschema tags.
+	go run ./cmd/linters/jsonschema --path . --fix
 
 .PHONY: test test-unit
 test-unit: ## Run the unit tests (no external dependencies required).

--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ To lint the code, run:
 make lint
 ```
 
+This includes a custom linter that checks for unescaped commas in `jsonschema` struct tags. The commas in `description` fields must be escaped with `\\,` to prevent silent truncation. You can run just this linter with:
+
+```bash
+make lint-jsonschema
+```
+
+See the [JSONSchema Linter documentation](internal/linter/jsonschema/README.md) for more details.
+
 ## License
 
 This project is licensed under the [Apache License, Version 2.0](LICENSE).

--- a/cmd/linters/jsonschema/main.go
+++ b/cmd/linters/jsonschema/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	linter "github.com/grafana/mcp-grafana/internal/linter/jsonschema"
+)
+
+func main() {
+	var (
+		basePath string
+		help     bool
+		fix      bool
+	)
+
+	flag.StringVar(&basePath, "path", ".", "Base directory to scan for Go files")
+	flag.BoolVar(&help, "help", false, "Show help message")
+	flag.BoolVar(&fix, "fix", false, "Automatically fix unescaped commas")
+	flag.Parse()
+
+	if help {
+		fmt.Println("jsonschema-linter - A tool to find unescaped commas in jsonschema struct tags")
+		fmt.Println("\nUsage:")
+		flag.PrintDefaults()
+		os.Exit(0)
+	}
+
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(basePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving path: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Initialize linter
+	jsonLinter := &linter.JSONSchemaLinter{
+		FixMode: fix,
+	}
+
+	// Find unescaped commas
+	err = jsonLinter.FindUnescapedCommas(absPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error scanning files: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print errors
+	jsonLinter.PrintErrors()
+
+	// Exit with error code if issues were found
+	if len(jsonLinter.Errors) > 0 {
+		os.Exit(1)
+	}
+}

--- a/internal/linter/jsonschema/README.md
+++ b/internal/linter/jsonschema/README.md
@@ -1,0 +1,61 @@
+# JSONSchema Linter
+
+This linter helps detect and prevent a common issue with Go struct tags in this project. 
+
+## The Problem
+
+In Go struct tags using `jsonschema`, commas in the `description` field need to be escaped using `\\,` syntax. If commas aren't properly escaped, the description is silently truncated at the comma.
+
+For example:
+
+```go
+// Problematic (description will be truncated at the first comma):
+type Example struct {
+    Field string `jsonschema:"description=This is a description, but it will be truncated here"`
+}
+
+// Correct (commas properly escaped):
+type Example struct {
+    Field string `jsonschema:"description=This is a description\\, and it will be fully included"`
+}
+```
+
+## Usage
+
+You can use this linter by running:
+
+```shell
+make lint-jsonschema
+```
+
+or directly:
+
+```shell
+go run ./cmd/linters/jsonschema --path .
+```
+
+### Auto-fixing issues
+
+The linter can automatically fix unescaped commas in jsonschema descriptions by running:
+
+```shell
+make lint-jsonschema-fix
+```
+
+or directly:
+
+```shell
+go run ./cmd/linters/jsonschema --path . --fix
+```
+
+This will scan the codebase for unescaped commas and automatically escape them, then report what was fixed.
+
+## Flags
+
+- `--path`: Base directory to scan for Go files (default: ".")
+- `--fix`: Automatically fix unescaped commas
+- `--help`: Display help information
+
+## Integration
+
+This linter is integrated into the default `make lint` command, ensuring all PRs are checked for this issue.

--- a/internal/linter/jsonschema/jsonschema_lint.go
+++ b/internal/linter/jsonschema/jsonschema_lint.go
@@ -1,0 +1,230 @@
+package linter
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// JSONSchemaLinter checks for unescaped commas in jsonschema struct tags
+type JSONSchemaLinter struct {
+	FilePaths []string
+	Errors    []JSONSchemaError
+	FixMode   bool
+	Fixed     map[string]bool
+}
+
+// JSONSchemaError represents a linting error with file position details
+type JSONSchemaError struct {
+	FilePath string
+	Line     int
+	Column   int
+	Offset   int // Byte offset in the file
+	Struct   string
+	Field    string
+	Tag      string
+	FixedTag string
+}
+
+// tagPattern matches jsonschema tags with description containing unescaped commas
+// It captures:
+// 1. The jsonschema tag
+// 2. Parts of the description containing unescaped commas
+var tagPattern = regexp.MustCompile(`jsonschema:"([^"]*)description=([^"]*[^\\],[^"]*)"`) 
+
+// FindUnescapedCommas scans Go files for jsonschema struct tags with unescaped commas in descriptions
+func (l *JSONSchemaLinter) FindUnescapedCommas(baseDir string) error {
+	// Reset errors
+	l.Errors = nil
+	if l.FixMode {
+		l.Fixed = make(map[string]bool)
+	}
+
+	// Walk through the directory and find Go files
+	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip non-Go files
+		if !info.IsDir() && strings.HasSuffix(path, ".go") {
+			l.FilePaths = append(l.FilePaths, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("error walking directory: %v", err)
+	}
+
+	// Parse all Go files and check for the unescaped commas
+	for _, path := range l.FilePaths {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("error parsing file %s: %v", path, err)
+		}
+
+		fileErrors := []JSONSchemaError{}
+
+		// Visit all struct types
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok || ts.Type == nil {
+				return true
+			}
+
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+
+			structName := ts.Name.Name
+
+			// Check each field of the struct
+			for _, field := range st.Fields.List {
+				if field.Tag == nil {
+					continue
+				}
+
+				tag := field.Tag.Value
+
+				// Check if the tag has a jsonschema description with unescaped comma
+				matches := tagPattern.FindStringSubmatch(tag)
+				if len(matches) > 0 {
+					fieldName := ""
+					if len(field.Names) > 0 {
+						fieldName = field.Names[0].Name
+					}
+
+					// Generate the fixed tag by escaping the commas in the description
+					fixedTag := tag
+					if len(matches) > 2 {
+						descWithUnescapedCommas := matches[2]
+						// Escape all unescaped commas
+						fixedDesc := escapeUnescapedCommas(descWithUnescapedCommas)
+						// Replace the original description with the fixed one
+						fixedTag = strings.Replace(tag, descWithUnescapedCommas, fixedDesc, 1)
+					}
+
+					pos := fset.Position(field.Tag.Pos())
+					errorInfo := JSONSchemaError{
+						FilePath: path,
+						Line:     pos.Line,
+						Column:   pos.Column,
+						Offset:   pos.Offset,
+						Struct:   structName,
+						Field:    fieldName,
+						Tag:      tag,
+						FixedTag: fixedTag,
+					}
+					fileErrors = append(fileErrors, errorInfo)
+				}
+			}
+
+			return true
+		})
+
+		// Add all errors for this file
+		l.Errors = append(l.Errors, fileErrors...)
+
+		// If in fix mode and we found errors, fix the file
+		if l.FixMode && len(fileErrors) > 0 {
+			err := l.fixFile(path, fileErrors)
+			if err != nil {
+				return fmt.Errorf("error fixing file %s: %v", path, err)
+			}
+			l.Fixed[path] = true
+		}
+	}
+
+	return nil
+}
+
+// escapeUnescapedCommas escapes any unescaped commas in the description
+func escapeUnescapedCommas(desc string) string {
+	// Use regex to find all commas that are not preceded by a backslash
+	r := regexp.MustCompile(`([^\\]),`)
+	// Replace them with the same text but with an escaped comma
+	return r.ReplaceAllString(desc, `$1\\,`)
+}
+
+// fixFile applies the fixes to a file
+func (l *JSONSchemaLinter) fixFile(path string, errors []JSONSchemaError) error {
+	// Read the file content
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading file %s: %v", path, err)
+	}
+
+	// Convert to string for easier manipulation
+	fileContent := string(content)
+
+	// Sort errors by offset in reverse order to avoid offset changes
+	sort.Slice(errors, func(i, j int) bool {
+		return errors[i].Offset > errors[j].Offset
+	})
+
+	// Apply fixes
+	for _, e := range errors {
+		// Find the tag in the file content
+		tagStart := strings.Index(fileContent[e.Offset:], e.Tag)
+		if tagStart == -1 {
+			continue
+		}
+		absOffset := e.Offset + tagStart
+
+		// Replace the tag with the fixed version
+		fixedContent := fileContent[:absOffset] + e.FixedTag + fileContent[absOffset+len(e.Tag):]
+		fileContent = fixedContent
+	}
+
+	// Write back to the file
+	err = os.WriteFile(path, []byte(fileContent), 0644)
+	if err != nil {
+		return fmt.Errorf("error writing file %s: %v", path, err)
+	}
+
+	return nil
+}
+
+// PrintErrors outputs all the found errors
+func (l *JSONSchemaLinter) PrintErrors() {
+	if len(l.Errors) == 0 {
+		fmt.Println("No unescaped commas found in jsonschema descriptions.")
+		return
+	}
+
+	if l.FixMode {
+		fmt.Printf("Found and fixed %d unescaped commas in jsonschema descriptions:\n\n", len(l.Errors))
+	} else {
+		fmt.Printf("Found %d unescaped commas in jsonschema descriptions:\n\n", len(l.Errors))
+	}
+
+	for i, err := range l.Errors {
+		relPath, _ := filepath.Rel(".", err.FilePath)
+		fmt.Printf("%d. %s:%d:%d - Struct: %s, Field: %s\n",
+			i+1, relPath, err.Line, err.Column, err.Struct, err.Field)
+		fmt.Printf("   - %s\n", err.Tag)
+		if l.FixMode {
+			fmt.Printf("   - Fixed to: %s\n\n", err.FixedTag)
+		} else {
+			fmt.Printf("   - Commas in description must be escaped with \\\\,\n\n")
+		}
+	}
+
+	if !l.FixMode {
+		fmt.Println("Please escape all commas in jsonschema descriptions with \\\\, to prevent truncation.")
+		fmt.Println("You can run with --fix to automatically fix these issues.")
+	} else {
+		fixedFileCount := len(l.Fixed)
+		fmt.Printf("Fixed %d file(s).\n", fixedFileCount)
+	}
+}

--- a/internal/linter/jsonschema/jsonschema_lint.go
+++ b/internal/linter/jsonschema/jsonschema_lint.go
@@ -36,7 +36,11 @@ type JSONSchemaError struct {
 // It captures:
 // 1. The jsonschema tag
 // 2. Parts of the description containing unescaped commas
-var tagPattern = regexp.MustCompile(`jsonschema:"([^"]*)description=([^"]*[^\\],[^"]*)"`) 
+// The pattern correctly handles:
+// - Simple unescaped comma: "description=Something, with comma"
+// - Escaped quote followed by unescaped comma: "description=With \"quote, and comma"
+// - But not match escaped comma: "description=With escaped\, comma"
+var tagPattern = regexp.MustCompile(`jsonschema:"([^"]*)description=(.*?[^\\],)([^"]*)"`)
 
 // FindUnescapedCommas scans Go files for jsonschema struct tags with unescaped commas in descriptions
 func (l *JSONSchemaLinter) FindUnescapedCommas(baseDir string) error {

--- a/internal/linter/jsonschema/jsonschema_lint_test.go
+++ b/internal/linter/jsonschema/jsonschema_lint_test.go
@@ -1,0 +1,144 @@
+package linter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindUnescapedCommas(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir, err := os.MkdirTemp("", "jsonschema-linter-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create test files
+	testFiles := map[string]string{
+		"valid.go": `package test
+
+// Valid has properly escaped commas
+type Valid struct {
+	Name string ` + "`json:\"name\" jsonschema:\"description=A valid field\\, with escaped comma\"`" + `
+	Age  int    ` + "`json:\"age\" jsonschema:\"description=Another valid field\"`" + `
+}
+`,
+		"invalid.go": `package test
+
+// Invalid has unescaped commas
+type Invalid struct {
+	Name string ` + "`json:\"name\" jsonschema:\"description=An invalid field, with unescaped comma\"`" + `
+	Age  int    ` + "`json:\"age\" jsonschema:\"description=Another valid field\"`" + `
+}
+`,
+		"mixed.go": `package test
+
+// Mixed has both valid and invalid fields
+type Mixed struct {
+	Valid   string ` + "`json:\"valid\" jsonschema:\"description=A valid field\\, with escaped comma\"`" + `
+	Invalid string ` + "`json:\"invalid\" jsonschema:\"description=An invalid field, with unescaped comma\"`" + `
+}
+`,
+	}
+
+	for filename, content := range testFiles {
+		filePath := filepath.Join(tmpDir, filename)
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to write test file %s: %v", filename, err)
+		}
+	}
+
+	// Run the linter
+	linter := &JSONSchemaLinter{}
+	err = linter.FindUnescapedCommas(tmpDir)
+	if err != nil {
+		t.Fatalf("Linter failed: %v", err)
+	}
+
+	// Check if we found the expected errors
+	if len(linter.Errors) != 2 {
+		t.Errorf("Expected 2 errors, got %d", len(linter.Errors))
+	}
+
+	// Check if the errors are in the expected files
+	fileErrors := make(map[string]int)
+	for _, e := range linter.Errors {
+		fileName := filepath.Base(e.FilePath)
+		fileErrors[fileName]++
+	}
+
+	if fileErrors["invalid.go"] != 1 {
+		t.Errorf("Expected 1 error in invalid.go, got %d", fileErrors["invalid.go"])
+	}
+
+	if fileErrors["mixed.go"] != 1 {
+		t.Errorf("Expected 1 error in mixed.go, got %d", fileErrors["mixed.go"])
+	}
+
+	if fileErrors["valid.go"] != 0 {
+		t.Errorf("Expected 0 errors in valid.go, got %d", fileErrors["valid.go"])
+	}
+}
+
+func TestFixUnescapedCommas(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir, err := os.MkdirTemp("", "jsonschema-linter-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a test file with unescaped commas
+	invalidContent := `package test
+
+// Invalid has unescaped commas
+type Invalid struct {
+	Name string ` + "`json:\"name\" jsonschema:\"description=An invalid field, with unescaped comma\"`" + `
+	Age  int    ` + "`json:\"age\" jsonschema:\"description=Another field, also with unescaped comma\"`" + `
+}
+`
+
+	// Expected content after fixing
+	// Note: We need double backslashes in the actual file, so we use double escaped backslashes here
+	expectedContent := `package test
+
+// Invalid has unescaped commas
+type Invalid struct {
+	Name string ` + "`json:\"name\" jsonschema:\"description=An invalid field\\\\, with unescaped comma\"`" + `
+	Age  int    ` + "`json:\"age\" jsonschema:\"description=Another field\\\\, also with unescaped comma\"`" + `
+}
+`
+
+	filePath := filepath.Join(tmpDir, "invalid.go")
+	if err := os.WriteFile(filePath, []byte(invalidContent), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Run the linter with fix mode enabled
+	linter := &JSONSchemaLinter{FixMode: true}
+	err = linter.FindUnescapedCommas(tmpDir)
+	if err != nil {
+		t.Fatalf("Linter failed: %v", err)
+	}
+
+	// Check if we found the expected errors
+	if len(linter.Errors) != 2 {
+		t.Errorf("Expected 2 errors, got %d", len(linter.Errors))
+	}
+
+	// Verify the file was fixed
+	fixedContent, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read fixed file: %v", err)
+	}
+
+	if string(fixedContent) != expectedContent {
+		t.Errorf("File not fixed correctly.\nExpected:\n%s\n\nGot:\n%s", expectedContent, string(fixedContent))
+	}
+
+	// Verify the fixed field was correctly tracked
+	if !linter.Fixed[filePath] {
+		t.Errorf("Fixed file not tracked in linter.Fixed")
+	}
+}

--- a/internal/linter/jsonschema/jsonschema_lint_test.go
+++ b/internal/linter/jsonschema/jsonschema_lint_test.go
@@ -81,6 +81,32 @@ type Mixed struct {
 	}
 }
 
+// TestEscapedQuotesWithComma tests if the regex correctly identifies unescaped commas
+// in jsonschema tags that contain escaped quotes
+func TestEscapedQuotesWithComma(t *testing.T) {
+	testCases := []struct {
+		tag         string
+		shouldMatch bool
+		description string
+	}{
+		{`jsonschema:"description=This has an unescaped, comma"`, true, "Simple unescaped comma"},
+		{`jsonschema:"description=This has escaped quote \"followed by, comma"`, true, "Escaped quote then unescaped comma"},
+		{`jsonschema:"description=This has escaped quote \", comma"`, true, "Escaped quote, comma with space"},
+		{`jsonschema:"description=This has escaped quote \\\"and escaped\\, comma"`, false, "Properly escaped quote and comma"},
+		{`jsonschema:"description=No comma here"`, false, "No comma at all"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			matches := tagPattern.FindStringSubmatch(tc.tag)
+			hasMatch := len(matches) > 0
+			if hasMatch != tc.shouldMatch {
+				t.Fatalf("Test failed for %s: expected match=%v, got=%v\n", tc.description, tc.shouldMatch, hasMatch)
+			}
+		})
+	}
+}
+
 func TestFixUnescapedCommas(t *testing.T) {
 	// Create a temporary directory for test files
 	tmpDir, err := os.MkdirTemp("", "jsonschema-linter-test")

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -19,7 +19,7 @@ const (
 type ListAlertRulesParams struct {
 	Limit          int        `json:"limit,omitempty" jsonschema:"description=The maximum number of results to return. Default is 100."`
 	Page           int        `json:"page,omitempty" jsonschema:"description=The page number to return."`
-	LabelSelectors []Selector `json:"label_selectors,omitempty" jsonschema:"description=Optionally, a list of matchers to filter alert rules by labels"`
+	LabelSelectors []Selector `json:"label_selectors,omitempty" jsonschema:"description=Optionally\\, a list of matchers to filter alert rules by labels"`
 }
 
 func (p ListAlertRulesParams) validate() error {

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -12,7 +12,7 @@ import (
 )
 
 type ListDatasourcesParams struct {
-	Type string `json:"type,omitempty" jsonschema:"description=The type of datasources to search for. For example, 'prometheus', 'loki', 'tempo', etc..."`
+	Type string `json:"type,omitempty" jsonschema:"description=The type of datasources to search for. For example\\, 'prometheus'\\, 'loki'\\, 'tempo'\\, etc..."`
 }
 
 type dataSourceSummary struct {

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -12,7 +12,7 @@ import (
 type ListIncidentsParams struct {
 	Limit  int    `json:"limit" jsonschema:"description=The maximum number of incidents to return"`
 	Drill  bool   `json:"drill" jsonschema:"description=Whether to include drill incidents"`
-	Status string `json:"status" jsonschema:"description=The status of the incidents to include. Valid values: 'active', 'resolved'"`
+	Status string `json:"status" jsonschema:"description=The status of the incidents to include. Valid values: 'active'\\, 'resolved'"`
 }
 
 func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.QueryIncidentPreviewsResponse, error) {
@@ -90,7 +90,7 @@ var CreateIncident = mcpgrafana.MustTool(
 type AddActivityToIncidentParams struct {
 	IncidentID string `json:"incidentId" jsonschema:"description=The ID of the incident to add the activity to"`
 	Body       string `json:"body" jsonschema:"description=The body of the activity. URLs will be parsed and attached as context"`
-	EventTime  string `json:"eventTime" jsonschema:"description=The time that the activity occurred. If not provided, the current time will be used"`
+	EventTime  string `json:"eventTime" jsonschema:"description=The time that the activity occurred. If not provided\\, the current time will be used"`
 }
 
 func addActivityToIncident(ctx context.Context, args AddActivityToIncidentParams) (*incident.ActivityItem, error) {

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -183,8 +183,8 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 // ListLokiLabelNamesParams defines the parameters for listing Loki label names
 type ListLokiLabelNamesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query in RFC3339 format (defaults to now)"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
 }
 
 // listLokiLabelNames lists all label names in a Loki datasource
@@ -216,9 +216,9 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 // ListLokiLabelValuesParams defines the parameters for listing Loki label values
 type ListLokiLabelValuesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	LabelName     string `json:"labelName" jsonschema:"required,description=The name of the label to retrieve values for (e.g. 'app', 'env', 'pod')"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query in RFC3339 format (defaults to now)"`
+	LabelName     string `json:"labelName" jsonschema:"required,description=The name of the label to retrieve values for (e.g. 'app'\\, 'env'\\, 'pod')"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
 }
 
 // listLokiLabelValues lists all values for a specific label in a Loki datasource
@@ -341,11 +341,11 @@ func (c *Client) fetchLogs(ctx context.Context, query, startRFC3339, endRFC3339 
 // QueryLokiLogsParams defines the parameters for querying Loki logs
 type QueryLokiLogsParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL query to execute against Loki. This can be a simple label matcher or a complex query with filters, parsers, and expressions. Supports full LogQL syntax including label matchers, filter operators, pattern expressions, and pipeline operations."`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query in RFC3339 format"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query in RFC3339 format"`
-	Limit         int    `json:"limit,omitempty" jsonschema:"description=Optionally, the maximum number of log lines to return (default: 10, max: 100)"`
-	Direction     string `json:"direction,omitempty" jsonschema:"description=Optionally, the direction of the query: 'forward' (oldest first) or 'backward' (newest first, default)"`
+	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL query to execute against Loki. This can be a simple label matcher or a complex query with filters\\, parsers\\, and expressions. Supports full LogQL syntax including label matchers\\, filter operators\\, pattern expressions\\, and pipeline operations."`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of log lines to return (default: 10\\, max: 100)"`
+	Direction     string `json:"direction,omitempty" jsonschema:"description=Optionally\\, the direction of the query: 'forward' (oldest first) or 'backward' (newest first\\, default)"`
 }
 
 // LogEntry represents a single log entry or metric sample with metadata
@@ -485,9 +485,9 @@ func (c *Client) fetchStats(ctx context.Context, query, startRFC3339, endRFC3339
 // QueryLokiStatsParams defines the parameters for querying Loki stats
 type QueryLokiStatsParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL matcher expression to execute. This parameter only accepts label matcher expressions and does not support full LogQL queries. Line filters, pattern operations, and metric aggregations are not supported by the stats API endpoint. Only simple label selectors can be used here."`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query in RFC3339 format"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query in RFC3339 format"`
+	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL matcher expression to execute. This parameter only accepts label matcher expressions and does not support full LogQL queries. Line filters\\, pattern operations\\, and metric aggregations are not supported by the stats API endpoint. Only simple label selectors can be used here."`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format"`
 }
 
 // queryLokiStats queries stats from a Loki datasource using LogQL

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -117,7 +117,7 @@ func getOnCallShiftServiceFromContext(ctx context.Context) (*aapi.OnCallShiftSer
 
 type ListOnCallSchedulesParams struct {
 	TeamID     string `json:"teamId,omitempty" jsonschema:"description=The ID of the team to list schedules for"`
-	ScheduleID string `json:"scheduleId,omitempty" jsonschema:"description=The ID of the schedule to get details for. If provided, returns only that schedule's details"`
+	ScheduleID string `json:"scheduleId,omitempty" jsonschema:"description=The ID of the schedule to get details for. If provided\\, returns only that schedule's details"`
 	Page       int    `json:"page,omitempty" jsonschema:"description=The page number to return (1-based)"`
 }
 
@@ -304,8 +304,8 @@ var ListOnCallTeams = mcpgrafana.MustTool(
 )
 
 type ListOnCallUsersParams struct {
-	UserID   string `json:"userId,omitempty" jsonschema:"description=The ID of the user to get details for. If provided, returns only that user's details"`
-	Username string `json:"username,omitempty" jsonschema:"description=The username to filter users by. If provided, returns only the user matching this username"`
+	UserID   string `json:"userId,omitempty" jsonschema:"description=The ID of the user to get details for. If provided\\, returns only that user's details"`
+	Username string `json:"username,omitempty" jsonschema:"description=The username to filter users by. If provided\\, returns only the user matching this username"`
 	Page     int    `json:"page,omitempty" jsonschema:"description=The page number to return"`
 }
 

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -87,8 +87,8 @@ type QueryPrometheusParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	Expr          string `json:"expr" jsonschema:"required,description=The PromQL expression to query"`
 	StartRFC3339  string `json:"startRfc3339" jsonschema:"required,description=The start time in RFC3339 format"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=The end time in RFC3339 format. Required if queryType is 'range', ignored if queryType is 'instant'"`
-	StepSeconds   int    `json:"stepSeconds,omitempty" jsonschema:"description=The time series step size in seconds. Required if queryType is 'range', ignored if queryType is 'instant'"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=The end time in RFC3339 format. Required if queryType is 'range'\\, ignored if queryType is 'instant'"`
+	StepSeconds   int    `json:"stepSeconds,omitempty" jsonschema:"description=The time series step size in seconds. Required if queryType is 'range'\\, ignored if queryType is 'instant'"`
 	QueryType     string `json:"queryType,omitempty" jsonschema:"description=The type of query to use. Either 'range' or 'instant'"`
 }
 
@@ -261,10 +261,10 @@ func (s Selector) Matches(lbls labels.Labels) (bool, error) {
 
 type ListPrometheusLabelNamesParams struct {
 	DatasourceUID string     `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally, a list of label matchers to filter the results by"`
-	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the time range to filter the results by"`
-	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the time range to filter the results by"`
-	Limit         int        `json:"limit,omitempty" jsonschema:"description=Optionally, the maximum number of results to return"`
+	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally\\, a list of label matchers to filter the results by"`
+	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the time range to filter the results by"`
+	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the time range to filter the results by"`
+	Limit         int        `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of results to return"`
 }
 
 func listPrometheusLabelNames(ctx context.Context, args ListPrometheusLabelNamesParams) ([]string, error) {
@@ -317,10 +317,10 @@ var ListPrometheusLabelNames = mcpgrafana.MustTool(
 type ListPrometheusLabelValuesParams struct {
 	DatasourceUID string     `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LabelName     string     `json:"labelName" jsonschema:"required,description=The name of the label to query"`
-	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally, a list of selectors to filter the results by"`
-	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally, the start time of the query"`
-	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally, the end time of the query"`
-	Limit         int        `json:"limit,omitempty" jsonschema:"description=Optionally, the maximum number of results to return"`
+	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally\\, a list of selectors to filter the results by"`
+	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query"`
+	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query"`
+	Limit         int        `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of results to return"`
 }
 
 func listPrometheusLabelValues(ctx context.Context, args ListPrometheusLabelValuesParams) (model.LabelValues, error) {


### PR DESCRIPTION
Commas in jsonschema `description` fields inside struct field tags need
to be escaped; otherwise, they're treated as another field and the
description is silently truncated. This commit fixes all instances of
that, and adds a linter which checks for the presence of any unescaped
commas in the `jsonschema` descriptions. The linter also includes a
`--fix` mode to automatically fix any issues, and is integrated in CI so
we should catch this in future. (Thanks Claude & Zed!)
