### PR TITLE
fix: always fixup schemes of Grafana client based on final Grafana URL

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -167,20 +167,21 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string) *client.Gr
 	var parsedURL *url.URL
 	var err error
 
-	if grafanaURL != "" {
-		parsedURL, err = url.Parse(grafanaURL)
-		if err != nil {
-			panic(fmt.Errorf("invalid Grafana URL: %w", err))
-		}
-		cfg.Host = parsedURL.Host
-		cfg.BasePath = makeBasePath(parsedURL.Path)
-		// The Grafana client will always prefer HTTPS even if the URL is HTTP,
-		// so we need to limit the schemes to HTTP if the URL is HTTP.
-		if parsedURL.Scheme == "http" {
-			cfg.Schemes = []string{"http"}
-		}
-	} else {
-		parsedURL, _ = url.Parse(defaultGrafanaURL)
+	if grafanaURL == "" {
+		grafanaURL = defaultGrafanaURL
+	}
+
+	parsedURL, err = url.Parse(grafanaURL)
+	if err != nil {
+		panic(fmt.Errorf("invalid Grafana URL: %w", err))
+	}
+	cfg.Host = parsedURL.Host
+	cfg.BasePath = makeBasePath(parsedURL.Path)
+
+	// The Grafana client will always prefer HTTPS even if the URL is HTTP,
+	// so we need to limit the schemes to HTTP if the URL is HTTP.
+	if parsedURL.Scheme == "http" {
+		cfg.Schemes = []string{"http"}
 	}
 
 	if apiKey != "" {
@@ -215,6 +216,9 @@ var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, 
 	uEnv, apiKeyEnv := urlAndAPIKeyFromEnv()
 	if u == "" {
 		u = uEnv
+	}
+	if u == "" {
+		u = defaultGrafanaURL
 	}
 	if apiKey == "" {
 		apiKey = apiKeyEnv

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -173,7 +173,7 @@ func TestExtractGrafanaClientFromHeaders(t *testing.T) {
 		ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
 		c := GrafanaClientFromContext(ctx)
 		url := minURLFromClient(c)
-		assert.Equal(t, "localhost", url.host)
+		assert.Equal(t, "localhost:3000", url.host)
 		assert.Equal(t, "/api", url.basePath)
 	})
 


### PR DESCRIPTION
When constructing the Grafana client we need to ensure that it doesn't
try to use HTTPS when the final Grafana URL scheme is HTTP.

This particularly affects the case where the Grafana URL is not
provided and the server is running on SSE mode. This is because:

- in stdio mode we use `ExtractGrafanaClientFromEnv`, which falls
  back to explicitly using the `defaultGrafanaURL` variable if the
  GRAFANA_URL environment variable is not set, so a non-empty value
  is passed to `NewGrafanaClient`
- in SSE mode we use `ExtractGrafanaClientFromHeaders`, which does not
  fall back to `defaultGrafanaURL` and instead passes an empty string,
  therefore relying on the `NewGrafanaClient` to use the default
  schemes.

Fixes #162.
