### PR TITLE
fix: update connectrpc/connect-go to resolve the compile error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/mcp-grafana
 go 1.24.6
 
 require (
-	connectrpc.com/connect v1.19.0
+	connectrpc.com/connect v1.19.1
 	github.com/PaesslerAG/gval v1.2.4
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/go-openapi/runtime v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-connectrpc.com/connect v1.19.0 h1:LuqUbq01PqbtL0o7vn0WMRXzR2nNsiINe5zfcJ24pJM=
-connectrpc.com/connect v1.19.0/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
+connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/gval v1.2.4 h1:rhX7MpjJlcxYwL2eTTYIOBUyEKZ+A96T9vQySWkVUiU=
 github.com/PaesslerAG/gval v1.2.4/go.mod h1:XRFLwvmkTEdYziLdaCeCa5ImcGVrfQbeNUbVR+C6xac=


### PR DESCRIPTION
GoReleaser failed at v0.7.3.

https://github.com/grafana/mcp-grafana/releases/tag/v0.7.3
https://github.com/grafana/mcp-grafana/actions/runs/18408789518/job/52455289488

```
  ⨯ release failed after 6m38s
    error=
    │ build failed: exit status 1: # connectrpc.com/connect
Error:     │ ../../../go/pkg/mod/connectrpc.com/connect@v1.19.0/envelope.go:378:24: math.MaxUint32 (untyped int constant 4294967295) overflows int
    target=linux_386_sse2
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.12.5/x64/goreleaser' failed with exit code 1
```

This pull request updates connect-go to the latest version to resolve the problem.

- https://github.com/connectrpc/connect-go/pull/887
- https://github.com/connectrpc/connect-go/releases/tag/v1.19.1

## Test

I confirmed I can reproduce the issue on my machine and resolved it by this change.

GoReleaser version: 2.12.5

```console
$ goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Release engineering, simplified.
https://goreleaser.com

GitVersion:    2.12.5
GitCommit:     8696231b52efc02e322102545fbe97a74c4a60fa
GitTreeState:  false
BuildDate:     2025-10-01T12:01:10Z
BuiltBy:       goreleaser
GoVersion:     go1.25.1
Compiler:      gc
ModuleSum:     h1:hPlijBXQhZ2F0aQv+oPHCuwLarq18EK/1Y20BngR690=
Platform:      darwin/arm64
```

Reproduced the issue:

```console
$ GOOS=linux GOARCH=386 goreleaser build --single-target --clean --snapshot
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=e7aa22c7d0780f4d4aba92db52f0fe059efff9a2 branch=main current_tag=v0.7.3 previous_tag=v0.7.2 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • partial
  • snapshotting
    • building snapshot...                           version=0.7.3-SNAPSHOT-e7aa22c
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  match=target=linux_386_sse2
    • partial build                                  match=target=linux_386_sse2
    • building                                       binary=dist/default_linux_386_sse2/mcp-grafana
  ⨯ build failed after 1s                           
    error=
    │ build failed: exit status 1: # connectrpc.com/connect
    │ ../../../../../go/pkg/mod/connectrpc.com/connect@v1.19.0/envelope.go:378:24: math.MaxUint32 (untyped int constant 4294967295) overflows int
    target=linux_386_sse2
```

Resolved the issue:

```console
$ GOOS=linux GOARCH=386 goreleaser build --single-target --clean --snapshot
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=e7aa22c7d0780f4d4aba92db52f0fe059efff9a2 branch=main current_tag=v0.7.3 previous_tag=v0.7.2 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • partial
  • snapshotting
    • building snapshot...                           version=0.7.3-SNAPSHOT-e7aa22c
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  match=target=linux_386_sse2
    • partial build                                  match=target=linux_386_sse2
    • building                                       binary=dist/default_linux_386_sse2/mcp-grafana
  • writing artifacts metadata
  • build succeeded after 4s
  • thanks for using GoReleaser!
```