### PR TITLE
chore(renovate): group GitHub Actions updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,12 @@
     ],
     "prConcurrentLimit": 5,
     "minimumReleaseAge": "14 days",
-    "rebaseWhen": "behind-base-branch"
+    "rebaseWhen": "behind-base-branch",
+    "packageRules": [
+        {
+            "description": "Group all GitHub Actions updates together",
+            "matchManagers": ["github-actions"],
+            "groupName": "github-actions"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary

Groups all GitHub Actions updates (both version and digest updates) into a single PR instead of creating separate PRs for each.

## Changes

- Added `packageRules` configuration to `renovate.json` that matches the `github-actions` manager and groups updates with `groupName: "github-actions"`

## Why

Previously, Renovate was creating separate PRs for:
- Version updates (e.g., `actions/checkout` v6.0.1 → v6.0.2)
- Digest updates (e.g., `goreleaser/goreleaser-action` SHA pinning)

This resulted in multiple small PRs for the same category of dependencies. Grouping them reduces PR noise and makes it easier to review action updates together.

## Testing

This is a Renovate configuration change. The next time Renovate runs, it will create grouped PRs for GitHub Actions updates instead of individual ones.

🤖 Generated with [Claude Code](https://claude.ai/code)