### PR TITLE
added streamable-http support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ run: ## Run the MCP server in stdio mode.
 run-sse: ## Run the MCP server in SSE mode.
 	go run ./cmd/mcp-grafana --transport sse --log-level debug --debug
 
+PHONY: run-streamable-http
+run-streamable-http: ## Run the MCP server in StreamableHTTP mode.
+	go run ./cmd/mcp-grafana --transport streamable-http --log-level debug --debug
+
 .PHONY: run-test-services
 run-test-services: ## Run the docker-compose services required for the unit and integration tests.
 	docker-compose up -d --build

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ the OnCall tools, use `--disable-oncall`.
      docker pull mcp/grafana
      docker run --rm -p 8000:8000 -e GRAFANA_URL=http://localhost:3000 -e GRAFANA_API_KEY=<your service account token> mcp/grafana
      ```
+     
+     3. **Streamable HTTP Mode**: In this mode, the server operates as an independent process that can handle multiple client connections. You must expose port 8000 using the `-p` flag: For this mode you must explicitly override the default with `-t streamable-http`
+
+     ```bash
+     docker pull mcp/grafana
+     docker run --rm -p 8000:8000 -e GRAFANA_URL=http://localhost:3000 -e GRAFANA_API_KEY=<your service account token> mcp/grafana -t streamable-http
+     ```
 
    - **Download binary**: Download the latest release of `mcp-grafana` from the [releases page](https://github.com/grafana/mcp-grafana/releases) and place it in your `$PATH`.
 


### PR DESCRIPTION
## Add Streamable HTTP Mode Support for MCP Server

### Summary
Introduces streamable HTTP mode for the MCP server, enabling real-time streaming of responses over HTTP connections.

### Compatibility
Fully backward compatible - existing non-streaming clients continue to work unchanged.