### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-02-19
+
+### Added
+
+- Elasticsearch datasource support with Lucene and Query DSL syntax, time range filtering, and configurable result limits ([#424](https://github.com/grafana/mcp-grafana/pull/424))
+- CloudWatch datasource support with namespace, metric, and dimension discovery tools plus a guided query workflow ([#536](https://github.com/grafana/mcp-grafana/pull/536))
+
+### Fixed
+
+- Support standard HTTP proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) for connecting through corporate proxies ([#578](https://github.com/grafana/mcp-grafana/pull/578))
+
 ## [0.10.0] - 2026-02-12
 
 ### Added
@@ -28,4 +39,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.11.0]: https://github.com/grafana/mcp-grafana/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/grafana/mcp-grafana/compare/v0.9.0...v0.10.0


### PR DESCRIPTION
## Summary

- Bump version to v0.11.0
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.11.0` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (changelog update) with no runtime or behavioral impact.
> 
> **Overview**
> Updates `CHANGELOG.md` for the `v0.11.0` release, documenting new Elasticsearch and CloudWatch datasource support and a fix to honor standard proxy environment variables.
> 
> Adds the `v0.11.0` compare link entry at the bottom of the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c12dd22098cc0bed355c3563018749142447b910. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->