### PR TITLE
Add user agent tracking for minimal usage tracking

### DIFF
--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -80,7 +80,7 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 		// Explicitly clear environment variables to ensure test isolation
 		t.Setenv("GRAFANA_URL", "")
 		t.Setenv("GRAFANA_API_KEY", "")
-		
+
 		req, err := http.NewRequest("GET", "http://example.com", nil)
 		require.NoError(t, err)
 		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
@@ -239,7 +239,7 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		type TestParams struct {
 			Message string `json:"message" jsonschema:"description=Test message"`
 		}
-		
+
 		testHandler := func(ctx context.Context, args TestParams) (string, error) {
 			return "Hello " + args.Message, nil
 		}
@@ -295,7 +295,7 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		type TestParams struct {
 			ShouldFail bool `json:"shouldFail" jsonschema:"description=Whether to fail"`
 		}
-		
+
 		testHandler := func(ctx context.Context, args TestParams) (string, error) {
 			if args.ShouldFail {
 				return "", assert.AnError
@@ -358,7 +358,7 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		type TestParams struct {
 			Message string `json:"message" jsonschema:"description=Test message"`
 		}
-		
+
 		testHandler := func(ctx context.Context, args TestParams) (string, error) {
 			return "processed", nil
 		}
@@ -406,7 +406,7 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		type TestParams struct {
 			SensitiveData string `json:"sensitiveData" jsonschema:"description=Potentially sensitive data"`
 		}
-		
+
 		testHandler := func(ctx context.Context, args TestParams) (string, error) {
 			return "processed", nil
 		}
@@ -451,7 +451,7 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		attributes := span.Attributes()
 		assertHasAttribute(t, attributes, "mcp.tool.name", "sensitive_tool")
 		assertHasAttribute(t, attributes, "mcp.tool.description", "A tool with sensitive data")
-		
+
 		// Verify arguments are NOT present
 		for _, attr := range attributes {
 			assert.NotEqual(t, "mcp.tool.arguments", string(attr.Key), "Arguments should not be logged by default for PII safety")
@@ -466,7 +466,7 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		type TestParams struct {
 			SafeData string `json:"safeData" jsonschema:"description=Non-sensitive data"`
 		}
-		
+
 		testHandler := func(ctx context.Context, args TestParams) (string, error) {
 			return "processed", nil
 		}
@@ -531,7 +531,7 @@ func TestHTTPTracingConfiguration(t *testing.T) {
 
 	t.Run("tracing works gracefully without OpenTelemetry configured", func(t *testing.T) {
 		// No OpenTelemetry tracer provider configured
-		
+
 		// Create context (tracing always enabled for context propagation)
 		config := GrafanaConfig{}
 		ctx := WithGrafanaConfig(context.Background(), config)

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,6 +1,7 @@
 package mcpgrafana
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -78,5 +79,135 @@ func TestHTTPTransport(t *testing.T) {
 		}
 		_, err := tlsConfig.HTTPTransport(http.DefaultTransport.(*http.Transport))
 		assert.Error(t, err)
+	})
+}
+
+// mockRoundTripper is a mock implementation of http.RoundTripper for testing
+type mockRoundTripper struct {
+	capturedRequest *http.Request
+	response        *http.Response
+	err             error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.capturedRequest = req
+	if m.response != nil {
+		return m.response, m.err
+	}
+	// Return a default successful response
+	return &http.Response{
+		StatusCode: 200,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+	}, m.err
+}
+
+func TestUserAgentTransport(t *testing.T) {
+	tests := []struct {
+		name              string
+		userAgent         string
+		existingUserAgent string
+		expectedUserAgent string
+	}{
+		{
+			name:              "sets user agent when not present",
+			userAgent:         "mcp-grafana/1.0.0",
+			existingUserAgent: "",
+			expectedUserAgent: "mcp-grafana/1.0.0",
+		},
+		{
+			name:              "does not override existing user agent",
+			userAgent:         "mcp-grafana/1.0.0",
+			existingUserAgent: "existing-client/2.0.0",
+			expectedUserAgent: "existing-client/2.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock round tripper
+			mockRT := &mockRoundTripper{}
+
+			// Create user agent transport
+			transport := &UserAgentTransport{
+				rt:        mockRT,
+				UserAgent: tt.userAgent,
+			}
+
+			// Create request
+			req, err := http.NewRequest("GET", "http://example.com", nil)
+			require.NoError(t, err)
+
+			// Set existing user agent if specified
+			if tt.existingUserAgent != "" {
+				req.Header.Set("User-Agent", tt.existingUserAgent)
+			}
+
+			// Make request through transport
+			_, err = transport.RoundTrip(req)
+			require.NoError(t, err)
+
+			// Verify user agent header
+			assert.Equal(t, tt.expectedUserAgent, mockRT.capturedRequest.Header.Get("User-Agent"))
+		})
+	}
+}
+
+func TestVersion(t *testing.T) {
+	version := Version()
+	assert.NotEmpty(t, version)
+	// Version should be either "(devel)" for development builds or a proper version
+	assert.True(t, version == "(devel)" || len(version) > 0)
+}
+
+func TestUserAgent(t *testing.T) {
+	userAgent := UserAgent()
+	assert.Contains(t, userAgent, "mcp-grafana/")
+	assert.NotEqual(t, "mcp-grafana/", userAgent) // Should have version appended
+
+	// Should match the pattern mcp-grafana/{version}
+	version := Version()
+	expected := fmt.Sprintf("mcp-grafana/%s", version)
+	assert.Equal(t, expected, userAgent)
+}
+
+func TestNewUserAgentTransport(t *testing.T) {
+	t.Run("with explicit user agent", func(t *testing.T) {
+		mockRT := &mockRoundTripper{}
+		userAgent := "test-agent/1.0.0"
+
+		transport := NewUserAgentTransport(mockRT, userAgent)
+
+		assert.Equal(t, mockRT, transport.rt)
+		assert.Equal(t, userAgent, transport.UserAgent)
+	})
+
+	t.Run("with default user agent", func(t *testing.T) {
+		mockRT := &mockRoundTripper{}
+
+		transport := NewUserAgentTransport(mockRT)
+
+		assert.Equal(t, mockRT, transport.rt)
+		assert.Equal(t, UserAgent(), transport.UserAgent)
+		assert.Contains(t, transport.UserAgent, "mcp-grafana/")
+	})
+}
+
+func TestNewUserAgentTransportWithNilRoundTripper(t *testing.T) {
+	t.Run("with explicit user agent", func(t *testing.T) {
+		userAgent := "test-agent/1.0.0"
+
+		transport := NewUserAgentTransport(nil, userAgent)
+
+		assert.Equal(t, http.DefaultTransport, transport.rt)
+		assert.Equal(t, userAgent, transport.UserAgent)
+	})
+
+	t.Run("with default user agent", func(t *testing.T) {
+		transport := NewUserAgentTransport(nil)
+
+		assert.Equal(t, http.DefaultTransport, transport.rt)
+		assert.Equal(t, UserAgent(), transport.UserAgent)
+		assert.Contains(t, transport.UserAgent, "mcp-grafana/")
 	})
 }

--- a/tools.go
+++ b/tools.go
@@ -91,7 +91,7 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 		config := GrafanaConfigFromContext(ctx)
 		ctx, span := otel.Tracer("mcp-grafana").Start(ctx, fmt.Sprintf("mcp.tool.%s", name))
 		defer span.End()
-		
+
 		// Add tool metadata as span attributes
 		span.SetAttributes(
 			attribute.String("mcp.tool.name", name),
@@ -104,8 +104,8 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 			span.SetStatus(codes.Error, "failed to marshal arguments")
 			return nil, fmt.Errorf("marshal args: %w", err)
 		}
-		
-		   // Add arguments as span attribute only if adding args to trace attributes is enabled
+
+		// Add arguments as span attribute only if adding args to trace attributes is enabled
 		if config.IncludeArgumentsInSpans {
 			span.SetAttributes(attribute.String("mcp.tool.arguments", string(argBytes)))
 		}

--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -52,6 +52,15 @@ func newAlertingClientFromContext(ctx context.Context) (*alertingClient, error) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create custom transport: %w", err)
 		}
+		// Wrap with user agent
+		client.httpClient.Transport = mcpgrafana.NewUserAgentTransport(
+			client.httpClient.Transport,
+		)
+	} else {
+		// No custom TLS, but still add user agent
+		client.httpClient.Transport = mcpgrafana.NewUserAgentTransport(
+			http.DefaultTransport,
+		)
 	}
 
 	return client, nil

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -29,13 +29,17 @@ func newAssertsClient(ctx context.Context) (*Client, error) {
 		}
 	}
 
+	authTransport := &authRoundTripper{
+		apiKey:      cfg.APIKey,
+		accessToken: cfg.AccessToken,
+		idToken:     cfg.IDToken,
+		underlying:  transport,
+	}
+
 	client := &http.Client{
-		Transport: &authRoundTripper{
-			apiKey:      cfg.APIKey,
-			accessToken: cfg.AccessToken,
-			idToken:     cfg.IDToken,
-			underlying:  transport,
-		},
+		Transport: mcpgrafana.NewUserAgentTransport(
+			authTransport,
+		),
 	}
 
 	return &Client{

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -64,13 +64,17 @@ func newLokiClient(ctx context.Context, uid string) (*Client, error) {
 		}
 	}
 
+	authTransport := &authRoundTripper{
+		accessToken: cfg.AccessToken,
+		idToken:     cfg.IDToken,
+		apiKey:      cfg.APIKey,
+		underlying:  transport,
+	}
+
 	client := &http.Client{
-		Transport: &authRoundTripper{
-			accessToken: cfg.AccessToken,
-			idToken:     cfg.IDToken,
-			apiKey:      cfg.APIKey,
-			underlying:  transport,
-		},
+		Transport: mcpgrafana.NewUserAgentTransport(
+			authTransport,
+		),
 	}
 
 	return &Client{

--- a/tools/pyroscope.go
+++ b/tools/pyroscope.go
@@ -286,13 +286,17 @@ func fetchPyroscopeProfile(ctx context.Context, args FetchPyroscopeProfileParams
 
 func newPyroscopeClient(ctx context.Context, uid string) (*pyroscopeClient, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	authTransport := &authRoundTripper{
+		accessToken: cfg.AccessToken,
+		idToken:     cfg.IDToken,
+		apiKey:      cfg.APIKey,
+		underlying:  http.DefaultTransport,
+	}
+
 	httpClient := &http.Client{
-		Transport: &authRoundTripper{
-			accessToken: cfg.AccessToken,
-			idToken:     cfg.IDToken,
-			apiKey:      cfg.APIKey,
-			underlying:  http.DefaultTransport,
-		},
+		Transport: mcpgrafana.NewUserAgentTransport(
+			authTransport,
+		),
 		Timeout: 10 * time.Second,
 	}
 


### PR DESCRIPTION
- Custom User-Agent headers on all HTTP clients (Grafana, Incident, OnCall, Alerting, Loki, Pyroscope, Asserts)
- UserAgent() helper and variadic NewUserAgentTransport() for clean API
- Format: mcp-grafana/{version} with automatic version detection

Fixes #228
