### PR TITLE
Add read/write mode definition to tools

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -39,9 +39,11 @@ type Tool struct {
 //
 //	mcpgrafana.MustTool(name, description, toolHandler).Register(server)
 func (t *Tool) Register(mcp *server.MCPServer, toolMode ToolMode) {
-	if t.Mode == toolMode {
-		mcp.AddTool(t.Tool, t.Handler)
+	// Don't register write tools in read mode
+	if t.Mode == ToolModeWrite && toolMode == ToolModeRead {
+		return
 	}
+	mcp.AddTool(t.Tool, t.Handler)
 }
 
 // MustTool creates a new Tool from the given name, description, and toolHandler.
@@ -56,7 +58,7 @@ func MustTool[T any, R any](
 	if err != nil {
 		panic(err)
 	}
-	return Tool{Tool: tool, Handler: handler}
+	return Tool{Tool: tool, Handler: handler, Mode: toolMode}
 }
 
 // ToolHandlerFunc is the type of a handler function for a tool.

--- a/tools.go
+++ b/tools.go
@@ -12,6 +12,13 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+type ToolMode string
+
+const (
+	ToolModeRead  ToolMode = "read"
+	ToolModeWrite ToolMode = "write"
+)
+
 // Tool is a struct that represents a tool definition and the function used
 // to handle tool calls.
 //
@@ -21,6 +28,7 @@ import (
 type Tool struct {
 	Tool    mcp.Tool
 	Handler server.ToolHandlerFunc
+	Mode    ToolMode
 }
 
 // Register adds the Tool to the given MCPServer.
@@ -30,14 +38,17 @@ type Tool struct {
 // statement:
 //
 //	mcpgrafana.MustTool(name, description, toolHandler).Register(server)
-func (t *Tool) Register(mcp *server.MCPServer) {
-	mcp.AddTool(t.Tool, t.Handler)
+func (t *Tool) Register(mcp *server.MCPServer, toolMode ToolMode) {
+	if t.Mode == toolMode {
+		mcp.AddTool(t.Tool, t.Handler)
+	}
 }
 
 // MustTool creates a new Tool from the given name, description, and toolHandler.
 // It panics if the tool cannot be created.
 func MustTool[T any, R any](
 	name, description string,
+	toolMode ToolMode,
 	toolHandler ToolHandlerFunc[T, R],
 	options ...mcp.ToolOption,
 ) Tool {

--- a/tools/admin.go
+++ b/tools/admin.go
@@ -31,9 +31,10 @@ func listTeams(ctx context.Context, args ListTeamsParams) (*models.SearchTeamQue
 var ListTeams = mcpgrafana.MustTool(
 	"list_teams",
 	"Search for Grafana teams by a query string. Returns a list of matching teams with details like name, ID, and URL.",
+	mcpgrafana.ToolModeRead,
 	listTeams,
 )
 
-func AddAdminTools(mcp *server.MCPServer) {
-	ListTeams.Register(mcp)
+func AddAdminTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	ListTeams.Register(mcp, toolMode)
 }

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -148,6 +148,7 @@ func applyPagination(items []alertingRule, limit, page int) ([]alertingRule, err
 var ListAlertRules = mcpgrafana.MustTool(
 	"list_alert_rules",
 	"Lists Grafana alert rules, returning a summary including UID, title, current state (e.g., 'pending', 'firing', 'inactive'), and labels. Supports filtering by labels using selectors and pagination. Example label selector: `[{'name': 'severity', 'type': '=', 'value': 'critical'}]`. Inactive state means the alert state is normal, not firing",
+	mcpgrafana.ToolModeRead,
 	listAlertRules,
 	mcp.WithTitleAnnotation("List alert rules"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -182,6 +183,7 @@ func getAlertRuleByUID(ctx context.Context, args GetAlertRuleByUIDParams) (*mode
 var GetAlertRuleByUID = mcpgrafana.MustTool(
 	"get_alert_rule_by_uid",
 	"Retrieves the full configuration and detailed status of a specific Grafana alert rule identified by its unique ID (UID). The response includes fields like title, condition, query data, folder UID, rule group, state settings (no data, error), evaluation interval, annotations, and labels.",
+	mcpgrafana.ToolModeRead,
 	getAlertRuleByUID,
 	mcp.WithTitleAnnotation("Get alert rule details"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -258,14 +260,15 @@ func applyLimitToContactPoints(items []*models.EmbeddedContactPoint, limit int) 
 var ListContactPoints = mcpgrafana.MustTool(
 	"list_contact_points",
 	"Lists Grafana notification contact points, returning a summary including UID, name, and type for each. Supports filtering by name - exact match - and limiting the number of results.",
+	mcpgrafana.ToolModeRead,
 	listContactPoints,
 	mcp.WithTitleAnnotation("List notification contact points"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddAlertingTools(mcp *server.MCPServer) {
-	ListAlertRules.Register(mcp)
-	GetAlertRuleByUID.Register(mcp)
-	ListContactPoints.Register(mcp)
+func AddAlertingTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	ListAlertRules.Register(mcp, toolMode)
+	GetAlertRuleByUID.Register(mcp, toolMode)
+	ListContactPoints.Register(mcp, toolMode)
 }

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -137,12 +137,13 @@ func getAssertions(ctx context.Context, args GetAssertionsParams) (string, error
 var GetAssertions = mcpgrafana.MustTool(
 	"get_assertions",
 	"Get assertion summary for a given entity with its type, name, env, site, namespace, and a time range",
+	mcpgrafana.ToolModeRead,
 	getAssertions,
 	mcp.WithTitleAnnotation("Get assertions summary"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddAssertsTools(mcp *server.MCPServer) {
-	GetAssertions.Register(mcp)
+func AddAssertsTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	GetAssertions.Register(mcp, toolMode)
 }

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -54,6 +54,7 @@ func updateDashboard(ctx context.Context, args UpdateDashboardParams) (*models.P
 var GetDashboardByUID = mcpgrafana.MustTool(
 	"get_dashboard_by_uid",
 	"Retrieves the complete dashboard, including panels, variables, and settings, for a specific dashboard identified by its UID.",
+	mcpgrafana.ToolModeRead,
 	getDashboardByUID,
 	mcp.WithTitleAnnotation("Get dashboard details"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -63,6 +64,7 @@ var GetDashboardByUID = mcpgrafana.MustTool(
 var UpdateDashboard = mcpgrafana.MustTool(
 	"update_dashboard",
 	"Create or update a dashboard",
+	mcpgrafana.ToolModeWrite,
 	updateDashboard,
 	mcp.WithTitleAnnotation("Create or update dashboard"),
 	mcp.WithDestructiveHintAnnotation(true),
@@ -145,14 +147,15 @@ func GetDashboardPanelQueriesTool(ctx context.Context, args DashboardPanelQuerie
 var GetDashboardPanelQueries = mcpgrafana.MustTool(
 	"get_dashboard_panel_queries",
 	"Get the title, query string, and datasource information for each panel in a dashboard. The datasource is an object with fields `uid` (which may be a concrete UID or a template variable like \"$datasource\") and `type`. If the datasource UID is a template variable, it won't be usable directly for queries. Returns an array of objects, each representing a panel, with fields: title, query, and datasource (an object with uid and type).",
+	mcpgrafana.ToolModeRead,
 	GetDashboardPanelQueriesTool,
 	mcp.WithTitleAnnotation("Get dashboard panel queries"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddDashboardTools(mcp *server.MCPServer) {
-	GetDashboardByUID.Register(mcp)
-	UpdateDashboard.Register(mcp)
-	GetDashboardPanelQueries.Register(mcp)
+func AddDashboardTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	GetDashboardByUID.Register(mcp, toolMode)
+	UpdateDashboard.Register(mcp, toolMode)
+	GetDashboardPanelQueries.Register(mcp, toolMode)
 }

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -67,6 +67,7 @@ func summarizeDatasources(dataSources models.DataSourceList) []dataSourceSummary
 var ListDatasources = mcpgrafana.MustTool(
 	"list_datasources",
 	"List available Grafana datasources. Optionally filter by datasource type (e.g., 'prometheus', 'loki'). Returns a summary list including ID, UID, name, type, and default status.",
+	mcpgrafana.ToolModeRead,
 	listDatasources,
 	mcp.WithTitleAnnotation("List datasources"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -93,6 +94,7 @@ func getDatasourceByUID(ctx context.Context, args GetDatasourceByUIDParams) (*mo
 var GetDatasourceByUID = mcpgrafana.MustTool(
 	"get_datasource_by_uid",
 	"Retrieves detailed information about a specific datasource using its UID. Returns the full datasource model, including name, type, URL, access settings, JSON data, and secure JSON field status.",
+	mcpgrafana.ToolModeRead,
 	getDatasourceByUID,
 	mcp.WithTitleAnnotation("Get datasource by UID"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -115,14 +117,15 @@ func getDatasourceByName(ctx context.Context, args GetDatasourceByNameParams) (*
 var GetDatasourceByName = mcpgrafana.MustTool(
 	"get_datasource_by_name",
 	"Retrieves detailed information about a specific datasource using its name. Returns the full datasource model, including UID, type, URL, access settings, JSON data, and secure JSON field status.",
+	mcpgrafana.ToolModeRead,
 	getDatasourceByName,
 	mcp.WithTitleAnnotation("Get datasource by name"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddDatasourceTools(mcp *server.MCPServer) {
-	ListDatasources.Register(mcp)
-	GetDatasourceByUID.Register(mcp)
-	GetDatasourceByName.Register(mcp)
+func AddDatasourceTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	ListDatasources.Register(mcp, toolMode)
+	GetDatasourceByUID.Register(mcp, toolMode)
+	GetDatasourceByName.Register(mcp, toolMode)
 }

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -49,6 +49,7 @@ func listIncidents(ctx context.Context, args ListIncidentsParams) (*incident.Que
 var ListIncidents = mcpgrafana.MustTool(
 	"list_incidents",
 	"List Grafana incidents. Allows filtering by status ('active', 'resolved') and optionally including drill incidents. Returns a preview list with basic details.",
+	mcpgrafana.ToolModeRead,
 	listIncidents,
 	mcp.WithTitleAnnotation("List incidents"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -88,6 +89,7 @@ func createIncident(ctx context.Context, args CreateIncidentParams) (*incident.I
 var CreateIncident = mcpgrafana.MustTool(
 	"create_incident",
 	"Create a new Grafana incident. Requires title, severity, and room prefix. Allows setting status and labels. This tool should be used judiciously and sparingly, and only after confirmation from the user, as it may notify or alarm lots of people.",
+	mcpgrafana.ToolModeWrite,
 	createIncident,
 	mcp.WithTitleAnnotation("Create incident"),
 )
@@ -116,15 +118,16 @@ func addActivityToIncident(ctx context.Context, args AddActivityToIncidentParams
 var AddActivityToIncident = mcpgrafana.MustTool(
 	"add_activity_to_incident",
 	"Add a note (userNote activity) to an existing incident's timeline using its ID. The note body can include URLs which will be attached as context. Use this to add context to an incident.",
+	mcpgrafana.ToolModeWrite,
 	addActivityToIncident,
 	mcp.WithTitleAnnotation("Add activity to incident"),
 )
 
-func AddIncidentTools(mcp *server.MCPServer) {
-	ListIncidents.Register(mcp)
-	CreateIncident.Register(mcp)
-	AddActivityToIncident.Register(mcp)
-	GetIncident.Register(mcp)
+func AddIncidentTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	ListIncidents.Register(mcp, toolMode)
+	CreateIncident.Register(mcp, toolMode)
+	AddActivityToIncident.Register(mcp, toolMode)
+	GetIncident.Register(mcp, toolMode)
 }
 
 type GetIncidentParams struct {
@@ -148,6 +151,7 @@ func getIncident(ctx context.Context, args GetIncidentParams) (*incident.Inciden
 var GetIncident = mcpgrafana.MustTool(
 	"get_incident",
 	"Get a single incident by ID. Returns the full incident details including title, status, severity, labels, timestamps, and other metadata.",
+	mcpgrafana.ToolModeRead,
 	getIncident,
 	mcp.WithTitleAnnotation("Get incident details"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -222,6 +222,7 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 var ListLokiLabelNames = mcpgrafana.MustTool(
 	"list_loki_label_names",
 	"Lists all available label names (keys) found in logs within a specified Loki datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
+	mcpgrafana.ToolModeRead,
 	listLokiLabelNames,
 	mcp.WithTitleAnnotation("List Loki label names"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -263,6 +264,7 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 var ListLokiLabelValues = mcpgrafana.MustTool(
 	"list_loki_label_values",
 	"Retrieves all unique values associated with a specific `labelName` within a Loki datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
+	mcpgrafana.ToolModeRead,
 	listLokiLabelValues,
 	mcp.WithTitleAnnotation("List Loki label values"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -473,6 +475,7 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) ([]LogEntry, e
 var QueryLokiLogs = mcpgrafana.MustTool(
 	"query_loki_logs",
 	"Executes a LogQL query against a Loki datasource to retrieve log entries or metric values. Returns a list of results, each containing a timestamp, labels, and either a log line (`line`) or a numeric metric value (`value`). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). Supports full LogQL syntax for log and metric queries (e.g., `{app=\"foo\"} |= \"error\"`, `rate({app=\"bar\"}[1m])`). Prefer using `query_loki_stats` first to check stream size and `list_loki_label_names` and `list_loki_label_values` to verify labels exist.",
+	mcpgrafana.ToolModeRead,
 	queryLokiLogs,
 	mcp.WithTitleAnnotation("Query Loki logs"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -533,6 +536,7 @@ func queryLokiStats(ctx context.Context, args QueryLokiStatsParams) (*Stats, err
 var QueryLokiStats = mcpgrafana.MustTool(
 	"query_loki_stats",
 	"Retrieves statistics about log streams matching a given LogQL *selector* within a Loki datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
+	mcpgrafana.ToolModeRead,
 	queryLokiStats,
 	mcp.WithTitleAnnotation("Get Loki log statistics"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -540,9 +544,9 @@ var QueryLokiStats = mcpgrafana.MustTool(
 )
 
 // AddLokiTools registers all Loki tools with the MCP server
-func AddLokiTools(mcp *server.MCPServer) {
-	ListLokiLabelNames.Register(mcp)
-	ListLokiLabelValues.Register(mcp)
-	QueryLokiStats.Register(mcp)
-	QueryLokiLogs.Register(mcp)
+func AddLokiTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	ListLokiLabelNames.Register(mcp, toolMode)
+	ListLokiLabelValues.Register(mcp, toolMode)
+	QueryLokiStats.Register(mcp, toolMode)
+	QueryLokiLogs.Register(mcp, toolMode)
 }

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -192,6 +192,7 @@ func listOnCallSchedules(ctx context.Context, args ListOnCallSchedulesParams) ([
 var ListOnCallSchedules = mcpgrafana.MustTool(
 	"list_oncall_schedules",
 	"List Grafana OnCall schedules, optionally filtering by team ID. If a specific schedule ID is provided, retrieves details for only that schedule. Returns a list of schedule summaries including ID, name, team ID, timezone, and shift IDs. Supports pagination.",
+	mcpgrafana.ToolModeRead,
 	listOnCallSchedules,
 	mcp.WithTitleAnnotation("List OnCall schedules"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -219,6 +220,7 @@ func getOnCallShift(ctx context.Context, args GetOnCallShiftParams) (*aapi.OnCal
 var GetOnCallShift = mcpgrafana.MustTool(
 	"get_oncall_shift",
 	"Get detailed information for a specific Grafana OnCall shift using its ID. A shift represents a designated time period within a schedule when users are actively on-call. Returns the full shift details.",
+	mcpgrafana.ToolModeRead,
 	getOnCallShift,
 	mcp.WithTitleAnnotation("Get OnCall shift"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -282,6 +284,7 @@ func getCurrentOnCallUsers(ctx context.Context, args GetCurrentOnCallUsersParams
 var GetCurrentOnCallUsers = mcpgrafana.MustTool(
 	"get_current_oncall_users",
 	"Get the list of users currently on-call for a specific Grafana OnCall schedule ID. Returns the schedule ID, name, and a list of detailed user objects for those currently on call.",
+	mcpgrafana.ToolModeRead,
 	getCurrentOnCallUsers,
 	mcp.WithTitleAnnotation("Get current on-call users"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -314,6 +317,7 @@ func listOnCallTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*aapi.T
 var ListOnCallTeams = mcpgrafana.MustTool(
 	"list_oncall_teams",
 	"List teams configured in Grafana OnCall. Returns a list of team objects with their details. Supports pagination.",
+	mcpgrafana.ToolModeRead,
 	listOnCallTeams,
 	mcp.WithTitleAnnotation("List OnCall teams"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -360,16 +364,17 @@ func listOnCallUsers(ctx context.Context, args ListOnCallUsersParams) ([]*aapi.U
 var ListOnCallUsers = mcpgrafana.MustTool(
 	"list_oncall_users",
 	"List users from Grafana OnCall. Can retrieve all users, a specific user by ID, or filter by username. Returns a list of user objects with their details. Supports pagination.",
+	mcpgrafana.ToolModeRead,
 	listOnCallUsers,
 	mcp.WithTitleAnnotation("List OnCall users"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddOnCallTools(mcp *server.MCPServer) {
-	ListOnCallSchedules.Register(mcp)
-	GetOnCallShift.Register(mcp)
-	GetCurrentOnCallUsers.Register(mcp)
-	ListOnCallTeams.Register(mcp)
-	ListOnCallUsers.Register(mcp)
+func AddOnCallTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	ListOnCallSchedules.Register(mcp, toolMode)
+	GetOnCallShift.Register(mcp, toolMode)
+	GetCurrentOnCallUsers.Register(mcp, toolMode)
+	ListOnCallTeams.Register(mcp, toolMode)
+	ListOnCallUsers.Register(mcp, toolMode)
 }

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -97,6 +97,7 @@ func listPrometheusMetricMetadata(ctx context.Context, args ListPrometheusMetric
 var ListPrometheusMetricMetadata = mcpgrafana.MustTool(
 	"list_prometheus_metric_metadata",
 	"List Prometheus metric metadata. Returns metadata about metrics currently scraped from targets. Note: This endpoint is experimental.",
+	mcpgrafana.ToolModeRead,
 	listPrometheusMetricMetadata,
 	mcp.WithTitleAnnotation("List Prometheus metric metadata"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -172,6 +173,7 @@ func queryPrometheus(ctx context.Context, args QueryPrometheusParams) (model.Val
 var QueryPrometheus = mcpgrafana.MustTool(
 	"query_prometheus",
 	"Query Prometheus using a PromQL expression. Supports both instant queries (at a single point in time) and range queries (over a time range). Time can be specified either in RFC3339 format or as relative time expressions like 'now', 'now-1h', 'now-30m', etc.",
+	mcpgrafana.ToolModeRead,
 	queryPrometheus,
 	mcp.WithTitleAnnotation("Query Prometheus metrics"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -242,6 +244,7 @@ func listPrometheusMetricNames(ctx context.Context, args ListPrometheusMetricNam
 var ListPrometheusMetricNames = mcpgrafana.MustTool(
 	"list_prometheus_metric_names",
 	"List metric names in a Prometheus datasource. Retrieves all metric names and then filters them locally using the provided regex. Supports pagination.",
+	mcpgrafana.ToolModeRead,
 	listPrometheusMetricNames,
 	mcp.WithTitleAnnotation("List Prometheus metric names"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -347,6 +350,7 @@ func listPrometheusLabelNames(ctx context.Context, args ListPrometheusLabelNames
 var ListPrometheusLabelNames = mcpgrafana.MustTool(
 	"list_prometheus_label_names",
 	"List label names in a Prometheus datasource. Allows filtering by series selectors and time range.",
+	mcpgrafana.ToolModeRead,
 	listPrometheusLabelNames,
 	mcp.WithTitleAnnotation("List Prometheus label names"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -406,16 +410,17 @@ func listPrometheusLabelValues(ctx context.Context, args ListPrometheusLabelValu
 var ListPrometheusLabelValues = mcpgrafana.MustTool(
 	"list_prometheus_label_values",
 	"Get the values for a specific label name in Prometheus. Allows filtering by series selectors and time range.",
+	mcpgrafana.ToolModeRead,
 	listPrometheusLabelValues,
 	mcp.WithTitleAnnotation("List Prometheus label values"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddPrometheusTools(mcp *server.MCPServer) {
-	ListPrometheusMetricMetadata.Register(mcp)
-	QueryPrometheus.Register(mcp)
-	ListPrometheusMetricNames.Register(mcp)
-	ListPrometheusLabelNames.Register(mcp)
-	ListPrometheusLabelValues.Register(mcp)
+func AddPrometheusTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	ListPrometheusMetricMetadata.Register(mcp, toolMode)
+	QueryPrometheus.Register(mcp, toolMode)
+	ListPrometheusMetricNames.Register(mcp, toolMode)
+	ListPrometheusLabelNames.Register(mcp, toolMode)
+	ListPrometheusLabelValues.Register(mcp, toolMode)
 }

--- a/tools/search.go
+++ b/tools/search.go
@@ -35,12 +35,13 @@ func searchDashboards(ctx context.Context, args SearchDashboardsParams) (models.
 var SearchDashboards = mcpgrafana.MustTool(
 	"search_dashboards",
 	"Search for Grafana dashboards by a query string. Returns a list of matching dashboards with details like title, UID, folder, tags, and URL.",
+	mcpgrafana.ToolModeRead,
 	searchDashboards,
 	mcp.WithTitleAnnotation("Search dashboards"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddSearchTools(mcp *server.MCPServer) {
-	SearchDashboards.Register(mcp)
+func AddSearchTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	SearchDashboards.Register(mcp, toolMode)
 }

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -176,6 +176,7 @@ func getSiftInvestigation(ctx context.Context, args GetSiftInvestigationParams) 
 var GetSiftInvestigation = mcpgrafana.MustTool(
 	"get_sift_investigation",
 	"Retrieves an existing Sift investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').",
+	mcpgrafana.ToolModeRead,
 	getSiftInvestigation,
 	mcp.WithTitleAnnotation("Get Sift investigation"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -218,6 +219,7 @@ func getSiftAnalysis(ctx context.Context, args GetSiftAnalysisParams) (*analysis
 var GetSiftAnalysis = mcpgrafana.MustTool(
 	"get_sift_analysis",
 	"Retrieves a specific analysis from an investigation by its UUID. The investigation ID and analysis ID should be provided as strings in UUID format.",
+	mcpgrafana.ToolModeRead,
 	getSiftAnalysis,
 	mcp.WithTitleAnnotation("Get Sift analysis"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -253,6 +255,7 @@ func listSiftInvestigations(ctx context.Context, args ListSiftInvestigationsPara
 var ListSiftInvestigations = mcpgrafana.MustTool(
 	"list_sift_investigations",
 	"Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",
+	mcpgrafana.ToolModeRead,
 	listSiftInvestigations,
 	mcp.WithTitleAnnotation("List Sift investigations"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -340,6 +343,7 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 var FindErrorPatternLogs = mcpgrafana.MustTool(
 	"find_error_pattern_logs",
 	"Searches Loki logs for elevated error patterns compared to the last day's average, waits for the analysis to complete, and returns the results including any patterns found.",
+	mcpgrafana.ToolModeRead,
 	findErrorPatternLogs,
 	mcp.WithTitleAnnotation("Find error patterns in logs"),
 	mcp.WithReadOnlyHintAnnotation(true),
@@ -406,18 +410,19 @@ func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*analys
 var FindSlowRequests = mcpgrafana.MustTool(
 	"find_slow_requests",
 	"Searches relevant Tempo datasources for slow requests, waits for the analysis to complete, and returns the results.",
+	mcpgrafana.ToolModeRead,
 	findSlowRequests,
 	mcp.WithTitleAnnotation("Find slow requests"),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
 // AddSiftTools registers all Sift tools with the MCP server
-func AddSiftTools(mcp *server.MCPServer) {
-	GetSiftInvestigation.Register(mcp)
-	GetSiftAnalysis.Register(mcp)
-	ListSiftInvestigations.Register(mcp)
-	FindErrorPatternLogs.Register(mcp)
-	FindSlowRequests.Register(mcp)
+func AddSiftTools(mcp *server.MCPServer, toolMode mcpgrafana.ToolMode) {
+	GetSiftInvestigation.Register(mcp, toolMode)
+	GetSiftAnalysis.Register(mcp, toolMode)
+	ListSiftInvestigations.Register(mcp, toolMode)
+	FindErrorPatternLogs.Register(mcp, toolMode)
+	FindSlowRequests.Register(mcp, toolMode)
 }
 
 // makeRequest is a helper method to make HTTP requests and handle common response patterns


### PR DESCRIPTION
Currently there's no good way to avoid using tools that can persist changes.

Adding the notion of mode to separate the "read" tools from the "write" tools.

Notes for reviewers:
- Not sure if read or write is the best terms here, open to suggestions
- Sift tools are a bit tricky, since error pattern and slow request technically creates an investigation