### PR TITLE
fix: support standard HTTP proxy environment variables

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -363,7 +363,6 @@ func NewExtraHeadersRoundTripper(rt http.RoundTripper, headers map[string]string
 	}
 }
 
-
 func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper) (http.RoundTripper, error) {
 	if base == nil {
 		base = http.DefaultTransport
@@ -577,6 +576,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 				if _, ok := transportField.Interface().(http.RoundTripper); ok {
 					// Wrap with timeout transport, then user agent, then otel
 					timeoutTransport := &http.Transport{
+						Proxy: http.ProxyFromEnvironment,
 						DialContext: (&net.Dialer{
 							Timeout:   timeout,
 							KeepAlive: 30 * time.Second,


### PR DESCRIPTION
Problem: The MCP Grafana server currently ignores standard HTTP proxy environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY). This occurs because the custom http.Transport in mcpgrafana.go is initialized without the Proxy field, causing it to bypass system-level proxy settings. This prevents the server from working in corporate environments that require a proxy to reach external Grafana instances.

Solution: Add Proxy: http.ProxyFromEnvironment to the http.Transport configuration. This is the standard way in Go to ensure the transport respects the environment variables.

Validation: I have verified this fix using a controlled environment with an unreachable proxy (http://10.255.255.255:8080) and an external URL (https://google.com).
1. With Original Code: Setting a non-existent proxy had no effect. The server successfully connected to the target URL in ~0.3s and returned a 404 Not Found (from Google). This confirms the original code was bypassing the proxy and performing a direct connection.
2. With Patched Code: After adding ProxyFromEnvironment, the server correctly attempted to use the proxy. The connection failed after a 5.0s timeout with an unexpected EOF error. This confirms the server is now respecting the proxy settings and attempting to route traffic through the configured gateway.

All tests were performed using go run ./cmd/mcp-grafana -t stdio.
Fixes #576

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to HTTP transport wiring; main risk is altered network routing in environments that already set proxy variables.
> 
> **Overview**
> The custom `http.Transport` used for Grafana API calls is updated to set `Proxy: http.ProxyFromEnvironment`, so requests respect standard proxy environment variables instead of always dialing directly.
> 
> This change only affects outbound connectivity behavior (e.g., corporate proxy routing) and does not modify request/response handling beyond transport configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93274d82be844f6ca2f8f2565999996d13fab978. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->