### PR TITLE
ci(docker): add multi-platform build support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,7 @@ jobs:
           context: .
           file: ./Dockerfile
           repository: grafana/mcp-grafana
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.tag.outputs.is_stable == 'true' && 'latest' || '' }}
             ${{ steps.tag.outputs.version }}


### PR DESCRIPTION
Add multi-platform build support for Docker images

Configure Docker workflow to build images for both linux/amd64 and linux/arm64 platforms. This enables the container to run on ARM-based systems such as Apple Silicon and ARM servers.