### PR TITLE
feat: accept X-Grafana-Service-Account-Token in headers too

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -41,8 +41,9 @@ const (
 
 	grafanaExtraHeadersEnvVar = "GRAFANA_EXTRA_HEADERS"
 
-	grafanaURLHeader    = "X-Grafana-URL"
-	grafanaAPIKeyHeader = "X-Grafana-API-Key"
+	grafanaURLHeader                 = "X-Grafana-URL"
+	grafanaServiceAccountTokenHeader = "X-Grafana-Service-Account-Token"
+	grafanaAPIKeyHeader              = "X-Grafana-API-Key" // Deprecated: use X-Grafana-Service-Account-Token instead
 )
 
 func urlAndAPIKeyFromEnv() (string, string) {
@@ -116,7 +117,15 @@ func orgIdFromHeaders(req *http.Request) int64 {
 
 func urlAndAPIKeyFromHeaders(req *http.Request) (string, string) {
 	u := strings.TrimRight(req.Header.Get(grafanaURLHeader), "/")
-	apiKey := req.Header.Get(grafanaAPIKeyHeader)
+	
+	// Check for the new service account token header first
+	apiKey := req.Header.Get(grafanaServiceAccountTokenHeader)
+	if apiKey != "" {
+		return u, apiKey
+	}
+	
+	// Fall back to the deprecated API key header
+	apiKey = req.Header.Get(grafanaAPIKeyHeader)
 	return u, apiKey
 }
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -158,6 +158,37 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 		assert.Equal(t, "my-test-api-key", config.APIKey)
 	})
 
+	t.Run("with service account token header", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "")
+		t.Setenv("GRAFANA_API_KEY", "")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
+		req.Header.Set(grafanaServiceAccountTokenHeader, "my-service-account-token")
+		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
+		config := GrafanaConfigFromContext(ctx)
+		assert.Equal(t, "http://my-test-url.grafana.com", config.URL)
+		assert.Equal(t, "my-service-account-token", config.APIKey)
+	})
+
+	t.Run("service account token header takes precedence over api key header", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "")
+		t.Setenv("GRAFANA_API_KEY", "")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
+		req.Header.Set(grafanaServiceAccountTokenHeader, "my-service-account-token")
+		req.Header.Set(grafanaAPIKeyHeader, "my-deprecated-api-key")
+		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
+		config := GrafanaConfigFromContext(ctx)
+		assert.Equal(t, "http://my-test-url.grafana.com", config.URL)
+		assert.Equal(t, "my-service-account-token", config.APIKey)
+	})
+
 	t.Run("no headers, with env", func(t *testing.T) {
 		t.Setenv("GRAFANA_USERNAME", "foo")
 		t.Setenv("GRAFANA_PASSWORD", "bar")


### PR DESCRIPTION
Similar to how we now accept a service-account-named env var.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to header parsing for Grafana credentials and adds tests; behavior is backwards compatible except when both headers are set, where the new token now intentionally wins.
> 
> **Overview**
> Adds support for authenticating via the `X-Grafana-Service-Account-Token` request header, mirroring the existing `GRAFANA_SERVICE_ACCOUNT_TOKEN` env var.
> 
> Header extraction now prefers the service account token header and falls back to the deprecated `X-Grafana-API-Key`, with unit tests covering the new header and precedence behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737cfb7271d065243b164849ae68e303dfe42fd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->