### PR TITLE
Fix Prometheus datasource proxy URL to use resources endpoint

### DIFF
--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -37,7 +37,7 @@ func promClientFromContext(ctx context.Context, uid string) (promv1.API, error) 
 	}
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	url := fmt.Sprintf("%s/api/datasources/proxy/uid/%s", strings.TrimRight(cfg.URL, "/"), uid)
+	url := fmt.Sprintf("%s/api/datasources/uid/%s/resources", strings.TrimRight(cfg.URL, "/"), uid)
 
 	// Create custom transport with TLS configuration if available
 	rt := api.DefaultRoundTripper


### PR DESCRIPTION
Use `/api/datasources/uid/{uid}/resources` instead of `/api/datasources/proxy/uid/{uid}` for Prometheus API calls, because the former has better handling of custom auth for Azure.

Fixes #467
