### PR TITLE
Prevent panic if didn't find patterns.

### DIFF
--- a/tools/sift.go
+++ b/tools/sift.go
@@ -304,6 +304,10 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 
 	datasourceUID := completedInvestigation.Datasources.LokiDatasource.UID
 
+	if errorPatternLogsAnalysis.Result.Details == nil {
+		// No patterns found, return the analysis without examples
+		return errorPatternLogsAnalysis, nil
+	}
 	for _, pattern := range errorPatternLogsAnalysis.Result.Details["patterns"].([]any) {
 		patternMap, ok := pattern.(map[string]any)
 		if !ok {


### PR DESCRIPTION
Details can be nil if, for example, no logs are found. This PR prevents this tool from panicking.