### PR TITLE
fix(ci): push Docker images with version tags, not just latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*.*.*"
   pull_request:
     branches:
       - main
-  release:
-    types: [published]
+  # Trigger after goreleaser completes on tags - this is more reliable than
+  # push.tags which wasn't triggering consistently
+  workflow_run:
+    workflows: ["goreleaser"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -18,16 +20,27 @@ permissions:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    # For workflow_run events, only run if goreleaser succeeded
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          # For workflow_run, checkout the commit that triggered goreleaser
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: Check if tag push
+      - name: Check if release build
         id: check
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            echo "is_tag=true" >> $GITHUB_OUTPUT
+          # For workflow_run events, check if it was triggered by a tag
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            if [[ "${{ github.event.workflow_run.head_branch }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+              echo "is_tag=true" >> $GITHUB_OUTPUT
+              echo "version=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+            else
+              echo "is_tag=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "is_tag=false" >> $GITHUB_OUTPUT
           fi
@@ -36,7 +49,8 @@ jobs:
         id: tag
         if: steps.check.outputs.is_tag == 'true'
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
+          VERSION="${{ steps.check.outputs.version }}"
+          VERSION=${VERSION#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           # Check if this is a stable release (no rc, alpha, beta, etc.)
           if [[ ! "$VERSION" =~ (rc|alpha|beta|pre|dev) ]]; then
@@ -60,7 +74,10 @@ jobs:
   mcp-registry:
     runs-on: ubuntu-latest
     needs: docker
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Run only for workflow_run events triggered by a tag
+    if: >
+      github.event_name == 'workflow_run' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     permissions:
       contents: read
       id-token: write
@@ -69,22 +86,19 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Extract version from tag
         id: version
         run: |
-          # Get the tag from the triggering workflow
-          TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
-          if [ -z "$TAG" ]; then
-            echo "No tag found at HEAD"
-            exit 1
-          fi
+          # Get the tag from the workflow_run event
+          TAG="${{ github.event.workflow_run.head_branch }}"
           echo "VERSION=$TAG" >> $GITHUB_OUTPUT
 
       - name: Extract image tag from version
         id: image-tag
         run: |
-          # Extract the image tag from the version
+          # Extract the image tag from the version (remove 'v' prefix)
           VERSION="${{ steps.version.outputs.VERSION }}"
           echo "IMAGE_TAG=${VERSION#v}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

- The `docker.yml` workflow was configured to push versioned tags (e.g., `0.9.0`) alongside `latest`, but the `push.tags` trigger was never actually firing
- Looking at workflow run history, only the `goreleaser` workflow runs on tag pushes - the docker workflow never triggered
- This resulted in only `latest` being pushed to Docker Hub, with no version tags

## Changes

- Replace unreliable `push.tags` trigger with `workflow_run` trigger that fires after `goreleaser` completes
- Update tag detection logic to use `workflow_run` event data instead of `GITHUB_REF`
- Fix checkout refs to use the correct commit SHA from the triggering workflow
- Update `mcp-registry` job conditions to work with `workflow_run` events

## How it works now

When a tag like `v0.10.0` is pushed:
1. Goreleaser workflow runs and creates the GitHub release (this already works)
2. Docker workflow triggers automatically after goreleaser succeeds
3. Docker images are pushed with both `0.10.0` and `latest` tags
4. MCP registry is updated with the versioned image reference

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test with a new release tag to confirm both version and latest tags are pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)