### PR TITLE
chore: use latest mcp-publisher in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y jq
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.3.0/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
           chmod +x mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/
 


### PR DESCRIPTION
Claude says the older version doesn't support the latest schema?
Not entirely convinced but let's see.
