### PR TITLE
ci: use GitHub App token in auto-tag to trigger releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -17,19 +17,11 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
-      - name: Get GitHub App secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
-        with:
-          repo_secrets: |
-            APP_ID=grafana-delivery-bot:app-id
-            APP_PRIVATE_KEY=grafana-delivery-bot:private-key
-
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.APP_PRIVATE_KEY }}
+          github_app: grafana-mcp-delivery-bot
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Use `grafana-delivery-bot` GitHub App token instead of `GITHUB_TOKEN` when pushing tags in the auto-tag workflow
- Tags pushed with `GITHUB_TOKEN` [do not trigger downstream workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), so `release.yml` and `docker.yml` were never firing automatically

## What changed

1. Added `id-token: write` permission (required for Vault OIDC auth)
2. Fetch `grafana-delivery-bot` app-id and private-key from Vault via `get-vault-secrets`
3. Generate a short-lived token via `actions/create-github-app-token`
4. Pass that token to the checkout step so `git push` authenticates as the app

## Test plan

- [ ] Verify `grafana-delivery-bot` is installed on this repo and its credentials exist in Vault
- [ ] Merge the v0.11.2 release PR after this lands and confirm `release.yml` + `docker.yml` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI authentication/permissions for tag pushes; misconfiguration could prevent tagging or unintentionally broaden repo-write capability if the app token is over-scoped.
> 
> **Overview**
> Updates the `Auto-tag release` GitHub Actions workflow to authenticate `git push` with a short-lived GitHub App token (via `grafana/shared-workflows/actions/create-github-app-token`) instead of the default `GITHUB_TOKEN`, so tags created on merged `release/v*` PRs can trigger downstream workflows.
> 
> Adds `id-token: write` permissions and passes the generated app token to `actions/checkout` for subsequent tag creation/push.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d878a736acfeb03d9b48298c75fab6e539dab7b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->