### PR TITLE
refactor: extract Grafana Client creation from context functions

### DIFF
--- a/tools/cloud_testing_utils.go
+++ b/tools/cloud_testing_utils.go
@@ -11,11 +11,14 @@ import (
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
-// createCloudTestContext creates a context with Grafana URL and API key for cloud integration tests.
+// createCloudTestContext creates a context with a Grafana URL, Grafana API key and
+// Grafana client for cloud integration tests.
 // The test will be skipped if required environment variables are not set.
 // testName is used to customize the skip message (e.g. "OnCall", "Sift", "Incident")
 // urlEnv and apiKeyEnv specify the environment variable names for the Grafana URL and API key.
 func createCloudTestContext(t *testing.T, testName, urlEnv, apiKeyEnv string) context.Context {
+	ctx := context.Background()
+
 	grafanaURL := os.Getenv(urlEnv)
 	if grafanaURL == "" {
 		t.Skipf("%s environment variable not set, skipping cloud %s integration tests", urlEnv, testName)
@@ -26,9 +29,11 @@ func createCloudTestContext(t *testing.T, testName, urlEnv, apiKeyEnv string) co
 		t.Skipf("%s environment variable not set, skipping cloud %s integration tests", apiKeyEnv, testName)
 	}
 
-	ctx := context.Background()
+	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey)
+
 	ctx = mcpgrafana.WithGrafanaURL(ctx, grafanaURL)
 	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, grafanaApiKey)
+	ctx = mcpgrafana.WithGrafanaClient(ctx, client)
 
 	return ctx
 }

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -284,6 +285,7 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 	}
 
 	// Get all analyses from the completed investigation
+	slog.Debug("Getting analyses", "investigation_id", completedInvestigation.ID)
 	analyses, err := client.getSiftAnalyses(ctx, completedInvestigation.ID)
 	if err != nil {
 		return nil, fmt.Errorf("getting analyses: %w", err)
@@ -301,6 +303,7 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 	if errorPatternLogsAnalysis == nil {
 		return nil, fmt.Errorf("ErrorPatternLogs analysis not found in investigation %s", completedInvestigation.ID)
 	}
+	slog.Debug("Found ErrorPatternLogs analysis", "analysis_id", errorPatternLogsAnalysis.ID)
 
 	datasourceUID := completedInvestigation.Datasources.LokiDatasource.UID
 
@@ -479,10 +482,12 @@ func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation 
 		return nil, fmt.Errorf("marshaling investigation: %w", err)
 	}
 
+	slog.Debug("Creating investigation", "payload", string(jsonData))
 	buf, err := c.makeRequest(ctx, "POST", "/api/plugins/grafana-ml-app/resources/sift/api/v1/investigations", jsonData)
 	if err != nil {
 		return nil, err
 	}
+	slog.Debug("Investigation created", "response", string(buf))
 
 	investigationResponse := struct {
 		Status string        `json:"status"`
@@ -506,6 +511,7 @@ func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation 
 		case <-timeout:
 			return nil, fmt.Errorf("timeout waiting for investigation completion after 5 minutes")
 		case <-ticker.C:
+			slog.Debug("Polling investigation status", "investigation_id", investigationResponse.Data.ID)
 			investigation, err := c.getSiftInvestigation(ctx, investigationResponse.Data.ID)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
There was a bunch of duplicated code when creating the Grafana client from
context, and I want to be able to do this in tests too, so this just refactors
the code for later.
