### PR TITLE
test: add test case for finding log error patterns

### DIFF
--- a/tools/cloud_testing_utils.go
+++ b/tools/cloud_testing_utils.go
@@ -11,11 +11,14 @@ import (
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
-// createCloudTestContext creates a context with Grafana URL and API key for cloud integration tests.
+// createCloudTestContext creates a context with a Grafana URL, Grafana API key and
+// Grafana client for cloud integration tests.
 // The test will be skipped if required environment variables are not set.
 // testName is used to customize the skip message (e.g. "OnCall", "Sift", "Incident")
 // urlEnv and apiKeyEnv specify the environment variable names for the Grafana URL and API key.
 func createCloudTestContext(t *testing.T, testName, urlEnv, apiKeyEnv string) context.Context {
+	ctx := context.Background()
+
 	grafanaURL := os.Getenv(urlEnv)
 	if grafanaURL == "" {
 		t.Skipf("%s environment variable not set, skipping cloud %s integration tests", urlEnv, testName)
@@ -26,9 +29,11 @@ func createCloudTestContext(t *testing.T, testName, urlEnv, apiKeyEnv string) co
 		t.Skipf("%s environment variable not set, skipping cloud %s integration tests", apiKeyEnv, testName)
 	}
 
-	ctx := context.Background()
+	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey)
+
 	ctx = mcpgrafana.WithGrafanaURL(ctx, grafanaURL)
 	ctx = mcpgrafana.WithGrafanaAPIKey(ctx, grafanaApiKey)
+	ctx = mcpgrafana.WithGrafanaClient(ctx, client)
 
 	return ctx
 }

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -284,6 +285,7 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 	}
 
 	// Get all analyses from the completed investigation
+	slog.Debug("Getting analyses", "investigation_id", completedInvestigation.ID)
 	analyses, err := client.getSiftAnalyses(ctx, completedInvestigation.ID)
 	if err != nil {
 		return nil, fmt.Errorf("getting analyses: %w", err)
@@ -301,6 +303,7 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 	if errorPatternLogsAnalysis == nil {
 		return nil, fmt.Errorf("ErrorPatternLogs analysis not found in investigation %s", completedInvestigation.ID)
 	}
+	slog.Debug("Found ErrorPatternLogs analysis", "analysis_id", errorPatternLogsAnalysis.ID)
 
 	datasourceUID := completedInvestigation.Datasources.LokiDatasource.UID
 
@@ -479,10 +482,12 @@ func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation 
 		return nil, fmt.Errorf("marshaling investigation: %w", err)
 	}
 
+	slog.Debug("Creating investigation", "payload", string(jsonData))
 	buf, err := c.makeRequest(ctx, "POST", "/api/plugins/grafana-ml-app/resources/sift/api/v1/investigations", jsonData)
 	if err != nil {
 		return nil, err
 	}
+	slog.Debug("Investigation created", "response", string(buf))
 
 	investigationResponse := struct {
 		Status string        `json:"status"`
@@ -506,6 +511,7 @@ func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation 
 		case <-timeout:
 			return nil, fmt.Errorf("timeout waiting for investigation completion after 5 minutes")
 		case <-ticker.C:
+			slog.Debug("Polling investigation status", "investigation_id", investigationResponse.Data.ID)
 			investigation, err := c.getSiftInvestigation(ctx, investigationResponse.Data.ID)
 			if err != nil {
 				return nil, err

--- a/tools/sift_cloud_test.go
+++ b/tools/sift_cloud_test.go
@@ -11,6 +11,7 @@ package tools
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,5 +113,26 @@ func TestCloudSiftInvestigations(t *testing.T) {
 		assert.NotEmpty(t, analysis.Name, "Analysis should have a name")
 		assert.NotEmpty(t, analysis.InvestigationID, "Analysis should have an investigation ID")
 		assert.NotNil(t, analysis.Result, "Analysis should have a result")
+	})
+
+	t.Run("find error patterns", func(t *testing.T) {
+		// Find error patterns
+		analysis, err := findErrorPatternLogs(ctx, FindErrorPatternLogsParams{
+			Name: "Test Sift",
+			Labels: map[string]string{
+				"namespace": "hosted-grafana",
+				"cluster":   "dev-eu-west-2",
+				"slug":      "mcptests",
+			},
+			Start: time.Now().Add(-5 * time.Minute),
+			End:   time.Now(),
+		})
+		require.NoError(t, err, "Should not error when finding error patterns")
+		assert.NotNil(t, analysis, "Result should not be nil")
+
+		// Verify all required fields are present
+		assert.NotEmpty(t, analysis.Name, "Analysis should have a name")
+		assert.NotEmpty(t, analysis.InvestigationID, "Analysis should have an investigation ID")
+		assert.NotEmpty(t, analysis.Result.Message, "Analysis  should have a message")
 	})
 }

--- a/tools/sift_cloud_test.go
+++ b/tools/sift_cloud_test.go
@@ -49,11 +49,19 @@ func TestCloudSiftInvestigations(t *testing.T) {
 	})
 
 	// Get an investigation ID from the list to test getting a specific investigation
-	investigations, err := listSiftInvestigations(ctx, ListSiftInvestigationsParams{Limit: 1})
+	investigations, err := listSiftInvestigations(ctx, ListSiftInvestigationsParams{Limit: 10})
 	require.NoError(t, err, "Should not error when listing investigations")
 	require.NotEmpty(t, investigations, "Should have at least one investigation to test with")
 
-	investigationID := investigations[0].ID.String()
+	// Find an investigation with at least one analysis.
+	var investigationID string
+	for _, investigation := range investigations {
+		if len(investigation.Analyses.Items) > 0 {
+			investigationID = investigation.ID.String()
+			break
+		}
+	}
+	require.NotEmpty(t, investigationID, "Should have at least one investigation with at least one analysis")
 
 	// Test getting a specific investigation
 	t.Run("get specific investigation", func(t *testing.T) {


### PR DESCRIPTION
This adds a cloud integration test for the functions underlying the error pattern tool.

The commits are pretty atomic so it might be worth checking them out independently, but it's basically:

- add some logs when creating an investigation (note: we don't log any sensitive stuff, just investigation request/response and some IDs really)
- include a Grafana client in the test context, required to get Loki datasource IDs so we can fetch some examples
- when testing analysis stuff, rather than fetching just 1 investigation, fetch 10 in case the first has no analyses (which can happen if the investigation refused to start due to lack of matching log streams etc)
- add the actual test.

I had hoped this would find the cause of #123 but so far no dice :thinking: 