### PR TITLE
Support username/password authentication

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      # Set auth here so stdio transport and background process pick them up
+      GRAFANA_USERNAME: admin
+      GRAFANA_PASSWORD: admin
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 .PHONY: test-python-e2e
 test-python-e2e: ## Run Python E2E tests (requires docker-compose services and SSE server to be running, use `make run-test-services` and `make run-sse` to start them).
 	cd tests && uv sync --all-groups
-	cd tests && uv run pytest
+	cd tests && GRAFANA_USERNAME=admin GRAFANA_PASSWORD=admin uv run pytest
 
 .PHONY: run
 run: ## Run the MCP server in stdio mode.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Scopes define the specific resources that permissions apply to. Each action requ
 
 This MCP server works with both local Grafana instances and Grafana Cloud. For Grafana Cloud, use your instance URL (e.g., `https://myinstance.grafana.net`) instead of `http://localhost:3000` in the configuration examples below.
 
-1. Create a service account in Grafana with enough permissions to use the tools you want to use,
+1. If using API key authentication, create a service account in Grafana with enough permissions to use the tools you want to use,
    generate a service account token, and copy it to the clipboard for use in the configuration file.
    Follow the [Grafana documentation][service-account] for details.
 
@@ -264,7 +264,10 @@ This MCP server works with both local Grafana instances and Grafana Cloud. For G
          "args": [],
          "env": {
            "GRAFANA_URL": "http://localhost:3000",  // Or "https://myinstance.grafana.net" for Grafana Cloud
-           "GRAFANA_API_KEY": "<your service account token>"
+           "GRAFANA_API_KEY": "<your service account token>",
+           // If using username/password authentication
+           "GRAFANA_USERNAME": "<your username>",
+           "GRAFANA_PASSWORD": "<your password>"
          }
        }
      }
@@ -294,7 +297,10 @@ This MCP server works with both local Grafana instances and Grafana Cloud. For G
       ],
       "env": {
         "GRAFANA_URL": "http://localhost:3000",  // Or "https://myinstance.grafana.net" for Grafana Cloud
-        "GRAFANA_API_KEY": "<your service account token>"
+        "GRAFANA_API_KEY": "<your service account token>",
+        // If using username/password authentication
+        "GRAFANA_USERNAME": "<your username>",
+        "GRAFANA_PASSWORD": "<your password>"
       }
     }
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,9 @@ services:
   grafana:
     image: grafana/grafana
     environment:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_BASIC_ENABLED: "true"
+      GF_AUTH_ADMIN_USER: admin
+      GF_AUTH_ADMIN_PASSWORD: admin
       GF_LOG_LEVEL: debug
       GF_SERVER_ROUTER_LOGGING: "true"
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,7 @@ services:
   grafana:
     image: grafana/grafana
     environment:
-      GF_AUTH_BASIC_ENABLED: "true"
-      GF_AUTH_ADMIN_USER: admin
-      GF_AUTH_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
       GF_LOG_LEVEL: debug
       GF_SERVER_ROUTER_LOGGING: "true"
     ports:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def grafana_headers():
     }
     if key := os.environ.get("GRAFANA_API_KEY"):
         headers["X-Grafana-API-Key"] = key
-    elif (username := os.environ.get("USERNAME")) and (password := os.environ.get("PASSWORD")):
+    elif (username := os.environ.get("GRAFANA_USERNAME")) and (password := os.environ.get("GRAFANA_PASSWORD")):
         credentials = f"{username}:{password}"
         headers["Authorization"] = "Basic " + base64.b64encode(credentials.encode("utf-8")).decode()
     return headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import asyncio
 import gc
+import base64
 from dotenv import load_dotenv
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
@@ -47,6 +48,9 @@ def grafana_env():
     env = {"GRAFANA_URL": os.environ.get("GRAFANA_URL", DEFAULT_GRAFANA_URL)}
     if key := os.environ.get("GRAFANA_API_KEY"):
         env["GRAFANA_API_KEY"] = key
+    elif (username := os.environ.get("GRAFANA_USERNAME")) and (password := os.environ.get("GRAFANA_USERNAME")):
+        env["GRAFANA_USERNAME"] = username
+        env["GRAFANA_PASSWORD"] = password
     return env
 
 
@@ -57,6 +61,9 @@ def grafana_headers():
     }
     if key := os.environ.get("GRAFANA_API_KEY"):
         headers["X-Grafana-API-Key"] = key
+    elif (username := os.environ.get("USERNAME")) and (password := os.environ.get("PASSWORD")):
+        credentials = f"{username}:{password}"
+        headers["Authorization"] = "Basic " + base64.b64encode(credentials.encode("utf-8")).decode()
     return headers
 
 

--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -25,6 +25,7 @@ type alertingClient struct {
 	accessToken string
 	idToken     string
 	apiKey      string
+	basicAuth   *url.Userinfo
 	httpClient  *http.Client
 }
 
@@ -41,6 +42,7 @@ func newAlertingClientFromContext(ctx context.Context) (*alertingClient, error) 
 		accessToken: cfg.AccessToken,
 		idToken:     cfg.IDToken,
 		apiKey:      cfg.APIKey,
+		basicAuth:   cfg.BasicAuth,
 		httpClient: &http.Client{
 			Timeout: defaultTimeout,
 		},
@@ -83,6 +85,9 @@ func (c *alertingClient) makeRequest(ctx context.Context, path string) (*http.Re
 		req.Header.Set("X-Grafana-Id", c.idToken)
 	} else if c.apiKey != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
+	} else if c.basicAuth != nil {
+		password, _ := c.basicAuth.Password()
+		req.SetBasicAuth(c.basicAuth.Username(), password)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -33,6 +33,7 @@ func newAssertsClient(ctx context.Context) (*Client, error) {
 		apiKey:      cfg.APIKey,
 		accessToken: cfg.AccessToken,
 		idToken:     cfg.IDToken,
+		basicAuth:   cfg.BasicAuth,
 		underlying:  transport,
 	}
 

--- a/tools/cloud_testing_utils.go
+++ b/tools/cloud_testing_utils.go
@@ -29,7 +29,7 @@ func createCloudTestContext(t *testing.T, testName, urlEnv, apiKeyEnv string) co
 		t.Skipf("%s environment variable not set, skipping cloud %s integration tests", apiKeyEnv, testName)
 	}
 
-	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey)
+	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey, nil)
 
 	config := mcpgrafana.GrafanaConfig{
 		URL:    grafanaURL,

--- a/tools/datasources_test.go
+++ b/tools/datasources_test.go
@@ -42,14 +42,17 @@ func newTestContext() context.Context {
 
 	if apiKey := os.Getenv("GRAFANA_API_KEY"); apiKey != "" {
 		cfg.APIKey = apiKey
+	} else {
+		cfg.BasicAuth = url.UserPassword("admin", "admin")
 	}
 
 	client := client.NewHTTPClientWithConfig(strfmt.Default, cfg)
 
 	grafanaCfg := mcpgrafana.GrafanaConfig{
-		Debug:  true,
-		URL:    "http://localhost:3000",
-		APIKey: cfg.APIKey,
+		Debug:     true,
+		URL:       "http://localhost:3000",
+		APIKey:    cfg.APIKey,
+		BasicAuth: cfg.BasicAuth,
 	}
 
 	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -68,6 +68,7 @@ func newLokiClient(ctx context.Context, uid string) (*Client, error) {
 		accessToken: cfg.AccessToken,
 		idToken:     cfg.IDToken,
 		apiKey:      cfg.APIKey,
+		basicAuth:   cfg.BasicAuth,
 		underlying:  transport,
 	}
 

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -185,6 +185,7 @@ type authRoundTripper struct {
 	accessToken string
 	idToken     string
 	apiKey      string
+	basicAuth   *url.Userinfo
 	underlying  http.RoundTripper
 }
 
@@ -194,6 +195,9 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		req.Header.Set("X-Grafana-Id", rt.idToken)
 	} else if rt.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+rt.apiKey)
+	} else if rt.basicAuth != nil {
+		password, _ := rt.basicAuth.Password()
+		req.SetBasicAuth(rt.basicAuth.Username(), password)
 	}
 
 	resp, err := rt.underlying.RoundTrip(req)

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -64,6 +64,9 @@ func promClientFromContext(ctx context.Context, uid string) (promv1.API, error) 
 		rt = config.NewAuthorizationCredentialsRoundTripper(
 			"Bearer", config.NewInlineSecret(cfg.APIKey), rt,
 		)
+	} else if cfg.BasicAuth != nil {
+		password, _ := cfg.BasicAuth.Password()
+		rt = config.NewBasicAuthRoundTripper(config.NewInlineSecret(cfg.BasicAuth.Username()), config.NewInlineSecret(password), rt)
 	}
 	c, err := api.NewClient(api.Config{
 		Address:      url,

--- a/tools/pyroscope.go
+++ b/tools/pyroscope.go
@@ -290,6 +290,7 @@ func newPyroscopeClient(ctx context.Context, uid string) (*pyroscopeClient, erro
 		accessToken: cfg.AccessToken,
 		idToken:     cfg.IDToken,
 		apiKey:      cfg.APIKey,
+		basicAuth:   cfg.BasicAuth,
 		underlying:  http.DefaultTransport,
 	}
 

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -126,6 +126,7 @@ func newSiftClient(cfg mcpgrafana.GrafanaConfig) (*siftClient, error) {
 			accessToken: cfg.AccessToken,
 			idToken:     cfg.IDToken,
 			apiKey:      cfg.APIKey,
+			basicAuth:   cfg.BasicAuth,
 			underlying:  transport,
 		},
 	}


### PR DESCRIPTION
Implements #256

Supports connecting via [basic auth](https://grafana.com/docs/grafana/latest/developers/http_api/authentication/#basic-auth) if the instance supports it. 
Configured via either
- Environment variables
  * `GRAFANA_USERNAME`
  * `GRAFANA_PASSWORD`
- HTTP Headers using standard HTTP basic auth

Works locally when connecting to grafana instance that has basic auth
<img width="1204" height="25" alt="image" src="https://github.com/user-attachments/assets/652030e9-53f4-4667-9d09-29c902951cdc" />
