### PR TITLE
feat: add Loki patterns query_loki_patterns tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The dashboard tools now include several strategies to manage context window usag
 
 - **Query Loki logs and metrics:** Run both log queries and metric queries using LogQL against Loki datasources.
 - **Query Loki metadata:** Retrieve label names, label values, and stream statistics from Loki datasources.
+- **Query Loki patterns:** Retrieve log patterns detected by Loki to identify common log structures and anomalies.
 
 ### Incidents
 
@@ -213,6 +214,7 @@ Scopes define the specific resources that permissions apply to. Each action requ
 | `list_loki_label_names`           | Loki        | List all available label names in logs                              | `datasources:query`                     | `datasources:uid:loki-uid`                          |
 | `list_loki_label_values`          | Loki        | List values for a specific log label                                | `datasources:query`                     | `datasources:uid:loki-uid`                          |
 | `query_loki_stats`                | Loki        | Get statistics about log streams                                    | `datasources:query`                     | `datasources:uid:loki-uid`                          |
+| `query_loki_patterns`             | Loki        | Query detected log patterns to identify common structures           | `datasources:query`                     | `datasources:uid:loki-uid`                          |
 | `list_alert_rules`                | Alerting    | List alert rules                                                    | `alert.rules:read`                      | `folders:*` or `folders:uid:alerts-folder`          |
 | `get_alert_rule_by_uid`           | Alerting    | Get alert rule by UID                                               | `alert.rules:read`                      | `folders:uid:alerts-folder`                         |
 | `create_alert_rule`               | Alerting    | Create a new alert rule                                             | `alert.rules:write`                     | `folders:*` or `folders:uid:alerts-folder`          |

--- a/testdata/loki-config.yml
+++ b/testdata/loki-config.yml
@@ -33,6 +33,14 @@ ruler:
     local:
       directory: /loki/rules
 
+pattern_ingester:
+  enabled: true
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+
 limits_config:
   allow_structured_metadata: true
   ingestion_rate_mb: 64

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -78,4 +78,21 @@ func TestLokiTools(t *testing.T) {
 		assert.NotNil(t, result, "Empty results should be an empty slice, not nil")
 		assert.Equal(t, 0, len(result), "Empty results should have length 0")
 	})
+
+	t.Run("query loki patterns", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryLokiPatterns(ctx, QueryLokiPatternsParams{
+			DatasourceUID: "loki",
+			LogQL:         `{container=~".+"}`,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Should return a result (may be empty if no patterns detected)")
+
+		// If we got patterns, check that they have the expected structure
+		for _, pattern := range result {
+			assert.NotEmpty(t, pattern.Pattern, "Pattern should have a pattern string")
+			// TotalCount should be non-negative
+			assert.GreaterOrEqual(t, pattern.TotalCount, int64(0), "TotalCount should be non-negative")
+		}
+	})
 }


### PR DESCRIPTION
Add new tool to query detected log patterns from Loki datasources.

This allows us to leverage the pattern matching done on the Loki server which can drastically reduce tool calls and token count for LLMs pattern matching.

Implements #498 