### PR TITLE
fix: remove main.version from goreleaser ldflags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,7 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags: "-s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"
 
 archives:
   - formats: tar.gz


### PR DESCRIPTION
Our `main.version` variable is no longer just a string, it's a
`sync.Once`, which means that it cannot be overridden by an
ldflags value. This commit updates the goreleaser config to
specify a custom value for 'ldflags', which removes the
`main.version` variable from the defaults.
