### PR TITLE
feat: add support to specify public URL via GRAFANA_PUBLIC_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,11 +410,14 @@ When an organization ID is provided, the MCP server will set the `X-Grafana-Org-
          "command": "mcp-grafana",
          "args": [],
          "env": {
-           "GRAFANA_URL": "http://localhost:3000",  // Or "https://myinstance.grafana.net" for Grafana Cloud
+           // URL of the Grafana instance used for connection. "https://myinstance.grafana.net" for Grafana Cloud.
+           "GRAFANA_URL": "http://localhost:3000",
            "GRAFANA_SERVICE_ACCOUNT_TOKEN": "<your service account token>",
            // If using username/password authentication
            "GRAFANA_USERNAME": "<your username>",
            "GRAFANA_PASSWORD": "<your password>",
+           // Optional: public URL of the Grafana instance used for generating links, if different from GRAFANA_URL.
+           "GRAFANA_PUBLIC_URL": "https://grafana.example.com",
            // Optional: specify organization ID for multi-org support
            "GRAFANA_ORG_ID": "1"
          }
@@ -445,11 +448,14 @@ When an organization ID is provided, the MCP server will set the `X-Grafana-Org-
         "stdio"
       ],
       "env": {
-        "GRAFANA_URL": "http://localhost:3000",  // Or "https://myinstance.grafana.net" for Grafana Cloud
+        // URL of the Grafana instance used for connection. "https://myinstance.grafana.net" for Grafana Cloud.
+        "GRAFANA_URL": "http://localhost:3000",
         "GRAFANA_SERVICE_ACCOUNT_TOKEN": "<your service account token>",
         // If using username/password authentication
         "GRAFANA_USERNAME": "<your username>",
         "GRAFANA_PASSWORD": "<your password>",
+        // Optional: public URL of the Grafana instance used for generating links, if different from GRAFANA_URL.
+        "GRAFANA_PUBLIC_URL": "https://grafana.example.com",
         // Optional: specify organization ID for multi-org support
         "GRAFANA_ORG_ID": "1"
       }

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/url"
@@ -28,7 +29,7 @@ type TimeRange struct {
 
 func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string, error) {
 	config := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := strings.TrimRight(config.URL, "/")
+	baseURL := strings.TrimRight(cmp.Or(config.PublicURL, config.URL), "/")
 
 	if baseURL == "" {
 		return "", fmt.Errorf("grafana url not configured. Please set GRAFANA_URL environment variable or X-Grafana-URL header")

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -32,6 +32,23 @@ func TestGenerateDeeplink(t *testing.T) {
 		assert.Equal(t, "http://localhost:3000/d/abc123", result)
 	})
 
+	t.Run("Dashboard deeplink with public URL", func(t *testing.T) {
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:       "http://localhost:3000",
+			PublicURL: "https://grafana.example.com",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		params := GenerateDeeplinkParams{
+			ResourceType: "dashboard",
+			DashboardUID: stringPtr("abc123"),
+		}
+
+		result, err := generateDeeplink(ctx, params)
+		require.NoError(t, err)
+		assert.Equal(t, "https://grafana.example.com/d/abc123", result)
+	})
+
 	t.Run("Panel deeplink", func(t *testing.T) {
 		panelID := 5
 		params := GenerateDeeplinkParams{


### PR DESCRIPTION
Add support to specify public URL via `GRAFANA_PUBLIC_URL` environment variable or `X-Grafana-Public-URL` header.

The public URL is used to generate links to Grafana. Useful when the MCP server access the Grafana instance via a **local** URL, while users access the Grafana instance with this **public** URL (where Grafana/MCP server behind load balancers or reverse proxies).