### PR TITLE
Added seed data to prometheus

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,10 @@ services:
     image: prom/prometheus
     ports:
       - "9090:9090"
-    command:
-      - --config.file=/etc/prometheus/prometheus.yml
+    entrypoint: /etc/prometheus/entrypoint.sh
+    volumes:
+      - ./testdata/prometheus-seed.yml:/etc/prometheus/prometheus-seed.yml
+      - ./testdata/prometheus-entrypoint.sh:/etc/prometheus/entrypoint.sh
 
   loki:
     image: grafana/loki:2.6.0

--- a/testdata/prometheus-entrypoint.sh
+++ b/testdata/prometheus-entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Prometheus entrypoint script to backfill recording rules and start Prometheus
+
+set -e
+
+echo "Starting Prometheus entrypoint script..."
+
+
+backfill() {
+    # Calculate time range for backfilling (5 hours ago from now)
+    # Get current time in seconds since epoch
+    CURRENT_TIME=$(date -u +%s)
+    # Subtract 5 hours (5 * 60 * 60 = 18000 seconds)
+    START_TIME=$((CURRENT_TIME - 18000))
+
+    # wait until Prometheus is up and running
+    until wget http://localhost:9090/-/healthy -q -O /dev/null; do
+        sleep 1
+    done
+
+    promtool tsdb create-blocks-from \
+        rules \
+        --url=http://localhost:9090 \
+        --start="${START_TIME}" \
+        --end="${CURRENT_TIME}" \
+        --eval-interval=30s \
+        /etc/prometheus/prometheus-seed.yml
+}
+
+# Start Prometheus with the regular configuration, this is needed for backfilling
+/bin/prometheus \
+    --config.file=/etc/prometheus/prometheus.yml &
+
+backfill
+
+# Restarting Prometheus after backfilling will allow to load the new blocks directly
+# without having to wait for the next compaction cycle
+kill %1
+echo "Starting Prometheus server..."
+# Start Prometheus with the regular configuration
+/bin/prometheus \
+    --config.file=/etc/prometheus/prometheus.yml
+

--- a/testdata/prometheus-seed.yml
+++ b/testdata/prometheus-seed.yml
@@ -1,0 +1,5 @@
+groups:
+  - name: seed
+    rules:
+    - record: test
+      expr: vector(1)

--- a/tools/prometheus_test.go
+++ b/tools/prometheus_test.go
@@ -233,7 +233,6 @@ func TestSelectorMatches(t *testing.T) {
 
 func TestPrometheusQueries(t *testing.T) {
 	t.Run("query prometheus range", func(t *testing.T) {
-		t.Skip("Skipping because we don't have a Prometheus instance with enough data")
 		end := time.Now()
 		start := end.Add(-10 * time.Minute)
 		for _, step := range []int{15, 60, 300} {
@@ -241,7 +240,7 @@ func TestPrometheusQueries(t *testing.T) {
 				ctx := newTestContext()
 				result, err := queryPrometheus(ctx, QueryPrometheusParams{
 					DatasourceUID: "prometheus",
-					Expr:          "up",
+					Expr:          "test",
 					StartRFC3339:  start.Format(time.RFC3339),
 					EndRFC3339:    end.Format(time.RFC3339),
 					StepSeconds:   step,
@@ -253,7 +252,7 @@ func TestPrometheusQueries(t *testing.T) {
 				expectedLen := int(end.Sub(start).Seconds()/float64(step)) + 1
 				assert.Len(t, matrix[0].Values, expectedLen)
 				assert.Less(t, matrix[0].Values[0].Timestamp.Sub(model.TimeFromUnix(start.Unix())), time.Duration(step)*time.Second)
-				assert.Equal(t, matrix[0].Metric["__name__"], model.LabelValue("up"))
+				assert.Equal(t, matrix[0].Metric["__name__"], model.LabelValue("test"))
 			})
 		}
 	})


### PR DESCRIPTION
# Enable Prometheus Recording Rule Backfilling for Testing

This PR enhances the Docker Compose setup for development and testing by adding support for pre-seeding Prometheus with recording rule data. This change:

1. Modifies the Prometheus service in our `docker-compose.yaml` to use a custom entrypoint script
2. Adds a backfilling mechanism that generates 5 hours of historical data for a test recording rule
3. Re-enables a previously skipped Prometheus range query test that now has sufficient historical data to work with

## Details

- Created a custom entrypoint script (`testdata/prometheus-entrypoint.sh`) that:
  - Starts Prometheus initially to make its API available
  - Uses `promtool tsdb create-blocks-from rules` to backfill 5 hours of data for a simple test recording rule
  - Restarts Prometheus to ensure the backfilled data is immediately available

- Added a simple recording rule definition in `testdata/prometheus-seed.yml` that creates a metric called `test` with a constant value of 1

- Updated our test to use the new `test` metric instead of `up`, removing the skip annotation since we now have predictable data to test against

This change will make our tests more reliable by ensuring consistent test data is available, regardless of how long the Prometheus instance has been running.