### PR TITLE
ci: use --package-path for go-to-wheel subpackage build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           # TODO: switch to `uvx go-to-wheel` once --package-path is released
           # (see https://github.com/simonw/go-to-wheel/pull/5)
-          uvx --from "go-to-wheel @ git+https://github.com/nikaro/go-to-wheel@feat/go-cmd" \
+          uvx --from "go-to-wheel @ git+https://github.com/nikaro/go-to-wheel@f7939c6868e195204eae1370f899933e555513e3" \
             go-to-wheel . \
             --package-path ./cmd/mcp-grafana \
             --name mcp-grafana \


### PR DESCRIPTION
## Summary

Fixes the PyPI publishing job added in #598 — `go-to-wheel` was building the root library package instead of the `./cmd/mcp-grafana` executable.

## Problem

`go-to-wheel` hardcodes `go build .` in the module root, which produces a library archive (`!<arch>`) instead of an executable because the root package is `package mcpgrafana`, not `package main`.

## Fix

Uses `--package-path ./cmd/mcp-grafana` from [simonw/go-to-wheel#5](https://github.com/simonw/go-to-wheel/pull/5) to specify the correct build target. Installed from the PR branch until the feature is released upstream.

Also removes the redundant `--ldflags "-s -w"` since go-to-wheel applies those by default.

## Tested locally

```
$ uvx --from "go-to-wheel @ git+https://github.com/nikaro/go-to-wheel@feat/go-cmd" \
    go-to-wheel . --package-path ./cmd/mcp-grafana --name mcp-grafana --version 0.0.1 \
    --output-dir /tmp/test --platforms linux-amd64
Built 1 wheel(s)

$ file /tmp/extracted-binary
ELF 64-bit LSB executable, x86-64, statically linked, Go BuildID=...

$ uvx --from /tmp/test/mcp_grafana-0.0.1-py3-none-manylinux_2_17_x86_64.whl mcp-grafana --version
(devel)
```

## Test plan

- [x] Verified the wheel contains a proper ELF executable (not a library archive)
- [x] Verified `uvx mcp-grafana --version` works from the built wheel
- [ ] Test on next release tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/release-only change, but it alters how release artifacts are built and pins a tool to an external git commit, which can affect reproducibility and future releases if the fork changes/vanishes.
> 
> **Overview**
> Fixes the PyPI publishing workflow to build the wheel from the `./cmd/mcp-grafana` subpackage (the actual executable) by invoking `go-to-wheel` with `--package-path`.
> 
> Pins `go-to-wheel` to a specific git commit via `uvx --from ...` until the upstream flag is released, and drops the explicit `--ldflags "-s -w"` argument (now relying on `go-to-wheel` defaults).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b19e2c696b11fb74629275b6efd917e513d5983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->