### PR TITLE
fix: loki metric type query

### DIFF
--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -78,4 +78,50 @@ func TestLokiTools(t *testing.T) {
 		assert.NotNil(t, result, "Empty results should be an empty slice, not nil")
 		assert.Equal(t, 0, len(result), "Empty results should have length 0")
 	})
+
+	t.Run("query loki metrics instant", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryLokiLogs(ctx, QueryLokiLogsParams{
+			DatasourceUID: "loki",
+			LogQL:         `sum(rate({container=~".+"}[1m]))`,
+			QueryType:     "instant",
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, result, "Instant metric queries should return at least one sample")
+
+		for _, entry := range result {
+			assert.NotNil(t, entry.Labels, "Metric sample should include label map")
+			assert.Len(t, entry.Value, 2, "Metric sample should include timestamp and value")
+			assert.Nil(t, entry.Values, "Instant queries should not populate range values")
+		}
+	})
+
+	t.Run("query loki metrics range", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryLokiLogs(ctx, QueryLokiLogsParams{
+			DatasourceUID: "loki",
+			LogQL:         `sum(rate({container=~".+"}[1m]))`,
+			QueryType:     "range",
+			StepSeconds:   10,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, result, "Range metric queries should return at least one series")
+
+		for _, entry := range result {
+			assert.NotNil(t, entry.Labels, "Metric series should include label map")
+			assert.NotEmpty(t, entry.Values, "Range queries should return time series samples")
+			assert.Nil(t, entry.Value, "Range queries should not populate instant values")
+		}
+	})
+
+	t.Run("query loki metrics range missing step seconds", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryLokiLogs(ctx, QueryLokiLogsParams{
+			DatasourceUID: "loki",
+			LogQL:         `sum(rate({container=~".+"}[1m]))`,
+			QueryType:     "range",
+		})
+		require.Error(t, err, "Range metric queries without step seconds should fail")
+		assert.Nil(t, result, "Error response should not return results slice")
+	})
 }


### PR DESCRIPTION
Summary:
- Fix Loki metric queries by routing instant requests through /loki/api/v1/query, range requests through /loki/api/v1/query_range, and correctly handling time, direction, and step parameters.
- Update LogEntry parsing so metric vectors and matrices populate labels and value fields correctly without mixing log semantics.

Issue
- Fix #368