### PR TITLE
docs: update enabled-tools description

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 - `--debug`: Enable debug mode for detailed HTTP request/response logging
 
 **Tool Configuration:**
-- `--enabled-tools`: Comma-separated list of enabled tools - default: all tools enabled
+- `--enabled-tools`: Comma-separated list of enabled categories - default: all categories enabled - example: "loki,datasources"
 - `--disable-search`: Disable search tools
 - `--disable-datasource`: Disable datasource tools
 - `--disable-incident`: Disable incident tools


### PR DESCRIPTION
Updated the README to avoid confusion by changing the phrase "list of enabled tools" to "list of enabled categories" for the `--enabled-tools` option.