### PR TITLE
feat: add notification_settings support to create/update alert rule tools

### DIFF
--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -581,6 +581,7 @@ type CreateAlertRuleParams struct {
 	Labels            map[string]string    `json:"labels,omitempty" jsonschema:"description=Optional labels"`
 	UID               *string              `json:"uid,omitempty" jsonschema:"description=Optional UID for the alert rule"`
 	OrgID             int64                `json:"orgID" jsonschema:"required,description=The organization ID"`
+	NotificationSettings *models.AlertRuleNotificationSettings `json:"notification_settings,omitempty" jsonschema:"description=Optional notification routing settings including receiver (contact point) name"`
 	DisableProvenance *bool                `json:"disableProvenance,omitempty" jsonschema:"description=If true\\, the alert will remain editable in the Grafana UI (sets X-Disable-Provenance header). If false\\, the alert will be marked with provenance 'api' and locked from UI editing. Defaults to true."`
 }
 
@@ -643,6 +644,7 @@ func createAlertRule(ctx context.Context, args CreateAlertRuleParams) (*models.P
 		Annotations:  args.Annotations,
 		Labels:       args.Labels,
 		OrgID:        &args.OrgID,
+		NotificationSettings: args.NotificationSettings,
 	}
 
 	if args.UID != nil {
@@ -694,6 +696,7 @@ type UpdateAlertRuleParams struct {
 	Annotations       map[string]string    `json:"annotations,omitempty" jsonschema:"description=Optional annotations"`
 	Labels            map[string]string    `json:"labels,omitempty" jsonschema:"description=Optional labels"`
 	OrgID             int64                `json:"orgID" jsonschema:"required,description=The organization ID"`
+	NotificationSettings *models.AlertRuleNotificationSettings `json:"notification_settings,omitempty" jsonschema:"description=Optional notification routing settings including receiver (contact point) name"`
 	DisableProvenance *bool                `json:"disableProvenance,omitempty" jsonschema:"description=If true\\, the alert will remain editable in the Grafana UI (sets X-Disable-Provenance header). If false\\, the alert will be marked with provenance 'api' and locked from UI editing. Defaults to true."`
 }
 
@@ -760,6 +763,7 @@ func updateAlertRule(ctx context.Context, args UpdateAlertRuleParams) (*models.P
 		Annotations:  args.Annotations,
 		Labels:       args.Labels,
 		OrgID:        &args.OrgID,
+		NotificationSettings: args.NotificationSettings,
 	}
 
 	// Validate the rule using the built-in OpenAPI validation


### PR DESCRIPTION
## Summary

Adds `notification_settings` parameter support to the `create_alert_rule` and `update_alert_rule` MCP tools, allowing clients to configure which contact point (receiver) an alert rule routes to directly.

## Problem

Currently there's no way to set the notification receiver on an alert rule via MCP. Users must manually configure this in the Grafana UI after creating/updating a rule.

## Solution

Added `NotificationSettings *models.AlertRuleNotificationSettings` to both `CreateAlertRuleParams` and `UpdateAlertRuleParams`, and wire it through to the `models.ProvisionedAlertRule` passed to the Grafana provisioning API.

The `grafana-openapi-client-go` model already has this field — this change just exposes it through the MCP tools.

## Usage

```json
{
  "notification_settings": {
    "receiver": "My Slack Channel"
  }
}
```

## Testing

Tested end-to-end: built patched binary locally, created an alert rule with `notification_settings.receiver` set, verified via `get_alert_rule_by_uid` that the setting persisted correctly.

Relates to #334