### PR TITLE
fix(docker): upgrade base image packages to resolve critical OpenSSL CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ FROM debian:bookworm-slim@sha256:56ff6d36d4eb3db13a741b342ec466f121480b5edded42e
 
 LABEL io.modelcontextprotocol.server.name="io.github.grafana/mcp-grafana"
 
-# Install ca-certificates for HTTPS requests
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+# Install ca-certificates for HTTPS requests and upgrade existing packages
+# to pick up security fixes (e.g. OpenSSL) newer than the base image snapshot
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user
 RUN useradd -r -u 1000 -m mcp-grafana


### PR DESCRIPTION
## Summary

- Add `apt-get upgrade -y` to the Docker runtime stage so that packages shipped in the `debian:bookworm-slim` base image are patched to their latest available versions at build time
- Resolves critical vulnerability **CVE-2025-15467** (CVSS 9.8, exploitability 3.9) affecting two packages in the current image:

| Package | Vulnerable Version | Fixed Version |
|---|---|---|
| `openssl` | `3.0.18-1~deb12u1` | `3.0.18-1~deb12u2` |
| `libssl3` | `3.0.18-1~deb12u1` | `3.0.18-1~deb12u2` |

- CVE details: https://security-tracker.debian.org/tracker/CVE-2025-15467
- This CVE has a public exploit and is flagged as **CRITICAL** by Wiz security scanning

## Context

The `debian:bookworm-slim` base image is pinned by SHA256 digest for reproducibility. However, the Dockerfile was only running `apt-get update` + `apt-get install ca-certificates` without upgrading existing packages, so OpenSSL (and other packages) remained at whatever version was baked into the image snapshot — even when Debian had published security fixes.

Adding `apt-get upgrade -y` ensures every rebuild picks up the latest security patches from the Debian bookworm repos for all pre-installed packages.

## Test plan

- [ ] Rebuild the Docker image and verify it builds successfully
- [ ] Run `docker run --rm <image> dpkg -l openssl libssl3` and confirm versions are `>= 3.0.18-1~deb12u2`
- [ ] Re-run Wiz/ECR security scan and confirm CVE-2025-15467 no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)