### PR TITLE
Add tool to update/create a dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This provides access to your Grafana instance and the surrounding ecosystem.
 ## Features
 
 - [x] Search for dashboards
-- [x] Get dashboard by UID
+- [x] Dashboards
+  - [x] Get dashboard by UID
+  - [x] Update or create a dashboard (DISCLAIMER: Be careful with context windows. See https://github.com/grafana/mcp-grafana/issues/101 for details)
 - [x] List and fetch datasource information
 - [ ] Query datasources
   - [x] Prometheus
@@ -49,6 +51,7 @@ This is useful if you don't use certain functionality or if you don't want to ta
 |-----------------------------------|-------------|--------------------------------------------------------------------|
 | `search_dashboards`               | Search      | Search for dashboards                                              |
 | `get_dashboard_by_uid`            | Dashboard   | Get a dashboard by uid                                             |
+| `update_dashboard`                | Dashboard   | Update or create a new dashboard                                   |
 | `list_datasources`                | Datasources | List datasources                                                   |
 | `get_datasource_by_uid`           | Datasources | Get a datasource by uid                                            |
 | `get_datasource_by_name`          | Datasources | Get a datasource by name                                           |

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -16,10 +16,37 @@ type GetDashboardByUIDParams struct {
 
 func getDashboardByUID(ctx context.Context, args GetDashboardByUIDParams) (*models.DashboardFullWithMeta, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	
+
 	dashboard, err := c.Dashboards.GetDashboardByUID(args.UID)
 	if err != nil {
 		return nil, fmt.Errorf("get dashboard by uid %s: %w", args.UID, err)
+	}
+	return dashboard.Payload, nil
+}
+
+type UpdateDashboardParams struct {
+	Dashboard map[string]interface{} `json:"dashboard" jsonschema:"required,description=The full dashboard JSON"`
+	FolderUID string                 `json:"folderUid" jsonschema:"optional,description=The UID of the dashboard's folder"`
+	Message   string                 `json:"message" jsonschema:"optional,description=Set a commit message for the version history"`
+	Overwrite bool                   `json:"overwrite" jsonschema:"optional,description=Overwrite the dashboard if it exists. Otherwise create one"`
+	UserID    int64                  `json:"userId" jsonschema:"optional,ID of the user making the change"`
+}
+
+// updateDashboard can be used to save an existing dashboard, or create a new one.
+// DISCLAIMER: Large-sized dashboard JSON can exhaust context windows. We will
+// implement features that address this in https://github.com/grafana/mcp-grafana/issues/101.
+func updateDashboard(ctx context.Context, args UpdateDashboardParams) (*models.PostDashboardOKBody, error) {
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	cmd := &models.SaveDashboardCommand{
+		Dashboard: args.Dashboard,
+		FolderUID: args.FolderUID,
+		Message:   args.Message,
+		Overwrite: args.Overwrite,
+		UserID:    args.UserID,
+	}
+	dashboard, err := c.Dashboards.PostDashboard(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("unable to save dashboard: %w", err)
 	}
 	return dashboard.Payload, nil
 }
@@ -30,6 +57,13 @@ var GetDashboardByUID = mcpgrafana.MustTool(
 	getDashboardByUID,
 )
 
+var UpdateDashboard = mcpgrafana.MustTool(
+	"update_dashboard",
+	"Create or update a dashboard",
+	updateDashboard,
+)
+
 func AddDashboardTools(mcp *server.MCPServer) {
 	GetDashboardByUID.Register(mcp)
+	UpdateDashboard.Register(mcp)
 }

--- a/tools/dashboard_test.go
+++ b/tools/dashboard_test.go
@@ -6,40 +6,128 @@
 package tools
 
 import (
+	"context"
 	"testing"
 
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	newTestDashboardName = "Integration Test"
+)
+
+// getExistingDashboardUID will fetch an existing dashboard for test purposes
+// It will search for exisiting dashboards and return the first, otherwise
+// will trigger a test error
+func getExistingTestDashboard(t *testing.T, ctx context.Context, dashboardName string) *models.Hit {
+	// Make sure we query for the existing dashboard, not a folder
+	if dashboardName == "" {
+		dashboardName = "Demo"
+	}
+	searchResults, err := searchDashboards(ctx, SearchDashboardsParams{
+		Query: dashboardName,
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(searchResults), 0, "No dashboards found")
+	return searchResults[0]
+}
+
+// getExistingTestDashboardJSON will fetch the JSON map for an existing
+// dashboard in the test environment
+func getTestDashboardJSON(t *testing.T, ctx context.Context, dashboard *models.Hit) map[string]interface{} {
+	result, err := getDashboardByUID(ctx, GetDashboardByUIDParams{
+		UID: dashboard.UID,
+	})
+	require.NoError(t, err)
+	dashboardMap, ok := result.Dashboard.(map[string]interface{})
+	require.True(t, ok, "Dashboard should be a map")
+	return dashboardMap
+}
+
 func TestDashboardTools(t *testing.T) {
 	t.Run("get dashboard by uid", func(t *testing.T) {
 		ctx := newTestContext()
-		
+
 		// First, let's search for a dashboard to get its UID
-		searchResults, err := searchDashboards(ctx, SearchDashboardsParams{})
-		require.NoError(t, err)
-		require.Greater(t, len(searchResults), 0, "No dashboards found")
-		
-		dashboardUID := searchResults[0].UID
-		
+		dashboard := getExistingTestDashboard(t, ctx, "")
+
 		// Now test the get dashboard by uid functionality
 		result, err := getDashboardByUID(ctx, GetDashboardByUIDParams{
-			UID: dashboardUID,
+			UID: dashboard.UID,
 		})
 		require.NoError(t, err)
 		dashboardMap, ok := result.Dashboard.(map[string]interface{})
 		require.True(t, ok, "Dashboard should be a map")
-		assert.Equal(t, dashboardUID, dashboardMap["uid"])
+		assert.Equal(t, dashboard.UID, dashboardMap["uid"])
 		assert.NotNil(t, result.Meta)
 	})
 
 	t.Run("get dashboard by uid - invalid uid", func(t *testing.T) {
 		ctx := newTestContext()
-		
+
 		_, err := getDashboardByUID(ctx, GetDashboardByUIDParams{
 			UID: "non-existent-uid",
 		})
 		require.Error(t, err)
+	})
+
+	t.Run("update dashboard - create new", func(t *testing.T) {
+		ctx := newTestContext()
+
+		// Get the dashboard JSON
+		// In this case, we will create a new dashboard with the same
+		// content but different Title, and disable "overwrite"
+		dashboard := getExistingTestDashboard(t, ctx, "")
+		dashboardMap := getTestDashboardJSON(t, ctx, dashboard)
+
+		// Avoid a clash by unsetting the existing IDs
+		delete(dashboardMap, "uid")
+		delete(dashboardMap, "id")
+
+		// Set a new title and tag
+		dashboardMap["title"] = newTestDashboardName
+		dashboardMap["tags"] = []string{"integration-test"}
+
+		params := UpdateDashboardParams{
+			Dashboard: dashboardMap,
+			Message:   "creating a new dashboard",
+			Overwrite: false,
+			UserID:    1,
+		}
+
+		// Only pass in the Folder UID if it exists
+		if dashboard.FolderUID != "" {
+			params.FolderUID = dashboard.FolderUID
+		}
+
+		// create the dashboard
+		_, err := updateDashboard(ctx, params)
+		require.NoError(t, err)
+	})
+
+	t.Run("update dashboard - overwrite existing", func(t *testing.T) {
+		ctx := newTestContext()
+
+		// Get the dashboard JSON for the non-provisioned dashboard we've created
+		dashboard := getExistingTestDashboard(t, ctx, newTestDashboardName)
+		dashboardMap := getTestDashboardJSON(t, ctx, dashboard)
+
+		params := UpdateDashboardParams{
+			Dashboard: dashboardMap,
+			Message:   "updating existing dashboard",
+			Overwrite: true,
+			UserID:    1,
+		}
+
+		// Only pass in the Folder UID if it exists
+		if dashboard.FolderUID != "" {
+			params.FolderUID = dashboard.FolderUID
+		}
+
+		// update the dashboard
+		_, err := updateDashboard(ctx, params)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Adds a new tool to update/create a dashboard. Also added a warning/disclaimer about context windows, which will be solved longer-term with https://github.com/grafana/mcp-grafana/issues/101.

Closes https://github.com/grafana/mcp-grafana/issues/90.