### PR TITLE
feat(docker): add Alpine-based Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,13 +16,13 @@ permissions:
   contents: read
 
 jobs:
-  docker:
+  prepare:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    outputs:
+      is_tag: ${{ steps.check.outputs.is_tag }}
+      version: ${{ steps.tag.outputs.version }}
+      is_stable: ${{ steps.tag.outputs.is_stable }}
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
       - name: Check if tag push
         id: check
         run: |
@@ -45,6 +45,14 @@ jobs:
             echo "is_stable=false" >> $GITHUB_OUTPUT
           fi
 
+  docker:
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
       - name: Build and Push to Docker Hub
         uses: grafana/shared-workflows/actions/build-push-to-dockerhub@7f983a8135eb58eaec83c96d8b842b2092e110e3
         with:
@@ -53,9 +61,29 @@ jobs:
           repository: grafana/mcp-grafana
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ steps.check.outputs.is_tag == 'true' && steps.tag.outputs.is_stable == 'true' && 'latest' || '' }}
-            ${{ steps.check.outputs.is_tag == 'true' && steps.tag.outputs.version || '' }}
-          push: ${{ steps.check.outputs.is_tag == 'true' }}
+            ${{ needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.is_stable == 'true' && 'latest' || '' }}
+            ${{ needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.version || '' }}
+          push: ${{ needs.prepare.outputs.is_tag == 'true' }}
+
+  docker-alpine:
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - name: Build and Push Alpine to Docker Hub
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@7f983a8135eb58eaec83c96d8b842b2092e110e3
+        with:
+          context: .
+          file: ./Dockerfile.alpine
+          repository: grafana/mcp-grafana
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.is_stable == 'true' && 'alpine' || '' }}
+            ${{ needs.prepare.outputs.is_tag == 'true' && format('{0}-alpine', needs.prepare.outputs.version) || '' }}
+          push: ${{ needs.prepare.outputs.is_tag == 'true' }}
 
   mcp-registry:
     runs-on: ubuntu-latest

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,44 @@
+# Build stage
+FROM golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy go.mod and go.sum files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy the source code
+COPY . .
+
+# Build the application
+RUN go build -o mcp-grafana ./cmd/mcp-grafana
+
+# Final stage
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+
+LABEL io.modelcontextprotocol.server.name="io.github.grafana/mcp-grafana"
+
+# Install ca-certificates for HTTPS requests and upgrade existing packages
+# to pick up security fixes newer than the base image snapshot
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
+
+# Create a non-root user
+RUN adduser -D -u 1000 mcp-grafana
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the binary from the builder stage
+COPY --from=builder --chown=1000:1000 /app/mcp-grafana /app/
+
+# Use the non-root user
+USER mcp-grafana
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Run the application
+ENTRYPOINT ["/app/mcp-grafana", "--transport", "sse", "--address", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.alpine` using `golang:1.24-alpine` (builder) and `alpine:3.21` (runtime) with pinned digests
- Updates CI to build and push Alpine variants in parallel with existing Debian images
- Tags: `:alpine` (latest stable) and `:x.y.z-alpine` (version tags)

## Details

The Alpine image is roughly half the size of the Debian-based image (~74MB vs ~147MB), providing a lighter alternative for users who prefer minimal container images.

The Dockerfile follows the same patterns as the existing Debian-based one:
- Multi-stage build with Go builder
- Non-root user (uid 1000)
- ca-certificates installed
- Package upgrades for security fixes
- Same entrypoint and port exposure

## Test plan

- [x] `Dockerfile.alpine` builds successfully locally
- [x] Container starts and responds to `--help`
- [ ] CI builds pass for both amd64 and arm64 platforms
- [ ] Tags are correctly applied (verified via CI workflow syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI-only changes that affect container publishing and tags, with no runtime code changes; main risk is mis-tagging or CI/push issues during releases.
> 
> **Overview**
> Adds an **Alpine-based Docker image** (`Dockerfile.alpine`) using a multi-stage Go build with pinned base image digests, `ca-certificates`, package upgrades, and a non-root runtime user.
> 
> Updates the GitHub Actions Docker workflow to introduce a `prepare` job that derives tag/version stability once, then builds/pushes both the existing Debian image and a new Alpine variant on tag releases, publishing `:alpine` (stable) and `:<version>-alpine` tags alongside `:latest`/`:<version>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d90b6f97e67fa5ea876432db2fa8206a2376f798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->