### PR TITLE
chore: strip 'v' prefix off Docker image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   release:
     types: [published]
 
@@ -15,15 +15,19 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Process tag name
+        id: tag
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
       - name: Build and Push to Docker Hub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@d3406054b466eed0423efa5a9a2bfa5dca71dab0
         with:
           context: .
           file: ./Dockerfile
           repository: grafana/mcp-grafana
           tags: |
             latest
-            ${{ github.ref_name }}
+            ${{ steps.tag.outputs.version }}
           push: true


### PR DESCRIPTION
Also pin the action versions so zizmor won't break later.
