### PR TITLE
ci: update mcp-tokens action, use new args

### DIFF
--- a/.github/workflows/token-baseline.yml
+++ b/.github/workflows/token-baseline.yml
@@ -35,7 +35,7 @@ jobs:
             ANTHROPIC_API_KEY=anthropic:api-key
 
       - name: Generate token baseline
-        uses: sd2k/mcp-tokens-action@cc16099a4815fe23d902419de92fadf61b20e67d
+        uses: sd2k/mcp-tokens-action@df95d01ebeb7f1cbad6d675fd8f30a448be23f12
         with:
           command: ./dist/mcp-grafana
           anthropic-api-key: ${{ env.ANTHROPIC_API_KEY }}

--- a/.github/workflows/token-check.yml
+++ b/.github/workflows/token-check.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -31,6 +32,7 @@ jobs:
           branch: main
           name: token-baseline
           path: baseline
+          workflow: token-baseline.yml
           if_no_artifact_found: warn
 
       - name: Get secrets
@@ -43,10 +45,12 @@ jobs:
             ANTHROPIC_API_KEY=anthropic:api-key
 
       - name: Analyze tokens
-        uses: sd2k/mcp-tokens-action@cc16099a4815fe23d902419de92fadf61b20e67d
+        uses: sd2k/mcp-tokens-action@df95d01ebeb7f1cbad6d675fd8f30a448be23f12
 
         with:
           command: ./dist/mcp-grafana
           anthropic-api-key: ${{ env.ANTHROPIC_API_KEY }}
           baseline: ${{ steps.download-baseline.outputs.found_artifact == 'true' && 'baseline/token-baseline.json' || '' }}
           threshold-percent: "5"
+          comment: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the version of sd2k/mcp-tokens-action, with new args so we get comments on PRs. See [this example](https://github.com/grafana/mcp-grafana/pull/418#issuecomment-3658053043).