### PR TITLE
fix: use new 'address' argument in Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ USER mcp-grafana
 EXPOSE 8000
 
 # Run the application
-ENTRYPOINT ["/app/mcp-grafana", "--transport", "sse", "--sse-address", "0.0.0.0:8000"]
+ENTRYPOINT ["/app/mcp-grafana", "--transport", "sse", "--address", "0.0.0.0:8000"]


### PR DESCRIPTION
The flag was changed from '--sse-address' to '--address' when
support for streamable HTTP was added.
