### PR TITLE
feat: Alpine container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine3.23 AS builder
+FROM golang:1.24-alpine3.23@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
 
 # Set the working directory
 WORKDIR /app
@@ -17,7 +17,7 @@ COPY . .
 RUN go build -o mcp-grafana ./cmd/mcp-grafana
 
 # Final stage
-FROM alpine:3.23.3
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 LABEL io.modelcontextprotocol.server.name="io.github.grafana/mcp-grafana"
 


### PR DESCRIPTION
I have recently noticed that the current container image has a few CVEs. These seems to be linked to the image being based on Debian.

This PR is about migrating to Alpine to both make the image more secure and also smaller.

## How did I test it?
- I tried to locally build the image ✅ 
- I tried to run the container and query it ✅ 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/runtime base images and provisioning steps change, but no application logic is modified; main risk is Alpine libc/package differences affecting runtime behavior.
> 
> **Overview**
> Switches the container build from Debian-based images to Alpine for both the Go builder (`golang:1.24-alpine3.23`) and runtime (`alpine:3.23.3`) stages.
> 
> Updates package/user setup accordingly by replacing `apt-get` with `apk` for upgrades and `ca-certificates`, and swapping `useradd` for `adduser` while keeping the non-root UID `1000` and the same built binary/entrypoint behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c4ae5a7dc17aadddaf2bf27556026ca53e31cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->