### PR TITLE
Add ToolHive as deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ the OnCall tools, use `--disable-oncall`.
      GOBIN="$HOME/go/bin" go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
      ```
 
+   - **ToolHive**: Use [ToolHive](https://github.com/stacklok/toolhive) for simplified MCP server deployment with enhanced security defaults.
+
+     ```bash
+     thv run grafana
+     ```
+
 3. Add the server configuration to your client configuration file. For example, for Claude Desktop:
 
    **If using the binary:**


### PR DESCRIPTION
Hey, the following PR adds ToolHive as an alternative way for users to run your MCP server easily and securely.

- Deploy MCP servers using Docker containers with a single command
- Handle setup complexity and dependency management
- Provide enhanced security defaults
- Make it easy for users to discover and run MCP servers locally

Just adding it as an option for folks who prefer this approach. Happy to adjust if needed!

Thanks for maintaining this cool project! 🙏