### PR TITLE
refactor: include 'streamable-http' in transport-related messages

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -119,23 +119,23 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			return fmt.Errorf("Server error: %v", err)
 		}
 	default:
-			   return fmt.Errorf(
-					   "Invalid transport type: %s. Must be 'stdio', 'sse' or 'streamable-http'",
-					   transport,
-			   )
+		return fmt.Errorf(
+			"Invalid transport type: %s. Must be 'stdio', 'sse' or 'streamable-http'",
+			transport,
+		)
 	}
 	return nil
 }
 
 func main() {
 	var transport string
-	   flag.StringVar(&transport, "t", "stdio", "Transport type (stdio, sse or streamable-http)")
-	   flag.StringVar(
-			   &transport,
-			   "transport",
-			   "stdio",
-			   "Transport type (stdio, sse or streamable-http)",
-	   )
+	flag.StringVar(&transport, "t", "stdio", "Transport type (stdio, sse or streamable-http)")
+	flag.StringVar(
+		&transport,
+		"transport",
+		"stdio",
+		"Transport type (stdio, sse or streamable-http)",
+	)
 	addr := flag.String("address", "localhost:8000", "The host and port to start the sse server on")
 	basePath := flag.String("base-path", "", "Base path for the sse server")
 	endpointPath := flag.String("endpoint-path", "/mcp", "Endpoint path for the streamable-http server")

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -119,23 +119,23 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			return fmt.Errorf("Server error: %v", err)
 		}
 	default:
-		return fmt.Errorf(
-			"Invalid transport type: %s. Must be 'stdio' or 'sse'",
-			transport,
-		)
+			   return fmt.Errorf(
+					   "Invalid transport type: %s. Must be 'stdio', 'sse' or 'streamable-http'",
+					   transport,
+			   )
 	}
 	return nil
 }
 
 func main() {
 	var transport string
-	flag.StringVar(&transport, "t", "stdio", "Transport type (stdio or sse)")
-	flag.StringVar(
-		&transport,
-		"transport",
-		"stdio",
-		"Transport type (stdio or sse)",
-	)
+	   flag.StringVar(&transport, "t", "stdio", "Transport type (stdio, sse or streamable-http)")
+	   flag.StringVar(
+			   &transport,
+			   "transport",
+			   "stdio",
+			   "Transport type (stdio, sse or streamable-http)",
+	   )
 	addr := flag.String("address", "localhost:8000", "The host and port to start the sse server on")
 	basePath := flag.String("base-path", "", "Base path for the sse server")
 	endpointPath := flag.String("endpoint-path", "/mcp", "Endpoint path for the streamable-http server")


### PR DESCRIPTION
### Adds 'streamable-http' to CLI transport flag help text and error messages.

Relates to #177 

Previously, the panic message excluded 'streamable-http', causing confusion. This PR adds it to the transport flag help text and error message to reflect support.

![Screenshot 2025-06-15 at 2 56 50 PM](https://github.com/user-attachments/assets/d4e88655-1def-4dbe-9697-084828b14dac)
