### PR TITLE
feat(asserts): expand KG navigation, MLT gateway, semantic search, and streaming tools

### DIFF
--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -282,24 +282,18 @@ var GetAssertions = mcpgrafana.MustTool(
 )
 
 func AddAssertsTools(s *server.MCPServer) {
-	// Existing
 	GetAssertions.Register(s)
-	// KG navigation (Phase 1)
 	GetGraphSchema.Register(s)
 	SearchEntities.Register(s)
 	GetEntity.Register(s)
 	GetConnectedEntities.Register(s)
 	ListEntities.Register(s)
 	CountEntities.Register(s)
-	// Assertions (Phase 1)
 	GetAssertionSummary.Register(s)
 	SearchRcaPatterns.Register(s)
-	// MLT gateway (Phase 2)
 	GetEntityMetrics.Register(s)
 	GetEntityLogs.Register(s)
 	GetEntityTraces.Register(s)
-	// Semantic search (Phase 3)
 	FindEntitiesSemantic.Register(s)
-	// Streaming (Phase 5)
 	AddAssertsStreamingTools(s)
 }

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -101,6 +102,137 @@ func (c *Client) fetchAssertsData(ctx context.Context, urlPath string, method st
 	return string(body), nil
 }
 
+func (c *Client) fetchAssertsDataGet(ctx context.Context, urlPath string, params url.Values) (string, error) {
+	u, err := url.Parse(c.baseURL + urlPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+	if params != nil {
+		u.RawQuery = params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close() //nolint:errcheck
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return string(body), nil
+}
+
+// slimEntity is a compact entity representation for LLM context efficiency.
+type slimEntity struct {
+	Type            string            `json:"type"`
+	Name            string            `json:"name"`
+	ID              json.Number       `json:"id,omitempty"`
+	Env             string            `json:"env,omitempty"`
+	Site            string            `json:"site,omitempty"`
+	Namespace       string            `json:"namespace,omitempty"`
+	Active          bool              `json:"active"`
+	AssertionCount  int               `json:"assertionCount,omitempty"`
+	ConnectedTypes  map[string]int    `json:"connectedTypes,omitempty"`
+	Properties      map[string]any    `json:"properties,omitempty"`
+}
+
+// graphEntityResponse matches the shape of GET /v1/entity/info.
+// Scope fields are unwrapped (flat) at the top level.
+type graphEntityResponse struct {
+	ID                   int64                  `json:"id"`
+	Type                 string                 `json:"type"`
+	Name                 string                 `json:"name"`
+	Active               bool                   `json:"active"`
+	Env                  string                 `json:"env,omitempty"`
+	Site                 string                 `json:"site,omitempty"`
+	Namespace            string                 `json:"namespace,omitempty"`
+	ConnectedEntityTypes map[string]int         `json:"connectedEntityTypes,omitempty"`
+	Properties           map[string]any         `json:"properties,omitempty"`
+	Assertion            json.RawMessage        `json:"assertion,omitempty"`
+	ConnectedAssertion   json.RawMessage        `json:"connectedAssertion,omitempty"`
+	AssertionCount       int                    `json:"assertionCount"`
+}
+
+func (g *graphEntityResponse) toSlim() slimEntity {
+	return slimEntity{
+		Type:           g.Type,
+		Name:           g.Name,
+		ID:             json.Number(fmt.Sprintf("%d", g.ID)),
+		Env:            g.Env,
+		Site:           g.Site,
+		Namespace:      g.Namespace,
+		Active:         g.Active,
+		AssertionCount: g.AssertionCount,
+		ConnectedTypes: g.ConnectedEntityTypes,
+	}
+}
+
+// entitySummaryResponse matches the shape of GET /public/v1/entities items.
+type entitySummaryResponse struct {
+	ID         string            `json:"id"`
+	Type       string            `json:"type"`
+	Name       string            `json:"name"`
+	Active     bool              `json:"active"`
+	Scope      map[string]string `json:"scope,omitempty"`
+	Properties map[string]any    `json:"properties,omitempty"`
+}
+
+func (e *entitySummaryResponse) toSlim() slimEntity {
+	s := slimEntity{
+		Type:   e.Type,
+		Name:   e.Name,
+		ID:     json.Number(e.ID),
+		Active: e.Active,
+	}
+	if e.Scope != nil {
+		s.Env = e.Scope["env"]
+		s.Site = e.Scope["site"]
+		s.Namespace = e.Scope["namespace"]
+	}
+	return s
+}
+
+// resolveEntityInfo fetches entity details and returns the parsed response.
+func (c *Client) resolveEntityInfo(ctx context.Context, entityType, entityName, env, site, namespace string) (*graphEntityResponse, error) {
+	params := url.Values{}
+	params.Set("entity_type", entityType)
+	params.Set("entity_name", entityName)
+	if env != "" {
+		params.Set("entityEnv", env)
+	}
+	if site != "" {
+		params.Set("entitySite", site)
+	}
+	if namespace != "" {
+		params.Set("entityNs", namespace)
+	}
+
+	data, err := c.fetchAssertsDataGet(ctx, "/v1/entity/info", params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve entity info: %w", err)
+	}
+
+	var entity graphEntityResponse
+	if err := json.Unmarshal([]byte(data), &entity); err != nil {
+		return nil, fmt.Errorf("failed to parse entity info: %w", err)
+	}
+	return &entity, nil
+}
+
 func getAssertions(ctx context.Context, args GetAssertionsParams) (string, error) {
 	client, err := newAssertsClient(ctx)
 	if err != nil {
@@ -149,6 +281,25 @@ var GetAssertions = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddAssertsTools(mcp *server.MCPServer) {
-	GetAssertions.Register(mcp)
+func AddAssertsTools(s *server.MCPServer) {
+	// Existing
+	GetAssertions.Register(s)
+	// KG navigation (Phase 1)
+	GetGraphSchema.Register(s)
+	SearchEntities.Register(s)
+	GetEntity.Register(s)
+	GetConnectedEntities.Register(s)
+	ListEntities.Register(s)
+	CountEntities.Register(s)
+	// Assertions (Phase 1)
+	GetAssertionSummary.Register(s)
+	SearchRcaPatterns.Register(s)
+	// MLT gateway (Phase 2)
+	GetEntityMetrics.Register(s)
+	GetEntityLogs.Register(s)
+	GetEntityTraces.Register(s)
+	// Semantic search (Phase 3)
+	FindEntitiesSemantic.Register(s)
+	// Streaming (Phase 5)
+	AddAssertsStreamingTools(s)
 }

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -90,7 +90,7 @@ func (c *Client) fetchAssertsData(ctx context.Context, urlPath string, method st
 		_ = resp.Body.Close() //nolint:errcheck
 	}()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024*48))
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -124,7 +124,7 @@ func (c *Client) fetchAssertsDataGet(ctx context.Context, urlPath string, params
 		_ = resp.Body.Close() //nolint:errcheck
 	}()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024*48))
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -287,13 +287,9 @@ func AddAssertsTools(s *server.MCPServer) {
 	SearchEntities.Register(s)
 	GetEntity.Register(s)
 	GetConnectedEntities.Register(s)
-	ListEntities.Register(s)
-	CountEntities.Register(s)
 	GetAssertionSummary.Register(s)
 	SearchRcaPatterns.Register(s)
 	GetEntityMetrics.Register(s)
 	GetEntityLogs.Register(s)
 	GetEntityTraces.Register(s)
-	FindEntitiesSemantic.Register(s)
-	AddAssertsStreamingTools(s)
 }

--- a/tools/asserts_cache.go
+++ b/tools/asserts_cache.go
@@ -1,0 +1,209 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type cacheEntry[T any] struct {
+	value     T
+	expiresAt time.Time
+}
+
+type ttlCache[T any] struct {
+	mu      sync.RWMutex
+	entries map[string]cacheEntry[T]
+	ttl     time.Duration
+}
+
+func newTTLCache[T any](ttl time.Duration) *ttlCache[T] {
+	return &ttlCache[T]{
+		entries: make(map[string]cacheEntry[T]),
+		ttl:     ttl,
+	}
+}
+
+func (c *ttlCache[T]) get(key string) (T, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		var zero T
+		return zero, false
+	}
+	return entry.value, true
+}
+
+func (c *ttlCache[T]) set(key string, value T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = cacheEntry[T]{
+		value:     value,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+var (
+	entityInfoCache     = newTTLCache[*graphEntityResponse](2 * time.Minute)
+	graphSchemaCache    = newTTLCache[string](15 * time.Minute)
+	drilldownLogCache   = newTTLCache[[]drilldownConfigEntry](15 * time.Minute)
+	drilldownTraceCache = newTTLCache[[]drilldownConfigEntry](15 * time.Minute)
+)
+
+func entityCacheKey(baseURL, entityType, entityName, env, site, ns string) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%s", baseURL, entityType, entityName, env, site, ns)
+}
+
+// resolveEntityInfoCached wraps resolveEntityInfo with a short-TTL cache
+// to avoid redundant /v1/entity/info calls when multiple tools operate on
+// the same entity within a session.
+func (c *Client) resolveEntityInfoCached(ctx context.Context, entityType, entityName, env, site, namespace string) (*graphEntityResponse, error) {
+	key := entityCacheKey(c.baseURL, entityType, entityName, env, site, namespace)
+
+	if cached, ok := entityInfoCache.get(key); ok {
+		return cached, nil
+	}
+
+	entity, err := c.resolveEntityInfo(ctx, entityType, entityName, env, site, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	entityInfoCache.set(key, entity)
+	return entity, nil
+}
+
+// drilldownConfigEntry is the parsed representation of a single drilldown
+// config from /v1/config/log-drilldown or /v1/config/trace-drilldown.
+type drilldownConfigEntry struct {
+	Name           string              `json:"name"`
+	Priority       int                 `json:"priority"`
+	MatchRules     []drilldownMatchRule `json:"entityPropertyMatchRules"`
+	PromMapping    map[string]string   `json:"entityPropertyToLabelMapping,omitempty"`
+	LogMapping     map[string]string   `json:"entityPropertyToLogLabelMapping,omitempty"`
+	TraceMapping   map[string]string   `json:"entityPropertyToTraceLabelMapping,omitempty"`
+	DefaultConfig  bool                `json:"defaultConfig"`
+	DataSourceUID  string              `json:"dataSourceUid,omitempty"`
+}
+
+type drilldownMatchRule struct {
+	EntityProperty string `json:"entityProperty"`
+	Value          string `json:"value"`
+	Op             string `json:"op"`
+}
+
+// matchesEntityType checks if a drilldown config applies to the given entity type.
+func (d *drilldownConfigEntry) matchesEntityType(entityType string) bool {
+	if d.DefaultConfig {
+		return true
+	}
+	for _, rule := range d.MatchRules {
+		if rule.EntityProperty == "type" && rule.Op == "EQ" && rule.Value == entityType {
+			return true
+		}
+	}
+	return false
+}
+
+// fetchDrilldownConfigs fetches and caches drilldown configs for a given mode.
+func fetchDrilldownConfigs(ctx context.Context, client *Client, mode string) []drilldownConfigEntry {
+	var cache *ttlCache[[]drilldownConfigEntry]
+	var endpoint string
+
+	switch mode {
+	case "log":
+		cache = drilldownLogCache
+		endpoint = "/v1/config/log-drilldown"
+	case "trace":
+		cache = drilldownTraceCache
+		endpoint = "/v1/config/trace-drilldown"
+	default:
+		return nil
+	}
+
+	if cached, ok := cache.get(client.baseURL); ok {
+		return cached
+	}
+
+	data, err := client.fetchAssertsDataGet(ctx, endpoint, nil)
+	if err != nil {
+		return nil
+	}
+
+	var configs []drilldownConfigEntry
+	if err := json.Unmarshal([]byte(data), &configs); err != nil {
+		return nil
+	}
+
+	cache.set(client.baseURL, configs)
+	return configs
+}
+
+// findDrilldownForEntity finds the best matching drilldown config for an
+// entity type. Prefers specific match rules over default configs.
+func findDrilldownForEntity(configs []drilldownConfigEntry, entityType string) *drilldownConfigEntry {
+	var defaultConfig *drilldownConfigEntry
+
+	for i := range configs {
+		cfg := &configs[i]
+		if cfg.DefaultConfig {
+			if defaultConfig == nil || cfg.Priority > defaultConfig.Priority {
+				defaultConfig = cfg
+			}
+			continue
+		}
+		if cfg.matchesEntityType(entityType) {
+			return cfg
+		}
+	}
+
+	return defaultConfig
+}
+
+// getEntityPropertyValue extracts a named property from a resolved entity.
+func getEntityPropertyValue(entity *graphEntityResponse, prop string) string {
+	switch prop {
+	case "name":
+		return entity.Name
+	case "type":
+		return entity.Type
+	case "env":
+		return entity.Env
+	case "site":
+		return entity.Site
+	case "namespace":
+		return entity.Namespace
+	default:
+		if entity.Properties != nil {
+			if v, ok := entity.Properties[prop]; ok {
+				return fmt.Sprintf("%v", v)
+			}
+		}
+		return ""
+	}
+}
+
+// buildLabelsFromMapping constructs a label selector string from a drilldown
+// config's property-to-label mapping and a resolved entity.
+func buildLabelsFromMapping(mapping map[string]string, entity *graphEntityResponse, separator string) string {
+	if len(mapping) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(mapping))
+	for entityProp, label := range mapping {
+		value := getEntityPropertyValue(entity, entityProp)
+		if value != "" {
+			parts = append(parts, fmt.Sprintf(`%s="%s"`, label, value))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return "{" + strings.Join(parts, separator) + "}"
+}

--- a/tools/asserts_cache.go
+++ b/tools/asserts_cache.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
 type cacheEntry[T any] struct {
@@ -41,9 +43,21 @@ func (c *ttlCache[T]) get(key string) (T, bool) {
 func (c *ttlCache[T]) set(key string, value T) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	now := time.Now()
+
+	// Evict expired entries periodically (every 100 writes or when cache is large)
+	if len(c.entries) > 100 {
+		for k, e := range c.entries {
+			if now.After(e.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+	}
+
 	c.entries[key] = cacheEntry[T]{
 		value:     value,
-		expiresAt: time.Now().Add(c.ttl),
+		expiresAt: now.Add(c.ttl),
 	}
 }
 
@@ -54,15 +68,20 @@ var (
 	drilldownTraceCache = newTTLCache[[]drilldownConfigEntry](15 * time.Minute)
 )
 
-func entityCacheKey(baseURL, entityType, entityName, env, site, ns string) string {
-	return fmt.Sprintf("%s|%s|%s|%s|%s|%s", baseURL, entityType, entityName, env, site, ns)
+func tenantCacheKey(baseURL string, orgID int64) string {
+	return fmt.Sprintf("%s|%d", baseURL, orgID)
+}
+
+func entityCacheKey(baseURL string, orgID int64, entityType, entityName, env, site, ns string) string {
+	return fmt.Sprintf("%s|%d|%s|%s|%s|%s|%s", baseURL, orgID, entityType, entityName, env, site, ns)
 }
 
 // resolveEntityInfoCached wraps resolveEntityInfo with a short-TTL cache
 // to avoid redundant /v1/entity/info calls when multiple tools operate on
 // the same entity within a session.
 func (c *Client) resolveEntityInfoCached(ctx context.Context, entityType, entityName, env, site, namespace string) (*graphEntityResponse, error) {
-	key := entityCacheKey(c.baseURL, entityType, entityName, env, site, namespace)
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	key := entityCacheKey(c.baseURL, cfg.OrgID, entityType, entityName, env, site, namespace)
 
 	if cached, ok := entityInfoCache.get(key); ok {
 		return cached, nil
@@ -125,7 +144,10 @@ func fetchDrilldownConfigs(ctx context.Context, client *Client, mode string) []d
 		return nil
 	}
 
-	if cached, ok := cache.get(client.baseURL); ok {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	cacheKey := tenantCacheKey(client.baseURL, cfg.OrgID)
+
+	if cached, ok := cache.get(cacheKey); ok {
 		return cached
 	}
 
@@ -139,7 +161,7 @@ func fetchDrilldownConfigs(ctx context.Context, client *Client, mode string) []d
 		return nil
 	}
 
-	cache.set(client.baseURL, configs)
+	cache.set(cacheKey, configs)
 	return configs
 }
 

--- a/tools/asserts_cloud_test.go
+++ b/tools/asserts_cloud_test.go
@@ -9,6 +9,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -16,30 +17,247 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	assertsTestEntityType = "Service"
+	assertsTestEntityName = "model-builder"
+	assertsTestEnv        = "dev-us-central-0"
+	assertsTestNamespace  = "asserts"
+)
+
 func TestAssertsCloudIntegration(t *testing.T) {
 	ctx := createCloudTestContext(t, "Asserts", "ASSERTS_GRAFANA_URL", "ASSERTS_GRAFANA_API_KEY")
 
-	t.Run("get assertions", func(t *testing.T) {
-		// Set up time range for the last hour
-		endTime := time.Now()
-		startTime := endTime.Add(-24 * time.Hour)
+	endTime := time.Now()
+	startTime := endTime.Add(-24 * time.Hour)
 
-		// Test parameters for a known service in the environment
-		params := GetAssertionsParams{
+	t.Run("get assertions", func(t *testing.T) {
+		result, err := getAssertions(ctx, GetAssertionsParams{
 			StartTime:  startTime,
 			EndTime:    endTime,
-			EntityType: "Service", // Adjust these values based on your actual environment
-			EntityName: "model-builder",
-			Env:        "dev-us-central-0",
-			Namespace:  "asserts",
-		}
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "summaries")
+	})
 
-		// Get assertions from the real Grafana instance
-		result, err := getAssertions(ctx, params)
-		require.NoError(t, err, "Failed to get assertions from Grafana")
-		assert.NotEmpty(t, result, "Expected non-empty assertions result")
+	t.Run("get graph schema", func(t *testing.T) {
+		result, err := getGraphSchema(ctx, GetGraphSchemaParams{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "entityTypes")
 
-		// Basic validation of the response structure
-		assert.Contains(t, result, "summaries", "Response should contain a summaries field")
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+		types, ok := parsed["entityTypes"].([]any)
+		require.True(t, ok, "entityTypes should be an array")
+		assert.GreaterOrEqual(t, len(types), 1, "should have at least one entity type")
+
+		first := types[0].(map[string]any)
+		assert.NotEmpty(t, first["type"], "entity type should have a type field")
+		assert.NotNil(t, first["connectedTypes"], "entity type should have connectedTypes")
+	})
+
+	t.Run("get graph schema is cached", func(t *testing.T) {
+		result1, err := getGraphSchema(ctx, GetGraphSchemaParams{})
+		require.NoError(t, err)
+
+		result2, err := getGraphSchema(ctx, GetGraphSchemaParams{})
+		require.NoError(t, err)
+
+		assert.Equal(t, result1, result2, "cached result should match")
+	})
+
+	t.Run("search entities", func(t *testing.T) {
+		result, err := searchEntities(ctx, SearchEntitiesParams{
+			EntityType: assertsTestEntityType,
+			SearchText: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+			StartTime:  startTime,
+			EndTime:    endTime,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+		entities, ok := parsed["entities"].([]any)
+		require.True(t, ok, "result should have entities array")
+		assert.GreaterOrEqual(t, len(entities), 1, "should find at least one entity")
+
+		first := entities[0].(map[string]any)
+		assert.Equal(t, assertsTestEntityType, first["type"])
+		assert.NotEmpty(t, first["name"])
+	})
+
+	t.Run("get entity slim", func(t *testing.T) {
+		result, err := getEntity(ctx, GetEntityParams{
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+
+		var parsed slimEntity
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+		assert.Equal(t, assertsTestEntityType, parsed.Type)
+		assert.Equal(t, assertsTestEntityName, parsed.Name)
+		assert.NotEmpty(t, parsed.ID)
+		assert.Nil(t, parsed.Properties, "slim output should not include properties")
+	})
+
+	t.Run("get entity detailed", func(t *testing.T) {
+		result, err := getEntity(ctx, GetEntityParams{
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+			Detailed:   true,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+
+		var parsed graphEntityResponse
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+		assert.Equal(t, assertsTestEntityType, parsed.Type)
+		assert.Equal(t, assertsTestEntityName, parsed.Name)
+		assert.Greater(t, parsed.ID, int64(0), "detailed output should have numeric ID")
+	})
+
+	t.Run("get connected entities", func(t *testing.T) {
+		result, err := getConnectedEntities(ctx, GetConnectedEntitiesParams{
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+			Limit:      5,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+		source, ok := parsed["source"].(map[string]any)
+		require.True(t, ok, "result should have source")
+		assert.Equal(t, assertsTestEntityName, source["name"])
+
+		connected, ok := parsed["connected"].([]any)
+		require.True(t, ok, "result should have connected array")
+		assert.GreaterOrEqual(t, len(connected), 0, "connected may be empty but should be present")
+	})
+
+	t.Run("search entities list mode", func(t *testing.T) {
+		result, err := searchEntities(ctx, SearchEntitiesParams{
+			Mode:       "list",
+			EntityType: assertsTestEntityType,
+			Limit:      5,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+		assert.Equal(t, "list", parsed["mode"])
+
+		entities, ok := parsed["entities"].([]any)
+		require.True(t, ok, "result should have entities array")
+		assert.GreaterOrEqual(t, len(entities), 1, "should list at least one entity")
+
+		assert.NotNil(t, parsed["pagination"], "result should include pagination")
+	})
+
+	t.Run("search entities count mode", func(t *testing.T) {
+		result, err := searchEntities(ctx, SearchEntitiesParams{
+			Mode:      "count",
+			Env:       assertsTestEnv,
+			StartTime: startTime,
+			EndTime:   endTime,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+		assert.GreaterOrEqual(t, len(parsed), 1, "should return at least one entity type count")
+	})
+
+	t.Run("get assertion summary", func(t *testing.T) {
+		result, err := getAssertionSummary(ctx, GetAssertionSummaryParams{
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+			StartTime:  startTime,
+			EndTime:    endTime,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+	})
+
+	t.Run("search rca patterns", func(t *testing.T) {
+		result, err := searchRcaPatterns(ctx, SearchRcaPatternsParams{
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+			StartTime:  startTime,
+			EndTime:    endTime,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+	})
+
+	t.Run("search entities semantic mode fallback", func(t *testing.T) {
+		result, err := searchEntities(ctx, SearchEntitiesParams{
+			Mode:       "semantic",
+			SearchText: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+			Limit:      5,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+		assert.Equal(t, "deterministic_fallback", parsed["mode"],
+			"without GRAFANA_SEARCH_SERVICE_URL, should fall back to deterministic search")
+
+		results, ok := parsed["results"].([]any)
+		require.True(t, ok, "result should have results array")
+		assert.GreaterOrEqual(t, len(results), 1, "fallback should find at least one entity matching the name")
+	})
+
+	t.Run("entity info cache eliminates redundant calls", func(t *testing.T) {
+		result1, err := getEntity(ctx, GetEntityParams{
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+		})
+		require.NoError(t, err)
+
+		result2, err := getEntity(ctx, GetEntityParams{
+			EntityType: assertsTestEntityType,
+			EntityName: assertsTestEntityName,
+			Env:        assertsTestEnv,
+			Namespace:  assertsTestNamespace,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, result1, result2, "cached entity info should return identical results")
 	})
 }

--- a/tools/asserts_kg.go
+++ b/tools/asserts_kg.go
@@ -1,0 +1,569 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// --- get_graph_schema ---
+
+type GetGraphSchemaParams struct{}
+
+type entityTypeDTO struct {
+	EntityType           string              `json:"entityType"`
+	Name                 string              `json:"name"`
+	Properties           []entityPropertyDTO `json:"properties"`
+	ConnectedEntityTypes []string            `json:"connectedEntityTypes"`
+	Active               bool                `json:"active"`
+}
+
+type entityPropertyDTO struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type entityTypesResponse struct {
+	Entities []entityTypeDTO `json:"entities"`
+}
+
+type schemaEntityType struct {
+	Type           string   `json:"type"`
+	Properties     []string `json:"properties"`
+	ConnectedTypes []string `json:"connectedTypes"`
+}
+
+func getGraphSchema(ctx context.Context, _ GetGraphSchemaParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	data, err := client.fetchAssertsDataGet(ctx, "/v1/entity_type", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch entity types: %w", err)
+	}
+
+	var resp entityTypesResponse
+	if err := json.Unmarshal([]byte(data), &resp); err != nil {
+		return "", fmt.Errorf("failed to parse entity types: %w", err)
+	}
+
+	schema := make([]schemaEntityType, 0, len(resp.Entities))
+	for _, et := range resp.Entities {
+		if !et.Active {
+			continue
+		}
+		props := make([]string, 0, len(et.Properties))
+		for _, p := range et.Properties {
+			props = append(props, p.Name)
+		}
+		schema = append(schema, schemaEntityType{
+			Type:           et.EntityType,
+			Properties:     props,
+			ConnectedTypes: et.ConnectedEntityTypes,
+		})
+	}
+
+	result, err := json.Marshal(map[string]any{"entityTypes": schema})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal schema: %w", err)
+	}
+	return string(result), nil
+}
+
+var GetGraphSchema = mcpgrafana.MustTool(
+	"get_graph_schema",
+	"Get the Knowledge Graph schema: entity types, their properties, and which types they connect to. Call this first to understand the graph structure before searching or traversing entities.",
+	getGraphSchema,
+	mcp.WithTitleAnnotation("Get KG schema"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- search_entities ---
+
+type SearchEntitiesParams struct {
+	EntityType    string `json:"entityType" jsonschema:"required,description=Entity type to search (e.g. Service\\, Node\\, Pod). Use get_graph_schema to see available types."`
+	SearchText    string `json:"searchText,omitempty" jsonschema:"description=Text to search in entity names"`
+	Env           string `json:"env,omitempty" jsonschema:"description=Filter by environment"`
+	Site          string `json:"site,omitempty" jsonschema:"description=Filter by site"`
+	Namespace     string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace"`
+	HasAssertions bool   `json:"hasAssertions,omitempty" jsonschema:"description=Only return entities with active assertions"`
+	StartTime     time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
+	EndTime       time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+}
+
+type searchRequestDTO struct {
+	TimeCriteria   timeCriteriaDTO    `json:"timeCriteria"`
+	ScopeCriteria  *scopeCriteriaDTO  `json:"scopeCriteria,omitempty"`
+	FilterCriteria []entityMatcherDTO `json:"filterCriteria"`
+	PageNum        int                `json:"pageNum"`
+}
+
+type timeCriteriaDTO struct {
+	Start int64 `json:"start"`
+	End   int64 `json:"end"`
+}
+
+type scopeCriteriaDTO struct {
+	NameAndValues map[string][]string `json:"nameAndValues"`
+}
+
+type entityMatcherDTO struct {
+	EntityType      string               `json:"entityType"`
+	PropertyMatchers []propertyMatcherDTO `json:"propertyMatchers,omitempty"`
+	HavingAssertion bool                 `json:"havingAssertion"`
+}
+
+type propertyMatcherDTO struct {
+	Name  string `json:"name"`
+	Value any    `json:"value"`
+	Op    string `json:"op"`
+}
+
+func searchEntities(ctx context.Context, args SearchEntitiesParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	matcher := entityMatcherDTO{
+		EntityType:      args.EntityType,
+		HavingAssertion: args.HasAssertions,
+	}
+	if args.SearchText != "" {
+		matcher.PropertyMatchers = append(matcher.PropertyMatchers, propertyMatcherDTO{
+			Name:  "name",
+			Value: args.SearchText,
+			Op:    "CONTAINS",
+		})
+	}
+
+	reqBody := searchRequestDTO{
+		TimeCriteria: timeCriteriaDTO{
+			Start: args.StartTime.UnixMilli(),
+			End:   args.EndTime.UnixMilli(),
+		},
+		FilterCriteria: []entityMatcherDTO{matcher},
+	}
+
+	scopeVals := make(map[string][]string)
+	if args.Env != "" {
+		scopeVals["env"] = []string{args.Env}
+	}
+	if args.Site != "" {
+		scopeVals["site"] = []string{args.Site}
+	}
+	if args.Namespace != "" {
+		scopeVals["namespace"] = []string{args.Namespace}
+	}
+	if len(scopeVals) > 0 {
+		reqBody.ScopeCriteria = &scopeCriteriaDTO{NameAndValues: scopeVals}
+	}
+
+	data, err := client.fetchAssertsData(ctx, "/v1/search", "POST", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to search entities: %w", err)
+	}
+
+	return data, nil
+}
+
+var SearchEntities = mcpgrafana.MustTool(
+	"search_entities",
+	"Search the Knowledge Graph for entities by type, name, scope, and assertion status. Returns a list of matching entities with their properties.",
+	searchEntities,
+	mcp.WithTitleAnnotation("Search KG entities"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- get_entity ---
+
+type GetEntityParams struct {
+	EntityType string `json:"entityType" jsonschema:"required,description=Entity type (e.g. Service\\, Node\\, Pod)"`
+	EntityName string `json:"entityName" jsonschema:"required,description=Entity name"`
+	Env        string `json:"env,omitempty" jsonschema:"description=Environment of the entity"`
+	Site       string `json:"site,omitempty" jsonschema:"description=Site of the entity"`
+	Namespace  string `json:"namespace,omitempty" jsonschema:"description=Namespace of the entity"`
+	Detailed   bool   `json:"detailed,omitempty" jsonschema:"description=If true\\, return full entity properties. Default is slim output."`
+}
+
+func getEntity(ctx context.Context, args GetEntityParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	entity, err := client.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	if err != nil {
+		return "", err
+	}
+
+	if args.Detailed {
+		result, err := json.Marshal(entity)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal entity: %w", err)
+		}
+		return string(result), nil
+	}
+
+	slim := entity.toSlim()
+	result, err := json.Marshal(slim)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal entity: %w", err)
+	}
+	return string(result), nil
+}
+
+var GetEntity = mcpgrafana.MustTool(
+	"get_entity",
+	"Get details for a specific Knowledge Graph entity by type and name. Returns entity properties, scope, connected types, and assertion summary.",
+	getEntity,
+	mcp.WithTitleAnnotation("Get KG entity"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- get_connected_entities ---
+
+type GetConnectedEntitiesParams struct {
+	EntityType    string `json:"entityType" jsonschema:"required,description=Type of the source entity"`
+	EntityName    string `json:"entityName" jsonschema:"required,description=Name of the source entity"`
+	Env           string `json:"env,omitempty" jsonschema:"description=Environment of the source entity"`
+	Site          string `json:"site,omitempty" jsonschema:"description=Site of the source entity"`
+	Namespace     string `json:"namespace,omitempty" jsonschema:"description=Namespace of the source entity"`
+	ConnectedType string `json:"connectedType,omitempty" jsonschema:"description=Filter connected entities by type"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"description=Max results to return (default 25\\, max 100)"`
+}
+
+func getConnectedEntities(ctx context.Context, args GetConnectedEntitiesParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	entity, err := client.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	if err != nil {
+		return "", err
+	}
+
+	params := url.Values{}
+	if args.ConnectedType != "" {
+		params.Set("type", args.ConnectedType)
+	}
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	params.Set("pagination.limit", fmt.Sprintf("%d", limit))
+
+	path := fmt.Sprintf("/public/v1/entities/%s/%d/connected", url.PathEscape(args.EntityType), entity.ID)
+	data, err := client.fetchAssertsDataGet(ctx, path, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch connected entities: %w", err)
+	}
+
+	var page struct {
+		Items []entitySummaryResponse `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(data), &page); err != nil {
+		return data, nil
+	}
+
+	slimItems := make([]slimEntity, 0, len(page.Items))
+	for i := range page.Items {
+		slimItems = append(slimItems, page.Items[i].toSlim())
+	}
+
+	result, err := json.Marshal(map[string]any{
+		"source":    entity.toSlim(),
+		"connected": slimItems,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal connected entities: %w", err)
+	}
+	return string(result), nil
+}
+
+var GetConnectedEntities = mcpgrafana.MustTool(
+	"get_connected_entities",
+	"Get entities connected to a source entity in the Knowledge Graph. Use get_graph_schema first to understand which types connect to which. Chain multiple calls for multi-hop traversal.",
+	getConnectedEntities,
+	mcp.WithTitleAnnotation("Get connected KG entities"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- list_entities ---
+
+type ListEntitiesParams struct {
+	EntityType string `json:"entityType" jsonschema:"required,description=Entity type to list"`
+	Env        string `json:"env,omitempty" jsonschema:"description=Filter by environment (RHS filter\\, e.g. eq:production)"`
+	Namespace  string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace (RHS filter\\, e.g. eq:default)"`
+	Name       string `json:"name,omitempty" jsonschema:"description=Filter by name (RHS filter\\, e.g. contains:checkout)"`
+	Limit      int    `json:"limit,omitempty" jsonschema:"description=Max results (default 25\\, max 100)"`
+	Offset     int    `json:"offset,omitempty" jsonschema:"description=Pagination offset (default 0)"`
+}
+
+func listEntities(ctx context.Context, args ListEntitiesParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	params := url.Values{}
+	if args.Env != "" {
+		params.Set("scope.env", args.Env)
+	}
+	if args.Namespace != "" {
+		params.Set("scope.namespace", args.Namespace)
+	}
+	if args.Name != "" {
+		params.Set("name", args.Name)
+	}
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	params.Set("pagination.limit", fmt.Sprintf("%d", limit))
+	if args.Offset > 0 {
+		params.Set("pagination.offset", fmt.Sprintf("%d", args.Offset))
+	}
+
+	path := fmt.Sprintf("/public/v1/entities/%s", url.PathEscape(args.EntityType))
+	data, err := client.fetchAssertsDataGet(ctx, path, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to list entities: %w", err)
+	}
+
+	var page struct {
+		Items      []entitySummaryResponse `json:"items"`
+		Pagination struct {
+			Limit  int `json:"limit"`
+			Offset int `json:"offset"`
+		} `json:"pagination"`
+	}
+	if err := json.Unmarshal([]byte(data), &page); err != nil {
+		return data, nil
+	}
+
+	slimItems := make([]slimEntity, 0, len(page.Items))
+	for i := range page.Items {
+		slimItems = append(slimItems, page.Items[i].toSlim())
+	}
+
+	result, err := json.Marshal(map[string]any{
+		"entities":   slimItems,
+		"pagination": page.Pagination,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal entities: %w", err)
+	}
+	return string(result), nil
+}
+
+var ListEntities = mcpgrafana.MustTool(
+	"list_entities",
+	"List entities of a given type in the Knowledge Graph with optional scope and name filters. Supports pagination.",
+	listEntities,
+	mcp.WithTitleAnnotation("List KG entities"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- count_entities ---
+
+type CountEntitiesParams struct {
+	Env       string `json:"env,omitempty" jsonschema:"description=Filter by environment"`
+	Site      string `json:"site,omitempty" jsonschema:"description=Filter by site"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace"`
+	StartTime time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
+	EndTime   time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+}
+
+type entityCountRequestDTO struct {
+	TimeCriteria  timeCriteriaDTO   `json:"timeCriteria"`
+	ScopeCriteria *scopeCriteriaDTO `json:"scopeCriteria,omitempty"`
+}
+
+func countEntities(ctx context.Context, args CountEntitiesParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	reqBody := entityCountRequestDTO{
+		TimeCriteria: timeCriteriaDTO{
+			Start: args.StartTime.UnixMilli(),
+			End:   args.EndTime.UnixMilli(),
+		},
+	}
+
+	scopeVals := make(map[string][]string)
+	if args.Env != "" {
+		scopeVals["env"] = []string{args.Env}
+	}
+	if args.Site != "" {
+		scopeVals["site"] = []string{args.Site}
+	}
+	if args.Namespace != "" {
+		scopeVals["namespace"] = []string{args.Namespace}
+	}
+	if len(scopeVals) > 0 {
+		reqBody.ScopeCriteria = &scopeCriteriaDTO{NameAndValues: scopeVals}
+	}
+
+	data, err := client.fetchAssertsData(ctx, "/v1/entity_type/count", "POST", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to count entities: %w", err)
+	}
+
+	return data, nil
+}
+
+var CountEntities = mcpgrafana.MustTool(
+	"count_entities",
+	"Get entity counts by type in the Knowledge Graph. Returns a map of entity type to count. Useful for understanding graph size without fetching full records.",
+	countEntities,
+	mcp.WithTitleAnnotation("Count KG entities"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- get_assertion_summary ---
+
+type GetAssertionSummaryParams struct {
+	EntityType string    `json:"entityType" jsonschema:"required,description=Entity type"`
+	EntityName string    `json:"entityName" jsonschema:"required,description=Entity name"`
+	Env        string    `json:"env,omitempty" jsonschema:"description=Environment"`
+	Site       string    `json:"site,omitempty" jsonschema:"description=Site"`
+	Namespace  string    `json:"namespace,omitempty" jsonschema:"description=Namespace"`
+	StartTime  time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
+	EndTime    time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+}
+
+type assertionsSummaryRequestDTO struct {
+	StartTime  int64          `json:"startTime"`
+	EndTime    int64          `json:"endTime"`
+	EntityKeys []entityKeyDTO `json:"entityKeys"`
+}
+
+type entityKeyDTO struct {
+	Type  string            `json:"type"`
+	Name  string            `json:"name"`
+	Scope map[string]string `json:"scope,omitempty"`
+}
+
+func getAssertionSummary(ctx context.Context, args GetAssertionSummaryParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	entityScope := make(map[string]string)
+	if args.Env != "" {
+		entityScope["env"] = args.Env
+	}
+	if args.Site != "" {
+		entityScope["site"] = args.Site
+	}
+	if args.Namespace != "" {
+		entityScope["namespace"] = args.Namespace
+	}
+
+	reqBody := assertionsSummaryRequestDTO{
+		StartTime: args.StartTime.UnixMilli(),
+		EndTime:   args.EndTime.UnixMilli(),
+		EntityKeys: []entityKeyDTO{
+			{
+				Type:  args.EntityType,
+				Name:  args.EntityName,
+				Scope: entityScope,
+			},
+		},
+	}
+
+	data, err := client.fetchAssertsData(ctx, "/v1/assertions/summary", "POST", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to get assertion summary: %w", err)
+	}
+
+	return data, nil
+}
+
+var GetAssertionSummary = mcpgrafana.MustTool(
+	"get_assertion_summary",
+	"Get assertion counts by category and severity for a Knowledge Graph entity. Returns aggregated assertion summary without full details.",
+	getAssertionSummary,
+	mcp.WithTitleAnnotation("Get KG assertion summary"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- search_rca_patterns ---
+
+type SearchRcaPatternsParams struct {
+	EntityType string    `json:"entityType" jsonschema:"required,description=Entity type"`
+	EntityName string    `json:"entityName" jsonschema:"required,description=Entity name"`
+	Env        string    `json:"env,omitempty" jsonschema:"description=Environment"`
+	Site       string    `json:"site,omitempty" jsonschema:"description=Site"`
+	Namespace  string    `json:"namespace,omitempty" jsonschema:"description=Namespace"`
+	StartTime  time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
+	EndTime    time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+}
+
+type rcaPatternSearchRequestDTO struct {
+	EntityType string `json:"entityType"`
+	EntityName string `json:"entityName"`
+	Env        string `json:"env,omitempty"`
+	Site       string `json:"site,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Start      int64  `json:"start"`
+	End        int64  `json:"end"`
+}
+
+func searchRcaPatterns(ctx context.Context, args SearchRcaPatternsParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	reqBody := rcaPatternSearchRequestDTO{
+		EntityType: args.EntityType,
+		EntityName: args.EntityName,
+		Env:        args.Env,
+		Site:       args.Site,
+		Namespace:  args.Namespace,
+		Start:      args.StartTime.UnixMilli(),
+		End:        args.EndTime.UnixMilli(),
+	}
+
+	data, err := client.fetchAssertsData(ctx, "/v1/patterns/search", "POST", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to search RCA patterns: %w", err)
+	}
+
+	return data, nil
+}
+
+var SearchRcaPatterns = mcpgrafana.MustTool(
+	"search_rca_patterns",
+	"Search for root cause analysis patterns for a Knowledge Graph entity. Returns potential root cause entities and their assertion correlation patterns.",
+	searchRcaPatterns,
+	mcp.WithTitleAnnotation("Search KG RCA patterns"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)

--- a/tools/asserts_kg.go
+++ b/tools/asserts_kg.go
@@ -44,6 +44,10 @@ func getGraphSchema(ctx context.Context, _ GetGraphSchemaParams) (string, error)
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
 	}
 
+	if cached, ok := graphSchemaCache.get(client.baseURL); ok {
+		return cached, nil
+	}
+
 	data, err := client.fetchAssertsDataGet(ctx, "/v1/entity_type", nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch entity types: %w", err)
@@ -74,7 +78,10 @@ func getGraphSchema(ctx context.Context, _ GetGraphSchemaParams) (string, error)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal schema: %w", err)
 	}
-	return string(result), nil
+
+	out := string(result)
+	graphSchemaCache.set(client.baseURL, out)
+	return out, nil
 }
 
 var GetGraphSchema = mcpgrafana.MustTool(
@@ -89,14 +96,17 @@ var GetGraphSchema = mcpgrafana.MustTool(
 // --- search_entities ---
 
 type SearchEntitiesParams struct {
-	EntityType    string `json:"entityType" jsonschema:"required,description=Entity type to search (e.g. Service\\, Node\\, Pod). Use get_graph_schema to see available types."`
-	SearchText    string `json:"searchText,omitempty" jsonschema:"description=Text to search in entity names"`
-	Env           string `json:"env,omitempty" jsonschema:"description=Filter by environment"`
+	Mode          string `json:"mode,omitempty" jsonschema:"description=Search mode: 'search' (default) for structured search via /v1/search\\, 'list' for paginated listing via public API\\, 'count' for entity type counts\\, 'semantic' for natural language search via vector similarity,enum=search,enum=list,enum=count,enum=semantic"`
+	EntityType    string `json:"entityType,omitempty" jsonschema:"description=Entity type (e.g. Service\\, Node\\, Pod). Required for search/list modes. Use get_graph_schema to see available types."`
+	SearchText    string `json:"searchText,omitempty" jsonschema:"description=Text to search for. In search mode: matches entity names (CONTAINS). In semantic mode: natural language query (e.g. 'the database handling payment orders')."`
+	Env           string `json:"env,omitempty" jsonschema:"description=Filter by environment. In list mode supports RHS filter syntax (e.g. eq:production)."`
 	Site          string `json:"site,omitempty" jsonschema:"description=Filter by site"`
-	Namespace     string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace"`
-	HasAssertions bool   `json:"hasAssertions,omitempty" jsonschema:"description=Only return entities with active assertions"`
-	StartTime     time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
-	EndTime       time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+	Namespace     string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace. In list mode supports RHS filter syntax."`
+	HasAssertions bool   `json:"hasAssertions,omitempty" jsonschema:"description=Only return entities with active assertions (search mode only)"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"description=Max results to return (default 25 for list\\, 10 for semantic)"`
+	Offset        int    `json:"offset,omitempty" jsonschema:"description=Pagination offset (list mode only)"`
+	StartTime     time.Time `json:"startTime,omitempty" jsonschema:"description=Start time in RFC3339 format (required for search and count modes)"`
+	EndTime       time.Time `json:"endTime,omitempty" jsonschema:"description=End time in RFC3339 format (required for search and count modes)"`
 }
 
 type searchRequestDTO struct {
@@ -127,7 +137,54 @@ type propertyMatcherDTO struct {
 	Op    string `json:"op"`
 }
 
+// searchResponseDTO matches the shape of POST /v1/search when type=graph.
+type searchResponseDTO struct {
+	Type string `json:"type"`
+	Data struct {
+		PageNum                  int                    `json:"pageNum"`
+		LastPage                 bool                   `json:"lastPage"`
+		SearchResultsMaxLimitHit bool                   `json:"searchResultsMaxLimitHit"`
+		Entities                 []graphEntityResponse  `json:"entities"`
+		Edges                    []searchEdgeDTO        `json:"edges"`
+	} `json:"data"`
+}
+
+type searchEdgeDTO struct {
+	Source      int64  `json:"source"`
+	Destination int64  `json:"destination"`
+	Type        string `json:"type"`
+}
+
+type slimSearchEdge struct {
+	Source      int64  `json:"source"`
+	Destination int64  `json:"destination"`
+	Type        string `json:"type"`
+}
+
+type entityCountRequestDTO struct {
+	TimeCriteria  timeCriteriaDTO   `json:"timeCriteria"`
+	ScopeCriteria *scopeCriteriaDTO `json:"scopeCriteria,omitempty"`
+}
+
 func searchEntities(ctx context.Context, args SearchEntitiesParams) (string, error) {
+	mode := args.Mode
+	if mode == "" {
+		mode = "search"
+	}
+
+	switch mode {
+	case "list":
+		return searchEntitiesList(ctx, args)
+	case "count":
+		return searchEntitiesCount(ctx, args)
+	case "semantic":
+		return searchEntitiesSemantic(ctx, args)
+	default:
+		return searchEntitiesDefault(ctx, args)
+	}
+}
+
+func searchEntitiesDefault(ctx context.Context, args SearchEntitiesParams) (string, error) {
 	client, err := newAssertsClient(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
@@ -172,12 +229,153 @@ func searchEntities(ctx context.Context, args SearchEntitiesParams) (string, err
 		return "", fmt.Errorf("failed to search entities: %w", err)
 	}
 
+	var resp searchResponseDTO
+	if err := json.Unmarshal([]byte(data), &resp); err != nil {
+		return data, nil
+	}
+
+	slimEntities := make([]slimEntity, 0, len(resp.Data.Entities))
+	for i := range resp.Data.Entities {
+		slimEntities = append(slimEntities, resp.Data.Entities[i].toSlim())
+	}
+
+	edges := make([]slimSearchEdge, 0, len(resp.Data.Edges))
+	for _, e := range resp.Data.Edges {
+		edges = append(edges, slimSearchEdge{
+			Source:      e.Source,
+			Destination: e.Destination,
+			Type:        e.Type,
+		})
+	}
+
+	result, err := json.Marshal(map[string]any{
+		"mode":     "search",
+		"entities": slimEntities,
+		"edges":    edges,
+		"pageNum":  resp.Data.PageNum,
+		"lastPage": resp.Data.LastPage,
+		"limitHit": resp.Data.SearchResultsMaxLimitHit,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal search results: %w", err)
+	}
+	return string(result), nil
+}
+
+func searchEntitiesList(ctx context.Context, args SearchEntitiesParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	params := url.Values{}
+	if args.Env != "" {
+		params.Set("scope.env", args.Env)
+	}
+	if args.Namespace != "" {
+		params.Set("scope.namespace", args.Namespace)
+	}
+	if args.SearchText != "" {
+		params.Set("name", args.SearchText)
+	}
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	params.Set("pagination.limit", fmt.Sprintf("%d", limit))
+	if args.Offset > 0 {
+		params.Set("pagination.offset", fmt.Sprintf("%d", args.Offset))
+	}
+
+	path := fmt.Sprintf("/public/v1/entities/%s", url.PathEscape(args.EntityType))
+	data, err := client.fetchAssertsDataGet(ctx, path, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to list entities: %w", err)
+	}
+
+	var page struct {
+		Items      []entitySummaryResponse `json:"items"`
+		Pagination struct {
+			Limit  int `json:"limit"`
+			Offset int `json:"offset"`
+		} `json:"pagination"`
+	}
+	if err := json.Unmarshal([]byte(data), &page); err != nil {
+		return data, nil
+	}
+
+	slimItems := make([]slimEntity, 0, len(page.Items))
+	for i := range page.Items {
+		slimItems = append(slimItems, page.Items[i].toSlim())
+	}
+
+	result, err := json.Marshal(map[string]any{
+		"mode":       "list",
+		"entities":   slimItems,
+		"pagination": page.Pagination,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal entities: %w", err)
+	}
+	return string(result), nil
+}
+
+func searchEntitiesCount(ctx context.Context, args SearchEntitiesParams) (string, error) {
+	client, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	reqBody := entityCountRequestDTO{
+		TimeCriteria: timeCriteriaDTO{
+			Start: args.StartTime.UnixMilli(),
+			End:   args.EndTime.UnixMilli(),
+		},
+	}
+
+	scopeVals := make(map[string][]string)
+	if args.Env != "" {
+		scopeVals["env"] = []string{args.Env}
+	}
+	if args.Site != "" {
+		scopeVals["site"] = []string{args.Site}
+	}
+	if args.Namespace != "" {
+		scopeVals["namespace"] = []string{args.Namespace}
+	}
+	if len(scopeVals) > 0 {
+		reqBody.ScopeCriteria = &scopeCriteriaDTO{NameAndValues: scopeVals}
+	}
+
+	data, err := client.fetchAssertsData(ctx, "/v1/entity_type/count", "POST", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to count entities: %w", err)
+	}
+
 	return data, nil
+}
+
+func searchEntitiesSemantic(ctx context.Context, args SearchEntitiesParams) (string, error) {
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+
+	semanticArgs := FindEntitiesSemanticParams{
+		Query:     args.SearchText,
+		Limit:     limit,
+		Env:       args.Env,
+		Namespace: args.Namespace,
+	}
+	return findEntitiesSemantic(ctx, semanticArgs)
 }
 
 var SearchEntities = mcpgrafana.MustTool(
 	"search_entities",
-	"Search the Knowledge Graph for entities by type, name, scope, and assertion status. Returns a list of matching entities with their properties.",
+	"Search the Knowledge Graph for entities. Supports four modes: 'search' (default) for structured search by type/name/scope, 'list' for paginated entity listing, 'count' for entity type counts, 'semantic' for natural language search via vector similarity. Use get_graph_schema first to understand available entity types.",
 	searchEntities,
 	mcp.WithTitleAnnotation("Search KG entities"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -201,7 +399,7 @@ func getEntity(ctx context.Context, args GetEntityParams) (string, error) {
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
 	}
 
-	entity, err := client.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	entity, err := client.resolveEntityInfoCached(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
 	if err != nil {
 		return "", err
 	}
@@ -249,7 +447,7 @@ func getConnectedEntities(ctx context.Context, args GetConnectedEntitiesParams) 
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
 	}
 
-	entity, err := client.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	entity, err := client.resolveEntityInfoCached(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
 	if err != nil {
 		return "", err
 	}
@@ -304,144 +502,6 @@ var GetConnectedEntities = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-// --- list_entities ---
-
-type ListEntitiesParams struct {
-	EntityType string `json:"entityType" jsonschema:"required,description=Entity type to list"`
-	Env        string `json:"env,omitempty" jsonschema:"description=Filter by environment (RHS filter\\, e.g. eq:production)"`
-	Namespace  string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace (RHS filter\\, e.g. eq:default)"`
-	Name       string `json:"name,omitempty" jsonschema:"description=Filter by name (RHS filter\\, e.g. contains:checkout)"`
-	Limit      int    `json:"limit,omitempty" jsonschema:"description=Max results (default 25\\, max 100)"`
-	Offset     int    `json:"offset,omitempty" jsonschema:"description=Pagination offset (default 0)"`
-}
-
-func listEntities(ctx context.Context, args ListEntitiesParams) (string, error) {
-	client, err := newAssertsClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to create Asserts client: %w", err)
-	}
-
-	params := url.Values{}
-	if args.Env != "" {
-		params.Set("scope.env", args.Env)
-	}
-	if args.Namespace != "" {
-		params.Set("scope.namespace", args.Namespace)
-	}
-	if args.Name != "" {
-		params.Set("name", args.Name)
-	}
-	limit := args.Limit
-	if limit <= 0 {
-		limit = 25
-	}
-	if limit > 100 {
-		limit = 100
-	}
-	params.Set("pagination.limit", fmt.Sprintf("%d", limit))
-	if args.Offset > 0 {
-		params.Set("pagination.offset", fmt.Sprintf("%d", args.Offset))
-	}
-
-	path := fmt.Sprintf("/public/v1/entities/%s", url.PathEscape(args.EntityType))
-	data, err := client.fetchAssertsDataGet(ctx, path, params)
-	if err != nil {
-		return "", fmt.Errorf("failed to list entities: %w", err)
-	}
-
-	var page struct {
-		Items      []entitySummaryResponse `json:"items"`
-		Pagination struct {
-			Limit  int `json:"limit"`
-			Offset int `json:"offset"`
-		} `json:"pagination"`
-	}
-	if err := json.Unmarshal([]byte(data), &page); err != nil {
-		return data, nil
-	}
-
-	slimItems := make([]slimEntity, 0, len(page.Items))
-	for i := range page.Items {
-		slimItems = append(slimItems, page.Items[i].toSlim())
-	}
-
-	result, err := json.Marshal(map[string]any{
-		"entities":   slimItems,
-		"pagination": page.Pagination,
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal entities: %w", err)
-	}
-	return string(result), nil
-}
-
-var ListEntities = mcpgrafana.MustTool(
-	"list_entities",
-	"List entities of a given type in the Knowledge Graph with optional scope and name filters. Supports pagination.",
-	listEntities,
-	mcp.WithTitleAnnotation("List KG entities"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-)
-
-// --- count_entities ---
-
-type CountEntitiesParams struct {
-	Env       string `json:"env,omitempty" jsonschema:"description=Filter by environment"`
-	Site      string `json:"site,omitempty" jsonschema:"description=Filter by site"`
-	Namespace string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace"`
-	StartTime time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
-	EndTime   time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
-}
-
-type entityCountRequestDTO struct {
-	TimeCriteria  timeCriteriaDTO   `json:"timeCriteria"`
-	ScopeCriteria *scopeCriteriaDTO `json:"scopeCriteria,omitempty"`
-}
-
-func countEntities(ctx context.Context, args CountEntitiesParams) (string, error) {
-	client, err := newAssertsClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to create Asserts client: %w", err)
-	}
-
-	reqBody := entityCountRequestDTO{
-		TimeCriteria: timeCriteriaDTO{
-			Start: args.StartTime.UnixMilli(),
-			End:   args.EndTime.UnixMilli(),
-		},
-	}
-
-	scopeVals := make(map[string][]string)
-	if args.Env != "" {
-		scopeVals["env"] = []string{args.Env}
-	}
-	if args.Site != "" {
-		scopeVals["site"] = []string{args.Site}
-	}
-	if args.Namespace != "" {
-		scopeVals["namespace"] = []string{args.Namespace}
-	}
-	if len(scopeVals) > 0 {
-		reqBody.ScopeCriteria = &scopeCriteriaDTO{NameAndValues: scopeVals}
-	}
-
-	data, err := client.fetchAssertsData(ctx, "/v1/entity_type/count", "POST", reqBody)
-	if err != nil {
-		return "", fmt.Errorf("failed to count entities: %w", err)
-	}
-
-	return data, nil
-}
-
-var CountEntities = mcpgrafana.MustTool(
-	"count_entities",
-	"Get entity counts by type in the Knowledge Graph. Returns a map of entity type to count. Useful for understanding graph size without fetching full records.",
-	countEntities,
-	mcp.WithTitleAnnotation("Count KG entities"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-)
 
 // --- get_assertion_summary ---
 

--- a/tools/asserts_kg.go
+++ b/tools/asserts_kg.go
@@ -173,6 +173,8 @@ func searchEntities(ctx context.Context, args SearchEntitiesParams) (string, err
 	}
 
 	switch mode {
+	case "search":
+		return searchEntitiesDefault(ctx, args)
 	case "list":
 		return searchEntitiesList(ctx, args)
 	case "count":
@@ -180,7 +182,7 @@ func searchEntities(ctx context.Context, args SearchEntitiesParams) (string, err
 	case "semantic":
 		return searchEntitiesSemantic(ctx, args)
 	default:
-		return searchEntitiesDefault(ctx, args)
+		return "", fmt.Errorf("unknown search mode: %q (valid: search, list, count, semantic)", mode)
 	}
 }
 
@@ -271,6 +273,9 @@ func searchEntitiesList(ctx context.Context, args SearchEntitiesParams) (string,
 	params := url.Values{}
 	if args.Env != "" {
 		params.Set("scope.env", args.Env)
+	}
+	if args.Site != "" {
+		params.Set("scope.site", args.Site)
 	}
 	if args.Namespace != "" {
 		params.Set("scope.namespace", args.Namespace)
@@ -368,6 +373,7 @@ func searchEntitiesSemantic(ctx context.Context, args SearchEntitiesParams) (str
 		Query:     args.SearchText,
 		Limit:     limit,
 		Env:       args.Env,
+		Site:      args.Site,
 		Namespace: args.Namespace,
 	}
 	return findEntitiesSemantic(ctx, semanticArgs)

--- a/tools/asserts_kg.go
+++ b/tools/asserts_kg.go
@@ -44,7 +44,10 @@ func getGraphSchema(ctx context.Context, _ GetGraphSchemaParams) (string, error)
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
 	}
 
-	if cached, ok := graphSchemaCache.get(client.baseURL); ok {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	cacheKey := tenantCacheKey(client.baseURL, cfg.OrgID)
+
+	if cached, ok := graphSchemaCache.get(cacheKey); ok {
 		return cached, nil
 	}
 
@@ -80,7 +83,7 @@ func getGraphSchema(ctx context.Context, _ GetGraphSchemaParams) (string, error)
 	}
 
 	out := string(result)
-	graphSchemaCache.set(client.baseURL, out)
+	graphSchemaCache.set(cacheKey, out)
 	return out, nil
 }
 
@@ -150,12 +153,6 @@ type searchResponseDTO struct {
 }
 
 type searchEdgeDTO struct {
-	Source      int64  `json:"source"`
-	Destination int64  `json:"destination"`
-	Type        string `json:"type"`
-}
-
-type slimSearchEdge struct {
 	Source      int64  `json:"source"`
 	Destination int64  `json:"destination"`
 	Type        string `json:"type"`
@@ -233,7 +230,7 @@ func searchEntitiesDefault(ctx context.Context, args SearchEntitiesParams) (stri
 
 	var resp searchResponseDTO
 	if err := json.Unmarshal([]byte(data), &resp); err != nil {
-		return data, nil
+		return "", fmt.Errorf("failed to parse search response: %w", err)
 	}
 
 	slimEntities := make([]slimEntity, 0, len(resp.Data.Entities))
@@ -241,19 +238,10 @@ func searchEntitiesDefault(ctx context.Context, args SearchEntitiesParams) (stri
 		slimEntities = append(slimEntities, resp.Data.Entities[i].toSlim())
 	}
 
-	edges := make([]slimSearchEdge, 0, len(resp.Data.Edges))
-	for _, e := range resp.Data.Edges {
-		edges = append(edges, slimSearchEdge{
-			Source:      e.Source,
-			Destination: e.Destination,
-			Type:        e.Type,
-		})
-	}
-
 	result, err := json.Marshal(map[string]any{
 		"mode":     "search",
 		"entities": slimEntities,
-		"edges":    edges,
+		"edges":    resp.Data.Edges,
 		"pageNum":  resp.Data.PageNum,
 		"lastPage": resp.Data.LastPage,
 		"limitHit": resp.Data.SearchResultsMaxLimitHit,
@@ -309,7 +297,7 @@ func searchEntitiesList(ctx context.Context, args SearchEntitiesParams) (string,
 		} `json:"pagination"`
 	}
 	if err := json.Unmarshal([]byte(data), &page); err != nil {
-		return data, nil
+		return "", fmt.Errorf("failed to parse list response: %w", err)
 	}
 
 	slimItems := make([]slimEntity, 0, len(page.Items))
@@ -481,7 +469,7 @@ func getConnectedEntities(ctx context.Context, args GetConnectedEntitiesParams) 
 		Items []entitySummaryResponse `json:"items"`
 	}
 	if err := json.Unmarshal([]byte(data), &page); err != nil {
-		return data, nil
+		return "", fmt.Errorf("failed to parse connected entities response: %w", err)
 	}
 
 	slimItems := make([]slimEntity, 0, len(page.Items))

--- a/tools/asserts_kg_test.go
+++ b/tools/asserts_kg_test.go
@@ -1,0 +1,417 @@
+//go:build unit
+// +build unit
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupMockAssertsKGServer(handler http.HandlerFunc) (*httptest.Server, context.Context) {
+	srv := httptest.NewServer(handler)
+	config := mcpgrafana.GrafanaConfig{
+		URL:    srv.URL,
+		APIKey: "test-api-key",
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+	return srv, ctx
+}
+
+func TestGetGraphSchema(t *testing.T) {
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/plugins/grafana-asserts-app/resources/asserts/api-server/v1/entity_type", r.URL.Path)
+		require.Equal(t, "GET", r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := `{
+			"entities": [
+				{
+					"entityType": "Service",
+					"name": "Service",
+					"properties": [
+						{"name": "job", "type": "string"},
+						{"name": "namespace", "type": "string"}
+					],
+					"connectedEntityTypes": ["Pod", "Node", "Database"],
+					"active": true
+				},
+				{
+					"entityType": "Pod",
+					"name": "Pod",
+					"properties": [
+						{"name": "pod", "type": "string"}
+					],
+					"connectedEntityTypes": ["Service", "Node"],
+					"active": true
+				},
+				{
+					"entityType": "OldType",
+					"name": "OldType",
+					"properties": [],
+					"connectedEntityTypes": [],
+					"active": false
+				}
+			]
+		}`
+		_, _ = w.Write([]byte(resp))
+	})
+	defer srv.Close()
+
+	result, err := getGraphSchema(ctx, GetGraphSchemaParams{})
+	require.NoError(t, err)
+
+	var parsed struct {
+		EntityTypes []schemaEntityType `json:"entityTypes"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	assert.Len(t, parsed.EntityTypes, 2)
+	assert.Equal(t, "Service", parsed.EntityTypes[0].Type)
+	assert.Equal(t, []string{"job", "namespace"}, parsed.EntityTypes[0].Properties)
+	assert.Equal(t, []string{"Pod", "Node", "Database"}, parsed.EntityTypes[0].ConnectedTypes)
+	assert.Equal(t, "Pod", parsed.EntityTypes[1].Type)
+}
+
+func TestSearchEntities(t *testing.T) {
+	startTime := time.Date(2026, 2, 25, 10, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, 2, 25, 11, 0, 0, 0, time.UTC)
+
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/plugins/grafana-asserts-app/resources/asserts/api-server/v1/search", r.URL.Path)
+		require.Equal(t, "POST", r.Method)
+
+		var body searchRequestDTO
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, startTime.UnixMilli(), body.TimeCriteria.Start)
+		assert.Equal(t, endTime.UnixMilli(), body.TimeCriteria.End)
+		require.Len(t, body.FilterCriteria, 1)
+		assert.Equal(t, "Service", body.FilterCriteria[0].EntityType)
+		assert.True(t, body.FilterCriteria[0].HavingAssertion)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"entities": [{"type": "Service", "name": "checkout"}]}`))
+	})
+	defer srv.Close()
+
+	result, err := searchEntities(ctx, SearchEntitiesParams{
+		EntityType:    "Service",
+		HasAssertions: true,
+		StartTime:     startTime,
+		EndTime:       endTime,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result, "checkout")
+}
+
+func TestSearchEntitiesWithScope(t *testing.T) {
+	startTime := time.Date(2026, 2, 25, 10, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, 2, 25, 11, 0, 0, 0, time.UTC)
+
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		var body searchRequestDTO
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		require.NotNil(t, body.ScopeCriteria)
+		assert.Equal(t, []string{"production"}, body.ScopeCriteria.NameAndValues["env"])
+		assert.Equal(t, []string{"us-east"}, body.ScopeCriteria.NameAndValues["site"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"entities": []}`))
+	})
+	defer srv.Close()
+
+	_, err := searchEntities(ctx, SearchEntitiesParams{
+		EntityType: "Service",
+		Env:        "production",
+		Site:       "us-east",
+		StartTime:  startTime,
+		EndTime:    endTime,
+	})
+	require.NoError(t, err)
+}
+
+func TestSearchEntitiesWithSearchText(t *testing.T) {
+	startTime := time.Date(2026, 2, 25, 10, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, 2, 25, 11, 0, 0, 0, time.UTC)
+
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		var body searchRequestDTO
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		require.Len(t, body.FilterCriteria[0].PropertyMatchers, 1)
+		assert.Equal(t, "name", body.FilterCriteria[0].PropertyMatchers[0].Name)
+		assert.Equal(t, "checkout", body.FilterCriteria[0].PropertyMatchers[0].Value)
+		assert.Equal(t, "CONTAINS", body.FilterCriteria[0].PropertyMatchers[0].Op)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"entities": [{"type": "Service", "name": "checkout-service"}]}`))
+	})
+	defer srv.Close()
+
+	result, err := searchEntities(ctx, SearchEntitiesParams{
+		EntityType: "Service",
+		SearchText: "checkout",
+		StartTime:  startTime,
+		EndTime:    endTime,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result, "checkout-service")
+}
+
+func TestGetEntity(t *testing.T) {
+	t.Run("slim output", func(t *testing.T) {
+		srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "GET", r.Method)
+			require.Contains(t, r.URL.Path, "/v1/entity/info")
+			assert.Equal(t, "Service", r.URL.Query().Get("entity_type"))
+			assert.Equal(t, "checkout", r.URL.Query().Get("entity_name"))
+			assert.Equal(t, "production", r.URL.Query().Get("entityEnv"))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": 42,
+				"type": "Service",
+				"name": "checkout",
+				"active": true,
+				"env": "production",
+				"namespace": "default",
+				"connectedEntityTypes": {"Pod": 3, "Node": 2},
+				"properties": {"job": "checkout", "instance": "10.0.0.1:8080"},
+				"assertionCount": 5
+			}`))
+		})
+		defer srv.Close()
+
+		result, err := getEntity(ctx, GetEntityParams{
+			EntityType: "Service",
+			EntityName: "checkout",
+			Env:        "production",
+		})
+		require.NoError(t, err)
+
+		var slim slimEntity
+		require.NoError(t, json.Unmarshal([]byte(result), &slim))
+		assert.Equal(t, "Service", slim.Type)
+		assert.Equal(t, "checkout", slim.Name)
+		assert.Equal(t, "production", slim.Env)
+		assert.Equal(t, 5, slim.AssertionCount)
+		assert.Equal(t, map[string]int{"Pod": 3, "Node": 2}, slim.ConnectedTypes)
+		assert.Nil(t, slim.Properties)
+	})
+
+	t.Run("detailed output", func(t *testing.T) {
+		srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": 42,
+				"type": "Service",
+				"name": "checkout",
+				"active": true,
+				"properties": {"job": "checkout", "instance": "10.0.0.1:8080"}
+			}`))
+		})
+		defer srv.Close()
+
+		result, err := getEntity(ctx, GetEntityParams{
+			EntityType: "Service",
+			EntityName: "checkout",
+			Detailed:   true,
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, `"instance"`)
+		assert.Contains(t, result, `"10.0.0.1:8080"`)
+	})
+}
+
+func TestGetConnectedEntities(t *testing.T) {
+	callCount := 0
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if callCount == 1 {
+			require.Contains(t, r.URL.Path, "/v1/entity/info")
+			_, _ = w.Write([]byte(`{"id": 42, "type": "Service", "name": "checkout", "active": true}`))
+			return
+		}
+
+		require.Contains(t, r.URL.Path, "/public/v1/entities/Service/42/connected")
+		assert.Equal(t, "Pod", r.URL.Query().Get("type"))
+		assert.Equal(t, "10", r.URL.Query().Get("pagination.limit"))
+
+		_, _ = w.Write([]byte(`{
+			"items": [
+				{"id": "100", "type": "Pod", "name": "checkout-abc123", "active": true, "scope": {"namespace": "default"}},
+				{"id": "101", "type": "Pod", "name": "checkout-def456", "active": true, "scope": {"namespace": "default"}}
+			],
+			"pagination": {"limit": 10, "offset": 0}
+		}`))
+	})
+	defer srv.Close()
+
+	result, err := getConnectedEntities(ctx, GetConnectedEntitiesParams{
+		EntityType:    "Service",
+		EntityName:    "checkout",
+		ConnectedType: "Pod",
+		Limit:         10,
+	})
+	require.NoError(t, err)
+
+	var parsed struct {
+		Source    slimEntity   `json:"source"`
+		Connected []slimEntity `json:"connected"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+	assert.Equal(t, "Service", parsed.Source.Type)
+	assert.Equal(t, "checkout", parsed.Source.Name)
+	assert.Len(t, parsed.Connected, 2)
+	assert.Equal(t, "Pod", parsed.Connected[0].Type)
+	assert.Equal(t, "checkout-abc123", parsed.Connected[0].Name)
+}
+
+func TestListEntities(t *testing.T) {
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "GET", r.Method)
+		require.Contains(t, r.URL.Path, "/public/v1/entities/Service")
+		assert.Equal(t, "eq:production", r.URL.Query().Get("scope.env"))
+		assert.Equal(t, "25", r.URL.Query().Get("pagination.limit"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"items": [
+				{"id": "1", "type": "Service", "name": "api-gateway", "active": true, "scope": {"env": "production"}},
+				{"id": "2", "type": "Service", "name": "checkout", "active": true, "scope": {"env": "production"}}
+			],
+			"pagination": {"limit": 25, "offset": 0}
+		}`))
+	})
+	defer srv.Close()
+
+	result, err := listEntities(ctx, ListEntitiesParams{
+		EntityType: "Service",
+		Env:        "eq:production",
+	})
+	require.NoError(t, err)
+
+	var parsed struct {
+		Entities   []slimEntity `json:"entities"`
+		Pagination struct {
+			Limit  int `json:"limit"`
+			Offset int `json:"offset"`
+		} `json:"pagination"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+	assert.Len(t, parsed.Entities, 2)
+	assert.Equal(t, "api-gateway", parsed.Entities[0].Name)
+}
+
+func TestCountEntities(t *testing.T) {
+	startTime := time.Date(2026, 2, 25, 10, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, 2, 25, 11, 0, 0, 0, time.UTC)
+
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/plugins/grafana-asserts-app/resources/asserts/api-server/v1/entity_type/count", r.URL.Path)
+		require.Equal(t, "POST", r.Method)
+
+		var body entityCountRequestDTO
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, startTime.UnixMilli(), body.TimeCriteria.Start)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"Service": 42, "Pod": 128, "Node": 5}`))
+	})
+	defer srv.Close()
+
+	result, err := countEntities(ctx, CountEntitiesParams{
+		StartTime: startTime,
+		EndTime:   endTime,
+	})
+	require.NoError(t, err)
+
+	var counts map[string]int
+	require.NoError(t, json.Unmarshal([]byte(result), &counts))
+	assert.Equal(t, 42, counts["Service"])
+	assert.Equal(t, 128, counts["Pod"])
+	assert.Equal(t, 5, counts["Node"])
+}
+
+func TestGetAssertionSummary(t *testing.T) {
+	startTime := time.Date(2026, 2, 25, 10, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, 2, 25, 11, 0, 0, 0, time.UTC)
+
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/plugins/grafana-asserts-app/resources/asserts/api-server/v1/assertions/summary", r.URL.Path)
+		require.Equal(t, "POST", r.Method)
+
+		var body assertionsSummaryRequestDTO
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, startTime.UnixMilli(), body.StartTime)
+		require.Len(t, body.EntityKeys, 1)
+		assert.Equal(t, "Service", body.EntityKeys[0].Type)
+		assert.Equal(t, "checkout", body.EntityKeys[0].Name)
+		assert.Equal(t, "production", body.EntityKeys[0].Scope["env"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"summaries": [{"entityType": "Service", "totalCount": 3}]}`))
+	})
+	defer srv.Close()
+
+	result, err := getAssertionSummary(ctx, GetAssertionSummaryParams{
+		EntityType: "Service",
+		EntityName: "checkout",
+		Env:        "production",
+		StartTime:  startTime,
+		EndTime:    endTime,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result, "totalCount")
+}
+
+func TestSearchRcaPatterns(t *testing.T) {
+	startTime := time.Date(2026, 2, 25, 10, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, 2, 25, 11, 0, 0, 0, time.UTC)
+
+	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/plugins/grafana-asserts-app/resources/asserts/api-server/v1/patterns/search", r.URL.Path)
+		require.Equal(t, "POST", r.Method)
+
+		var body rcaPatternSearchRequestDTO
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "Service", body.EntityType)
+		assert.Equal(t, "checkout", body.EntityName)
+		assert.Equal(t, startTime.UnixMilli(), body.Start)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"patterns": [{"name": "HighLatency", "rootCause": "Database"}]}`))
+	})
+	defer srv.Close()
+
+	result, err := searchRcaPatterns(ctx, SearchRcaPatternsParams{
+		EntityType: "Service",
+		EntityName: "checkout",
+		StartTime:  startTime,
+		EndTime:    endTime,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result, "HighLatency")
+}

--- a/tools/asserts_kg_test.go
+++ b/tools/asserts_kg_test.go
@@ -100,7 +100,7 @@ func TestSearchEntities(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"entities": [{"type": "Service", "name": "checkout"}]}`))
+		_, _ = w.Write([]byte(`{"type":"graph","data":{"entities":[{"type":"Service","name":"checkout","active":true}],"edges":[],"pageNum":0,"lastPage":true}}`))
 	})
 	defer srv.Close()
 
@@ -128,7 +128,7 @@ func TestSearchEntitiesWithScope(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"entities": []}`))
+		_, _ = w.Write([]byte(`{"type":"graph","data":{"entities":[],"edges":[],"pageNum":0,"lastPage":true}}`))
 	})
 	defer srv.Close()
 
@@ -157,7 +157,7 @@ func TestSearchEntitiesWithSearchText(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"entities": [{"type": "Service", "name": "checkout-service"}]}`))
+		_, _ = w.Write([]byte(`{"type":"graph","data":{"entities":[{"type":"Service","name":"checkout-service","active":true}],"edges":[],"pageNum":0,"lastPage":true}}`))
 	})
 	defer srv.Close()
 
@@ -285,7 +285,7 @@ func TestGetConnectedEntities(t *testing.T) {
 	assert.Equal(t, "checkout-abc123", parsed.Connected[0].Name)
 }
 
-func TestListEntities(t *testing.T) {
+func TestSearchEntitiesListMode(t *testing.T) {
 	srv, ctx := setupMockAssertsKGServer(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "GET", r.Method)
 		require.Contains(t, r.URL.Path, "/public/v1/entities/Service")
@@ -304,13 +304,15 @@ func TestListEntities(t *testing.T) {
 	})
 	defer srv.Close()
 
-	result, err := listEntities(ctx, ListEntitiesParams{
+	result, err := searchEntities(ctx, SearchEntitiesParams{
+		Mode:       "list",
 		EntityType: "Service",
 		Env:        "eq:production",
 	})
 	require.NoError(t, err)
 
 	var parsed struct {
+		Mode       string       `json:"mode"`
 		Entities   []slimEntity `json:"entities"`
 		Pagination struct {
 			Limit  int `json:"limit"`
@@ -318,11 +320,12 @@ func TestListEntities(t *testing.T) {
 		} `json:"pagination"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+	assert.Equal(t, "list", parsed.Mode)
 	assert.Len(t, parsed.Entities, 2)
 	assert.Equal(t, "api-gateway", parsed.Entities[0].Name)
 }
 
-func TestCountEntities(t *testing.T) {
+func TestSearchEntitiesCountMode(t *testing.T) {
 	startTime := time.Date(2026, 2, 25, 10, 0, 0, 0, time.UTC)
 	endTime := time.Date(2026, 2, 25, 11, 0, 0, 0, time.UTC)
 
@@ -340,7 +343,8 @@ func TestCountEntities(t *testing.T) {
 	})
 	defer srv.Close()
 
-	result, err := countEntities(ctx, CountEntitiesParams{
+	result, err := searchEntities(ctx, SearchEntitiesParams{
+		Mode:      "count",
 		StartTime: startTime,
 		EndTime:   endTime,
 	})

--- a/tools/asserts_mlt.go
+++ b/tools/asserts_mlt.go
@@ -1,0 +1,422 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// entityLabelMapping defines how KG entity properties map to telemetry labels.
+var entityLabelMapping = map[string]struct {
+	PromLabels func(name, env, site, ns string) string
+	LokiLabels func(name, env, site, ns string) string
+	TraceAttrs func(name, env, site, ns string) string
+}{
+	"Service": {
+		PromLabels: func(name, _, _, ns string) string {
+			parts := []string{fmt.Sprintf(`job="%s"`, name)}
+			if ns != "" {
+				parts = append(parts, fmt.Sprintf(`namespace="%s"`, ns))
+			}
+			return "{" + strings.Join(parts, ", ") + "}"
+		},
+		LokiLabels: func(name, _, _, ns string) string {
+			parts := []string{fmt.Sprintf(`app="%s"`, name)}
+			if ns != "" {
+				parts = append(parts, fmt.Sprintf(`namespace="%s"`, ns))
+			}
+			return "{" + strings.Join(parts, ", ") + "}"
+		},
+		TraceAttrs: func(name, _, _, ns string) string {
+			parts := []string{fmt.Sprintf(`resource.service.name="%s"`, name)}
+			if ns != "" {
+				parts = append(parts, fmt.Sprintf(`resource.k8s.namespace.name="%s"`, ns))
+			}
+			return "{" + strings.Join(parts, " && ") + "}"
+		},
+	},
+	"Node": {
+		PromLabels: func(name, _, _, _ string) string {
+			return fmt.Sprintf(`{instance=~"%s.*"}`, name)
+		},
+		LokiLabels: func(name, _, _, _ string) string {
+			return fmt.Sprintf(`{node_name="%s"}`, name)
+		},
+		TraceAttrs: func(name, _, _, _ string) string {
+			return fmt.Sprintf(`{resource.k8s.node.name="%s"}`, name)
+		},
+	},
+	"Pod": {
+		PromLabels: func(name, _, _, ns string) string {
+			parts := []string{fmt.Sprintf(`pod="%s"`, name)}
+			if ns != "" {
+				parts = append(parts, fmt.Sprintf(`namespace="%s"`, ns))
+			}
+			return "{" + strings.Join(parts, ", ") + "}"
+		},
+		LokiLabels: func(name, _, _, ns string) string {
+			parts := []string{fmt.Sprintf(`pod="%s"`, name)}
+			if ns != "" {
+				parts = append(parts, fmt.Sprintf(`namespace="%s"`, ns))
+			}
+			return "{" + strings.Join(parts, ", ") + "}"
+		},
+		TraceAttrs: func(name, _, _, ns string) string {
+			parts := []string{fmt.Sprintf(`resource.k8s.pod.name="%s"`, name)}
+			if ns != "" {
+				parts = append(parts, fmt.Sprintf(`resource.k8s.namespace.name="%s"`, ns))
+			}
+			return "{" + strings.Join(parts, " && ") + "}"
+		},
+	},
+	"Namespace": {
+		PromLabels: func(name, _, _, _ string) string {
+			return fmt.Sprintf(`{namespace="%s"}`, name)
+		},
+		LokiLabels: func(name, _, _, _ string) string {
+			return fmt.Sprintf(`{namespace="%s"}`, name)
+		},
+		TraceAttrs: func(name, _, _, _ string) string {
+			return fmt.Sprintf(`{resource.k8s.namespace.name="%s"}`, name)
+		},
+	},
+}
+
+// defaultMetrics returns key PromQL templates for an entity type.
+// The %s placeholder is replaced with label matchers.
+var defaultMetrics = map[string][]string{
+	"Service": {
+		`rate(http_server_requests_seconds_count%s[5m])`,
+		`sum(rate(http_server_requests_seconds_count{status=~"5.."}%s[5m]))`,
+		`histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket%s[5m])) by (le))`,
+	},
+	"Node": {
+		`100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"%s}[5m])) * 100)`,
+		`node_memory_MemAvailable_bytes%s / node_memory_MemTotal_bytes%s * 100`,
+	},
+	"Pod": {
+		`rate(container_cpu_usage_seconds_total%s[5m])`,
+		`container_memory_working_set_bytes%s`,
+	},
+}
+
+func buildPromLabels(entityType, name, env, site, ns string) string {
+	if mapping, ok := entityLabelMapping[entityType]; ok {
+		return mapping.PromLabels(name, env, site, ns)
+	}
+	parts := []string{fmt.Sprintf(`job="%s"`, name)}
+	if ns != "" {
+		parts = append(parts, fmt.Sprintf(`namespace="%s"`, ns))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func buildLokiLabels(entityType, name, env, site, ns string) string {
+	if mapping, ok := entityLabelMapping[entityType]; ok {
+		return mapping.LokiLabels(name, env, site, ns)
+	}
+	parts := []string{fmt.Sprintf(`app="%s"`, name)}
+	if ns != "" {
+		parts = append(parts, fmt.Sprintf(`namespace="%s"`, ns))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func buildTraceAttrs(entityType, name, env, site, ns string) string {
+	if mapping, ok := entityLabelMapping[entityType]; ok {
+		return mapping.TraceAttrs(name, env, site, ns)
+	}
+	return fmt.Sprintf(`{resource.service.name="%s"}`, name)
+}
+
+// injectLabels replaces %s in a PromQL template with label matchers.
+// For templates like `metric{existing="filter"%s}`, the labels should be
+// comma-prefixed. For `metric%s`, the full `{labels}` block is used.
+func injectLabels(template, labels string) string {
+	inner := strings.TrimPrefix(strings.TrimSuffix(labels, "}"), "{")
+	count := strings.Count(template, "%s")
+	args := make([]any, count)
+	for i := range args {
+		if strings.Contains(template, "{") {
+			args[i] = ", " + inner
+		} else {
+			args[i] = labels
+		}
+	}
+	return fmt.Sprintf(template, args...)
+}
+
+// --- get_entity_metrics ---
+
+type GetEntityMetricsParams struct {
+	EntityType    string    `json:"entityType" jsonschema:"required,description=Entity type (e.g. Service\\, Node\\, Pod)"`
+	EntityName    string    `json:"entityName" jsonschema:"required,description=Entity name"`
+	Env           string    `json:"env,omitempty" jsonschema:"description=Environment"`
+	Site          string    `json:"site,omitempty" jsonschema:"description=Site"`
+	Namespace     string    `json:"namespace,omitempty" jsonschema:"description=Namespace"`
+	DatasourceUID string    `json:"datasourceUid" jsonschema:"required,description=Prometheus datasource UID to query"`
+	MetricName    string    `json:"metricName,omitempty" jsonschema:"description=Specific PromQL expression. If omitted\\, returns default metrics for the entity type (request rate\\, error rate\\, latency for Service; CPU\\, memory for Node/Pod)."`
+	StartTime     time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
+	EndTime       time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+	StepSeconds   int       `json:"stepSeconds,omitempty" jsonschema:"description=Step interval in seconds for range queries (default 60)"`
+}
+
+func getEntityMetrics(ctx context.Context, args GetEntityMetricsParams) (string, error) {
+	assertsClient, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	entity, err := assertsClient.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve entity: %w", err)
+	}
+
+	labels := buildPromLabels(args.EntityType, entity.Name, entity.Env, entity.Site, entity.Namespace)
+
+	step := args.StepSeconds
+	if step <= 0 {
+		step = 60
+	}
+
+	var queries []string
+	if args.MetricName != "" {
+		query := args.MetricName
+		if !strings.Contains(query, "{") {
+			query = query + labels
+		}
+		queries = []string{query}
+	} else if templates, ok := defaultMetrics[args.EntityType]; ok {
+		for _, tmpl := range templates {
+			queries = append(queries, injectLabels(tmpl, labels))
+		}
+	} else {
+		queries = []string{fmt.Sprintf(`up%s`, labels)}
+	}
+
+	type queryResult struct {
+		Query  string `json:"query"`
+		Result any    `json:"result,omitempty"`
+		Error  string `json:"error,omitempty"`
+	}
+
+	results := make([]queryResult, 0, len(queries))
+	for _, q := range queries {
+		promArgs := QueryPrometheusParams{
+			DatasourceUID: args.DatasourceUID,
+			Expr:          q,
+			StartTime:     args.StartTime.Format(time.RFC3339),
+			EndTime:       args.EndTime.Format(time.RFC3339),
+			StepSeconds:   step,
+			QueryType:     "range",
+		}
+		result, queryErr := queryPrometheus(ctx, promArgs)
+		qr := queryResult{Query: q}
+		if queryErr != nil {
+			qr.Error = queryErr.Error()
+		} else {
+			qr.Result = result
+		}
+		results = append(results, qr)
+	}
+
+	output := map[string]any{
+		"entity":  entity.toSlim(),
+		"labels":  labels,
+		"metrics": results,
+	}
+
+	resultJSON, err := json.Marshal(output)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal metrics: %w", err)
+	}
+	return string(resultJSON), nil
+}
+
+var GetEntityMetrics = mcpgrafana.MustTool(
+	"get_entity_metrics",
+	"Get Prometheus metrics for a Knowledge Graph entity. Resolves entity labels from the KG and queries Prometheus. If no metric is specified, returns default metrics for the entity type (request rate, error rate, latency for Service; CPU, memory for Node/Pod).",
+	getEntityMetrics,
+	mcp.WithTitleAnnotation("Get KG entity metrics"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- get_entity_logs ---
+
+type GetEntityLogsParams struct {
+	EntityType    string    `json:"entityType" jsonschema:"required,description=Entity type (e.g. Service\\, Node\\, Pod)"`
+	EntityName    string    `json:"entityName" jsonschema:"required,description=Entity name"`
+	Env           string    `json:"env,omitempty" jsonschema:"description=Environment"`
+	Site          string    `json:"site,omitempty" jsonschema:"description=Site"`
+	Namespace     string    `json:"namespace,omitempty" jsonschema:"description=Namespace"`
+	DatasourceUID string    `json:"datasourceUid" jsonschema:"required,description=Loki datasource UID to query"`
+	Filter        string    `json:"filter,omitempty" jsonschema:"description=Log line filter expression (e.g. error\\, timeout\\, exception)"`
+	StartTime     time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
+	EndTime       time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+	Limit         int       `json:"limit,omitempty" jsonschema:"description=Max log lines to return (default 50)"`
+}
+
+func getEntityLogs(ctx context.Context, args GetEntityLogsParams) (string, error) {
+	assertsClient, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	entity, err := assertsClient.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve entity: %w", err)
+	}
+
+	streamSelector := buildLokiLabels(args.EntityType, entity.Name, entity.Env, entity.Site, entity.Namespace)
+
+	query := streamSelector
+	if args.Filter != "" {
+		query = fmt.Sprintf(`%s |~ "%s"`, streamSelector, args.Filter)
+	}
+
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	lokiClient, err := newLokiClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Loki client: %w", err)
+	}
+
+	lokiResult, err := lokiClient.fetchQuery(ctx, fetchQueryParams{
+		Query:     query,
+		Start:     args.StartTime.Format(time.RFC3339),
+		End:       args.EndTime.Format(time.RFC3339),
+		Limit:     limit,
+		Direction: "backward",
+		QueryType: "range",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to query logs: %w", err)
+	}
+
+	output := map[string]any{
+		"entity":  entity.toSlim(),
+		"query":   query,
+		"results": lokiResult,
+	}
+
+	outputJSON, err := json.Marshal(output)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal output: %w", err)
+	}
+	return string(outputJSON), nil
+}
+
+var GetEntityLogs = mcpgrafana.MustTool(
+	"get_entity_logs",
+	"Get Loki logs for a Knowledge Graph entity. Resolves entity labels from the KG and queries Loki. Optionally filter log lines by a text pattern.",
+	getEntityLogs,
+	mcp.WithTitleAnnotation("Get KG entity logs"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- get_entity_traces ---
+
+type GetEntityTracesParams struct {
+	EntityType    string    `json:"entityType" jsonschema:"required,description=Entity type (e.g. Service\\, Node\\, Pod)"`
+	EntityName    string    `json:"entityName" jsonschema:"required,description=Entity name"`
+	Env           string    `json:"env,omitempty" jsonschema:"description=Environment"`
+	Site          string    `json:"site,omitempty" jsonschema:"description=Site"`
+	Namespace     string    `json:"namespace,omitempty" jsonschema:"description=Namespace"`
+	DatasourceUID string    `json:"datasourceUid" jsonschema:"required,description=Tempo datasource UID to query"`
+	MinDuration   string    `json:"minDuration,omitempty" jsonschema:"description=Minimum trace duration filter (e.g. 500ms\\, 1s)"`
+	StartTime     time.Time `json:"startTime" jsonschema:"required,description=Start time in RFC3339 format"`
+	EndTime       time.Time `json:"endTime" jsonschema:"required,description=End time in RFC3339 format"`
+	Limit         int       `json:"limit,omitempty" jsonschema:"description=Max traces to return (default 20)"`
+}
+
+func getEntityTraces(ctx context.Context, args GetEntityTracesParams) (string, error) {
+	assertsClient, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Asserts client: %w", err)
+	}
+
+	entity, err := assertsClient.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve entity: %w", err)
+	}
+
+	traceSelector := buildTraceAttrs(args.EntityType, entity.Name, entity.Env, entity.Site, entity.Namespace)
+	query := traceSelector
+	if args.MinDuration != "" {
+		query = fmt.Sprintf(`%s | duration > %s`, traceSelector, args.MinDuration)
+	}
+
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	tempoBaseURL := fmt.Sprintf("%s/api/datasources/proxy/uid/%s", strings.TrimRight(cfg.URL, "/"), args.DatasourceUID)
+
+	transport, buildErr := mcpgrafana.BuildTransport(&cfg, nil)
+	if buildErr != nil {
+		return "", fmt.Errorf("failed to build transport: %w", buildErr)
+	}
+	transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
+
+	tempoClient := &Client{
+		httpClient: &http.Client{Transport: mcpgrafana.NewUserAgentTransport(transport)},
+		baseURL:    tempoBaseURL,
+	}
+
+	params := url.Values{}
+	params.Set("q", query)
+	params.Set("limit", fmt.Sprintf("%d", limit))
+	params.Set("start", fmt.Sprintf("%d", args.StartTime.Unix()))
+	params.Set("end", fmt.Sprintf("%d", args.EndTime.Unix()))
+
+	data, err := tempoClient.fetchAssertsDataGet(ctx, "/tempo/api/search", params)
+	if err != nil {
+		output := map[string]any{
+			"entity":  entity.toSlim(),
+			"traceQL": query,
+			"note":    "Tempo search failed. Use the traceQL query with query_loki_logs or a Tempo datasource tool.",
+			"error":   err.Error(),
+		}
+		result, marshalErr := json.Marshal(output)
+		if marshalErr != nil {
+			return "", fmt.Errorf("failed to marshal trace query: %w", marshalErr)
+		}
+		return string(result), nil
+	}
+
+	output := map[string]any{
+		"entity":  entity.toSlim(),
+		"query":   query,
+		"results": json.RawMessage(data),
+	}
+
+	resultJSON, err := json.Marshal(output)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal traces: %w", err)
+	}
+	return string(resultJSON), nil
+}
+
+var GetEntityTraces = mcpgrafana.MustTool(
+	"get_entity_traces",
+	"Get traces for a Knowledge Graph entity from Tempo. Resolves entity labels from the KG and constructs a TraceQL query. Optionally filter by minimum duration.",
+	getEntityTraces,
+	mcp.WithTitleAnnotation("Get KG entity traces"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)

--- a/tools/asserts_mlt.go
+++ b/tools/asserts_mlt.go
@@ -94,7 +94,7 @@ var entityLabelMapping = map[string]struct {
 var defaultMetrics = map[string][]string{
 	"Service": {
 		`rate(http_server_requests_seconds_count%s[5m])`,
-		`sum(rate(http_server_requests_seconds_count{status=~"5.."}%s[5m]))`,
+		`sum(rate(http_server_requests_seconds_count{status=~"5.."%s}[5m]))`,
 		`histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket%s[5m])) by (le))`,
 	},
 	"Node": {
@@ -168,18 +168,60 @@ type GetEntityMetricsParams struct {
 	StepSeconds   int       `json:"stepSeconds,omitempty" jsonschema:"description=Step interval in seconds for range queries (default 60)"`
 }
 
+// resolvePromLabels attempts to use the tenant's drilldown config for label
+// mapping, falling back to hardcoded defaults if unavailable.
+func resolvePromLabels(ctx context.Context, client *Client, entity *graphEntityResponse) string {
+	configs := fetchDrilldownConfigs(ctx, client, "log")
+	if configs != nil {
+		if cfg := findDrilldownForEntity(configs, entity.Type); cfg != nil && len(cfg.PromMapping) > 0 {
+			if labels := buildLabelsFromMapping(cfg.PromMapping, entity, ", "); labels != "" {
+				return labels
+			}
+		}
+	}
+	return buildPromLabels(entity.Type, entity.Name, entity.Env, entity.Site, entity.Namespace)
+}
+
+// resolveLokiLabels attempts to use the tenant's log drilldown config,
+// falling back to hardcoded defaults if unavailable.
+func resolveLokiLabels(ctx context.Context, client *Client, entity *graphEntityResponse) string {
+	configs := fetchDrilldownConfigs(ctx, client, "log")
+	if configs != nil {
+		if cfg := findDrilldownForEntity(configs, entity.Type); cfg != nil && len(cfg.LogMapping) > 0 {
+			if labels := buildLabelsFromMapping(cfg.LogMapping, entity, ", "); labels != "" {
+				return labels
+			}
+		}
+	}
+	return buildLokiLabels(entity.Type, entity.Name, entity.Env, entity.Site, entity.Namespace)
+}
+
+// resolveTraceAttrs attempts to use the tenant's trace drilldown config,
+// falling back to hardcoded defaults if unavailable.
+func resolveTraceAttrs(ctx context.Context, client *Client, entity *graphEntityResponse) string {
+	configs := fetchDrilldownConfigs(ctx, client, "trace")
+	if configs != nil {
+		if cfg := findDrilldownForEntity(configs, entity.Type); cfg != nil && len(cfg.TraceMapping) > 0 {
+			if labels := buildLabelsFromMapping(cfg.TraceMapping, entity, " && "); labels != "" {
+				return labels
+			}
+		}
+	}
+	return buildTraceAttrs(entity.Type, entity.Name, entity.Env, entity.Site, entity.Namespace)
+}
+
 func getEntityMetrics(ctx context.Context, args GetEntityMetricsParams) (string, error) {
 	assertsClient, err := newAssertsClient(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
 	}
 
-	entity, err := assertsClient.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	entity, err := assertsClient.resolveEntityInfoCached(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve entity: %w", err)
 	}
 
-	labels := buildPromLabels(args.EntityType, entity.Name, entity.Env, entity.Site, entity.Namespace)
+	labels := resolvePromLabels(ctx, assertsClient, entity)
 
 	step := args.StepSeconds
 	if step <= 0 {
@@ -270,12 +312,12 @@ func getEntityLogs(ctx context.Context, args GetEntityLogsParams) (string, error
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
 	}
 
-	entity, err := assertsClient.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	entity, err := assertsClient.resolveEntityInfoCached(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve entity: %w", err)
 	}
 
-	streamSelector := buildLokiLabels(args.EntityType, entity.Name, entity.Env, entity.Site, entity.Namespace)
+	streamSelector := resolveLokiLabels(ctx, assertsClient, entity)
 
 	query := streamSelector
 	if args.Filter != "" {
@@ -347,12 +389,12 @@ func getEntityTraces(ctx context.Context, args GetEntityTracesParams) (string, e
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
 	}
 
-	entity, err := assertsClient.resolveEntityInfo(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	entity, err := assertsClient.resolveEntityInfoCached(ctx, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve entity: %w", err)
 	}
 
-	traceSelector := buildTraceAttrs(args.EntityType, entity.Name, entity.Env, entity.Site, entity.Namespace)
+	traceSelector := resolveTraceAttrs(ctx, assertsClient, entity)
 	query := traceSelector
 	if args.MinDuration != "" {
 		query = fmt.Sprintf(`%s | duration > %s`, traceSelector, args.MinDuration)
@@ -384,7 +426,7 @@ func getEntityTraces(ctx context.Context, args GetEntityTracesParams) (string, e
 	params.Set("start", fmt.Sprintf("%d", args.StartTime.Unix()))
 	params.Set("end", fmt.Sprintf("%d", args.EndTime.Unix()))
 
-	data, err := tempoClient.fetchAssertsDataGet(ctx, "/tempo/api/search", params)
+	data, err := tempoClient.fetchAssertsDataGet(ctx, "/api/search", params)
 	if err != nil {
 		output := map[string]any{
 			"entity":  entity.toSlim(),

--- a/tools/asserts_mlt.go
+++ b/tools/asserts_mlt.go
@@ -321,7 +321,8 @@ func getEntityLogs(ctx context.Context, args GetEntityLogsParams) (string, error
 
 	query := streamSelector
 	if args.Filter != "" {
-		query = fmt.Sprintf(`%s |~ "%s"`, streamSelector, args.Filter)
+		escaped := strings.NewReplacer(`"`, `\"`, `\`, `\\`).Replace(args.Filter)
+		query = fmt.Sprintf(`%s |~ "%s"`, streamSelector, escaped)
 	}
 
 	limit := args.Limit

--- a/tools/asserts_mlt_test.go
+++ b/tools/asserts_mlt_test.go
@@ -1,0 +1,174 @@
+//go:build unit
+// +build unit
+
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildPromLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityType string
+		entityName string
+		env        string
+		site       string
+		namespace  string
+		want       string
+	}{
+		{
+			name:       "Service with namespace",
+			entityType: "Service",
+			entityName: "checkout",
+			namespace:  "prod",
+			want:       `{job="checkout", namespace="prod"}`,
+		},
+		{
+			name:       "Service without namespace",
+			entityType: "Service",
+			entityName: "checkout",
+			want:       `{job="checkout"}`,
+		},
+		{
+			name:       "Node",
+			entityType: "Node",
+			entityName: "ip-10-0-1-5",
+			want:       `{instance=~"ip-10-0-1-5.*"}`,
+		},
+		{
+			name:       "Pod with namespace",
+			entityType: "Pod",
+			entityName: "checkout-abc123",
+			namespace:  "prod",
+			want:       `{pod="checkout-abc123", namespace="prod"}`,
+		},
+		{
+			name:       "Namespace",
+			entityType: "Namespace",
+			entityName: "production",
+			want:       `{namespace="production"}`,
+		},
+		{
+			name:       "Unknown type falls back to job label",
+			entityType: "Database",
+			entityName: "postgres",
+			namespace:  "prod",
+			want:       `{job="postgres", namespace="prod"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPromLabels(tt.entityType, tt.entityName, tt.env, tt.site, tt.namespace)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildLokiLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityType string
+		entityName string
+		namespace  string
+		want       string
+	}{
+		{
+			name:       "Service with namespace",
+			entityType: "Service",
+			entityName: "checkout",
+			namespace:  "prod",
+			want:       `{app="checkout", namespace="prod"}`,
+		},
+		{
+			name:       "Pod with namespace",
+			entityType: "Pod",
+			entityName: "checkout-abc",
+			namespace:  "prod",
+			want:       `{pod="checkout-abc", namespace="prod"}`,
+		},
+		{
+			name:       "Node",
+			entityType: "Node",
+			entityName: "ip-10-0-1-5",
+			want:       `{node_name="ip-10-0-1-5"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildLokiLabels(tt.entityType, tt.entityName, "", "", tt.namespace)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildTraceAttrs(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityType string
+		entityName string
+		namespace  string
+		want       string
+	}{
+		{
+			name:       "Service with namespace",
+			entityType: "Service",
+			entityName: "checkout",
+			namespace:  "prod",
+			want:       `{resource.service.name="checkout" && resource.k8s.namespace.name="prod"}`,
+		},
+		{
+			name:       "Pod with namespace",
+			entityType: "Pod",
+			entityName: "checkout-abc",
+			namespace:  "prod",
+			want:       `{resource.k8s.pod.name="checkout-abc" && resource.k8s.namespace.name="prod"}`,
+		},
+		{
+			name:       "Unknown type falls back to service.name",
+			entityType: "Database",
+			entityName: "postgres",
+			want:       `{resource.service.name="postgres"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTraceAttrs(tt.entityType, tt.entityName, "", "", tt.namespace)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInjectLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		labels   string
+		want     string
+	}{
+		{
+			name:     "simple metric with labels",
+			template: `up%s`,
+			labels:   `{job="checkout"}`,
+			want:     `up{job="checkout"}`,
+		},
+		{
+			name:     "metric with existing braces",
+			template: `rate(http_server_requests_seconds_count{status=~"5.."%s}[5m])`,
+			labels:   `{job="checkout", namespace="prod"}`,
+			want:     `rate(http_server_requests_seconds_count{status=~"5..", job="checkout", namespace="prod"}[5m])`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := injectLabels(tt.template, tt.labels)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tools/asserts_semantic.go
+++ b/tools/asserts_semantic.go
@@ -1,0 +1,185 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const (
+	entityCollectionName = "kg-entities"
+	defaultEmbedder      = "vertex/gemini-embedding-001"
+	defaultSearchLimit   = 10
+)
+
+type searchServiceClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func newSearchServiceClient(ctx context.Context) (*searchServiceClient, error) {
+	baseURL := os.Getenv("GRAFANA_SEARCH_SERVICE_URL")
+	if baseURL == "" {
+		return nil, fmt.Errorf("GRAFANA_SEARCH_SERVICE_URL not set. The semantic search tool requires the Loop search service (pgvector)")
+	}
+
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build transport: %w", err)
+	}
+	transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
+
+	return &searchServiceClient{
+		httpClient: &http.Client{Transport: mcpgrafana.NewUserAgentTransport(transport)},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+	}, nil
+}
+
+type vectorRetrieveRequest struct {
+	Query  string         `json:"query"`
+	Limit  int            `json:"limit"`
+	Filter map[string]any `json:"filter,omitempty"`
+}
+
+type vectorRetrieveResponse struct {
+	Results []vectorResult `json:"results"`
+}
+
+type vectorResult struct {
+	Key      string         `json:"key"`
+	Content  string         `json:"content"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Distance float64        `json:"distance"`
+}
+
+func (c *searchServiceClient) retrieve(ctx context.Context, collection string, req *vectorRetrieveRequest) (*vectorRetrieveResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	path := fmt.Sprintf("%s/collections/%s/vectors/retrieve", c.baseURL, collection)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", path, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close() //nolint:errcheck
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search service returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result vectorRetrieveResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
+}
+
+// --- find_entities_semantic ---
+
+type FindEntitiesSemanticParams struct {
+	Query     string `json:"query" jsonschema:"required,description=Natural language query to find entities (e.g. 'the database handling payment orders'\\, 'services with high latency')"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"description=Max results to return (default 10)"`
+	Env       string `json:"env,omitempty" jsonschema:"description=Filter by environment"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace"`
+}
+
+func findEntitiesSemantic(ctx context.Context, args FindEntitiesSemanticParams) (string, error) {
+	client, err := newSearchServiceClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	limit := args.Limit
+	if limit <= 0 {
+		limit = defaultSearchLimit
+	}
+
+	filter := make(map[string]any)
+	if args.Env != "" {
+		filter["env"] = args.Env
+	}
+	if args.Namespace != "" {
+		filter["namespace"] = args.Namespace
+	}
+
+	var filterPtr map[string]any
+	if len(filter) > 0 {
+		filterPtr = filter
+	}
+
+	resp, err := client.retrieve(ctx, entityCollectionName, &vectorRetrieveRequest{
+		Query:  args.Query,
+		Limit:  limit,
+		Filter: filterPtr,
+	})
+	if err != nil {
+		return "", fmt.Errorf("semantic search failed: %w", err)
+	}
+
+	type semanticResult struct {
+		EntityType string  `json:"entityType,omitempty"`
+		EntityName string  `json:"entityName,omitempty"`
+		Content    string  `json:"content"`
+		Score      float64 `json:"score"`
+	}
+
+	results := make([]semanticResult, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		sr := semanticResult{
+			Content: r.Content,
+			Score:   1 - r.Distance, // cosine distance → similarity
+		}
+		if r.Metadata != nil {
+			if v, ok := r.Metadata["entityType"].(string); ok {
+				sr.EntityType = v
+			}
+			if v, ok := r.Metadata["entityName"].(string); ok {
+				sr.EntityName = v
+			}
+		}
+		results = append(results, sr)
+	}
+
+	output, err := json.Marshal(map[string]any{
+		"query":   args.Query,
+		"results": results,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal results: %w", err)
+	}
+	return string(output), nil
+}
+
+var FindEntitiesSemantic = mcpgrafana.MustTool(
+	"find_entities_semantic",
+	"Find Knowledge Graph entities using natural language search. Uses vector similarity to match entity descriptions. Requires GRAFANA_SEARCH_SERVICE_URL to be set. Example: 'the database handling payment orders'.",
+	findEntitiesSemantic,
+	mcp.WithTitleAnnotation("Find KG entities by meaning"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)

--- a/tools/asserts_semantic.go
+++ b/tools/asserts_semantic.go
@@ -9,14 +9,13 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
 )
 
 const (
 	entityCollectionName = "kg-entities"
-	defaultEmbedder      = "vertex/gemini-embedding-001"
 	defaultSearchLimit   = 10
 )
 
@@ -111,7 +110,7 @@ type FindEntitiesSemanticParams struct {
 func findEntitiesSemantic(ctx context.Context, args FindEntitiesSemanticParams) (string, error) {
 	client, err := newSearchServiceClient(ctx)
 	if err != nil {
-		return "", err
+		return findEntitiesFallback(ctx, args)
 	}
 
 	limit := args.Limit
@@ -138,7 +137,7 @@ func findEntitiesSemantic(ctx context.Context, args FindEntitiesSemanticParams) 
 		Filter: filterPtr,
 	})
 	if err != nil {
-		return "", fmt.Errorf("semantic search failed: %w", err)
+		return findEntitiesFallback(ctx, args)
 	}
 
 	type semanticResult struct {
@@ -152,7 +151,7 @@ func findEntitiesSemantic(ctx context.Context, args FindEntitiesSemanticParams) 
 	for _, r := range resp.Results {
 		sr := semanticResult{
 			Content: r.Content,
-			Score:   1 - r.Distance, // cosine distance → similarity
+			Score:   1 - r.Distance,
 		}
 		if r.Metadata != nil {
 			if v, ok := r.Metadata["entityType"].(string); ok {
@@ -166,7 +165,8 @@ func findEntitiesSemantic(ctx context.Context, args FindEntitiesSemanticParams) 
 	}
 
 	output, err := json.Marshal(map[string]any{
-		"query":   args.Query,
+		"query":  args.Query,
+		"mode":   "semantic",
 		"results": results,
 	})
 	if err != nil {
@@ -175,11 +175,75 @@ func findEntitiesSemantic(ctx context.Context, args FindEntitiesSemanticParams) 
 	return string(output), nil
 }
 
-var FindEntitiesSemantic = mcpgrafana.MustTool(
-	"find_entities_semantic",
-	"Find Knowledge Graph entities using natural language search. Uses vector similarity to match entity descriptions. Requires GRAFANA_SEARCH_SERVICE_URL to be set. Example: 'the database handling payment orders'.",
-	findEntitiesSemantic,
-	mcp.WithTitleAnnotation("Find KG entities by meaning"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-)
+// findEntitiesFallback uses deterministic name search via /v1/search when
+// the semantic search service is unavailable. Less powerful but still useful
+// for queries like "find the payment service".
+func findEntitiesFallback(ctx context.Context, args FindEntitiesSemanticParams) (string, error) {
+	assertsClient, err := newAssertsClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("semantic search unavailable and fallback failed: %w", err)
+	}
+
+	now := time.Now()
+	matcher := entityMatcherDTO{
+		PropertyMatchers: []propertyMatcherDTO{
+			{Name: "name", Value: args.Query, Op: "CONTAINS"},
+		},
+	}
+
+	reqBody := searchRequestDTO{
+		TimeCriteria: timeCriteriaDTO{
+			Start: now.Add(-24 * time.Hour).UnixMilli(),
+			End:   now.UnixMilli(),
+		},
+		FilterCriteria: []entityMatcherDTO{matcher},
+	}
+
+	scopeVals := make(map[string][]string)
+	if args.Env != "" {
+		scopeVals["env"] = []string{args.Env}
+	}
+	if args.Namespace != "" {
+		scopeVals["namespace"] = []string{args.Namespace}
+	}
+	if len(scopeVals) > 0 {
+		reqBody.ScopeCriteria = &scopeCriteriaDTO{NameAndValues: scopeVals}
+	}
+
+	data, err := assertsClient.fetchAssertsData(ctx, "/v1/search", "POST", reqBody)
+	if err != nil {
+		return "", fmt.Errorf("fallback search failed: %w", err)
+	}
+
+	var resp searchResponseDTO
+	if err := json.Unmarshal([]byte(data), &resp); err != nil {
+		return data, nil
+	}
+
+	limit := args.Limit
+	if limit <= 0 {
+		limit = defaultSearchLimit
+	}
+
+	entities := resp.Data.Entities
+	if len(entities) > limit {
+		entities = entities[:limit]
+	}
+
+	slimEntities := make([]slimEntity, 0, len(entities))
+	for i := range entities {
+		slimEntities = append(slimEntities, entities[i].toSlim())
+	}
+
+	output, err := json.Marshal(map[string]any{
+		"query":    args.Query,
+		"mode":     "deterministic_fallback",
+		"note":     "Semantic search unavailable. Results are from deterministic name matching.",
+		"results":  slimEntities,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal fallback results: %w", err)
+	}
+	return string(output), nil
+}
+

--- a/tools/asserts_semantic.go
+++ b/tools/asserts_semantic.go
@@ -123,6 +123,9 @@ func findEntitiesSemantic(ctx context.Context, args FindEntitiesSemanticParams) 
 	if args.Env != "" {
 		filter["env"] = args.Env
 	}
+	if args.Site != "" {
+		filter["site"] = args.Site
+	}
 	if args.Namespace != "" {
 		filter["namespace"] = args.Namespace
 	}
@@ -221,7 +224,7 @@ func findEntitiesFallback(ctx context.Context, args FindEntitiesSemanticParams) 
 
 	var resp searchResponseDTO
 	if err := json.Unmarshal([]byte(data), &resp); err != nil {
-		return data, nil
+		return "", fmt.Errorf("failed to parse fallback search response: %w", err)
 	}
 
 	limit := args.Limit

--- a/tools/asserts_semantic.go
+++ b/tools/asserts_semantic.go
@@ -104,6 +104,7 @@ type FindEntitiesSemanticParams struct {
 	Query     string `json:"query" jsonschema:"required,description=Natural language query to find entities (e.g. 'the database handling payment orders'\\, 'services with high latency')"`
 	Limit     int    `json:"limit,omitempty" jsonschema:"description=Max results to return (default 10)"`
 	Env       string `json:"env,omitempty" jsonschema:"description=Filter by environment"`
+	Site      string `json:"site,omitempty" jsonschema:"description=Filter by site"`
 	Namespace string `json:"namespace,omitempty" jsonschema:"description=Filter by namespace"`
 }
 
@@ -202,6 +203,9 @@ func findEntitiesFallback(ctx context.Context, args FindEntitiesSemanticParams) 
 	scopeVals := make(map[string][]string)
 	if args.Env != "" {
 		scopeVals["env"] = []string{args.Env}
+	}
+	if args.Site != "" {
+		scopeVals["site"] = []string{args.Site}
 	}
 	if args.Namespace != "" {
 		scopeVals["namespace"] = []string{args.Namespace}

--- a/tools/asserts_streaming.go
+++ b/tools/asserts_streaming.go
@@ -1,0 +1,303 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// assertsSubscriptionManager tracks entity assertion subscriptions and
+// delivers notifications via MCP server-initiated events.
+// Requires SSE or StreamableHTTP transport.
+type assertsSubscriptionManager struct {
+	mu            sync.Mutex
+	mcpServer     *server.MCPServer
+	subscriptions map[string]*assertionSubscription
+	stopCh        chan struct{}
+	running       bool
+}
+
+type assertionSubscription struct {
+	ID         string    `json:"id"`
+	SessionID  string    `json:"sessionId"`
+	EntityType string    `json:"entityType"`
+	EntityName string    `json:"entityName"`
+	Env        string    `json:"env,omitempty"`
+	Site       string    `json:"site,omitempty"`
+	Namespace  string    `json:"namespace,omitempty"`
+	CreatedAt  time.Time `json:"createdAt"`
+	LastCheck  time.Time `json:"lastCheck"`
+}
+
+var (
+	globalSubManager     *assertsSubscriptionManager
+	globalSubManagerOnce sync.Once
+)
+
+func getOrCreateSubManager(s *server.MCPServer) *assertsSubscriptionManager {
+	globalSubManagerOnce.Do(func() {
+		globalSubManager = &assertsSubscriptionManager{
+			mcpServer:     s,
+			subscriptions: make(map[string]*assertionSubscription),
+			stopCh:        make(chan struct{}),
+		}
+	})
+	return globalSubManager
+}
+
+func (m *assertsSubscriptionManager) subscribe(sub *assertionSubscription) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.subscriptions[sub.ID] = sub
+	if !m.running {
+		m.running = true
+		go m.pollLoop()
+	}
+}
+
+func (m *assertsSubscriptionManager) unsubscribe(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, existed := m.subscriptions[id]
+	delete(m.subscriptions, id)
+	if len(m.subscriptions) == 0 && m.running {
+		close(m.stopCh)
+		m.running = false
+		m.stopCh = make(chan struct{})
+	}
+	return existed
+}
+
+func (m *assertsSubscriptionManager) listSubscriptions() []*assertionSubscription {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	subs := make([]*assertionSubscription, 0, len(m.subscriptions))
+	for _, sub := range m.subscriptions {
+		subs = append(subs, sub)
+	}
+	return subs
+}
+
+func (m *assertsSubscriptionManager) pollLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.checkAssertions()
+		}
+	}
+}
+
+func (m *assertsSubscriptionManager) checkAssertions() {
+	m.mu.Lock()
+	subs := make([]*assertionSubscription, 0, len(m.subscriptions))
+	for _, sub := range m.subscriptions {
+		subs = append(subs, sub)
+	}
+	m.mu.Unlock()
+
+	for _, sub := range subs {
+		now := time.Now()
+		ctx := context.Background()
+
+		cfg := mcpgrafana.GrafanaConfig{}
+		ctx = mcpgrafana.WithGrafanaConfig(ctx, cfg)
+
+		client, err := newAssertsClient(ctx)
+		if err != nil {
+			continue
+		}
+
+		entityScope := make(map[string]string)
+		if sub.Env != "" {
+			entityScope["env"] = sub.Env
+		}
+		if sub.Site != "" {
+			entityScope["site"] = sub.Site
+		}
+		if sub.Namespace != "" {
+			entityScope["namespace"] = sub.Namespace
+		}
+
+		reqBody := assertionsSummaryRequestDTO{
+			StartTime: sub.LastCheck.UnixMilli(),
+			EndTime:   now.UnixMilli(),
+			EntityKeys: []entityKeyDTO{
+				{
+					Type:  sub.EntityType,
+					Name:  sub.EntityName,
+					Scope: entityScope,
+				},
+			},
+		}
+
+		data, err := client.fetchAssertsData(ctx, "/v1/assertions/summary", "POST", reqBody)
+		if err != nil {
+			continue
+		}
+
+		m.mu.Lock()
+		if s, ok := m.subscriptions[sub.ID]; ok {
+			s.LastCheck = now
+		}
+		m.mu.Unlock()
+
+		notification := map[string]any{
+			"subscriptionId": sub.ID,
+			"entityType":     sub.EntityType,
+			"entityName":     sub.EntityName,
+			"checkTime":      now.Format(time.RFC3339),
+			"summary":        json.RawMessage(data),
+		}
+
+		_ = m.mcpServer.SendNotificationToSpecificClient(
+			sub.SessionID,
+			"notifications/asserts/assertions",
+			notification,
+		)
+	}
+}
+
+// --- subscribe_entity_assertions ---
+
+type SubscribeEntityAssertionsParams struct {
+	EntityType string `json:"entityType" jsonschema:"required,description=Entity type to watch"`
+	EntityName string `json:"entityName" jsonschema:"required,description=Entity name to watch"`
+	Env        string `json:"env,omitempty" jsonschema:"description=Environment"`
+	Site       string `json:"site,omitempty" jsonschema:"description=Site"`
+	Namespace  string `json:"namespace,omitempty" jsonschema:"description=Namespace"`
+}
+
+func subscribeEntityAssertions(ctx context.Context, args SubscribeEntityAssertionsParams) (string, error) {
+	if globalSubManager == nil {
+		return "", fmt.Errorf("streaming not initialized. Requires SSE or StreamableHTTP transport")
+	}
+
+	sessionID := ""
+	if sid, ok := ctx.Value(sessionIDKey).(string); ok {
+		sessionID = sid
+	}
+
+	subID := fmt.Sprintf("%s/%s/%s/%s", args.EntityType, args.EntityName, args.Env, args.Namespace)
+
+	sub := &assertionSubscription{
+		ID:         subID,
+		SessionID:  sessionID,
+		EntityType: args.EntityType,
+		EntityName: args.EntityName,
+		Env:        args.Env,
+		Site:       args.Site,
+		Namespace:  args.Namespace,
+		CreatedAt:  time.Now(),
+		LastCheck:  time.Now(),
+	}
+
+	globalSubManager.subscribe(sub)
+
+	result, err := json.Marshal(map[string]any{
+		"subscriptionId": subID,
+		"status":         "active",
+		"pollInterval":   "30s",
+		"note":           "Assertion changes will be delivered via MCP notifications (notifications/asserts/assertions). Requires SSE or StreamableHTTP transport.",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(result), nil
+}
+
+type contextKey string
+
+const sessionIDKey contextKey = "mcp_session_id"
+
+var SubscribeEntityAssertions = mcpgrafana.MustTool(
+	"subscribe_entity_assertions",
+	"Subscribe to assertion changes for a Knowledge Graph entity. Notifications are delivered via MCP server events every 30 seconds when assertions change. Requires SSE or StreamableHTTP transport.",
+	subscribeEntityAssertions,
+	mcp.WithTitleAnnotation("Subscribe to KG entity assertions"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- unsubscribe_entity_assertions ---
+
+type UnsubscribeEntityAssertionsParams struct {
+	SubscriptionID string `json:"subscriptionId" jsonschema:"required,description=Subscription ID returned by subscribe_entity_assertions"`
+}
+
+func unsubscribeEntityAssertions(_ context.Context, args UnsubscribeEntityAssertionsParams) (string, error) {
+	if globalSubManager == nil {
+		return "", fmt.Errorf("streaming not initialized")
+	}
+
+	existed := globalSubManager.unsubscribe(args.SubscriptionID)
+
+	result, err := json.Marshal(map[string]any{
+		"subscriptionId": args.SubscriptionID,
+		"status":         "removed",
+		"existed":        existed,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(result), nil
+}
+
+var UnsubscribeEntityAssertions = mcpgrafana.MustTool(
+	"unsubscribe_entity_assertions",
+	"Unsubscribe from assertion change notifications for a Knowledge Graph entity.",
+	unsubscribeEntityAssertions,
+	mcp.WithTitleAnnotation("Unsubscribe from KG entity assertions"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// --- list_assertion_subscriptions ---
+
+type ListAssertionSubscriptionsParams struct{}
+
+func listAssertionSubscriptions(_ context.Context, _ ListAssertionSubscriptionsParams) (string, error) {
+	if globalSubManager == nil {
+		return "[]", nil
+	}
+
+	subs := globalSubManager.listSubscriptions()
+	result, err := json.Marshal(subs)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal subscriptions: %w", err)
+	}
+	return string(result), nil
+}
+
+var ListAssertionSubscriptions = mcpgrafana.MustTool(
+	"list_assertion_subscriptions",
+	"List all active assertion subscriptions for Knowledge Graph entities.",
+	listAssertionSubscriptions,
+	mcp.WithTitleAnnotation("List assertion subscriptions"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// InitAssertsStreaming initializes the streaming subscription manager.
+// Call this from AddAssertsTools when the MCP server supports SSE or StreamableHTTP.
+func InitAssertsStreaming(s *server.MCPServer) {
+	getOrCreateSubManager(s)
+}
+
+// AddAssertsStreamingTools registers the streaming tools.
+func AddAssertsStreamingTools(s *server.MCPServer) {
+	InitAssertsStreaming(s)
+	SubscribeEntityAssertions.Register(s)
+	UnsubscribeEntityAssertions.Register(s)
+	ListAssertionSubscriptions.Register(s)
+}

--- a/tools/asserts_streaming.go
+++ b/tools/asserts_streaming.go
@@ -113,10 +113,12 @@ func (m *assertsSubscriptionManager) checkAssertions() {
 
 	for _, sub := range subs {
 		now := time.Now()
-		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), sub.grafanaCfg)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx = mcpgrafana.WithGrafanaConfig(ctx, sub.grafanaCfg)
 
 		client, err := newAssertsClient(ctx)
 		if err != nil {
+			cancel()
 			continue
 		}
 
@@ -144,6 +146,7 @@ func (m *assertsSubscriptionManager) checkAssertions() {
 		}
 
 		data, err := client.fetchAssertsData(ctx, "/v1/assertions/summary", "POST", reqBody)
+		cancel()
 		if err != nil {
 			continue
 		}
@@ -192,7 +195,7 @@ func subscribeEntityAssertions(ctx context.Context, args SubscribeEntityAssertio
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
 
-	subID := fmt.Sprintf("%s/%s/%s/%s/%s", args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
+	subID := fmt.Sprintf("%s/%s/%s/%s/%s/%s", sessionID, args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
 
 	sub := &assertionSubscription{
 		ID:         subID,

--- a/tools/asserts_streaming.go
+++ b/tools/asserts_streaming.go
@@ -9,7 +9,7 @@ import (
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
 // assertsSubscriptionManager tracks entity assertion subscriptions and
@@ -17,22 +17,23 @@ import (
 // Requires SSE or StreamableHTTP transport.
 type assertsSubscriptionManager struct {
 	mu            sync.Mutex
-	mcpServer     *server.MCPServer
+	mcpServer     *mcpserver.MCPServer
 	subscriptions map[string]*assertionSubscription
 	stopCh        chan struct{}
 	running       bool
 }
 
 type assertionSubscription struct {
-	ID         string    `json:"id"`
-	SessionID  string    `json:"sessionId"`
-	EntityType string    `json:"entityType"`
-	EntityName string    `json:"entityName"`
-	Env        string    `json:"env,omitempty"`
-	Site       string    `json:"site,omitempty"`
-	Namespace  string    `json:"namespace,omitempty"`
-	CreatedAt  time.Time `json:"createdAt"`
-	LastCheck  time.Time `json:"lastCheck"`
+	ID         string                   `json:"id"`
+	SessionID  string                   `json:"sessionId"`
+	EntityType string                   `json:"entityType"`
+	EntityName string                   `json:"entityName"`
+	Env        string                   `json:"env,omitempty"`
+	Site       string                   `json:"site,omitempty"`
+	Namespace  string                   `json:"namespace,omitempty"`
+	CreatedAt  time.Time                `json:"createdAt"`
+	LastCheck  time.Time                `json:"lastCheck"`
+	grafanaCfg mcpgrafana.GrafanaConfig `json:"-"`
 }
 
 var (
@@ -40,7 +41,7 @@ var (
 	globalSubManagerOnce sync.Once
 )
 
-func getOrCreateSubManager(s *server.MCPServer) *assertsSubscriptionManager {
+func getOrCreateSubManager(s *mcpserver.MCPServer) *assertsSubscriptionManager {
 	globalSubManagerOnce.Do(func() {
 		globalSubManager = &assertsSubscriptionManager{
 			mcpServer:     s,
@@ -89,8 +90,12 @@ func (m *assertsSubscriptionManager) pollLoop() {
 	defer ticker.Stop()
 
 	for {
+		m.mu.Lock()
+		stopCh := m.stopCh
+		m.mu.Unlock()
+
 		select {
-		case <-m.stopCh:
+		case <-stopCh:
 			return
 		case <-ticker.C:
 			m.checkAssertions()
@@ -108,10 +113,7 @@ func (m *assertsSubscriptionManager) checkAssertions() {
 
 	for _, sub := range subs {
 		now := time.Now()
-		ctx := context.Background()
-
-		cfg := mcpgrafana.GrafanaConfig{}
-		ctx = mcpgrafana.WithGrafanaConfig(ctx, cfg)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), sub.grafanaCfg)
 
 		client, err := newAssertsClient(ctx)
 		if err != nil {
@@ -184,11 +186,13 @@ func subscribeEntityAssertions(ctx context.Context, args SubscribeEntityAssertio
 	}
 
 	sessionID := ""
-	if sid, ok := ctx.Value(sessionIDKey).(string); ok {
-		sessionID = sid
+	if session := mcpserver.ClientSessionFromContext(ctx); session != nil {
+		sessionID = session.SessionID()
 	}
 
-	subID := fmt.Sprintf("%s/%s/%s/%s", args.EntityType, args.EntityName, args.Env, args.Namespace)
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+
+	subID := fmt.Sprintf("%s/%s/%s/%s/%s", args.EntityType, args.EntityName, args.Env, args.Site, args.Namespace)
 
 	sub := &assertionSubscription{
 		ID:         subID,
@@ -200,6 +204,7 @@ func subscribeEntityAssertions(ctx context.Context, args SubscribeEntityAssertio
 		Namespace:  args.Namespace,
 		CreatedAt:  time.Now(),
 		LastCheck:  time.Now(),
+		grafanaCfg: cfg,
 	}
 
 	globalSubManager.subscribe(sub)
@@ -215,10 +220,6 @@ func subscribeEntityAssertions(ctx context.Context, args SubscribeEntityAssertio
 	}
 	return string(result), nil
 }
-
-type contextKey string
-
-const sessionIDKey contextKey = "mcp_session_id"
 
 var SubscribeEntityAssertions = mcpgrafana.MustTool(
 	"subscribe_entity_assertions",
@@ -290,12 +291,12 @@ var ListAssertionSubscriptions = mcpgrafana.MustTool(
 
 // InitAssertsStreaming initializes the streaming subscription manager.
 // Call this from AddAssertsTools when the MCP server supports SSE or StreamableHTTP.
-func InitAssertsStreaming(s *server.MCPServer) {
+func InitAssertsStreaming(s *mcpserver.MCPServer) {
 	getOrCreateSubManager(s)
 }
 
 // AddAssertsStreamingTools registers the streaming tools.
-func AddAssertsStreamingTools(s *server.MCPServer) {
+func AddAssertsStreamingTools(s *mcpserver.MCPServer) {
 	InitAssertsStreaming(s)
 	SubscribeEntityAssertions.Register(s)
 	UnsubscribeEntityAssertions.Register(s)


### PR DESCRIPTION
## Summary

Expands the Asserts MCP tools from 1 tool (`get_assertions`) to 10 tools, providing KG navigation, MLT gateway, semantic search, and assertion analysis capabilities.

**Addresses feedback from Ben Sully and Jia Xu on token budget:** consolidated from 16 tools down to 10. Overlapping search tools (`list_entities`, `count_entities`, `find_entities_semantic`) are merged into a single `search_entities` tool with a `mode` parameter. Streaming tools are deferred to a follow-up PR.

### Tools (10)

| Tool | Purpose |
|------|---------|
| `get_assertions` | LLM-generated health summary for an entity (existing) |
| `get_graph_schema` | Entity types, relationships, properties -- LLM self-directs traversal |
| `search_entities` | Unified search with 4 modes: `search` (structured), `list` (paginated), `count` (aggregation), `semantic` (vector similarity) |
| `get_entity` | Entity details with slim/detailed output |
| `get_connected_entities` | Traverse entity relationships for multi-hop exploration |
| `get_assertion_summary` | Assertion counts by category/severity |
| `search_rca_patterns` | Root cause analysis pattern search |
| `get_entity_metrics` | Prometheus metrics for a KG entity (requires Prometheus datasource) |
| `get_entity_logs` | Loki logs for a KG entity (requires Loki datasource) |
| `get_entity_traces` | Tempo traces for a KG entity (requires Tempo datasource) |

### Key design decisions

- **Slim output**: All tools return compact representations for LLM context efficiency
- **TTL caching**: Entity info (2 min), graph schema (15 min), drilldown configs (15 min) to reduce redundant API calls
- **Dynamic drilldown configs**: MLT label mappings fetched from tenant-specific config APIs, with hardcoded fallbacks
- **Semantic search fallback**: When Loop search service is unavailable, falls back to deterministic name matching

### Deferred to follow-up

- Streaming assertion subscriptions (3 tools -- requires SSE/StreamableHTTP transport)
- Code remains in `asserts_streaming.go` but is not registered

### Related

- Tracking issue: #606

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new network-facing tools (KG APIs, datasource proxy calls, optional external semantic search) plus caching behavior; correctness depends on API shapes and tenant configs but changes are mostly additive and read-only.
> 
> **Overview**
> Expands the Asserts MCP surface from just `get_assertions` to a broader Knowledge Graph/MLT toolkit: adds tools to fetch KG schema, search entities (structured/list/count/semantic), fetch entity details (slim vs detailed), traverse connected entities, fetch assertion summaries, and search RCA patterns.
> 
> Adds an MLT “gateway” layer that resolves KG entities into Prometheus/Loki/Tempo selectors (using tenant drilldown config APIs with fallbacks) and then queries the corresponding Grafana datasources for metrics/logs/traces. Introduces small TTL caches for entity info, graph schema, and drilldown configs, adds a GET helper with response-size limiting, and significantly expands unit + cloud integration coverage for the new tools.
> 
> Includes (but does not register) streaming subscription tooling to poll assertion summaries and push MCP notifications when using SSE/StreamableHTTP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8064d20fd28b5d63cf29d8acf4469f3c44fbff5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->