### PR TITLE
Add GitHub action for e2e tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install uv
         run: pip install uv

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -96,3 +96,44 @@ jobs:
           ASSERTS_GRAFANA_URL: ${{ vars.ASSERTS_GRAFANA_URL }}
           ASSERTS_GRAFANA_API_KEY: ${{ secrets.ASSERTS_GRAFANA_API_KEY }}
         run: make test-cloud
+
+  test-python-e2e:
+    name: Python E2E Tests
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install Python dependencies
+        run: |
+          cd tests
+          uv sync --all-groups
+
+      - name: Start docker-compose services
+        uses:  hoverkraft-tech/compose-action@8be2d741e891ac9b8ac20825e6f3904149599925
+        with:
+          compose-file: "docker-compose.yaml"
+
+      - name: Wait for Grafana server and Prometheus server to start and scrape
+        run: sleep 30
+
+      - name: Start MCP server in background
+        run: |
+          nohup go run ./cmd/mcp-grafana -t sse > mcp.log 2>&1 &
+          sleep 30
+
+      - name: Run Python e2e tests
+        run: |
+          cd tests
+          uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,11 @@ run: ## Run the MCP server in stdio mode.
 .PHONY: run-sse
 run-sse: ## Run the MCP server in SSE mode.
 	go run ./cmd/mcp-grafana --transport sse
+
+.PHONY: test-python-e2e
+test-python-e2e: ## Run Python E2E tests (requires Docker, MCP server, and Python deps)
+	docker-compose up -d
+	nohup go run ./cmd/mcp-grafana -t sse > mcp.log 2>&1 &
+	sleep 30
+	cd tests && uv sync --all-groups
+	cd tests && uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Print this help message.
 	@echo ""
 	@echo "Targets:"
 	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: build-image
 build-image: ## Build the Docker image.
@@ -28,12 +28,17 @@ test-unit: ## Run the unit tests (no external dependencies required).
 test: test-unit
 
 .PHONY: test-integration
-test-integration: ## Run only the Docker-based integration tests (Requires docker containers to be up and running).
+test-integration: ## Run only the Docker-based integration tests (requires docker-compose services to be running, use `make run-test-services` to start them).
 	go test -v -tags integration ./...
 
 .PHONY: test-cloud
 test-cloud: ## Run only the cloud-based tests (requires cloud Grafana instance and credentials).
 	go test -v -tags cloud ./tools
+
+.PHONY: test-python-e2e
+test-python-e2e: ## Run Python E2E tests (requires docker-compose services and SSE server to be running, use `make run-test-services` and `make run-sse` to start them).
+	cd tests && uv sync --all-groups
+	cd tests && uv run pytest
 
 .PHONY: run
 run: ## Run the MCP server in stdio mode.
@@ -41,12 +46,8 @@ run: ## Run the MCP server in stdio mode.
 
 .PHONY: run-sse
 run-sse: ## Run the MCP server in SSE mode.
-	go run ./cmd/mcp-grafana --transport sse
+	go run ./cmd/mcp-grafana --transport sse --log-level debug --debug
 
-.PHONY: test-python-e2e
-test-python-e2e: ## Run Python E2E tests (requires Docker, MCP server, and Python deps)
-	docker-compose up -d
-	nohup go run ./cmd/mcp-grafana -t sse > mcp.log 2>&1 &
-	sleep 30
-	cd tests && uv sync --all-groups
-	cd tests && uv run pytest
+.PHONY: run-test-services
+run-test-services: ## Run the docker-compose services required for the unit and integration tests.
+	docker-compose up -d --build


### PR DESCRIPTION
Added a git action for the python e2e tests and also a schedule for the workflow on a daily basis. 
e2e tests are not mandatory to merge for now as we are still iterating and they are still a bit flaky but at least we can get notified when something is systematically failing. 

Added a make command for the e2e tests but I got some weird results so I didn't use it in the git action. I can't iterate on this now though. I can do it on a separate PR. 

We can probably exclude the other actions from running on a daily basis if we think it's too much. 