### PR TITLE
Release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-02-24
+
+### Changed
+
+- Optimize Docker builds with Go cross-compilation for faster multi-platform image builds ([#600](https://github.com/grafana/mcp-grafana/pull/600))
+- Fix Python wheel subpackage build to use correct `--package-path` flag ([#601](https://github.com/grafana/mcp-grafana/pull/601))
+
 ## [0.11.1] - 2026-02-24
 
 ### Added
@@ -49,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.11.2]: https://github.com/grafana/mcp-grafana/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/grafana/mcp-grafana/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/grafana/mcp-grafana/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/grafana/mcp-grafana/compare/v0.9.0...v0.10.0


### PR DESCRIPTION
## Summary

- Bump version to v0.11.2
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.11.2` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `CHANGELOG.md` with no runtime or build logic modifications in this PR.
> 
> **Overview**
> Prepares release `v0.11.2` by adding a new `CHANGELOG.md` section capturing the release notes (Docker build optimization via Go cross-compilation and a Python wheel subpackage build flag fix) and wiring the `[0.11.2]` compare link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5fcebbe45b9f128357c751c6139d31e9cda0342. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->