### PR TITLE
chore: add Gemini extension config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,8 @@ before:
     - go mod tidy
 
 builds:
-  - env:
+  - id: default
+    env:
       - CGO_ENABLED=0
     main: ./cmd/mcp-grafana
     goos:
@@ -15,9 +16,24 @@ builds:
       - windows
       - darwin
     ldflags: "-s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"
+  - id: gemini-cli-extension
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/mcp-grafana
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags: "-s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"
 
 archives:
-  - formats: tar.gz
+  - id: default
+    ids:
+      - default
+    formats: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -27,6 +43,43 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: zip
+
+  # The Gemini CLI Extension format.
+  # See https://github.com/google-gemini/gemini-cli/blob/main/docs/extension-releasing.md#platform-specific-archives.
+  # We'll use platform and architecture specific archive names, which must look like:
+  #
+  # {platform}.{arch}.{name}.{extension}
+  #
+  # Where the fields are:
+  #
+  # - {name}: The name of your extension.
+  # - {platform}: The operating system. Supported values are:
+  # -     darwin (macOS)
+  # -     linux
+  # -     win32 (Windows)
+  # - {arch}: The architecture. Supported values are:
+  # -     x64
+  # -     arm64
+  # - {extension}: The file extension of the archive (e.g., .tar.gz or .zip).
+  #
+  # Examples:
+  # - darwin.arm64.{project}.tar.gz (specific to Apple Silicon Macs)
+  # - linux.x64.{project}.tar.gz
+  # - win32.{project}.zip
+  - id: gemini-cli-extension
+    ids:
+      - gemini-cli-extension
+    formats: tar.gz
+    files:
+      - gemini-extension.json
+    name_template: >-
+      {{ if eq .Os "windows" }}win32
+      {{- else }}{{ .Os }}{{ end }}.
+      {{- if eq .Arch "amd64" }}x64
+      {{- else }}{{ .Arch }}{{ end }}.grafana
     format_overrides:
       - goos: windows
         formats: zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,9 @@
+{
+  "name": "grafana",
+  "version": "0.7.0",
+  "mcpServers": {
+    "grafana": {
+      "command": "${extensionPath}${/}mcp-grafana"
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a gemini-extension.json config file to the repo,
following the instructions in the [Gemini CLI docs][docs].

[docs]: https://github.com/google-gemini/gemini-cli/blob/main/docs/extension-releasing.md
