### PR TITLE
ci: build Docker image on every commit, push only on tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,13 @@ name: Build and Push Docker Image
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*.*.*"
+  pull_request:
+    branches:
+      - main
   release:
     types: [published]
 
@@ -18,8 +23,18 @@ jobs:
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
+      - name: Check if tag push
+        id: check
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "is_tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_tag=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Process tag name
         id: tag
+        if: steps.check.outputs.is_tag == 'true'
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -38,13 +53,14 @@ jobs:
           repository: grafana/mcp-grafana
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ steps.tag.outputs.is_stable == 'true' && 'latest' || '' }}
-            ${{ steps.tag.outputs.version }}
-          push: true
+            ${{ steps.check.outputs.is_tag == 'true' && steps.tag.outputs.is_stable == 'true' && 'latest' || '' }}
+            ${{ steps.check.outputs.is_tag == 'true' && steps.tag.outputs.version || '' }}
+          push: ${{ steps.check.outputs.is_tag == 'true' }}
 
   mcp-registry:
     runs-on: ubuntu-latest
     needs: docker
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Docker builds are failing on the latest tag which is very annoying. This builds more regularly to test the builds succeed.