### PR TITLE
fix: add org ID param to cloud testing util function

### DIFF
--- a/tools/cloud_testing_utils.go
+++ b/tools/cloud_testing_utils.go
@@ -42,7 +42,7 @@ func createCloudTestContext(t *testing.T, testName, urlEnv, apiKeyEnv string) co
 		t.Skipf("Neither %s nor %s environment variables are set, skipping cloud %s integration tests", serviceAccountTokenEnv, apiKeyEnv, testName)
 	}
 
-	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey, nil)
+	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey, nil, 0)
 
 	config := mcpgrafana.GrafanaConfig{
 		URL:    grafanaURL,


### PR DESCRIPTION
Due to build directives it wasn't flagged until merging to main,
this should fix.
