### PR TITLE
feat(dashboard): support remove operation on array elements by index

### DIFF
--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -69,6 +71,13 @@ func updateDashboard(ctx context.Context, args UpdateDashboardParams) (*models.P
 
 // updateDashboardWithPatches applies patch operations to an existing dashboard
 func updateDashboardWithPatches(ctx context.Context, args UpdateDashboardParams) (*models.PostDashboardOKBody, error) {
+	// Sort array element remove operations from highest to lowest index to avoid index-shifting issues
+	sortedOps, err := sortArrayRemovesDescending(args.Operations)
+	if err != nil {
+		return nil, err
+	}
+	args.Operations = sortedOps
+
 	// Get the current dashboard
 	dashboard, err := getDashboardByUID(ctx, GetDashboardByUIDParams{UID: args.UID})
 	if err != nil {
@@ -130,6 +139,103 @@ func updateDashboardWithFullJSON(ctx context.Context, args UpdateDashboardParams
 	return dashboard.Payload, nil
 }
 
+// sortArrayRemovesDescending reorders remove operations on the same array
+// from highest index to lowest. This prevents the index-shifting footgun
+// where removing a lower index first causes subsequent operations to target wrong elements.
+// It also rejects duplicate indices on the same array (likely an LLM mistake).
+func sortArrayRemovesDescending(operations []PatchOperation) ([]PatchOperation, error) {
+	type arrayRemoveInfo struct {
+		arrayPath string
+		index     int
+		opIndex   int
+	}
+
+	// Collect array remove operations grouped by array path
+	removesByArray := make(map[string][]arrayRemoveInfo)
+
+	for i, op := range operations {
+		if op.Op != "remove" {
+			continue
+		}
+
+		// Parse the path to check if it's an array element removal
+		path := op.Path
+		if len(path) > 2 && path[:2] == "$." {
+			path = path[2:]
+		}
+
+		segments := parseJSONPath(path)
+		if len(segments) == 0 {
+			continue
+		}
+
+		// Check if the final segment is an array access
+		finalSeg := segments[len(segments)-1]
+		if !finalSeg.IsArray || finalSeg.IsAppend {
+			continue
+		}
+
+		// Build the array path (everything except the index)
+		arrayPath := ""
+		for j, seg := range segments {
+			if j > 0 {
+				arrayPath += "."
+			}
+			arrayPath += seg.Key
+			if seg.IsArray && j < len(segments)-1 {
+				arrayPath += fmt.Sprintf("[%d]", seg.Index)
+			}
+		}
+
+		removesByArray[arrayPath] = append(removesByArray[arrayPath], arrayRemoveInfo{
+			arrayPath: arrayPath,
+			index:     finalSeg.Index,
+			opIndex:   i,
+		})
+	}
+
+	// Check for duplicate indices and sort each group descending
+	for arrayPath, removes := range removesByArray {
+		// Check for duplicate indices
+		seen := make(map[int]bool)
+		for _, r := range removes {
+			if seen[r.index] {
+				return nil, fmt.Errorf("duplicate remove at index %d on '%s'; each index should only be removed once", r.index, arrayPath)
+			}
+			seen[r.index] = true
+		}
+
+		// Sort descending by index
+		sort.Slice(removes, func(i, j int) bool {
+			return removes[i].index > removes[j].index
+		})
+		removesByArray[arrayPath] = removes
+	}
+
+	// Rebuild the operations slice with array removes reordered
+	result := make([]PatchOperation, len(operations))
+	copy(result, operations)
+
+	for _, removes := range removesByArray {
+		if len(removes) <= 1 {
+			continue
+		}
+		// Collect the original positions of these remove ops
+		positions := make([]int, len(removes))
+		for i, r := range removes {
+			positions[i] = r.opIndex
+		}
+		// Sort positions ascending so we can place sorted removes in order
+		sort.Ints(positions)
+		// Place the sorted (descending by index) removes into the original positions
+		for i, pos := range positions {
+			result[pos] = operations[removes[i].opIndex]
+		}
+	}
+
+	return result, nil
+}
+
 var GetDashboardByUID = mcpgrafana.MustTool(
 	"get_dashboard_by_uid",
 	"Retrieves the complete dashboard, including panels, variables, and settings, for a specific dashboard identified by its UID. WARNING: Large dashboards can consume significant context window space. Consider using get_dashboard_summary for overview or get_dashboard_property for specific data instead.",
@@ -141,7 +247,7 @@ var GetDashboardByUID = mcpgrafana.MustTool(
 
 var UpdateDashboard = mcpgrafana.MustTool(
 	"update_dashboard",
-	"Create or update a dashboard using either full JSON or efficient patch operations. For new dashboards\\, provide the 'dashboard' field. For updating existing dashboards\\, use 'uid' + 'operations' for better context window efficiency. Patch operations support complex JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'\\, etc. Supports appending to arrays using '/- ' syntax: '$.panels/- ' appends to panels array\\, '$.panels[2]/- ' appends to nested array at index 2.",
+	"Create or update a dashboard using either full JSON or efficient patch operations. For new dashboards\\, provide the 'dashboard' field. For updating existing dashboards\\, use 'uid' + 'operations' for better context window efficiency. Patch operations support complex JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'\\, etc. Supports appending to arrays using '/- ' syntax: '$.panels/- ' appends to panels array\\, '$.panels[2]/- ' appends to nested array at index 2. Supports removing array elements by index: {\"op\": \"remove\"\\, \"path\": \"$.panels[2]\"}. Multiple removes on the same array are automatically reordered from highest to lowest index to avoid index-shifting issues.",
 	updateDashboard,
 	mcp.WithTitleAnnotation("Create or update dashboard"),
 	mcp.WithDestructiveHintAnnotation(true),
@@ -550,7 +656,12 @@ func removeAtSegment(current map[string]interface{}, segment JSONPathSegment) er
 	}
 
 	if segment.IsArray {
-		return fmt.Errorf("cannot remove array element %s[%d] (not supported)", segment.Key, segment.Index)
+		arr, err := validateArrayAccess(current, segment)
+		if err != nil {
+			return err
+		}
+		current[segment.Key] = slices.Delete(arr, segment.Index, segment.Index+1)
+		return nil
 	}
 
 	delete(current, segment.Key)

--- a/tools/dashboard_test.go
+++ b/tools/dashboard_test.go
@@ -7,6 +7,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -439,5 +440,93 @@ func TestDashboardTools(t *testing.T) {
 			},
 		})
 		require.Error(t, err, "Should fail when trying to append to non-array field")
+	})
+
+	t.Run("update dashboard - remove panel by index", func(t *testing.T) {
+		ctx := newTestContext()
+
+		// Get our test dashboard
+		dashboard := getExistingTestDashboard(t, ctx, newTestDashboardName)
+		dashboardMap := getTestDashboardJSON(t, ctx, dashboard)
+
+		// Get current panel count
+		panels, ok := dashboardMap["panels"].([]interface{})
+		require.True(t, ok, "Panels should be an array")
+		originalCount := len(panels)
+
+		// Append a panel first so we have something to remove
+		newPanel := map[string]interface{}{
+			"id":    998,
+			"title": "Panel To Remove",
+			"type":  "stat",
+			"targets": []interface{}{
+				map[string]interface{}{
+					"expr": "up",
+				},
+			},
+			"gridPos": map[string]interface{}{
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 16,
+			},
+		}
+
+		_, err := updateDashboard(ctx, UpdateDashboardParams{
+			UID: dashboard.UID,
+			Operations: []PatchOperation{
+				{
+					Op:    "add",
+					Path:  "$.panels/-",
+					Value: newPanel,
+				},
+			},
+			Message: "Appended panel for removal test",
+		})
+		require.NoError(t, err)
+
+		// Verify the panel was appended
+		updatedDashboard, err := getDashboardByUID(ctx, GetDashboardByUIDParams{
+			UID: dashboard.UID,
+		})
+		require.NoError(t, err)
+		updatedMap, ok := updatedDashboard.Dashboard.(map[string]interface{})
+		require.True(t, ok)
+		updatedPanels, ok := updatedMap["panels"].([]interface{})
+		require.True(t, ok)
+		require.Equal(t, originalCount+1, len(updatedPanels))
+
+		// Now remove the last panel by index
+		removeIndex := len(updatedPanels) - 1
+		_, err = updateDashboard(ctx, UpdateDashboardParams{
+			UID: dashboard.UID,
+			Operations: []PatchOperation{
+				{
+					Op:   "remove",
+					Path: fmt.Sprintf("$.panels[%d]", removeIndex),
+				},
+			},
+			Message: "Removed panel by index",
+		})
+		require.NoError(t, err)
+
+		// Verify the panel was removed
+		finalDashboard, err := getDashboardByUID(ctx, GetDashboardByUIDParams{
+			UID: dashboard.UID,
+		})
+		require.NoError(t, err)
+		finalMap, ok := finalDashboard.Dashboard.(map[string]interface{})
+		require.True(t, ok)
+		finalPanels, ok := finalMap["panels"].([]interface{})
+		require.True(t, ok)
+		assert.Equal(t, originalCount, len(finalPanels))
+
+		// Verify the removed panel is not present
+		for _, p := range finalPanels {
+			panel, ok := p.(map[string]interface{})
+			if ok {
+				assert.NotEqual(t, "Panel To Remove", panel["title"])
+			}
+		}
 	})
 }

--- a/tools/dashboard_unit_test.go
+++ b/tools/dashboard_unit_test.go
@@ -1,7 +1,10 @@
 package tools
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,4 +30,418 @@ func TestApplyJSONPath_TrailingWhitespace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "new", data["title"])
 	})
+}
+
+// Feature: dashboard-remove-array-element, Property 1: Array removal produces correct result
+// Validates: Requirements 1.1, 1.2, 1.3
+func TestProperty_ArrayRemovalProducesCorrectResult(t *testing.T) {
+	f := func(size uint8) bool {
+		// Ensure non-empty array (size 1-256)
+		n := int(size) + 1
+
+		// Build array of distinguishable elements
+		arr := make([]interface{}, n)
+		for j := 0; j < n; j++ {
+			arr[j] = j
+		}
+
+		// Pick a random valid index
+		idx := rand.Intn(n)
+
+		// Build expected result
+		expected := make([]interface{}, 0, n-1)
+		expected = append(expected, arr[:idx]...)
+		expected = append(expected, arr[idx+1:]...)
+
+		// Build the map and segment
+		current := map[string]interface{}{"items": copySlice(arr)}
+		segment := JSONPathSegment{Key: "items", IsArray: true, Index: idx}
+
+		// Execute
+		err := removeAtSegment(current, segment)
+		if err != nil {
+			return false
+		}
+
+		// Verify
+		result := current["items"].([]interface{})
+		if len(result) != n-1 {
+			return false
+		}
+		for k := range result {
+			if result[k] != expected[k] {
+				return false
+			}
+		}
+		return true
+	}
+
+	require.NoError(t, quick.Check(f, &quick.Config{MaxCount: 200}))
+}
+
+func copySlice(s []interface{}) []interface{} {
+	c := make([]interface{}, len(s))
+	copy(c, s)
+	return c
+}
+
+// Feature: dashboard-remove-array-element, Property 2: Out-of-bounds index returns error
+// Validates: Requirements 1.4, 1.5
+func TestProperty_OutOfBoundsIndexReturnsError(t *testing.T) {
+	f := func(size uint8, offset uint8) bool {
+		n := int(size) // array length 0-255
+
+		// Build array
+		arr := make([]interface{}, n)
+		for j := 0; j < n; j++ {
+			arr[j] = j
+		}
+
+		// Out-of-bounds index: n + offset (always >= n)
+		idx := n + int(offset)
+
+		// Build the map and segment
+		original := copySlice(arr)
+		current := map[string]interface{}{"items": copySlice(arr)}
+		segment := JSONPathSegment{Key: "items", IsArray: true, Index: idx}
+
+		// Execute
+		err := removeAtSegment(current, segment)
+
+		// Must return error
+		if err == nil {
+			return false
+		}
+
+		// Array must be unchanged
+		result := current["items"].([]interface{})
+		if len(result) != len(original) {
+			return false
+		}
+		for k := range result {
+			if result[k] != original[k] {
+				return false
+			}
+		}
+		return true
+	}
+
+	require.NoError(t, quick.Check(f, &quick.Config{MaxCount: 200}))
+}
+
+// Feature: dashboard-remove-array-element, Property 4: Object property removal is preserved
+// Validates: Requirements 3.1
+func TestProperty_ObjectPropertyRemovalPreserved(t *testing.T) {
+	f := func(numKeys uint8) bool {
+		// Build a map with 1 to 256 keys
+		n := int(numKeys) + 1
+		current := make(map[string]interface{})
+		for j := 0; j < n; j++ {
+			current[fmt.Sprintf("key_%d", j)] = j
+		}
+
+		// Pick a random key to remove
+		targetIdx := rand.Intn(n)
+		targetKey := fmt.Sprintf("key_%d", targetIdx)
+
+		// Snapshot other keys
+		otherKeys := make(map[string]interface{})
+		for k, v := range current {
+			if k != targetKey {
+				otherKeys[k] = v
+			}
+		}
+
+		// Execute removal (non-array segment)
+		segment := JSONPathSegment{Key: targetKey, IsArray: false}
+		err := removeAtSegment(current, segment)
+		if err != nil {
+			return false
+		}
+
+		// Target key must be absent
+		if _, exists := current[targetKey]; exists {
+			return false
+		}
+
+		// All other keys must be unchanged
+		if len(current) != len(otherKeys) {
+			return false
+		}
+		for k, v := range otherKeys {
+			if current[k] != v {
+				return false
+			}
+		}
+		return true
+	}
+
+	require.NoError(t, quick.Check(f, &quick.Config{MaxCount: 200}))
+}
+
+// Unit tests for removeAtSegment edge cases
+// Validates: Requirements 1.1, 1.4, 3.2
+func TestRemoveAtSegment_EdgeCases(t *testing.T) {
+	t.Run("remove first element", func(t *testing.T) {
+		current := map[string]interface{}{"items": []interface{}{"a", "b", "c"}}
+		segment := JSONPathSegment{Key: "items", IsArray: true, Index: 0}
+		err := removeAtSegment(current, segment)
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"b", "c"}, current["items"])
+	})
+
+	t.Run("remove middle element", func(t *testing.T) {
+		current := map[string]interface{}{"items": []interface{}{"a", "b", "c"}}
+		segment := JSONPathSegment{Key: "items", IsArray: true, Index: 1}
+		err := removeAtSegment(current, segment)
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"a", "c"}, current["items"])
+	})
+
+	t.Run("remove last element", func(t *testing.T) {
+		current := map[string]interface{}{"items": []interface{}{"a", "b", "c"}}
+		segment := JSONPathSegment{Key: "items", IsArray: true, Index: 2}
+		err := removeAtSegment(current, segment)
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"a", "b"}, current["items"])
+	})
+
+	t.Run("remove from single-element array", func(t *testing.T) {
+		current := map[string]interface{}{"items": []interface{}{"only"}}
+		segment := JSONPathSegment{Key: "items", IsArray: true, Index: 0}
+		err := removeAtSegment(current, segment)
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{}, current["items"])
+	})
+
+	t.Run("remove with append syntax returns error", func(t *testing.T) {
+		current := map[string]interface{}{"items": []interface{}{"a", "b"}}
+		segment := JSONPathSegment{Key: "items", IsAppend: true}
+		err := removeAtSegment(current, segment)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "append syntax")
+	})
+
+	t.Run("remove from non-array field returns error", func(t *testing.T) {
+		current := map[string]interface{}{"title": "hello"}
+		segment := JSONPathSegment{Key: "title", IsArray: true, Index: 0}
+		err := removeAtSegment(current, segment)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not an array")
+	})
+}
+
+// Feature: dashboard-remove-array-element, Property 3: Sequential removal shifts indices correctly
+// Validates: Requirements 2.2
+func TestProperty_SequentialRemovalShiftsIndices(t *testing.T) {
+	f := func(size uint8) bool {
+		// Ensure array of length >= 3 (need at least 3 elements for two sequential removals)
+		n := int(size) + 3
+
+		// Build array of distinguishable elements
+		arr := make([]interface{}, n)
+		for j := 0; j < n; j++ {
+			arr[j] = j
+		}
+
+		// Build the map
+		current := map[string]interface{}{"items": copySlice(arr)}
+
+		// Remove index 0 (removes original element 0)
+		segment := JSONPathSegment{Key: "items", IsArray: true, Index: 0}
+		err := removeAtSegment(current, segment)
+		if err != nil {
+			return false
+		}
+
+		// After removal, index 0 should be what was originally at index 1
+		result := current["items"].([]interface{})
+		if result[0] != arr[1] {
+			return false
+		}
+
+		// Remove index 0 again (removes what was originally element 1)
+		err = removeAtSegment(current, segment)
+		if err != nil {
+			return false
+		}
+
+		// Now index 0 should be what was originally at index 2
+		result = current["items"].([]interface{})
+		if result[0] != arr[2] {
+			return false
+		}
+
+		// Length should be n-2
+		return len(result) == n-2
+	}
+
+	require.NoError(t, quick.Check(f, &quick.Config{MaxCount: 200}))
+}
+
+// Feature: dashboard-remove-array-element, Property 5: Nested array removal via full path
+// Validates: Requirements 4.1
+func TestApplyJSONPath_NestedArrayRemoval(t *testing.T) {
+	t.Run("remove nested array element", func(t *testing.T) {
+		// Build a structure mimicking a dashboard with panels containing targets
+		data := map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"title": "Panel 1",
+					"targets": []interface{}{
+						map[string]interface{}{"expr": "query_a"},
+						map[string]interface{}{"expr": "query_b"},
+						map[string]interface{}{"expr": "query_c"},
+					},
+				},
+			},
+		}
+
+		// Remove targets[1] from panels[0]
+		err := applyJSONPath(data, "$.panels[0].targets[1]", nil, true)
+		require.NoError(t, err)
+
+		// Verify outer structure is intact
+		panels := data["panels"].([]interface{})
+		require.Len(t, panels, 1)
+
+		panel := panels[0].(map[string]interface{})
+		assert.Equal(t, "Panel 1", panel["title"])
+
+		// Verify inner array has the correct elements
+		targets := panel["targets"].([]interface{})
+		require.Len(t, targets, 2)
+		assert.Equal(t, "query_a", targets[0].(map[string]interface{})["expr"])
+		assert.Equal(t, "query_c", targets[1].(map[string]interface{})["expr"])
+	})
+
+	t.Run("remove from deeply nested path", func(t *testing.T) {
+		data := map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"title":   "Panel 1",
+					"targets": []interface{}{"t0", "t1", "t2"},
+				},
+				map[string]interface{}{
+					"title":   "Panel 2",
+					"targets": []interface{}{"t3", "t4"},
+				},
+			},
+		}
+
+		// Remove targets[0] from panels[1]
+		err := applyJSONPath(data, "$.panels[1].targets[0]", nil, true)
+		require.NoError(t, err)
+
+		// Verify panels[0] is untouched
+		panel0 := data["panels"].([]interface{})[0].(map[string]interface{})
+		assert.Len(t, panel0["targets"].([]interface{}), 3)
+
+		// Verify panels[1].targets has the correct element
+		panel1 := data["panels"].([]interface{})[1].(map[string]interface{})
+		targets := panel1["targets"].([]interface{})
+		require.Len(t, targets, 1)
+		assert.Equal(t, "t4", targets[0])
+	})
+}
+
+
+// Unit tests for sortArrayRemovesDescending
+// Validates: safe ordering of multiple array element removes
+func TestSortArrayRemovesDescending(t *testing.T) {
+	t.Run("single remove is unchanged", func(t *testing.T) {
+		ops := []PatchOperation{
+			{Op: "remove", Path: "$.panels[2]"},
+		}
+		result, err := sortArrayRemovesDescending(ops)
+		require.NoError(t, err)
+		assert.Equal(t, "$.panels[2]", result[0].Path)
+	})
+
+	t.Run("removes in descending order are unchanged", func(t *testing.T) {
+		ops := []PatchOperation{
+			{Op: "remove", Path: "$.panels[4]"},
+			{Op: "remove", Path: "$.panels[2]"},
+			{Op: "remove", Path: "$.panels[0]"},
+		}
+		result, err := sortArrayRemovesDescending(ops)
+		require.NoError(t, err)
+		assert.Equal(t, "$.panels[4]", result[0].Path)
+		assert.Equal(t, "$.panels[2]", result[1].Path)
+		assert.Equal(t, "$.panels[0]", result[2].Path)
+	})
+
+	t.Run("removes in ascending order are reordered", func(t *testing.T) {
+		ops := []PatchOperation{
+			{Op: "remove", Path: "$.panels[1]"},
+			{Op: "remove", Path: "$.panels[3]"},
+		}
+		result, err := sortArrayRemovesDescending(ops)
+		require.NoError(t, err)
+		assert.Equal(t, "$.panels[3]", result[0].Path)
+		assert.Equal(t, "$.panels[1]", result[1].Path)
+	})
+
+	t.Run("removes on different arrays are independent", func(t *testing.T) {
+		ops := []PatchOperation{
+			{Op: "remove", Path: "$.panels[1]"},
+			{Op: "remove", Path: "$.annotations[3]"},
+		}
+		result, err := sortArrayRemovesDescending(ops)
+		require.NoError(t, err)
+		assert.Equal(t, "$.panels[1]", result[0].Path)
+		assert.Equal(t, "$.annotations[3]", result[1].Path)
+	})
+
+	t.Run("nested array removes are sorted", func(t *testing.T) {
+		ops := []PatchOperation{
+			{Op: "remove", Path: "$.panels[0].targets[1]"},
+			{Op: "remove", Path: "$.panels[0].targets[3]"},
+		}
+		result, err := sortArrayRemovesDescending(ops)
+		require.NoError(t, err)
+		assert.Equal(t, "$.panels[0].targets[3]", result[0].Path)
+		assert.Equal(t, "$.panels[0].targets[1]", result[1].Path)
+	})
+
+	t.Run("mixed operations preserve non-remove order", func(t *testing.T) {
+		ops := []PatchOperation{
+			{Op: "replace", Path: "$.title", Value: "New Title"},
+			{Op: "remove", Path: "$.panels[1]"},
+			{Op: "add", Path: "$.panels/-", Value: map[string]interface{}{"id": 1}},
+			{Op: "remove", Path: "$.panels[2]"},
+		}
+		result, err := sortArrayRemovesDescending(ops)
+		require.NoError(t, err)
+		// Non-remove ops stay in place
+		assert.Equal(t, "replace", result[0].Op)
+		assert.Equal(t, "$.title", result[0].Path)
+		assert.Equal(t, "add", result[2].Op)
+		// Remove ops are reordered: 2 before 1
+		assert.Equal(t, "$.panels[2]", result[1].Path)
+		assert.Equal(t, "$.panels[1]", result[3].Path)
+	})
+
+	t.Run("non-array removes are unchanged", func(t *testing.T) {
+		ops := []PatchOperation{
+			{Op: "remove", Path: "$.description"},
+			{Op: "remove", Path: "$.tags"},
+		}
+		result, err := sortArrayRemovesDescending(ops)
+		require.NoError(t, err)
+		assert.Equal(t, "$.description", result[0].Path)
+		assert.Equal(t, "$.tags", result[1].Path)
+	})
+}
+
+func TestSortArrayRemovesDescending_SameIndexMultipleTimes(t *testing.T) {
+	// Same index multiple times is rejected - likely an LLM mistake
+	ops := []PatchOperation{
+		{Op: "remove", Path: "$.panels[11]"},
+		{Op: "remove", Path: "$.panels[11]"},
+		{Op: "remove", Path: "$.panels[11]"},
+	}
+	_, err := sortArrayRemovesDescending(ops)
+	require.Error(t, err, "Same index multiple times should be rejected")
+	assert.Contains(t, err.Error(), "duplicate remove")
 }


### PR DESCRIPTION
## Description

Adds support for removing array elements by index in the `update_dashboard` patch operations.

### Motivation

While using the MCP tool to clean up a Grafana dashboard, I needed to remove several redundant panel rows that were already covered in another dashboard. The tool returned:

```
cannot remove array element panels[11] (not supported)
```

The only workaround was to fetch the entire panels array, manually filter out the unwanted elements, and send a `replace` with the full filtered array as the value. For a dashboard with many large panels, this meant the LLM had to hold all panel definitions in context just to remove three of them — a massive context window cost compared to a simple `{"op": "remove", "path": "$.panels[11]"}`.

The LLM also attempted to work around the limitation by generating same-index patterns like `[11, 11, 11]`, expecting each remove to shift the array — a reasonable but incorrect assumption that silently targets wrong elements.

### The concern: index shifting

Removing an array element shifts all subsequent indices. In a multi-operation batch applied sequentially, this means a second `remove` can target the wrong element:

```
Before: [A, B, C, D, E]
Remove index 1 → [A, C, D, E]
Remove index 3 → removes E (was D before the shift)
```

### The solution: auto-sort removes descending

Rather than erroring and forcing an extra LLM round trip, we automatically sort multiple array element removes on the same array from **highest to lowest** index via `sortArrayRemovesDescending`. This means callers can pass removes in any order (e.g. `[2, 1, 3]`) and they'll be reordered to `[3, 2, 1]` before applying. Duplicate indices on the same array are still rejected as they're almost certainly an LLM mistake.

The tool description for `update_dashboard` now also mentions the remove-by-index capability and the auto-reordering behavior.

### Changes

**`tools/dashboard.go`**
- `removeAtSegment()`: handle `segment.IsArray` with `slices.Delete` instead of returning "not supported" error
- `sortArrayRemovesDescending()`: auto-sort multi-remove operations from highest to lowest index; reject duplicate indices
- `updateDashboardWithPatches()`: call sort before processing operations
- `UpdateDashboard` tool description: mention array element removal and auto-reordering

**`tools/dashboard_unit_test.go`** (new)
- 5 property-based tests via `testing/quick` (200 iterations each)
- Edge case unit tests for `removeAtSegment`
- 7 test cases for `sortArrayRemovesDescending` including ascending reordering, mixed ops, and same-index rejection

**`tools/dashboard_test.go`**
- Integration test: append a panel then remove it by index

### Usage

```json
{"op": "remove", "path": "$.panels[2]"}
```

Multiple removes (highest index first):
```json
[
  {"op": "remove", "path": "$.panels[4]"},
  {"op": "remove", "path": "$.panels[2]"},
  {"op": "remove", "path": "$.panels[0]"}
]
```

---

Happy to adjust anything based on feedback. Feel free to close this if it doesn't align with the project's direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dashboard mutation logic by changing how patch `remove` operations are applied and reordered; mistakes could delete the wrong elements, but the change is guarded with validation and extensive tests.
> 
> **Overview**
> `update_dashboard` patch operations now support removing array elements by index (e.g., `$.panels[2]`) instead of requiring callers to `replace` the full array.
> 
> To prevent multi-remove index shifting, array-element `remove` ops targeting the same array are automatically reordered from highest to lowest index and duplicate index removals are rejected. The tool description is updated accordingly, and new unit/property tests plus an integration test cover array removal, nested paths, bounds errors, and ordering behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02b6c34f9168e46b59136b83b0ace08acd47aa73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->