### PR TITLE
chore(renovate): configure single weekly grouped dependency update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,25 @@
 {
     "ignorePresets": [
-            "github>grafana/grafana-renovate-config//presets/base",
-            "github>grafana/grafana-renovate-config//presets/automerge",
-            "github>grafana/grafana-renovate-config//presets/labels",
-            "github>grafana/grafana-renovate-config//presets/npm"
+        "github>grafana/grafana-renovate-config//presets/base",
+        "github>grafana/grafana-renovate-config//presets/automerge",
+        "github>grafana/grafana-renovate-config//presets/labels",
+        "github>grafana/grafana-renovate-config//presets/npm"
     ],
     "extends": [
         "config:best-practices",
         ":disableDependencyDashboard",
         ":preserveSemverRanges",
-        "github>grafana/grafana-renovate-config//presets/plugin-ci-workflows"
+        "github>grafana/grafana-renovate-config//presets/plugin-ci-workflows",
+        "schedule:weekly"
     ],
     "prConcurrentLimit": 5,
     "minimumReleaseAge": "14 days",
     "rebaseWhen": "behind-base-branch",
     "packageRules": [
         {
-            "description": "Group all GitHub Actions updates together",
-            "matchManagers": ["github-actions"],
-            "groupName": "github-actions"
+            "description": "Group all dependency updates into a single weekly PR",
+            "matchPackagePatterns": ["*"],
+            "groupName": "all-dependencies"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Configure Renovate to create a single grouped PR on a weekly schedule instead of individual PRs for each dependency.

## Changes

- Add `schedule:weekly` preset to run Renovate weekly
- Add a single package rule that groups all dependencies (`matchPackagePatterns: ["*"]`) into one PR

## Motivation

Looking at the historical Renovate PRs, there were many individual PRs being created:
- Individual PRs for each Docker image update
- Individual PRs for each Go module update
- Multiple PRs per day/week adding review overhead

This configuration consolidates all updates into a single weekly PR, significantly reducing noise.

## Testing

- Configuration syntax is valid JSON
- Uses standard Renovate packageRules syntax
- The `schedule:weekly` preset is a built-in Renovate preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)