### PR TITLE
fix(schema): prevent bare boolean JSON Schema values for LLM provider compatibility

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -272,10 +272,12 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 		return zero, nil, fmt.Errorf("failed to marshal input schema: %w", err)
 	}
 
-	// Sanitize bare boolean schemas for LLM provider compatibility
-	schemaBytes, err = sanitizeBooleanSchemas(schemaBytes)
-	if err != nil {
-		return zero, nil, fmt.Errorf("failed to sanitize input schema: %w", err)
+	// Validate that no bare boolean schemas slipped through. The Mapper on the
+	// reflector handles interface{} types, but this check catches anything it
+	// misses and prevents future regressions. MustTool will panic at init time
+	// if this fails, making it impossible to register a tool with bare booleans.
+	if err := validateNoBooleanSchemas(name, schemaBytes); err != nil {
+		return zero, nil, err
 	}
 
 	t := mcp.Tool{
@@ -336,27 +338,24 @@ var (
 		FieldNameTag:               "",
 		IgnoredTypes:               nil,
 		Lookup:                     nil,
-		Mapper:                     nil,
-		Namer:                      nil,
-		KeyNamer:                   nil,
-		AdditionalFields:           nil,
-		CommentMap:                 nil,
+		// Mapper handles Go interface{}/any types which the jsonschema library
+		// would otherwise emit as bare boolean `true` schemas. Some LLM providers
+		// (e.g. Fireworks AI) reject bare boolean schemas. We map them to an empty
+		// object schema {} instead. The non-nil Extras field prevents the library's
+		// MarshalJSON from collapsing the empty schema back to `true`.
+		// See: https://github.com/grafana/mcp-grafana/issues/594
+		Mapper: func(t reflect.Type) *jsonschema.Schema {
+			if t.Kind() == reflect.Interface {
+				return &jsonschema.Schema{Extras: map[string]any{}}
+			}
+			return nil
+		},
+		Namer:            nil,
+		KeyNamer:         nil,
+		AdditionalFields: nil,
+		CommentMap:       nil,
 	}
 )
-
-// sanitizeBooleanSchemas replaces bare boolean JSON Schema values (true/false)
-// with equivalent object schemas ({} / {"not": {}}). The invopop/jsonschema
-// library emits bare `true` for Go interface{} types, which is valid per the
-// JSON Schema spec but rejected by some LLM providers (e.g., Fireworks AI).
-// See: https://github.com/grafana/mcp-grafana/issues/594
-func sanitizeBooleanSchemas(data []byte) ([]byte, error) {
-	var raw any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, err
-	}
-	sanitizeSchemaNode(raw)
-	return json.Marshal(raw)
-}
 
 // JSON Schema keywords whose values are single sub-schemas.
 var schemaValuedKeys = []string{
@@ -377,62 +376,88 @@ var schemaArrayKeys = []string{
 	"allOf", "anyOf", "oneOf", "prefixItems",
 }
 
-// sanitizeSchemaNode recursively walks a JSON value representing a JSON Schema
-// and replaces bare boolean sub-schemas with object equivalents in positions
-// where sub-schemas are expected.
-func sanitizeSchemaNode(v any) {
+// validateNoBooleanSchemas checks that a marshaled JSON Schema contains no bare
+// boolean values (true/false) in positions where sub-schemas are expected. Bare
+// booleans typically come from Go interface{} types and break some LLM providers.
+// This validation runs at tool creation time so that MustTool panics immediately
+// if a tool's schema contains bare booleans, preventing silent compatibility issues.
+func validateNoBooleanSchemas(toolName string, data []byte) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	return checkSchemaNode(toolName, raw, "$")
+}
+
+// checkSchemaNode recursively walks a JSON value representing a JSON Schema and
+// returns an error if any bare boolean values appear in sub-schema positions.
+func checkSchemaNode(toolName string, v any, path string) error {
 	obj, ok := v.(map[string]any)
 	if !ok {
-		return
+		return nil
 	}
 
-	// Replace bare booleans in single-schema-valued keys
+	// Check single-schema-valued keys
 	for _, key := range schemaValuedKeys {
 		if val, exists := obj[key]; exists {
-			obj[key] = replaceBooleanSchema(val)
-		}
-	}
-
-	// Replace bare booleans in schema-map-valued keys
-	for _, key := range schemaMapKeys {
-		if mapVal, ok := obj[key].(map[string]any); ok {
-			for k, v := range mapVal {
-				mapVal[k] = replaceBooleanSchema(v)
+			if b, ok := val.(bool); ok {
+				return fmt.Errorf(
+					"tool %q has bare boolean schema (%v) at %s.%s; "+
+						"this is likely caused by an interface{}/any field — "+
+						"add the type to the jsonschema reflector Mapper in tools.go",
+					toolName, b, path, key,
+				)
 			}
 		}
 	}
 
-	// Replace bare booleans in schema-array-valued keys
+	// Check schema-map-valued keys
+	for _, key := range schemaMapKeys {
+		if mapVal, ok := obj[key].(map[string]any); ok {
+			for k, v := range mapVal {
+				if b, ok := v.(bool); ok {
+					return fmt.Errorf(
+						"tool %q has bare boolean schema (%v) at %s.%s.%s; "+
+							"this is likely caused by an interface{}/any field — "+
+							"add the type to the jsonschema reflector Mapper in tools.go",
+						toolName, b, path, key, k,
+					)
+				}
+			}
+		}
+	}
+
+	// Check schema-array-valued keys
 	for _, key := range schemaArrayKeys {
 		if arrVal, ok := obj[key].([]any); ok {
 			for i, v := range arrVal {
-				arrVal[i] = replaceBooleanSchema(v)
+				if b, ok := v.(bool); ok {
+					return fmt.Errorf(
+						"tool %q has bare boolean schema (%v) at %s.%s[%d]; "+
+							"this is likely caused by an interface{}/any field — "+
+							"add the type to the jsonschema reflector Mapper in tools.go",
+						toolName, b, path, key, i,
+					)
+				}
 			}
 		}
 	}
 
 	// Recurse into all nested objects and arrays
-	for _, val := range obj {
+	for key, val := range obj {
 		switch v := val.(type) {
 		case map[string]any:
-			sanitizeSchemaNode(v)
+			if err := checkSchemaNode(toolName, v, path+"."+key); err != nil {
+				return err
+			}
 		case []any:
 			for _, item := range v {
-				sanitizeSchemaNode(item)
+				if err := checkSchemaNode(toolName, item, path+"."+key); err != nil {
+					return err
+				}
 			}
 		}
 	}
-}
 
-// replaceBooleanSchema converts a bare boolean JSON Schema value to an
-// equivalent object schema. Non-boolean values are returned unchanged.
-func replaceBooleanSchema(v any) any {
-	b, ok := v.(bool)
-	if !ok {
-		return v
-	}
-	if b {
-		return map[string]any{} // true → {} (accept any value)
-	}
-	return map[string]any{"not": map[string]any{}} // false → {"not": {}} (reject all values)
+	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #594

Some LLM providers (e.g. Fireworks AI) reject bare boolean values (`true`/`false`) in JSON Schema tool definitions. The `invopop/jsonschema` library emits `true` for Go `interface{}` types (like `AlertQuery.Model`), which breaks tool registration on these providers.

## Approach

Two-layer defense against bare boolean schemas:

1. **Mapper on jsonschema reflector** — Intercepts `interface{}` types during schema reflection and emits `{}` (empty object schema) instead of bare `true`. Uses `Extras: map[string]any{}` to prevent the library's `MarshalJSON` from collapsing the empty schema back to `true` via its `DeepEqual` optimization.

2. **`validateNoBooleanSchemas` validation** — Walks the marshaled JSON Schema and returns an error if any bare boolean values appear in sub-schema positions (properties, items, additionalProperties, allOf/anyOf/oneOf, etc.). This runs at tool creation time, so `MustTool` panics at init if the check fails — making it impossible to register a tool with bare booleans and catching future regressions immediately.

## Changes

- Added `Mapper` function to `jsonSchemaReflector` in `tools.go`
- Added `validateNoBooleanSchemas` and `checkSchemaNode` functions
- Added comprehensive tests for both the validation and the mapper

## Test plan

- [x] `TestValidateNoBooleanSchemas` — 9 subtests covering bare booleans in properties, additionalProperties, items, nested schemas, allOf/anyOf/oneOf, valid schemas, non-schema booleans, and error messages
- [x] `TestConvertToolHandlesInterfaceFields` — verifies the Mapper produces `{}` instead of bare `true` for `interface{}` fields
- [x] All existing tests pass unchanged
- [x] Go lint, unit, integration, and cloud tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect tool registration by adding schema validation that can make previously-accepted tools fail fast if their generated schema contains boolean sub-schemas; behavior should be safer but could break edge-case schemas.
> 
> **Overview**
> Tool schema generation is hardened to avoid emitting bare boolean JSON Schema values (e.g., `true` from `interface{}/any`), which some LLM providers reject.
> 
> This adds a `jsonschema.Reflector` `Mapper` that renders `interface{}/any` fields as empty object schemas (`{}`) and introduces `validateNoBooleanSchemas` to reject any remaining boolean sub-schemas during `ConvertTool` creation, plus unit tests covering common and nested failure cases and an interface-field regression test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c8bcf8d333d7f1239ac7342f0aba457836d5ed6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->