### PR TITLE
Add server-side filtering support to alerting client

### DIFF
--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -78,7 +78,7 @@ func listAlertRules(ctx context.Context, args ListAlertRulesParams) ([]alertRule
 	if err != nil {
 		return nil, fmt.Errorf("list alert rules (alerting client): %w", err)
 	}
-	runtimeResponse, err := alertingClient.GetRules(ctx)
+	runtimeResponse, err := alertingClient.GetRules(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("list alert rules (runtime): %w", err)
 	}

--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana-openapi-client-go/client"
+	grafanaModels "github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
@@ -66,8 +67,12 @@ func newAlertingClientFromContext(ctx context.Context) (*alertingClient, error) 
 	return client, nil
 }
 
-func (c *alertingClient) makeRequest(ctx context.Context, path string) (*http.Response, error) {
-	p := c.baseURL.JoinPath(path).String()
+func (c *alertingClient) makeRequest(ctx context.Context, path string, params url.Values) (*http.Response, error) {
+	u := c.baseURL.JoinPath(path)
+	if len(params) > 0 {
+		u.RawQuery = params.Encode()
+	}
+	p := u.String()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p, nil)
 	if err != nil {
@@ -106,8 +111,82 @@ func (c *alertingClient) makeRequest(ctx context.Context, path string) (*http.Re
 	return resp, nil
 }
 
-func (c *alertingClient) GetRules(ctx context.Context) (*rulesResponse, error) {
-	resp, err := c.makeRequest(ctx, rulesEndpointPath)
+const (
+	// maxRulesLimit is the hard limit on the number of rules to return.
+	maxRulesLimit = 200
+	// maxAlertsLimit is the hard limit on the number of alert instances per rule.
+	maxAlertsLimit = 200
+)
+
+// GetRulesOpts contains optional server-side filtering parameters for the
+// Prometheus rules API endpoint.
+// FolderUID, RuleGroup, RuleType, States, LimitAlerts are available since Grafana 10.0.
+// RuleName, SearchFolder, RuleLimit, Matcher require Grafana 12.4+.
+type GetRulesOpts struct {
+	FolderUID    string   // Filter by folder UID
+	SearchFolder string   // Search folders by full path using partial matching
+	RuleGroup    string   // Filter by exact rule group name
+	RuleName     string   // Search by rule name (substring match)
+	RuleType     string   // Filter by rule type (e.g. "alerting", "recording")
+	States       []string // Filter by rule state (e.g. "firing", "pending", "normal", "nodata", "error")
+	RuleLimit    int      // Maximum number of rules to return (max 200)
+	LimitAlerts int // Maximum number of alert instances per rule (max 200)
+	// Matchers filters alert instances by labels. Each matcher is JSON-encoded
+	// as a Prometheus matcher object (e.g. {"type":0,"name":"severity","value":"critical"}).
+	// Multiple matchers are AND-ed together.
+	Matchers []*labels.Matcher
+}
+
+func (o *GetRulesOpts) queryValues() url.Values {
+	params := url.Values{}
+	if o.FolderUID != "" {
+		params.Set("folder_uid", o.FolderUID)
+	}
+	if o.SearchFolder != "" {
+		params.Set("search.folder", o.SearchFolder)
+	}
+	if o.RuleGroup != "" {
+		params.Set("rule_group", o.RuleGroup)
+	}
+	if o.RuleName != "" {
+		params.Set("search.rule_name", o.RuleName)
+	}
+	if o.RuleType != "" {
+		params.Set("rule_type", o.RuleType)
+	}
+	for _, s := range o.States {
+		params.Add("state", s)
+	}
+	ruleLimit := o.RuleLimit
+	if ruleLimit > maxRulesLimit {
+		ruleLimit = maxRulesLimit
+	}
+	if ruleLimit > 0 {
+		params.Set("rule_limit", strconv.Itoa(ruleLimit))
+	}
+	limitAlerts := o.LimitAlerts
+	if limitAlerts > maxAlertsLimit {
+		limitAlerts = maxAlertsLimit
+	}
+	if limitAlerts > 0 {
+		params.Set("limit_alerts", strconv.Itoa(limitAlerts))
+	}
+	for _, m := range o.Matchers {
+		b, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		params.Add("matcher", string(b))
+	}
+	return params
+}
+
+func (c *alertingClient) GetRules(ctx context.Context, opts *GetRulesOpts) (*rulesResponse, error) {
+	var params url.Values
+	if opts != nil {
+		params = opts.queryValues()
+	}
+	resp, err := c.makeRequest(ctx, rulesEndpointPath, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get alert rules from Grafana API: %w", err)
 	}
@@ -175,7 +254,7 @@ func (c *alertingClient) GetDatasourceRules(ctx context.Context, datasourceUID s
 	// use the Grafana unified endpoint - maybe we need to use the datasource proxy endpoint in the future as this
 	// is an api for internal use
 	path := fmt.Sprintf("/api/prometheus/%s/api/v1/rules", datasourceUID)
-	resp, err := c.makeRequest(ctx, path)
+	resp, err := c.makeRequest(ctx, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get datasource rules: %w", err)
 	}
@@ -220,7 +299,7 @@ func (c *alertingClient) GetAlertmanagerConfig(ctx context.Context, datasourceUI
 	}
 
 	path := fmt.Sprintf("/api/datasources/proxy/uid/%s%s", datasourceUID, apiPath)
-	resp, err := c.makeRequest(ctx, path)
+	resp, err := c.makeRequest(ctx, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Alertmanager config: %w", err)
 	}
@@ -266,4 +345,24 @@ func (c *alertingClient) GetAlertmanagerConfig(ctx context.Context, datasourceUI
 	}
 
 	return &cfg, nil
+}
+
+// GetRuleVersions fetches the version history for a Grafana-managed alert rule.
+// The endpoint may not exist on older Grafana versions; callers should handle errors.
+func (c *alertingClient) GetRuleVersions(ctx context.Context, ruleUID string) ([]grafanaModels.GettableExtendedRuleNode, error) {
+	path := fmt.Sprintf("/api/ruler/grafana/api/v1/rule/%s/versions", ruleUID)
+	resp, err := c.makeRequest(ctx, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rule versions: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close() //nolint:errcheck
+	}()
+
+	var versions []grafanaModels.GettableExtendedRuleNode
+	if err := json.NewDecoder(resp.Body).Decode(&versions); err != nil {
+		return nil, fmt.Errorf("failed to decode rule versions response: %w", err)
+	}
+
+	return versions, nil
 }

--- a/tools/alerting_client_test.go
+++ b/tools/alerting_client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"testing"
 
+	grafanaModels "github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
@@ -68,7 +69,7 @@ func TestAlertingClient_GetRules(t *testing.T) {
 	})
 	defer server.Close()
 
-	rules, err := client.GetRules(context.Background())
+	rules, err := client.GetRules(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, rules)
 	require.ElementsMatch(t, rules.Data.RuleGroups, []ruleGroup{fakeruleGroup})
@@ -83,7 +84,7 @@ func TestAlertingClient_GetRules_Error(t *testing.T) {
 		})
 		defer server.Close()
 
-		rules, err := client.GetRules(context.Background())
+		rules, err := client.GetRules(context.Background(), nil)
 		require.Error(t, err)
 		require.Nil(t, rules)
 		require.ErrorContains(t, err, "grafana API returned status code 500: internal server error")
@@ -93,11 +94,258 @@ func TestAlertingClient_GetRules_Error(t *testing.T) {
 		server, client := setupMockServer(func(w http.ResponseWriter, r *http.Request) {})
 		server.Close()
 
-		rules, err := client.GetRules(context.Background())
+		rules, err := client.GetRules(context.Background(), nil)
 
 		require.Error(t, err)
 		require.Nil(t, rules)
 		require.ErrorContains(t, err, "failed to execute request")
+	})
+}
+
+func TestGetRulesOpts_queryValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     GetRulesOpts
+		expected url.Values
+	}{
+		{
+			name:     "empty opts produces empty values",
+			opts:     GetRulesOpts{},
+			expected: url.Values{},
+		},
+		{
+			name: "all fields populated",
+			opts: GetRulesOpts{
+				FolderUID:    "folder-1",
+				SearchFolder: "Grafana/Alerts",
+				RuleGroup:    "group-1",
+				RuleName:     "my-rule",
+				RuleType:     "alerting",
+				States:       []string{"firing", "pending"},
+				RuleLimit:    10,
+				LimitAlerts:  5,
+				Matchers:     []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "severity", "critical")},
+			},
+			expected: url.Values{
+				"folder_uid":       {"folder-1"},
+				"search.folder":    {"Grafana/Alerts"},
+				"rule_group":       {"group-1"},
+				"search.rule_name": {"my-rule"},
+				"rule_type":        {"alerting"},
+				"state":            {"firing", "pending"},
+				"rule_limit":       {"10"},
+				"limit_alerts":     {"5"},
+				"matcher":          {`{"Type":0,"Name":"severity","Value":"critical"}`},
+			},
+		},
+		{
+			name: "single filter",
+			opts: GetRulesOpts{
+				FolderUID: "abc",
+			},
+			expected: url.Values{
+				"folder_uid": {"abc"},
+			},
+		},
+		{
+			name: "zero limit is omitted",
+			opts: GetRulesOpts{
+				RuleLimit:   0,
+				LimitAlerts: 0,
+			},
+			expected: url.Values{},
+		},
+		{
+			name: "search_folder is mapped",
+			opts: GetRulesOpts{
+				SearchFolder: "Grafana/Alerts",
+			},
+			expected: url.Values{
+				"search.folder": {"Grafana/Alerts"},
+			},
+		},
+		{
+			name: "rule_limit capped at 200",
+			opts: GetRulesOpts{
+				RuleLimit: 500,
+			},
+			expected: url.Values{
+				"rule_limit": {"200"},
+			},
+		},
+		{
+			name: "limit_alerts capped at 200",
+			opts: GetRulesOpts{
+				LimitAlerts: 999,
+			},
+			expected: url.Values{
+				"limit_alerts": {"200"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.opts.queryValues()
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestAlertingClient_GetRules_WithOpts(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          *GetRulesOpts
+		assertRequest func(t *testing.T, r *http.Request)
+	}{
+		{
+			name: "nil opts produces no query params",
+			opts: nil,
+			assertRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				require.Equal(t, "", r.URL.RawQuery, "nil opts should produce no query params")
+			},
+		},
+		{
+			name: "basic filters",
+			opts: &GetRulesOpts{
+				FolderUID: "test-folder",
+				RuleGroup: "test-group",
+				RuleType:  "alerting",
+				RuleLimit: 10,
+			},
+			assertRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				q := r.URL.Query()
+				require.Equal(t, "test-folder", q.Get("folder_uid"))
+				require.Equal(t, "test-group", q.Get("rule_group"))
+				require.Equal(t, "alerting", q.Get("rule_type"))
+				require.Equal(t, "10", q.Get("rule_limit"))
+			},
+		},
+		{
+			name: "multiple states",
+			opts: &GetRulesOpts{
+				States: []string{"firing", "pending"},
+			},
+			assertRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				require.Equal(t, []string{"firing", "pending"}, r.URL.Query()["state"])
+			},
+		},
+		{
+			name: "search and matcher",
+			opts: &GetRulesOpts{
+				RuleName:    "cpu-alert",
+				LimitAlerts: 5,
+				Matchers:    []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "severity", "critical")},
+			},
+			assertRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				q := r.URL.Query()
+				require.Equal(t, "cpu-alert", q.Get("search.rule_name"))
+				require.Equal(t, `{"Type":0,"Name":"severity","Value":"critical"}`, q.Get("matcher"))
+				require.Equal(t, "5", q.Get("limit_alerts"))
+			},
+		},
+		{
+			name: "all fields",
+			opts: &GetRulesOpts{
+				FolderUID:    "prod-folder",
+				SearchFolder: "Grafana/Alerts",
+				RuleGroup:    "infra-group",
+				RuleName:     "high-cpu",
+				RuleType:     "alerting",
+				States:       []string{"firing", "pending"},
+				RuleLimit:    20,
+				LimitAlerts:  3,
+				Matchers:     []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "team", "alerting")},
+			},
+			assertRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				q := r.URL.Query()
+				require.Equal(t, "prod-folder", q.Get("folder_uid"))
+				require.Equal(t, "Grafana/Alerts", q.Get("search.folder"))
+				require.Equal(t, "infra-group", q.Get("rule_group"))
+				require.Equal(t, "high-cpu", q.Get("search.rule_name"))
+				require.Equal(t, "alerting", q.Get("rule_type"))
+				require.Equal(t, []string{"firing", "pending"}, q["state"])
+				require.Equal(t, "20", q.Get("rule_limit"))
+				require.Equal(t, "3", q.Get("limit_alerts"))
+				require.Equal(t, `{"Type":0,"Name":"team","Value":"alerting"}`, q.Get("matcher"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, client := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/api/prometheus/grafana/api/v1/rules", r.URL.Path)
+				tc.assertRequest(t, r)
+
+				resp := mockrulesResponse()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(w).Encode(resp)
+				require.NoError(t, err)
+			})
+			defer server.Close()
+
+			rules, err := client.GetRules(context.Background(), tc.opts)
+			require.NoError(t, err)
+			require.NotNil(t, rules)
+		})
+	}
+}
+
+func TestAlertingClient_GetRuleVersions(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server, client := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/ruler/grafana/api/v1/rule/test-uid/versions", r.URL.Path)
+			require.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+			resp := []grafanaModels.GettableExtendedRuleNode{
+				{
+					GrafanaAlert: &grafanaModels.GettableGrafanaRule{
+						UID:     "test-uid",
+						Title:   "Test Rule",
+						Version: 2,
+					},
+				},
+				{
+					GrafanaAlert: &grafanaModels.GettableGrafanaRule{
+						UID:     "test-uid",
+						Title:   "Test Rule Old",
+						Version: 1,
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			err := json.NewEncoder(w).Encode(resp)
+			require.NoError(t, err)
+		})
+		defer server.Close()
+
+		versions, err := client.GetRuleVersions(context.Background(), "test-uid")
+		require.NoError(t, err)
+		require.Len(t, versions, 2)
+		require.Equal(t, "test-uid", versions[0].GrafanaAlert.UID)
+		require.Equal(t, int64(2), versions[0].GrafanaAlert.Version)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server, client := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, err := w.Write([]byte("rule not found"))
+			require.NoError(t, err)
+		})
+		defer server.Close()
+
+		versions, err := client.GetRuleVersions(context.Background(), "nonexistent")
+		require.Error(t, err)
+		require.Nil(t, versions)
+		require.ErrorContains(t, err, "404")
 	})
 }
 


### PR DESCRIPTION
Add parameters support to makeRequest with server-side filters (folder_uid, rule_group, states, rule_type, rule_limit, limit_alerts, search_rule_name, search_folder, matcher), and GetRuleVersions function for fetching rule version history. 

The new parameters are not used anywhere yet. I will send a follow-up PR to start using them.

Server-side filtering requires Grafana 12.4+ for search and matcher params.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `alertingClient` request/`GetRules` API surface and introduces new query parameters, which could affect existing callers and Grafana compatibility if misused. Behavior is largely unchanged when passing `nil` options, and added tests reduce regression risk.
> 
> **Overview**
> Adds **optional server-side filtering** support to the alerting rules runtime fetch by extending `alertingClient.makeRequest` to accept query parameters and changing `GetRules` to accept `*GetRulesOpts` (with limit capping and query mapping for folder, group, type, state, search, matcher, and limits).
> 
> Introduces `GetRuleVersions` to fetch a Grafana-managed alert rule’s version history, and updates existing call sites/tests (e.g., `listAlertRules`) to use the new `GetRules(ctx, nil)` signature with expanded test coverage for option/query behavior and the new versions endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc65e2e47ba355d28ba33daf9c4e2bf1a26bf83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->