### PR TITLE
fix: specify prerelease_suffix for goreleaser git config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,9 @@ before:
   hooks:
     - go mod tidy
 
+git:
+  prerelease_suffix: "-rc"
+
 builds:
   - id: default
     env:


### PR DESCRIPTION
When a commit is tagged with multiple tags, by default goreleaser will
look at them, sort them alphabetically, then choose the last one to
use as the release tag. That's not what we want if we have tagged one
with the -rc suffix then one without, because the 'rc' one is picked
as the latest one.

By adding this config we can tell goreleaser what prereleases look like
and have it select the correct tag.
