### PR TITLE
feat: add title annotations to all tools

### DIFF
--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
@@ -148,6 +149,7 @@ var ListAlertRules = mcpgrafana.MustTool(
 	"list_alert_rules",
 	"Lists Grafana alert rules, returning a summary including UID, title, current state (e.g., 'pending', 'firing', 'inactive'), and labels. Supports filtering by labels using selectors and pagination. Example label selector: `[{'name': 'severity', 'type': '=', 'value': 'critical'}]`. Inactive state means the alert state is normal, not firing",
 	listAlertRules,
+	mcp.WithTitleAnnotation("List alert rules"),
 )
 
 type GetAlertRuleByUIDParams struct {
@@ -179,6 +181,7 @@ var GetAlertRuleByUID = mcpgrafana.MustTool(
 	"get_alert_rule_by_uid",
 	"Retrieves the full configuration and detailed status of a specific Grafana alert rule identified by its unique ID (UID). The response includes fields like title, condition, query data, folder UID, rule group, state settings (no data, error), evaluation interval, annotations, and labels.",
 	getAlertRuleByUID,
+	mcp.WithTitleAnnotation("Get alert rule details"),
 )
 
 type ListContactPointsParams struct {
@@ -252,6 +255,7 @@ var ListContactPoints = mcpgrafana.MustTool(
 	"list_contact_points",
 	"Lists Grafana notification contact points, returning a summary including UID, name, and type for each. Supports filtering by name - exact match - and limiting the number of results.",
 	listContactPoints,
+	mcp.WithTitleAnnotation("List notification contact points"),
 )
 
 func AddAlertingTools(mcp *server.MCPServer) {

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -134,6 +135,7 @@ var GetAssertions = mcpgrafana.MustTool(
 	"get_assertions",
 	"Get assertion summary for a given entity with its type, name, env, site, namespace, and a time range",
 	getAssertions,
+	mcp.WithTitleAnnotation("Get assertions summary"),
 )
 
 func AddAssertsTools(mcp *server.MCPServer) {

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -54,12 +55,14 @@ var GetDashboardByUID = mcpgrafana.MustTool(
 	"get_dashboard_by_uid",
 	"Retrieves the complete dashboard, including panels, variables, and settings, for a specific dashboard identified by its UID.",
 	getDashboardByUID,
+	mcp.WithTitleAnnotation("Get dashboard details"),
 )
 
 var UpdateDashboard = mcpgrafana.MustTool(
 	"update_dashboard",
 	"Create or update a dashboard",
 	updateDashboard,
+	mcp.WithTitleAnnotation("Create or update dashboard"),
 )
 
 type DashboardPanelQueriesParams struct {
@@ -140,6 +143,7 @@ var GetDashboardPanelQueries = mcpgrafana.MustTool(
 	"get_dashboard_panel_queries",
 	"Get the title, query string, and datasource information for each panel in a dashboard. The datasource is an object with fields `uid` (which may be a concrete UID or a template variable like \"$datasource\") and `type`. If the datasource UID is a template variable, it won't be usable directly for queries. Returns an array of objects, each representing a panel, with fields: title, query, and datasource (an object with uid and type).",
 	GetDashboardPanelQueriesTool,
+	mcp.WithTitleAnnotation("Get dashboard panel queries"),
 )
 
 func AddDashboardTools(mcp *server.MCPServer) {

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -67,6 +68,7 @@ var ListDatasources = mcpgrafana.MustTool(
 	"list_datasources",
 	"List available Grafana datasources. Optionally filter by datasource type (e.g., 'prometheus', 'loki'). Returns a summary list including ID, UID, name, type, and default status.",
 	listDatasources,
+	mcp.WithTitleAnnotation("List datasources"),
 )
 
 type GetDatasourceByUIDParams struct {
@@ -90,6 +92,7 @@ var GetDatasourceByUID = mcpgrafana.MustTool(
 	"get_datasource_by_uid",
 	"Retrieves detailed information about a specific datasource using its UID. Returns the full datasource model, including name, type, URL, access settings, JSON data, and secure JSON field status.",
 	getDatasourceByUID,
+	mcp.WithTitleAnnotation("Get datasource by UID"),
 )
 
 type GetDatasourceByNameParams struct {
@@ -109,6 +112,7 @@ var GetDatasourceByName = mcpgrafana.MustTool(
 	"get_datasource_by_name",
 	"Retrieves detailed information about a specific datasource using its name. Returns the full datasource model, including UID, type, URL, access settings, JSON data, and secure JSON field status.",
 	getDatasourceByName,
+	mcp.WithTitleAnnotation("Get datasource by name"),
 )
 
 func AddDatasourceTools(mcp *server.MCPServer) {

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/incident-go"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -49,6 +50,7 @@ var ListIncidents = mcpgrafana.MustTool(
 	"list_incidents",
 	"List Grafana incidents. Allows filtering by status ('active', 'resolved') and optionally including drill incidents. Returns a preview list with basic details.",
 	listIncidents,
+	mcp.WithTitleAnnotation("List incidents"),
 )
 
 type CreateIncidentParams struct {
@@ -85,6 +87,7 @@ var CreateIncident = mcpgrafana.MustTool(
 	"create_incident",
 	"Create a new Grafana incident. Requires title, severity, and room prefix. Allows setting status and labels. This tool should be used judiciously and sparingly, and only after confirmation from the user, as it may notify or alarm lots of people.",
 	createIncident,
+	mcp.WithTitleAnnotation("Create incident"),
 )
 
 type AddActivityToIncidentParams struct {
@@ -112,6 +115,7 @@ var AddActivityToIncident = mcpgrafana.MustTool(
 	"add_activity_to_incident",
 	"Add a note (userNote activity) to an existing incident's timeline using its ID. The note body can include URLs which will be attached as context. Use this to add context to an incident.",
 	addActivityToIncident,
+	mcp.WithTitleAnnotation("Add activity to incident"),
 )
 
 func AddIncidentTools(mcp *server.MCPServer) {
@@ -143,4 +147,5 @@ var GetIncident = mcpgrafana.MustTool(
 	"get_incident",
 	"Get a single incident by ID. Returns the full incident details including title, status, severity, labels, timestamps, and other metadata.",
 	getIncident,
+	mcp.WithTitleAnnotation("Get incident details"),
 )

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -222,6 +223,7 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 	"list_loki_label_names",
 	"Lists all available label names (keys) found in logs within a specified Loki datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
 	listLokiLabelNames,
+	mcp.WithTitleAnnotation("List Loki label names"),
 )
 
 // ListLokiLabelValuesParams defines the parameters for listing Loki label values
@@ -260,6 +262,7 @@ var ListLokiLabelValues = mcpgrafana.MustTool(
 	"list_loki_label_values",
 	"Retrieves all unique values associated with a specific `labelName` within a Loki datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
 	listLokiLabelValues,
+	mcp.WithTitleAnnotation("List Loki label values"),
 )
 
 // LogStream represents a stream of log entries from Loki
@@ -467,6 +470,7 @@ var QueryLokiLogs = mcpgrafana.MustTool(
 	"query_loki_logs",
 	"Executes a LogQL query against a Loki datasource to retrieve log entries or metric values. Returns a list of results, each containing a timestamp, labels, and either a log line (`line`) or a numeric metric value (`value`). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). Supports full LogQL syntax for log and metric queries (e.g., `{app=\"foo\"} |= \"error\"`, `rate({app=\"bar\"}[1m])`). Prefer using `query_loki_stats` first to check stream size and `list_loki_label_names` and `list_loki_label_values` to verify labels exist.",
 	queryLokiLogs,
+	mcp.WithTitleAnnotation("Query Loki logs"),
 )
 
 // fetchStats is a method to fetch stats data from Loki API
@@ -524,6 +528,7 @@ var QueryLokiStats = mcpgrafana.MustTool(
 	"query_loki_stats",
 	"Retrieves statistics about log streams matching a given LogQL *selector* within a Loki datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
 	queryLokiStats,
+	mcp.WithTitleAnnotation("Get Loki log statistics"),
 )
 
 // AddLokiTools registers all Loki tools with the MCP server

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -9,6 +9,7 @@ import (
 
 	aapi "github.com/grafana/amixr-api-go-client"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -192,6 +193,7 @@ var ListOnCallSchedules = mcpgrafana.MustTool(
 	"list_oncall_schedules",
 	"List Grafana OnCall schedules, optionally filtering by team ID. If a specific schedule ID is provided, retrieves details for only that schedule. Returns a list of schedule summaries including ID, name, team ID, timezone, and shift IDs. Supports pagination.",
 	listOnCallSchedules,
+	mcp.WithTitleAnnotation("List OnCall schedules"),
 )
 
 type GetOnCallShiftParams struct {
@@ -216,6 +218,7 @@ var GetOnCallShift = mcpgrafana.MustTool(
 	"get_oncall_shift",
 	"Get detailed information for a specific Grafana OnCall shift using its ID. A shift represents a designated time period within a schedule when users are actively on-call. Returns the full shift details.",
 	getOnCallShift,
+	mcp.WithTitleAnnotation("Get OnCall shift"),
 )
 
 // CurrentOnCallUsers represents the currently on-call users for a schedule
@@ -276,6 +279,7 @@ var GetCurrentOnCallUsers = mcpgrafana.MustTool(
 	"get_current_oncall_users",
 	"Get the list of users currently on-call for a specific Grafana OnCall schedule ID. Returns the schedule ID, name, and a list of detailed user objects for those currently on call.",
 	getCurrentOnCallUsers,
+	mcp.WithTitleAnnotation("Get current on-call users"),
 )
 
 type ListOnCallTeamsParams struct {
@@ -305,6 +309,7 @@ var ListOnCallTeams = mcpgrafana.MustTool(
 	"list_oncall_teams",
 	"List teams configured in Grafana OnCall. Returns a list of team objects with their details. Supports pagination.",
 	listOnCallTeams,
+	mcp.WithTitleAnnotation("List OnCall teams"),
 )
 
 type ListOnCallUsersParams struct {
@@ -348,6 +353,7 @@ var ListOnCallUsers = mcpgrafana.MustTool(
 	"list_oncall_users",
 	"List users from Grafana OnCall. Can retrieve all users, a specific user by ID, or filter by username. Returns a list of user objects with their details. Supports pagination.",
 	listOnCallUsers,
+	mcp.WithTitleAnnotation("List OnCall users"),
 )
 
 func AddOnCallTools(mcp *server.MCPServer) {

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -96,6 +97,7 @@ var ListPrometheusMetricMetadata = mcpgrafana.MustTool(
 	"list_prometheus_metric_metadata",
 	"List Prometheus metric metadata. Returns metadata about metrics currently scraped from targets. Note: This endpoint is experimental.",
 	listPrometheusMetricMetadata,
+	mcp.WithTitleAnnotation("List Prometheus metric metadata"),
 )
 
 type QueryPrometheusParams struct {
@@ -158,6 +160,7 @@ var QueryPrometheus = mcpgrafana.MustTool(
 	"query_prometheus",
 	"Query Prometheus using a PromQL expression. Supports both instant queries (at a single point in time) and range queries (over a time range).",
 	queryPrometheus,
+	mcp.WithTitleAnnotation("Query Prometheus metrics"),
 )
 
 type ListPrometheusMetricNamesParams struct {
@@ -225,6 +228,7 @@ var ListPrometheusMetricNames = mcpgrafana.MustTool(
 	"list_prometheus_metric_names",
 	"List metric names in a Prometheus datasource. Retrieves all metric names and then filters them locally using the provided regex. Supports pagination.",
 	listPrometheusMetricNames,
+	mcp.WithTitleAnnotation("List Prometheus metric names"),
 )
 
 type LabelMatcher struct {
@@ -327,6 +331,7 @@ var ListPrometheusLabelNames = mcpgrafana.MustTool(
 	"list_prometheus_label_names",
 	"List label names in a Prometheus datasource. Allows filtering by series selectors and time range.",
 	listPrometheusLabelNames,
+	mcp.WithTitleAnnotation("List Prometheus label names"),
 )
 
 type ListPrometheusLabelValuesParams struct {
@@ -383,6 +388,7 @@ var ListPrometheusLabelValues = mcpgrafana.MustTool(
 	"list_prometheus_label_values",
 	"Get the values for a specific label name in Prometheus. Allows filtering by series selectors and time range.",
 	listPrometheusLabelValues,
+	mcp.WithTitleAnnotation("List Prometheus label values"),
 )
 
 func AddPrometheusTools(mcp *server.MCPServer) {

--- a/tools/search.go
+++ b/tools/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/grafana/grafana-openapi-client-go/client/search"
@@ -35,6 +36,7 @@ var SearchDashboards = mcpgrafana.MustTool(
 	"search_dashboards",
 	"Search for Grafana dashboards by a query string. Returns a list of matching dashboards with details like title, UID, folder, tags, and URL.",
 	searchDashboards,
+	mcp.WithTitleAnnotation("Search dashboards"),
 )
 
 func AddSearchTools(mcp *server.MCPServer) {

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -175,6 +176,7 @@ var GetSiftInvestigation = mcpgrafana.MustTool(
 	"get_sift_investigation",
 	"Retrieves an existing Sift investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').",
 	getSiftInvestigation,
+	mcp.WithTitleAnnotation("Get Sift investigation"),
 )
 
 // GetSiftAnalysisParams defines the parameters for retrieving a specific analysis
@@ -214,6 +216,7 @@ var GetSiftAnalysis = mcpgrafana.MustTool(
 	"get_sift_analysis",
 	"Retrieves a specific analysis from an investigation by its UUID. The investigation ID and analysis ID should be provided as strings in UUID format.",
 	getSiftAnalysis,
+	mcp.WithTitleAnnotation("Get Sift analysis"),
 )
 
 // ListSiftInvestigationsParams defines the parameters for retrieving investigations
@@ -246,6 +249,7 @@ var ListSiftInvestigations = mcpgrafana.MustTool(
 	"list_sift_investigations",
 	"Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",
 	listSiftInvestigations,
+	mcp.WithTitleAnnotation("List Sift investigations"),
 )
 
 // FindErrorPatternLogsParams defines the parameters for running an ErrorPatternLogs check
@@ -328,6 +332,7 @@ var FindErrorPatternLogs = mcpgrafana.MustTool(
 	"find_error_pattern_logs",
 	"Searches Loki logs for elevated error patterns compared to the last day's average, waits for the analysis to complete, and returns the results including any patterns found.",
 	findErrorPatternLogs,
+	mcp.WithTitleAnnotation("Find error patterns in logs"),
 )
 
 // FindSlowRequestsParams defines the parameters for running an SlowRequests check
@@ -392,6 +397,7 @@ var FindSlowRequests = mcpgrafana.MustTool(
 	"find_slow_requests",
 	"Searches relevant Tempo datasources for slow requests, waits for the analysis to complete, and returns the results.",
 	findSlowRequests,
+	mcp.WithTitleAnnotation("Find slow requests"),
 )
 
 // AddSiftTools registers all Sift tools with the MCP server


### PR DESCRIPTION
This commit adds the ability to customise tools using `mcp.ToolOption`s, then updates all calls to `MustTool` to include a title annotation, which can be displayed in any UIs instead of the non-human-friendly name.