### PR TITLE
fix(dashboard): trim whitespace from patch operation paths

### DIFF
--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/PaesslerAG/gval"
 	"github.com/PaesslerAG/jsonpath"
@@ -374,6 +375,9 @@ var GetDashboardSummary = mcpgrafana.MustTool(
 
 // applyJSONPath applies a value to a JSONPath or removes it if remove=true
 func applyJSONPath(data map[string]interface{}, path string, value interface{}, remove bool) error {
+	// Trim whitespace to handle paths like "$.panels/- " (trailing space)
+	path = strings.TrimSpace(path)
+
 	// Remove the leading "$." if present
 	if len(path) > 2 && path[:2] == "$." {
 		path = path[2:]

--- a/tools/dashboard_unit_test.go
+++ b/tools/dashboard_unit_test.go
@@ -1,0 +1,30 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test for trailing whitespace in paths (bug fix)
+func TestApplyJSONPath_TrailingWhitespace(t *testing.T) {
+	t.Run("append with trailing space works", func(t *testing.T) {
+		data := map[string]interface{}{
+			"panels": []interface{}{"a", "b"},
+		}
+		// Path with trailing space - should be trimmed
+		err := applyJSONPath(data, "$.panels/- ", "c", false)
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"a", "b", "c"}, data["panels"])
+	})
+
+	t.Run("path with leading and trailing whitespace", func(t *testing.T) {
+		data := map[string]interface{}{
+			"title": "old",
+		}
+		err := applyJSONPath(data, "  $.title  ", "new", false)
+		require.NoError(t, err)
+		assert.Equal(t, "new", data["title"])
+	})
+}


### PR DESCRIPTION
## Description

Fixes a bug where trailing whitespace in patch operation paths caused incorrect parsing and misleading errors.

### Motivation

While using the MCP tool to append a panel to a dashboard, the LLM generated a path with a trailing space — `$.panels/- ` instead of `$.panels/-`. The tool returned:

```
operation 0 (add at $.panels/- ): at segment 0 (panels/-): append operation (/- ) can only be used at the final path segment
```

This is confusing because `panels/-` IS the final (and only) segment. The trailing space is invisible in most contexts, making the error hard to diagnose. The LLM couldn't self-correct because the path looked correct to it.

### The bug

A path like `$.panels/- ` (with trailing space) was parsed into two segments: `panels/-` and ` ` (space). The regex `([^.\[\]\/]+)` matched the trailing space as a second segment. This caused the append segment to be treated as a navigation (non-final) segment, which hit the guard:

```
append operation (/- ) can only be used at the final path segment
```

The path only has one real segment — `panels/-` IS the final segment. The space is noise.

### The fix

`strings.TrimSpace(path)` before parsing. Applied before the `$.` prefix strip so leading whitespace is also handled.

### Changes

**`tools/dashboard.go`**
- Add `strings.TrimSpace(path)` at the top of `applyJSONPath()`
- Add `"strings"` import

**`tools/dashboard_unit_test.go`** (new)
- Test: append with trailing space works
- Test: path with leading and trailing whitespace

---

Happy to adjust anything based on feedback. Feel free to close this if it doesn't align with the project's direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to JSONPath patch parsing plus regression tests; main risk is subtle behavior change for callers relying on whitespace being significant.
> 
> **Overview**
> Fixes a patching bug where leading/trailing whitespace in JSONPath strings (e.g. `$.panels/- `) caused `applyJSONPath` to mis-parse the path and raise misleading errors.
> 
> `applyJSONPath` now `strings.TrimSpace`s the path before further processing, and a new unit test file (`tools/dashboard_unit_test.go`) covers both trailing-space array append and general leading/trailing whitespace paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4afa08ce8601a6824394cc4c739692986bbbbee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->