### PR TITLE
fix(dashboard): improve update_dashboard tool descriptions and error messages to reduce LLM misuse

### DIFF
--- a/tools/dashboard_unit_test.go
+++ b/tools/dashboard_unit_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -444,4 +445,31 @@ func TestSortArrayRemovesDescending_SameIndexMultipleTimes(t *testing.T) {
 	_, err := sortArrayRemovesDescending(ops)
 	require.Error(t, err, "Same index multiple times should be rejected")
 	assert.Contains(t, err.Error(), "duplicate remove")
+}
+
+func TestUpdateDashboard_ValidationErrors(t *testing.T) {
+	t.Run("uid without operations", func(t *testing.T) {
+		_, err := updateDashboard(context.Background(), UpdateDashboardParams{
+			UID: "some-uid",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'uid' was provided without 'operations'")
+	})
+
+	t.Run("operations without uid", func(t *testing.T) {
+		_, err := updateDashboard(context.Background(), UpdateDashboardParams{
+			Operations: []PatchOperation{
+				{Op: "replace", Path: "$.title", Value: "New Title"},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'operations' were provided without 'uid'")
+	})
+
+	t.Run("empty params", func(t *testing.T) {
+		_, err := updateDashboard(context.Background(), UpdateDashboardParams{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no dashboard content provided")
+		assert.Contains(t, err.Error(), "Do NOT retry")
+	})
 }


### PR DESCRIPTION
Not sure if anyone else has run into this, but I've hit these failure modes many times when using `update_dashboard` through LLM clients (Claude Opus 4.6 in my case). After applying these changes and packaging for local testing, I haven't run into either issue again.

### Problem

LLMs repeatedly fail to call `update_dashboard` correctly, falling into two distinct failure patterns that they cannot self-correct from:

#### Case 1: Invalid params — `uid` without `operations`

The LLM calls `update_dashboard` with only supplementary fields:

```json
{
  "uid": "bf55vo1xxxxxsd",
  "folderUid": "ceu6xxxxxx30gc",
  "overwrite": true,
  "message": "Align Xxx dashboard with Xxx pattern..."
}
```

**Why this happens:** The JSON schema presents `dashboard`, `uid`, `operations`, `folderUid`, `message`, and `overwrite` all as independent optional fields. Nothing in the schema itself encodes the constraint that you must provide either `dashboard` OR (`uid` + `operations`). The LLM sees a flat bag of optional params and constructs what looks like a reasonable subset — metadata fields that describe *what* it wants to do, without the actual content. The `message` field describing the intended changes in detail reinforces this: the LLM appears to believe the message alone will drive the update.

#### Case 2: Empty params — `{}`

The LLM calls `update_dashboard` with a completely empty argument object, then retries the same empty call repeatedly.

**Why this happens:** When the target dashboard is very large (thousands of lines of JSON, dozens of panels, deeply nested objects), the LLM attempts to pass the full dashboard as the `dashboard` parameter but fails to actually generate it. The full JSON would require tens of thousands of output tokens just for the parameter value. The model either hits output token limits causing arguments to be truncated/dropped to `{}`, or the generation simply doesn't produce the massive JSON payload. The LLM then enters a retry loop — it sees the error, says "I'll do it properly this time," but produces `{}` again because the underlying constraint hasn't changed.

### Solution

The fix targets two layers: prevention (better descriptions so the LLM doesn't make the mistake) and recovery (better error messages so the LLM can self-correct when it does).

**Prevention — tool description:** Restructure to lead with the two required modes and explicitly state that `folderUid`, `message`, and `overwrite` are supplementary and do nothing on their own. This is the first thing the LLM reads when planning a call.

**Prevention — param descriptions:** Put the pairing constraint on `uid` ("must be used together with `operations`"). This is the specific field being misused in Case 1, and the LLM reads param descriptions at argument-construction time. The supplementary fields (`folderUid`, `message`, etc.) don't need individual annotations since the tool description already covers that constraint.

**Recovery — error messages:** Split the catch-all error into two branches:
- `uid` without `operations`: specific message telling the LLM what's missing
- Empty params: prescriptive message explaining both modes, recommending patch mode, and explicitly saying "Do NOT retry this same call"

### Changes

- Tool description: restructured to lead with two required modes, supplementary fields called out
- `uid` param: "Must be used together with 'operations'. Providing 'uid' without 'operations' will fail."
- Error handling: added `uid`-without-`operations` branch with specific guidance
- Error handling: added `operations`-without-`uid` branch with specific guidance
- Error handling: made empty-params message prescriptive with "Do NOT retry" and patch mode recommendation

---

Happy to adjust anything based on feedback. Feel free to close this if it doesn't align with the project's direction.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to input validation, user-facing error strings, and tool schema descriptions; core dashboard update behavior is unchanged.
> 
> **Overview**
> Tightens `update_dashboard`’s contract by explicitly enforcing the two supported invocation modes (*full JSON* via `dashboard` vs *patch* via `uid` + `operations`).
> 
> Adds targeted validation branches and more prescriptive error messages for common misuse cases (`uid` without `operations`, `operations` without `uid`, and empty params), and updates the tool/param descriptions to clearly state required field pairings and that metadata-only fields are supplementary. New unit tests cover these validation errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3d2eb375f03a9dd93e8ab2c2aad7991e13572f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->