### PR TITLE
feat: add TLS configuration support to consolidated GrafanaConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ the OnCall tools, use `--disable-oncall`.
      docker pull mcp/grafana
      docker run --rm -p 8000:8000 -e GRAFANA_URL=http://localhost:3000 -e GRAFANA_API_KEY=<your service account token> mcp/grafana
      ```
-     
+
      3. **Streamable HTTP Mode**: In this mode, the server operates as an independent process that can handle multiple client connections. You must expose port 8000 using the `-p` flag: For this mode you must explicitly override the default with `-t streamable-http`
 
      ```bash
@@ -254,6 +254,124 @@ To use debug mode with the Claude Desktop configuration, update your config as f
 ```
 
 > Note: As with the standard configuration, the `-t stdio` argument is required to override the default SSE mode in the Docker image.
+
+### TLS Configuration
+
+If your Grafana instance is behind mTLS or requires custom TLS certificates, you can configure the MCP server to use custom certificates. The server supports the following TLS configuration options:
+
+- `--tls-cert-file`: Path to TLS certificate file for client authentication
+- `--tls-key-file`: Path to TLS private key file for client authentication
+- `--tls-ca-file`: Path to TLS CA certificate file for server verification
+- `--tls-skip-verify`: Skip TLS certificate verification (insecure, use only for testing)
+
+**Example with client certificate authentication:**
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "mcp-grafana",
+      "args": [
+        "--tls-cert-file", "/path/to/client.crt",
+        "--tls-key-file", "/path/to/client.key",
+        "--tls-ca-file", "/path/to/ca.crt"
+      ],
+      "env": {
+        "GRAFANA_URL": "https://secure-grafana.example.com",
+        "GRAFANA_API_KEY": "<your service account token>"
+      }
+    }
+  }
+}
+```
+
+**Example with Docker:**
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-v", "/path/to/certs:/certs:ro",
+        "-e", "GRAFANA_URL",
+        "-e", "GRAFANA_API_KEY",
+        "mcp/grafana",
+        "-t", "stdio",
+        "--tls-cert-file", "/certs/client.crt",
+        "--tls-key-file", "/certs/client.key",
+        "--tls-ca-file", "/certs/ca.crt"
+      ],
+      "env": {
+        "GRAFANA_URL": "https://secure-grafana.example.com",
+        "GRAFANA_API_KEY": "<your service account token>"
+      }
+    }
+  }
+}
+```
+
+The TLS configuration is applied to all HTTP clients used by the MCP server, including:
+- The main Grafana OpenAPI client
+- Prometheus datasource clients
+- Loki datasource clients
+- Incident management clients
+- Sift investigation clients
+- Alerting clients
+- Asserts clients
+
+**Direct CLI Usage Examples:**
+
+For testing with self-signed certificates:
+```bash
+./mcp-grafana --tls-skip-verify -debug
+```
+
+With client certificate authentication:
+```bash
+./mcp-grafana \
+  --tls-cert-file /path/to/client.crt \
+  --tls-key-file /path/to/client.key \
+  --tls-ca-file /path/to/ca.crt \
+  -debug
+```
+
+With custom CA certificate only:
+```bash
+./mcp-grafana --tls-ca-file /path/to/ca.crt
+```
+
+**Programmatic Usage:**
+
+If you're using this library programmatically, you can also create TLS-enabled context functions:
+
+```go
+// Using struct literals
+tlsConfig := &mcpgrafana.TLSConfig{
+    CertFile: "/path/to/client.crt",
+    KeyFile:  "/path/to/client.key",
+    CAFile:   "/path/to/ca.crt",
+}
+grafanaConfig := mcpgrafana.GrafanaConfig{
+    Debug:     true,
+    TLSConfig: tlsConfig,
+}
+contextFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
+
+// Or inline
+grafanaConfig := mcpgrafana.GrafanaConfig{
+    Debug: true,
+    TLSConfig: &mcpgrafana.TLSConfig{
+        CertFile: "/path/to/client.crt",
+        KeyFile:  "/path/to/client.key",
+        CAFile:   "/path/to/ca.crt",
+    },
+}
+contextFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
+```
 
 ## Development
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -41,6 +41,12 @@ type disabledTools struct {
 type grafanaConfig struct {
 	// Whether to enable debug mode for the Grafana transport.
 	debug bool
+
+	// TLS configuration
+	tlsCertFile   string
+	tlsKeyFile    string
+	tlsCAFile     string
+	tlsSkipVerify bool
 }
 
 func (dt *disabledTools) addFlags() {
@@ -61,6 +67,12 @@ func (dt *disabledTools) addFlags() {
 
 func (gc *grafanaConfig) addFlags() {
 	flag.BoolVar(&gc.debug, "debug", false, "Enable debug mode for the Grafana transport")
+
+	// TLS configuration flags
+	flag.StringVar(&gc.tlsCertFile, "tls-cert-file", "", "Path to TLS certificate file for client authentication")
+	flag.StringVar(&gc.tlsKeyFile, "tls-key-file", "", "Path to TLS private key file for client authentication")
+	flag.StringVar(&gc.tlsCAFile, "tls-ca-file", "", "Path to TLS CA certificate file for server verification")
+	flag.BoolVar(&gc.tlsSkipVerify, "tls-skip-verify", false, "Skip TLS certificate verification (insecure)")
 }
 
 func (dt *disabledTools) addTools(s *server.MCPServer) {
@@ -143,7 +155,16 @@ func main() {
 	gc.addFlags()
 	flag.Parse()
 
+	// Convert local grafanaConfig to mcpgrafana.GrafanaConfig
 	grafanaConfig := mcpgrafana.GrafanaConfig{Debug: gc.debug}
+	if gc.tlsCertFile != "" || gc.tlsKeyFile != "" || gc.tlsCAFile != "" || gc.tlsSkipVerify {
+		grafanaConfig.TLSConfig = &mcpgrafana.TLSConfig{
+			CertFile:   gc.tlsCertFile,
+			KeyFile:    gc.tlsKeyFile,
+			CAFile:     gc.tlsCAFile,
+			SkipVerify: gc.tlsSkipVerify,
+		}
+	}
 
 	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig); err != nil {
 		panic(err)

--- a/examples/tls_example.go
+++ b/examples/tls_example.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/grafana/mcp-grafana/tools"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func main() {
+	// Example 1: Basic TLS configuration with skip verify (for testing)
+	fmt.Println("Example 1: Basic TLS configuration with skip verify")
+	basicTLSExample()
+
+	// Example 2: Full mTLS configuration with client certificates
+	fmt.Println("\nExample 2: Full mTLS configuration")
+	fullTLSExample()
+
+	// Example 3: Running an MCP server with TLS support
+	fmt.Println("\nExample 3: MCP server with TLS support")
+	if len(os.Args) > 1 && os.Args[1] == "run-server" {
+		runServerWithTLS()
+	} else {
+		fmt.Println("Use 'go run tls_example.go run-server' to actually start the server")
+		showServerExample()
+	}
+}
+
+func basicTLSExample() {
+	// Create a TLS config that skips certificate verification
+	// This is useful for testing against self-signed certificates
+	tlsConfig := &mcpgrafana.TLSConfig{SkipVerify: true}
+
+	// Create a Grafana config with TLS support
+	grafanaConfig := mcpgrafana.GrafanaConfig{
+		Debug:     true,
+		TLSConfig: tlsConfig,
+	}
+
+	// Create a context function that includes TLS configuration
+	contextFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
+
+	// Test the context function
+	ctx := contextFunc(context.Background())
+
+	// Verify the configuration is applied
+	retrievedConfig := mcpgrafana.GrafanaConfigFromContext(ctx)
+	if retrievedConfig.TLSConfig != nil {
+		fmt.Printf("✓ TLS configuration applied: SkipVerify=%v\n", retrievedConfig.TLSConfig.SkipVerify)
+	}
+
+	fmt.Printf("✓ Debug mode enabled: %v\n", retrievedConfig.Debug)
+}
+
+func fullTLSExample() {
+	// Example paths for certificate files
+	// In a real scenario, these would point to actual certificate files
+	certFile := "/path/to/client.crt"
+	keyFile := "/path/to/client.key"
+	caFile := "/path/to/ca.crt"
+
+	// Create TLS config with client certificates and CA verification
+	tlsConfig := &mcpgrafana.TLSConfig{
+		CertFile: certFile,
+		KeyFile:  keyFile,
+		CAFile:   caFile,
+	}
+
+	// Create Grafana config with TLS support
+	grafanaConfig := mcpgrafana.GrafanaConfig{
+		Debug:     false,
+		TLSConfig: tlsConfig,
+	}
+
+	fmt.Printf("✓ TLS configuration created:\n")
+	fmt.Printf("  - Client cert: %s\n", tlsConfig.CertFile)
+	fmt.Printf("  - Client key: %s\n", tlsConfig.KeyFile)
+	fmt.Printf("  - CA file: %s\n", tlsConfig.CAFile)
+	fmt.Printf("  - Skip verify: %v\n", tlsConfig.SkipVerify)
+	fmt.Printf("  - Debug mode: %v\n", grafanaConfig.Debug)
+
+	// Create context functions for different transport types
+	stdioFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
+	sseFunc := mcpgrafana.ComposedSSEContextFunc(grafanaConfig)
+	httpFunc := mcpgrafana.ComposedHTTPContextFunc(grafanaConfig)
+
+	fmt.Printf("✓ Context functions created for all transport types\n")
+
+	_ = stdioFunc
+	_ = sseFunc
+	_ = httpFunc
+}
+
+func showServerExample() {
+	fmt.Println("Example MCP server configuration with TLS:")
+	fmt.Println(`// Create TLS configuration
+tlsConfig := &mcpgrafana.TLSConfig{
+    CertFile: "/path/to/client.crt",
+    KeyFile:  "/path/to/client.key",
+    CAFile:   "/path/to/ca.crt",
+}
+
+// Create Grafana configuration
+grafanaConfig := mcpgrafana.GrafanaConfig{
+    Debug: true,
+    TLSConfig: tlsConfig,
+}
+
+// Create MCP server
+s := server.NewMCPServer("mcp-grafana", "1.0.0")
+
+// Add tools
+tools.AddSearchTools(s)
+tools.AddDatasourceTools(s)
+// ... add other tools as needed
+
+// Create stdio server with TLS support
+srv := server.NewStdioServer(s)
+srv.SetContextFunc(mcpgrafana.ComposedStdioContextFunc(grafanaConfig))
+
+// Start server
+srv.Listen(ctx, os.Stdin, os.Stdout)`)
+}
+
+func runServerWithTLS() {
+	// Set up environment variables (in practice, these would be set externally)
+	if os.Getenv("GRAFANA_URL") == "" {
+		os.Setenv("GRAFANA_URL", "https://localhost:3000")
+	}
+	if os.Getenv("GRAFANA_API_KEY") == "" {
+		fmt.Println("Warning: GRAFANA_API_KEY not set")
+	}
+
+	// Create TLS configuration that skips verification for demo purposes
+	// In production, you would use real certificates
+	tlsConfig := &mcpgrafana.TLSConfig{SkipVerify: true}
+	grafanaConfig := mcpgrafana.GrafanaConfig{
+		Debug:     true,
+		TLSConfig: tlsConfig,
+	}
+
+	// Create MCP server
+	s := server.NewMCPServer("mcp-grafana-tls-example", "1.0.0")
+
+	// Add some basic tools
+	tools.AddSearchTools(s)
+	tools.AddDatasourceTools(s)
+	tools.AddDashboardTools(s)
+
+	// Create stdio server with TLS-enabled context function
+	srv := server.NewStdioServer(s)
+	srv.SetContextFunc(mcpgrafana.ComposedStdioContextFunc(grafanaConfig))
+
+	fmt.Printf("Starting MCP Grafana server with TLS support...\n")
+	fmt.Printf("Grafana URL: %s\n", os.Getenv("GRAFANA_URL"))
+	fmt.Printf("TLS Skip Verify: %v\n", tlsConfig.SkipVerify)
+
+	// Start the server
+	ctx := context.Background()
+	if err := srv.Listen(ctx, os.Stdin, os.Stdout); err != nil {
+		log.Fatalf("Server error: %v", err)
+	}
+}
+
+// Example of creating custom HTTP clients with TLS configuration
+func customClientExample() {
+	ctx := context.Background()
+
+	// Add Grafana configuration to context
+	tlsConfig := &mcpgrafana.TLSConfig{
+		CertFile: "/path/to/cert.pem",
+		KeyFile:  "/path/to/key.pem",
+		CAFile:   "/path/to/ca.pem",
+	}
+	config := mcpgrafana.GrafanaConfig{
+		TLSConfig: tlsConfig,
+	}
+	ctx = mcpgrafana.WithGrafanaConfig(ctx, config)
+
+	// Create custom HTTP transport with TLS
+	transport, err := tlsConfig.HTTPTransport(http.DefaultTransport.(*http.Transport))
+	if err != nil {
+		log.Fatalf("Failed to create transport: %v", err)
+	}
+
+	// Use the transport in your HTTP client
+	_ = transport
+	fmt.Println("✓ Custom HTTP transport created with TLS configuration")
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,82 @@
+package mcpgrafana
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTLSConfig_CreateTLSConfig(t *testing.T) {
+	t.Run("nil config returns nil", func(t *testing.T) {
+		var config *TLSConfig
+		tlsCfg, err := config.CreateTLSConfig()
+		assert.NoError(t, err)
+		assert.Nil(t, tlsCfg)
+	})
+
+	t.Run("skip verify only", func(t *testing.T) {
+		config := &TLSConfig{SkipVerify: true}
+		tlsCfg, err := config.CreateTLSConfig()
+		assert.NoError(t, err)
+		require.NotNil(t, tlsCfg)
+		assert.True(t, tlsCfg.InsecureSkipVerify)
+		assert.Empty(t, tlsCfg.Certificates)
+		assert.Nil(t, tlsCfg.RootCAs)
+	})
+
+	t.Run("invalid cert file", func(t *testing.T) {
+		config := &TLSConfig{
+			CertFile: "nonexistent.pem",
+			KeyFile:  "nonexistent.key",
+		}
+		_, err := config.CreateTLSConfig()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client certificate")
+	})
+
+	t.Run("invalid CA file", func(t *testing.T) {
+		config := &TLSConfig{
+			CAFile: "nonexistent-ca.pem",
+		}
+		_, err := config.CreateTLSConfig()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read CA certificate")
+	})
+}
+
+func TestHTTPTransport(t *testing.T) {
+	t.Run("nil TLS config", func(t *testing.T) {
+		var tlsConfig *TLSConfig
+		transport, err := tlsConfig.HTTPTransport(http.DefaultTransport.(*http.Transport))
+		assert.NoError(t, err)
+		assert.NotNil(t, transport)
+
+		// Should be default transport clone
+		httpTransport, ok := transport.(*http.Transport)
+		require.True(t, ok)
+		assert.NotNil(t, httpTransport)
+	})
+
+	t.Run("skip verify config", func(t *testing.T) {
+		tlsConfig := &TLSConfig{SkipVerify: true}
+		transport, err := tlsConfig.HTTPTransport(http.DefaultTransport.(*http.Transport))
+		assert.NoError(t, err)
+		require.NotNil(t, transport)
+
+		httpTransport, ok := transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, httpTransport.TLSClientConfig)
+		assert.True(t, httpTransport.TLSClientConfig.InsecureSkipVerify)
+	})
+
+	t.Run("invalid TLS config", func(t *testing.T) {
+		tlsConfig := &TLSConfig{
+			CertFile: "nonexistent.pem",
+			KeyFile:  "nonexistent.key",
+		}
+		_, err := tlsConfig.HTTPTransport(http.DefaultTransport.(*http.Transport))
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
This commit adds TLS configuration capabilities to the consolidated GrafanaConfig struct, allowing custom certificates for all HTTP clients used by the MCP server.

Changes:
- Add TLSConfig struct with CertFile, KeyFile, CAFile, and SkipVerify fields
- Integrate TLSConfig into GrafanaConfig struct
- Add TLS CLI flags to cmd/mcp-grafana/main.go
- Update all HTTP clients (Grafana, Incident, Loki, Prometheus, Sift, Asserts) to use custom TLS configuration when available
- Add TLS helper methods: CreateTLSConfig() and HTTPTransport()
- Include TLS example and test files
- Update README with comprehensive TLS configuration documentation

The TLS configuration is applied consistently across all clients, providing a unified approach to certificate management for secure Grafana environments.

Fixes #164.
Fixes #72.