### PR TITLE
feet(tools+context): Dynamic tool reg

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mark3labs/mcp-go/server"
+		"github.com/mark3labs/mcp-go/server"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/grafana/mcp-grafana/tools"
@@ -108,90 +108,50 @@ func (dt *disabledTools) addTools(s *server.MCPServer) {
 func (dt *disabledTools) addToolsDynamically(s *server.MCPServer) *mcpgrafana.DynamicToolManager {
 	dtm := mcpgrafana.NewDynamicToolManager(s)
 
-	// Register all available toolsets
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "search",
-		Description: "Tools for searching dashboards, folders, and other Grafana resources",
-		AddFunc:     tools.AddSearchTools,
-	})
+	// Parse enabled tools list
+	enabledTools := strings.Split(dt.enabledTools, ",")
 
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "datasource",
-		Description: "Tools for listing and fetching datasource details",
-		AddFunc:     tools.AddDatasourceTools,
-	})
+	// Helper function to check if a tool is enabled
+	isEnabled := func(toolName string) bool {
+		// If enabledTools is empty string, no tools should be available
+		if dt.enabledTools == "" {
+			return false
+		}
+		return slices.Contains(enabledTools, toolName)
+	}
 
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "incident",
-		Description: "Tools for managing Grafana Incident (create, update, search incidents)",
-		AddFunc:     tools.AddIncidentTools,
-	})
+	// Define all available toolsets
+	allToolsets := []struct {
+		name        string
+		description string
+		addFunc     func(*server.MCPServer)
+	}{
+		{"search", "Tools for searching dashboards, folders, and other Grafana resources", tools.AddSearchTools},
+		{"datasource", "Tools for listing and fetching datasource details", tools.AddDatasourceTools},
+		{"incident", "Tools for managing Grafana Incident (create, update, search incidents)", tools.AddIncidentTools},
+		{"prometheus", "Tools for querying Prometheus metrics and metadata", tools.AddPrometheusTools},
+		{"loki", "Tools for querying Loki logs and labels", tools.AddLokiTools},
+		{"alerting", "Tools for managing alert rules and notification contact points", tools.AddAlertingTools},
+		{"dashboard", "Tools for managing Grafana dashboards (get, update, extract queries)", tools.AddDashboardTools},
+		{"folder", "Tools for managing Grafana folders", tools.AddFolderTools},
+		{"oncall", "Tools for managing OnCall schedules, shifts, teams, and users", tools.AddOnCallTools},
+		{"asserts", "Tools for Grafana Asserts cloud functionality", tools.AddAssertsTools},
+		{"sift", "Tools for Sift investigations (analyze logs/traces, find errors, detect slow requests)", tools.AddSiftTools},
+		{"admin", "Tools for administrative tasks (list teams, manage users)", tools.AddAdminTools},
+		{"pyroscope", "Tools for profiling applications with Pyroscope", tools.AddPyroscopeTools},
+		{"navigation", "Tools for generating deeplink URLs to Grafana resources", tools.AddNavigationTools},
+	}
 
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "prometheus",
-		Description: "Tools for querying Prometheus metrics and metadata",
-		AddFunc:     tools.AddPrometheusTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "loki",
-		Description: "Tools for querying Loki logs and labels",
-		AddFunc:     tools.AddLokiTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "alerting",
-		Description: "Tools for managing alert rules and notification contact points",
-		AddFunc:     tools.AddAlertingTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "dashboard",
-		Description: "Tools for managing Grafana dashboards (get, update, extract queries)",
-		AddFunc:     tools.AddDashboardTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "folder",
-		Description: "Tools for managing Grafana folders",
-		AddFunc:     tools.AddFolderTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "oncall",
-		Description: "Tools for managing OnCall schedules, shifts, teams, and users",
-		AddFunc:     tools.AddOnCallTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "asserts",
-		Description: "Tools for Grafana Asserts cloud functionality",
-		AddFunc:     tools.AddAssertsTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "sift",
-		Description: "Tools for Sift investigations (analyze logs/traces, find errors, detect slow requests)",
-		AddFunc:     tools.AddSiftTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "admin",
-		Description: "Tools for administrative tasks (list teams, manage users)",
-		AddFunc:     tools.AddAdminTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "pyroscope",
-		Description: "Tools for profiling applications with Pyroscope",
-		AddFunc:     tools.AddPyroscopeTools,
-	})
-
-	dtm.RegisterToolset(&mcpgrafana.Toolset{
-		Name:        "navigation",
-		Description: "Tools for generating deeplink URLs to Grafana resources",
-		AddFunc:     tools.AddNavigationTools,
-	})
+	// Only register toolsets that are enabled
+	for _, toolset := range allToolsets {
+		if isEnabled(toolset.name) {
+			dtm.RegisterToolset(&mcpgrafana.Toolset{
+				Name:        toolset.name,
+				Description: toolset.description,
+				AddFunc:     toolset.addFunc,
+			})
+		}
+	}
 
 	// Add the dynamic discovery tools themselves
 	mcpgrafana.AddDynamicDiscoveryTools(dtm, s)

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -212,7 +212,6 @@ func newServer(dt disabledTools) *server.MCPServer {
 		// Tools will be added dynamically when toolsets are enabled
 		dt.addToolsDynamically(s)
 	} else {
-		// Use static tool registration
 		dt.addTools(s)
 	}
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -36,6 +36,7 @@ func maybeAddTools(s *server.MCPServer, tf func(*server.MCPServer), enabledTools
 // disabledTools indicates whether each category of tools should be disabled.
 type disabledTools struct {
 	enabledTools string
+	dynamicTools bool
 
 	search, datasource, incident,
 	prometheus, loki, alerting,
@@ -57,6 +58,7 @@ type grafanaConfig struct {
 
 func (dt *disabledTools) addFlags() {
 	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,admin,pyroscope,navigation", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
+	flag.BoolVar(&dt.dynamicTools, "dynamic-toolsets", getEnvBool("GRAFANA_DYNAMIC_TOOLSETS", false), "Enable dynamic tool discovery. When enabled, only discovery tools are registered initially, and other toolsets can be enabled on-demand.")
 
 	flag.BoolVar(&dt.search, "disable-search", false, "Disable search tools")
 	flag.BoolVar(&dt.datasource, "disable-datasource", false, "Disable datasource tools")
@@ -102,8 +104,130 @@ func (dt *disabledTools) addTools(s *server.MCPServer) {
 	maybeAddTools(s, tools.AddNavigationTools, enabledTools, dt.navigation, "navigation")
 }
 
+// NEW: addToolsDynamically sets up dynamic tool discovery
+func (dt *disabledTools) addToolsDynamically(s *server.MCPServer) *mcpgrafana.DynamicToolManager {
+	dtm := mcpgrafana.NewDynamicToolManager(s)
+
+	// Register all available toolsets
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "search",
+		Description: "Tools for searching dashboards, folders, and other Grafana resources",
+		AddFunc:     tools.AddSearchTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "datasource",
+		Description: "Tools for listing and fetching datasource details",
+		AddFunc:     tools.AddDatasourceTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "incident",
+		Description: "Tools for managing Grafana Incident (create, update, search incidents)",
+		AddFunc:     tools.AddIncidentTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "prometheus",
+		Description: "Tools for querying Prometheus metrics and metadata",
+		AddFunc:     tools.AddPrometheusTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "loki",
+		Description: "Tools for querying Loki logs and labels",
+		AddFunc:     tools.AddLokiTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "alerting",
+		Description: "Tools for managing alert rules and notification contact points",
+		AddFunc:     tools.AddAlertingTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "dashboard",
+		Description: "Tools for managing Grafana dashboards (get, update, extract queries)",
+		AddFunc:     tools.AddDashboardTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "folder",
+		Description: "Tools for managing Grafana folders",
+		AddFunc:     tools.AddFolderTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "oncall",
+		Description: "Tools for managing OnCall schedules, shifts, teams, and users",
+		AddFunc:     tools.AddOnCallTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "asserts",
+		Description: "Tools for Grafana Asserts cloud functionality",
+		AddFunc:     tools.AddAssertsTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "sift",
+		Description: "Tools for Sift investigations (analyze logs/traces, find errors, detect slow requests)",
+		AddFunc:     tools.AddSiftTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "admin",
+		Description: "Tools for administrative tasks (list teams, manage users)",
+		AddFunc:     tools.AddAdminTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "pyroscope",
+		Description: "Tools for profiling applications with Pyroscope",
+		AddFunc:     tools.AddPyroscopeTools,
+	})
+
+	dtm.RegisterToolset(&mcpgrafana.Toolset{
+		Name:        "navigation",
+		Description: "Tools for generating deeplink URLs to Grafana resources",
+		AddFunc:     tools.AddNavigationTools,
+	})
+
+	// Add the dynamic discovery tools themselves
+	mcpgrafana.AddDynamicDiscoveryTools(dtm, s)
+
+	return dtm
+}
+
 func newServer(dt disabledTools) *server.MCPServer {
-	s := server.NewMCPServer("mcp-grafana", mcpgrafana.Version(), server.WithInstructions(`
+	var instructions string
+	if dt.dynamicTools {
+		instructions = `
+	This server provides access to your Grafana instance and the surrounding ecosystem with dynamic tool discovery.
+
+	Getting Started:
+	1. Use 'grafana_list_toolsets' to see all available toolsets
+	2. Use 'grafana_enable_toolset' to enable specific functionality you need
+	3. Once enabled, the toolset's tools will be available for use
+
+	Available Toolset Categories:
+	- search: Search dashboards, folders, and resources
+	- datasource: Manage datasources
+	- prometheus: Query Prometheus metrics
+	- loki: Query Loki logs
+	- dashboard: Manage dashboards
+	- folder: Manage folders
+	- incident: Manage incidents
+	- alerting: Manage alerts
+	- oncall: Manage OnCall schedules
+	- asserts: Grafana Asserts functionality
+	- sift: Sift investigations
+	- admin: Administrative tasks
+	- pyroscope: Application profiling
+	- navigation: Generate deeplinks
+	`
+	} else {
+		instructions = `
 	This server provides access to your Grafana instance and the surrounding ecosystem.
 
 	Available Capabilities:
@@ -117,8 +241,23 @@ func newServer(dt disabledTools) *server.MCPServer {
 	- Admin: List teams and perform administrative tasks.
 	- Pyroscope: Profile applications and fetch profiling data.
 	- Navigation: Generate deeplink URLs for Grafana resources like dashboards, panels, and Explore queries.
-	`))
-	dt.addTools(s)
+	`
+	}
+
+	// Create server with tool capabilities enabled for dynamic tool discovery
+	s := server.NewMCPServer("mcp-grafana", mcpgrafana.Version(),
+		server.WithInstructions(instructions),
+		server.WithToolCapabilities(true)) // Enable listChanged notifications
+
+	if dt.dynamicTools {
+		// For dynamic toolsets, start with only discovery tools
+		// Tools will be added dynamically when toolsets are enabled
+		dt.addToolsDynamically(s)
+	} else {
+		// Use static tool registration
+		dt.addTools(s)
+	}
+
 	return s
 }
 
@@ -286,6 +425,14 @@ func main() {
 	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig, tls); err != nil {
 		panic(err)
 	}
+}
+
+// getEnvBool reads a boolean from an environment variable
+func getEnvBool(key string, defaultValue bool) bool {
+	if value, exists := os.LookupEnv(key); exists {
+		return value == "1" || strings.ToLower(value) == "true"
+	}
+	return defaultValue
 }
 
 func parseLevel(level string) slog.Level {

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-		"github.com/mark3labs/mcp-go/server"
+	"github.com/mark3labs/mcp-go/server"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/grafana/mcp-grafana/tools"
@@ -58,7 +58,7 @@ type grafanaConfig struct {
 
 func (dt *disabledTools) addFlags() {
 	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,admin,pyroscope,navigation", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
-	flag.BoolVar(&dt.dynamicTools, "dynamic-toolsets", getEnvBool("GRAFANA_DYNAMIC_TOOLSETS", false), "Enable dynamic tool discovery. When enabled, only discovery tools are registered initially, and other toolsets can be enabled on-demand.")
+	flag.BoolVar(&dt.dynamicTools, "dynamic-toolsets", false, "Enable dynamic tool discovery. When enabled, only discovery tools are registered initially, and other toolsets can be enabled on-demand.")
 
 	flag.BoolVar(&dt.search, "disable-search", false, "Disable search tools")
 	flag.BoolVar(&dt.datasource, "disable-datasource", false, "Disable datasource tools")
@@ -104,14 +104,12 @@ func (dt *disabledTools) addTools(s *server.MCPServer) {
 	maybeAddTools(s, tools.AddNavigationTools, enabledTools, dt.navigation, "navigation")
 }
 
-// NEW: addToolsDynamically sets up dynamic tool discovery
+// addToolsDynamically sets up dynamic tool discovery
 func (dt *disabledTools) addToolsDynamically(s *server.MCPServer) *mcpgrafana.DynamicToolManager {
 	dtm := mcpgrafana.NewDynamicToolManager(s)
 
-	// Parse enabled tools list
 	enabledTools := strings.Split(dt.enabledTools, ",")
 
-	// Helper function to check if a tool is enabled
 	isEnabled := func(toolName string) bool {
 		// If enabledTools is empty string, no tools should be available
 		if dt.enabledTools == "" {
@@ -207,7 +205,7 @@ func newServer(dt disabledTools) *server.MCPServer {
 	// Create server with tool capabilities enabled for dynamic tool discovery
 	s := server.NewMCPServer("mcp-grafana", mcpgrafana.Version(),
 		server.WithInstructions(instructions),
-		server.WithToolCapabilities(true)) // Enable listChanged notifications
+		server.WithToolCapabilities(true))
 
 	if dt.dynamicTools {
 		// For dynamic toolsets, start with only discovery tools
@@ -385,14 +383,6 @@ func main() {
 	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig, tls); err != nil {
 		panic(err)
 	}
-}
-
-// getEnvBool reads a boolean from an environment variable
-func getEnvBool(key string, defaultValue bool) bool {
-	if value, exists := os.LookupEnv(key); exists {
-		return value == "1" || strings.ToLower(value) == "true"
-	}
-	return defaultValue
 }
 
 func parseLevel(level string) slog.Level {

--- a/dynamic_tools.go
+++ b/dynamic_tools.go
@@ -1,0 +1,183 @@
+package mcpgrafana
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Toolset represents a category of related tools that can be dynamically enabled or disabled
+type Toolset struct {
+	Name        string
+	Description string
+	Tools       []Tool
+	AddFunc     func(*server.MCPServer)
+}
+
+// DynamicToolManager manages dynamic tool registration and discovery
+type DynamicToolManager struct {
+	server   *server.MCPServer
+	toolsets map[string]*Toolset
+	enabled  map[string]bool
+	mu       sync.RWMutex
+}
+
+// NewDynamicToolManager creates a new dynamic tool manager
+func NewDynamicToolManager(srv *server.MCPServer) *DynamicToolManager {
+	return &DynamicToolManager{
+		server:   srv,
+		toolsets: make(map[string]*Toolset),
+		enabled:  make(map[string]bool),
+	}
+}
+
+// RegisterToolset registers a toolset for dynamic discovery
+func (dtm *DynamicToolManager) RegisterToolset(toolset *Toolset) {
+	dtm.mu.Lock()
+	defer dtm.mu.Unlock()
+	dtm.toolsets[toolset.Name] = toolset
+	slog.Debug("Registered toolset", "name", toolset.Name, "description", toolset.Description)
+}
+
+// EnableToolset enables a specific toolset by name
+func (dtm *DynamicToolManager) EnableToolset(ctx context.Context, name string) error {
+	dtm.mu.Lock()
+	defer dtm.mu.Unlock()
+
+	toolset, exists := dtm.toolsets[name]
+	if !exists {
+		return fmt.Errorf("toolset not found: %s", name)
+	}
+
+	if dtm.enabled[name] {
+		slog.Debug("Toolset already enabled", "name", name)
+		return nil
+	}
+
+	// Add tools using the toolset's AddFunc
+	if toolset.AddFunc != nil {
+		toolset.AddFunc(dtm.server)
+	}
+
+	dtm.enabled[name] = true
+	slog.Info("Enabled toolset", "name", name)
+	
+	// Log the current state
+	slog.Info("Toolset enabled successfully", "name", name, "total_enabled", len(dtm.enabled))
+
+	return nil
+}
+
+// DisableToolset disables a specific toolset
+// Note: mcp-go doesn't support removing tools at runtime, so this just marks it as disabled
+func (dtm *DynamicToolManager) DisableToolset(name string) error {
+	dtm.mu.Lock()
+	defer dtm.mu.Unlock()
+
+	if _, exists := dtm.toolsets[name]; !exists {
+		return fmt.Errorf("toolset not found: %s", name)
+	}
+
+	dtm.enabled[name] = false
+	slog.Info("Disabled toolset", "name", name)
+	return nil
+}
+
+// ListToolsets returns information about all available toolsets
+func (dtm *DynamicToolManager) ListToolsets() []ToolsetInfo {
+	dtm.mu.RLock()
+	defer dtm.mu.RUnlock()
+
+	toolsets := make([]ToolsetInfo, 0, len(dtm.toolsets))
+	for name, toolset := range dtm.toolsets {
+		toolsets = append(toolsets, ToolsetInfo{
+			Name:        name,
+			Description: toolset.Description,
+			Enabled:     dtm.enabled[name],
+		})
+	}
+	return toolsets
+}
+
+// ToolsetInfo provides information about a toolset
+type ToolsetInfo struct {
+	Name        string `json:"name" jsonschema:"required,description=The name of the toolset"`
+	Description string `json:"description" jsonschema:"description=Description of what the toolset provides"`
+	Enabled     bool   `json:"enabled" jsonschema:"description=Whether the toolset is currently enabled"`
+}
+
+// AddDynamicDiscoveryTools adds the list and enable toolset tools to the server
+func AddDynamicDiscoveryTools(dtm *DynamicToolManager, srv *server.MCPServer) {
+	// Tool to list all available toolsets
+	type ListToolsetsRequest struct {
+		// Empty struct for tools that don't need parameters
+	}
+
+	listToolsetsHandler := func(ctx context.Context, request ListToolsetsRequest) ([]ToolsetInfo, error) {
+		return dtm.ListToolsets(), nil
+	}
+
+	listToolsetsTool := MustTool(
+		"grafana_list_toolsets",
+		"List all available Grafana toolsets that can be enabled dynamically. Each toolset provides a category of related functionality.",
+		listToolsetsHandler,
+	)
+	listToolsetsTool.Register(srv)
+
+	// Tool to enable a specific toolset
+	type EnableToolsetRequest struct {
+		Toolset string `json:"toolset" jsonschema:"required,description=The name of the toolset to enable (e.g. 'prometheus' 'loki' 'dashboard' 'incident')"`
+	}
+
+	enableToolsetHandler := func(ctx context.Context, request EnableToolsetRequest) (string, error) {
+		if err := dtm.EnableToolset(ctx, request.Toolset); err != nil {
+			return "", err
+		}
+
+		// Get toolset info to provide better guidance
+		toolsetInfo := dtm.getToolsetInfo(request.Toolset)
+		if toolsetInfo == nil {
+			return fmt.Sprintf("Successfully enabled toolset: %s. The tools are now available for use.", request.Toolset), nil
+		}
+
+		return fmt.Sprintf("Successfully enabled toolset: %s\n\nDescription: %s\n\nNote: All tools are already registered and available. You can now use the tools from this toolset directly.",
+			request.Toolset, toolsetInfo.Description), nil
+	}
+
+	enableToolsetTool := MustTool(
+		"grafana_enable_toolset",
+		"Enable a specific Grafana toolset to make its tools available. Use grafana_list_toolsets to see available toolsets.",
+		enableToolsetHandler,
+	)
+	enableToolsetTool.Register(srv)
+}
+
+// getToolsetInfo returns information about a specific toolset
+func (dtm *DynamicToolManager) getToolsetInfo(name string) *Toolset {
+	dtm.mu.RLock()
+	defer dtm.mu.RUnlock()
+	return dtm.toolsets[name]
+}
+// sendToolListChangedNotification sends a proper MCP ToolListChangedNotification
+func (dtm *DynamicToolManager) sendToolListChangedNotification(ctx context.Context) {
+	// Create notification parameters as map[string]any
+	params := map[string]any{
+		"_meta": map[string]any{
+			"message": "Tool list has been updated. New tools are now available.",
+		},
+	}
+
+	// Send notification to all connected clients
+	dtm.server.SendNotificationToAllClients("tools/list_changed", params)
+
+	// Also try to send to the current context if available
+	if err := dtm.server.SendNotificationToClient(ctx, "tools/list_changed", params); err != nil {
+		slog.Debug("Failed to send notification to client", "error", err)
+	}
+
+	slog.Info("Sent tool list changed notification to clients")
+}
+

--- a/dynamic_tools.go
+++ b/dynamic_tools.go
@@ -58,13 +58,17 @@ func (dtm *DynamicToolManager) EnableToolset(ctx context.Context, name string) e
 	}
 
 	// Add tools using the toolset's AddFunc
+	// Note: The mcp-go library automatically sends a tools/list_changed notification
+	// when AddTool is called (via the Register method), so we don't need to manually
+	// send notifications here. This happens because WithToolCapabilities(true) was set
+	// during server initialization.
 	if toolset.AddFunc != nil {
 		toolset.AddFunc(dtm.server)
 	}
 
 	dtm.enabled[name] = true
 	slog.Info("Enabled toolset", "name", name)
-	
+
 	// Log the current state
 	slog.Info("Toolset enabled successfully", "name", name, "total_enabled", len(dtm.enabled))
 
@@ -161,23 +165,3 @@ func (dtm *DynamicToolManager) getToolsetInfo(name string) *Toolset {
 	defer dtm.mu.RUnlock()
 	return dtm.toolsets[name]
 }
-// sendToolListChangedNotification sends a proper MCP ToolListChangedNotification
-func (dtm *DynamicToolManager) sendToolListChangedNotification(ctx context.Context) {
-	// Create notification parameters as map[string]any
-	params := map[string]any{
-		"_meta": map[string]any{
-			"message": "Tool list has been updated. New tools are now available.",
-		},
-	}
-
-	// Send notification to all connected clients
-	dtm.server.SendNotificationToAllClients("tools/list_changed", params)
-
-	// Also try to send to the current context if available
-	if err := dtm.server.SendNotificationToClient(ctx, "tools/list_changed", params); err != nil {
-		slog.Debug("Failed to send notification to client", "error", err)
-	}
-
-	slog.Info("Sent tool list changed notification to clients")
-}
-

--- a/dynamic_tools.go
+++ b/dynamic_tools.go
@@ -68,10 +68,6 @@ func (dtm *DynamicToolManager) EnableToolset(ctx context.Context, name string) e
 
 	dtm.enabled[name] = true
 	slog.Info("Enabled toolset", "name", name)
-
-	// Log the current state
-	slog.Info("Toolset enabled successfully", "name", name, "total_enabled", len(dtm.enabled))
-
 	return nil
 }
 
@@ -115,10 +111,7 @@ type ToolsetInfo struct {
 
 // AddDynamicDiscoveryTools adds the list and enable toolset tools to the server
 func AddDynamicDiscoveryTools(dtm *DynamicToolManager, srv *server.MCPServer) {
-	// Tool to list all available toolsets
-	type ListToolsetsRequest struct {
-		// Empty struct for tools that don't need parameters
-	}
+	type ListToolsetsRequest struct{}
 
 	listToolsetsHandler := func(ctx context.Context, request ListToolsetsRequest) ([]ToolsetInfo, error) {
 		return dtm.ListToolsets(), nil

--- a/dynamic_tools_test.go
+++ b/dynamic_tools_test.go
@@ -1,0 +1,131 @@
+//go:build unit
+// +build unit
+
+package mcpgrafana
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDynamicToolManager(t *testing.T) {
+	srv := server.NewMCPServer("test-server", "1.0.0")
+	dtm := NewDynamicToolManager(srv)
+
+	assert.NotNil(t, dtm)
+	assert.NotNil(t, dtm.server)
+	assert.NotNil(t, dtm.toolsets)
+	assert.NotNil(t, dtm.enabled)
+}
+
+func TestRegisterAndListToolsets(t *testing.T) {
+	srv := server.NewMCPServer("test-server", "1.0.0")
+	dtm := NewDynamicToolManager(srv)
+
+	// Create a test toolset
+	toolset := &Toolset{
+		Name:        "test_toolset",
+		Description: "A test toolset for unit testing",
+		Tools:       []Tool{},
+		AddFunc: func(s *server.MCPServer) {
+			// Mock add function
+		},
+	}
+
+	// Register the toolset
+	dtm.RegisterToolset(toolset)
+
+	// List toolsets
+	toolsets := dtm.ListToolsets()
+	require.Len(t, toolsets, 1)
+	assert.Equal(t, "test_toolset", toolsets[0].Name)
+	assert.Equal(t, "A test toolset for unit testing", toolsets[0].Description)
+	assert.False(t, toolsets[0].Enabled) // Should be disabled by default
+}
+
+func TestEnableToolset(t *testing.T) {
+	srv := server.NewMCPServer("test-server", "1.0.0")
+	dtm := NewDynamicToolManager(srv)
+
+	// Track if AddFunc was called
+	addFuncCalled := false
+
+	// Create a test toolset
+	toolset := &Toolset{
+		Name:        "test_toolset",
+		Description: "A test toolset",
+		Tools:       []Tool{},
+		AddFunc: func(s *server.MCPServer) {
+			addFuncCalled = true
+		},
+	}
+
+	dtm.RegisterToolset(toolset)
+
+	// Enable the toolset
+	ctx := context.Background()
+	err := dtm.EnableToolset(ctx, "test_toolset")
+	require.NoError(t, err)
+	assert.True(t, addFuncCalled, "AddFunc should have been called")
+
+	// Check that it's enabled
+	toolsets := dtm.ListToolsets()
+	require.Len(t, toolsets, 1)
+	assert.True(t, toolsets[0].Enabled)
+
+	// Enabling again should not error
+	err = dtm.EnableToolset(ctx, "test_toolset")
+	require.NoError(t, err)
+}
+
+func TestEnableNonExistentToolset(t *testing.T) {
+	srv := server.NewMCPServer("test-server", "1.0.0")
+	dtm := NewDynamicToolManager(srv)
+
+	ctx := context.Background()
+	err := dtm.EnableToolset(ctx, "non_existent_toolset")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "toolset not found")
+}
+
+func TestDisableToolset(t *testing.T) {
+	srv := server.NewMCPServer("test-server", "1.0.0")
+	dtm := NewDynamicToolManager(srv)
+
+	// Create and register a toolset
+	toolset := &Toolset{
+		Name:        "test_toolset",
+		Description: "A test toolset",
+		Tools:       []Tool{},
+		AddFunc:     nil,
+	}
+	dtm.RegisterToolset(toolset)
+
+	// Enable it first
+	ctx := context.Background()
+	err := dtm.EnableToolset(ctx, "test_toolset")
+	require.NoError(t, err)
+
+	// Verify it's enabled
+	toolsets := dtm.ListToolsets()
+	require.Len(t, toolsets, 1)
+	assert.True(t, toolsets[0].Enabled)
+
+	// Disable it
+	err = dtm.DisableToolset("test_toolset")
+	require.NoError(t, err)
+
+	// Verify it's disabled
+	toolsets = dtm.ListToolsets()
+	require.Len(t, toolsets, 1)
+	assert.False(t, toolsets[0].Enabled)
+
+	// Try to disable a non-existent toolset
+	err = dtm.DisableToolset("non_existent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "toolset not found")
+}


### PR DESCRIPTION
## Dynamic Toolset Discovery and Loading
### Summary
Adds dynamic toolset functionality that allows clients to discover and selectively enable tool categories at runtime, significantly reducing context window usage by only loading tools when needed.

### Motivation
MCP tool descriptions can consume substantial context window space. By enabling dynamic discovery, clients only load the tools they actually need, preserving context for more important data.

### Implementation

New flag: `--dynamic-toolsets` enables dynamic toolset mode
Discovery tools: Added grafana_list_toolsets and grafana_enable_toolset meta-tools
Notification support: Sends tools/list_changed notification when toolsets are enabled, triggering client refresh

#### Integration with --enabled-tools:
- No flag --> all toolsets discoverable
- `--enabled-tools=""` --> no toolsets discoverable
- `--enabled-tools="datasources,dashboards"` --> only specified toolsets discoverable

#### Client Compatibility
✅ Supported: Cursor, VSCode (support notifications)
❌ Not yet: Claude Desktop, Claude Code (no notification support) there are open issues though for it

#### Known Behavior
Slight delay expected: There may be a few seconds of delay between calling grafana_enable_toolset and the tools becoming available in the client, as the client needs to receive and process the `tools/list_changed` notification.

Note: This is opt-in via the `--dynamic-toolsets` flag. Existing static tool registration remains the default behavior.

#### How it works with Cursor. 
Currently Sonnet 4.5 model selected - 1m tokens available for this conversation

Normal behavior all tools available: 
- At the beginning 13.9% of context used
   <img width="1113" height="588" alt="image" src="https://github.com/user-attachments/assets/fc62a407-eee8-4b9a-80e2-aade20caca68" />

- How many tools are available 14.1%
   <img width="1110" height="593" alt="image" src="https://github.com/user-attachments/assets/e8bf5413-008e-495c-b2fd-ed51df331a6a" />

- List my prometheus datasources 14.8%
   <img width="800" height="975" alt="image" src="https://github.com/user-attachments/assets/46cb7d04-be0d-422f-ab93-9b0caa921f03" />



Dynamic tool discovery enabled with all tools discoverable. 
- At the beginning 5.5% of context used
    <img width="974" height="500" alt="image" src="https://github.com/user-attachments/assets/69ca682b-fd99-4f85-9ebc-9146f645307a" />

- List available toolsets - 5.9%
   <img width="977" height="983" alt="image" src="https://github.com/user-attachments/assets/e358f16f-1107-4c38-8142-96c5f54e2418" />

- Enable Datasource toolset 
   <img width="977" height="404" alt="image" src="https://github.com/user-attachments/assets/647b0ac9-0488-42f5-8ec3-e006430422b7" />

- List Datasources 7%
    <img width="973" height="955" alt="image" src="https://github.com/user-attachments/assets/cd9cc8f1-5159-4649-92c3-feec1140dcb6" />

