### PR TITLE
fix: include default values in jsonschema

### DIFF
--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -22,8 +22,8 @@ const (
 )
 
 type ListAlertRulesParams struct {
-	Limit          int        `json:"limit,omitempty" jsonschema:"description=The maximum number of results to return. Default is 100."`
-	Page           int        `json:"page,omitempty" jsonschema:"description=The page number to return."`
+	Limit          int        `json:"limit,omitempty" jsonschema:"default=100,description=The maximum number of results to return"`
+	Page           int        `json:"page,omitempty" jsonschema:"default=1,description=The page number to return"`
 	LabelSelectors []Selector `json:"label_selectors,omitempty" jsonschema:"description=Optionally\\, a list of matchers to filter alert rules by labels"`
 }
 
@@ -307,7 +307,7 @@ var GetAlertRuleByUID = mcpgrafana.MustTool(
 )
 
 type ListContactPointsParams struct {
-	Limit int     `json:"limit,omitempty" jsonschema:"description=The maximum number of results to return. Default is 100."`
+	Limit int     `json:"limit,omitempty" jsonschema:"default=100,description=The maximum number of results to return"`
 	Name  *string `json:"name,omitempty" jsonschema:"description=Filter contact points by name"`
 }
 

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -11,7 +11,7 @@ import (
 )
 
 type ListIncidentsParams struct {
-	Limit  int    `json:"limit" jsonschema:"description=The maximum number of incidents to return"`
+	Limit  int    `json:"limit" jsonschema:"default=10,description=The maximum number of incidents to return"`
 	Drill  bool   `json:"drill" jsonschema:"description=Whether to include drill incidents"`
 	Status string `json:"status" jsonschema:"description=The status of the incidents to include. Valid values: 'active'\\, 'resolved'"`
 }

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -384,7 +384,7 @@ type QueryLokiLogsParams struct {
 	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL query to execute against Loki. This can be a simple label matcher or a complex query with filters\\, parsers\\, and expressions. Supports full LogQL syntax including label matchers\\, filter operators\\, pattern expressions\\, and pipeline operations."`
 	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format"`
 	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format"`
-	Limit         int    `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of log lines to return (default: 10\\, max: 100)"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"default=10,description=Optionally\\, the maximum number of log lines to return (max: 100)"`
 	Direction     string `json:"direction,omitempty" jsonschema:"description=Optionally\\, the direction of the query: 'forward' (oldest first) or 'backward' (newest first\\, default)"`
 }
 

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -85,7 +85,7 @@ func promClientFromContext(ctx context.Context, uid string) (promv1.API, error) 
 
 type ListPrometheusMetricMetadataParams struct {
 	DatasourceUID  string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	Limit          int    `json:"limit" jsonschema:"description=The maximum number of metrics to return"`
+	Limit          int    `json:"limit" jsonschema:"default=10,description=The maximum number of metrics to return"`
 	LimitPerMetric int    `json:"limitPerMetric" jsonschema:"description=The maximum number of metrics to return per metric"`
 	Metric         string `json:"metric" jsonschema:"description=The metric to query"`
 }
@@ -196,8 +196,8 @@ var QueryPrometheus = mcpgrafana.MustTool(
 type ListPrometheusMetricNamesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	Regex         string `json:"regex" jsonschema:"description=The regex to match against the metric names"`
-	Limit         int    `json:"limit,omitempty" jsonschema:"description=The maximum number of results to return"`
-	Page          int    `json:"page,omitempty" jsonschema:"description=The page number to return"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"default=10,description=The maximum number of results to return"`
+	Page          int    `json:"page,omitempty" jsonschema:"default=1,description=The page number to return"`
 }
 
 func listPrometheusMetricNames(ctx context.Context, args ListPrometheusMetricNamesParams) ([]string, error) {
@@ -315,7 +315,7 @@ type ListPrometheusLabelNamesParams struct {
 	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally\\, a list of label matchers to filter the results by"`
 	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the time range to filter the results by"`
 	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the time range to filter the results by"`
-	Limit         int        `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of results to return"`
+	Limit         int        `json:"limit,omitempty" jsonschema:"default=100,description=Optionally\\, the maximum number of results to return"`
 }
 
 func listPrometheusLabelNames(ctx context.Context, args ListPrometheusLabelNamesParams) ([]string, error) {
@@ -374,7 +374,7 @@ type ListPrometheusLabelValuesParams struct {
 	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally\\, a list of selectors to filter the results by"`
 	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query"`
 	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query"`
-	Limit         int        `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of results to return"`
+	Limit         int        `json:"limit,omitempty" jsonschema:"default=100,description=Optionally\\, the maximum number of results to return"`
 }
 
 func listPrometheusLabelValues(ctx context.Context, args ListPrometheusLabelValuesParams) (model.LabelValues, error) {

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -231,7 +231,7 @@ var GetSiftAnalysis = mcpgrafana.MustTool(
 
 // ListSiftInvestigationsParams defines the parameters for retrieving investigations
 type ListSiftInvestigationsParams struct {
-	Limit int `json:"limit,omitempty" jsonschema:"description=Maximum number of investigations to return. Defaults to 10 if not specified."`
+	Limit int `json:"limit,omitempty" jsonschema:"default=10,description=Maximum number of investigations to return"`
 }
 
 // listSiftInvestigations retrieves a list of investigations with an optional limit


### PR DESCRIPTION
Some of our tools have default values for some of their parameters,
which weren't being included in the jsonschema. This commit adds
those defaults to the jsonschema.

Fixes #397.
