### PR TITLE
ci: add PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,11 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -79,6 +78,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+        with:
+          enable-cache: false
 
       - name: Build wheels
         run: |


### PR DESCRIPTION
## Summary

- Adds a `pypi` job to the release workflow that builds Python wheels from the Go binary using [go-to-wheel](https://github.com/simonw/go-to-wheel) and publishes to PyPI via trusted publishing
- Enables `uvx mcp-grafana` and `pip install mcp-grafana` as installation methods
- Also scopes `contents: write` to the goreleaser job (fixes a pre-existing zizmor finding)

## Dependency

Uses `--package-path` from [simonw/go-to-wheel#5](https://github.com/simonw/go-to-wheel/pull/5) (installed from PR branch). Once that PR is released, the `--from` override can be removed.

## Setup required before merging

1. **Register `mcp-grafana` on PyPI** — Confirm the package name is available
2. **Configure trusted publishing on PyPI** — Add a [trusted publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) for this repo:
   - Owner: `grafana`
   - Repository: `mcp-grafana`
   - Workflow: `release.yml`
   - Environment: `pypi`
3. **Create the `pypi` environment** in the repo's Settings → Environments

## How it works

The new `pypi` job runs after the existing `goreleaser` job on version tags (`v*`). It:
1. Checks out the repo and sets up Go + uv
2. Runs `uvx go-to-wheel` to cross-compile the Go binary into platform-specific Python wheels (linux/macOS/Windows × amd64/arm64)
3. Publishes wheels to PyPI using OIDC trusted publishing (no API tokens needed)

## Tested locally

```
$ uvx --from "go-to-wheel @ git+https://github.com/nikaro/go-to-wheel@feat/go-cmd" \
    go-to-wheel . --package-path ./cmd/mcp-grafana --name mcp-grafana --version 0.0.1 \
    --output-dir /tmp/test --platforms linux-amd64
Built 1 wheel(s)

$ uvx --from /tmp/test/mcp_grafana-0.0.1-py3-none-manylinux_2_17_x86_64.whl mcp-grafana --version
(devel)
```

## Note on `--version` output

The binary in the wheel is built with `go build` (not `go install`), so `mcp-grafana --version` will show `(devel)` rather than the release version. This is cosmetic — the binary is functionally identical. A follow-up could add a linker variable to inject the version.

## Test plan

- [x] Verified `go-to-wheel --package-path` builds a working executable (not a library archive)
- [x] Verified `uvx mcp-grafana --version` works from the built wheel
- [ ] Verify `mcp-grafana` package name is available on PyPI
- [ ] Set up trusted publishing on PyPI
- [ ] Create `pypi` environment in repo settings
- [ ] Test on next release tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)