### PR TITLE
Release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-02-24
+
+### Added
+
+- New `run_panel_query` tool that executes dashboard panel queries directly, with support for Prometheus, Loki, ClickHouse, and CloudWatch datasources, template variable substitution, Grafana macro expansion, and batch multi-panel queries ([#542](https://github.com/grafana/mcp-grafana/pull/542))
+
+### Changed
+
+- Merge near-duplicate MCP tools to reduce overall tool count, making it easier for LLMs to select the right tool ([#596](https://github.com/grafana/mcp-grafana/pull/596))
+
 ## [0.11.0] - 2026-02-19
 
 ### Added
@@ -39,5 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.11.1]: https://github.com/grafana/mcp-grafana/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/grafana/mcp-grafana/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/grafana/mcp-grafana/compare/v0.9.0...v0.10.0


### PR DESCRIPTION
## Summary

- Bump version to v0.11.1
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.11.1` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (changelog update) with no runtime or behavioral impact.
> 
> **Overview**
> Adds a new `0.11.1` section to `CHANGELOG.md`, documenting the new `run_panel_query` tool and the consolidation of near-duplicate MCP tools.
> 
> Appends the `v0.11.0...v0.11.1` comparison link for the release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b9516f88d96de50f99ad49754e9257dc5e0ddb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->