### PR TITLE
chore: include custom cache-dependency-path in lint workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           go-version: "1.24"
           cache: true
+          cache-dependency-path: |
+            go.sum
+            go.tools.sum
 
       - name: Run linters
         run: make lint


### PR DESCRIPTION
See https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
for an example.
