### PR TITLE
feat: add accountId parameter to CloudWatch tools for cross-account monitoring

### DIFF
--- a/tools/cloudwatch.go
+++ b/tools/cloudwatch.go
@@ -36,6 +36,7 @@ type CloudWatchQueryParams struct {
 	Start         string            `json:"start,omitempty" jsonschema:"description=Start time. Formats: 'now-1h'\\, '2026-02-02T19:00:00Z'\\, '1738519200000' (Unix ms). Default: now-1h"`
 	End           string            `json:"end,omitempty" jsonschema:"description=End time. Formats: 'now'\\, '2026-02-02T20:00:00Z'\\, '1738522800000' (Unix ms). Default: now"`
 	Region        string            `json:"region" jsonschema:"required,description=AWS region (e.g. us-east-1)"`
+	AccountId     string            `json:"accountId,omitempty" jsonschema:"description=AWS account ID for cross-account monitoring. Specify an account ID to query metrics from a specific source account\\, or 'all' to query all accounts the monitoring account is permitted to query. Only relevant when using a CloudWatch monitoring account datasource."`
 }
 
 // CloudWatchQueryResult represents the result of a CloudWatch query
@@ -143,26 +144,30 @@ func (c *cloudWatchClient) query(ctx context.Context, args CloudWatchQueryParams
 	}
 
 	// Build the query payload
-	payload := map[string]interface{}{
-		"queries": []map[string]interface{}{
-			{
-				"datasource": map[string]string{
-					"uid":  args.DatasourceUID,
-					"type": CloudWatchDatasourceType,
-				},
-				"refId":      "A",
-				"type":       "timeSeriesQuery",
-				"namespace":  args.Namespace,
-				"metricName": args.MetricName,
-				"dimensions": dimensions,
-				"statistic":  statistic,
-				"period":     strconv.Itoa(period),
-				"region":     region,
-				"matchExact": true,
-			},
+	query := map[string]interface{}{
+		"datasource": map[string]string{
+			"uid":  args.DatasourceUID,
+			"type": CloudWatchDatasourceType,
 		},
-		"from": strconv.FormatInt(from.UnixMilli(), 10),
-		"to":   strconv.FormatInt(to.UnixMilli(), 10),
+		"refId":      "A",
+		"type":       "timeSeriesQuery",
+		"namespace":  args.Namespace,
+		"metricName": args.MetricName,
+		"dimensions": dimensions,
+		"statistic":  statistic,
+		"period":     strconv.Itoa(period),
+		"region":     region,
+		"matchExact": true,
+	}
+
+	if args.AccountId != "" {
+		query["accountId"] = args.AccountId
+	}
+
+	payload := map[string]interface{}{
+		"queries": []map[string]interface{}{query},
+		"from":    strconv.FormatInt(from.UnixMilli(), 10),
+		"to":      strconv.FormatInt(to.UnixMilli(), 10),
 	}
 
 	payloadBytes, err := json.Marshal(payload)
@@ -375,7 +380,9 @@ Time formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)
 
 Common namespaces: AWS/EC2, AWS/ECS, AWS/RDS, AWS/Lambda, ECS/ContainerInsights
 
-Example dimensions: ECS: {ClusterName, ServiceName}, EC2: {InstanceId}`,
+Example dimensions: ECS: {ClusterName, ServiceName}, EC2: {InstanceId}
+
+Cross-account monitoring: Use accountId to query metrics from a specific source account (e.g. '123456789012') or 'all' to query all linked accounts. Only applicable when using a CloudWatch monitoring account datasource.`,
 	queryCloudWatch,
 	mcp.WithTitleAnnotation("Query CloudWatch"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -386,6 +393,7 @@ Example dimensions: ECS: {ClusterName, ServiceName}, EC2: {InstanceId}`,
 type ListCloudWatchNamespacesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the CloudWatch datasource"`
 	Region        string `json:"region" jsonschema:"required,description=AWS region (e.g. us-east-1)"`
+	AccountId     string `json:"accountId,omitempty" jsonschema:"description=AWS account ID for cross-account monitoring. Specify an account ID to filter namespaces from a specific source account\\, or 'all' for all linked accounts."`
 }
 
 // cloudWatchResourceItem represents an item returned by CloudWatch resource APIs
@@ -444,6 +452,9 @@ func listCloudWatchNamespaces(ctx context.Context, args ListCloudWatchNamespaces
 	if args.Region != "" {
 		params.Set("region", args.Region)
 	}
+	if args.AccountId != "" {
+		params.Set("accountId", args.AccountId)
+	}
 
 	resourceURL := client.baseURL + "/api/datasources/uid/" + args.DatasourceUID + "/resources/namespaces"
 	if len(params) > 0 {
@@ -477,7 +488,7 @@ func listCloudWatchNamespaces(ctx context.Context, args ListCloudWatchNamespaces
 // ListCloudWatchNamespaces is a tool for listing CloudWatch namespaces
 var ListCloudWatchNamespaces = mcpgrafana.MustTool(
 	"list_cloudwatch_namespaces",
-	"START HERE for CloudWatch: List available namespaces (AWS/EC2, AWS/ECS, AWS/RDS, etc.). Requires region. NEXT: Use list_cloudwatch_metrics with a namespace.",
+	"START HERE for CloudWatch: List available namespaces (AWS/EC2, AWS/ECS, AWS/RDS, etc.). Requires region. Supports cross-account monitoring via optional accountId parameter. NEXT: Use list_cloudwatch_metrics with a namespace.",
 	listCloudWatchNamespaces,
 	mcp.WithTitleAnnotation("List CloudWatch namespaces"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -489,6 +500,7 @@ type ListCloudWatchMetricsParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the CloudWatch datasource"`
 	Namespace     string `json:"namespace" jsonschema:"required,description=CloudWatch namespace (e.g. AWS/ECS\\, AWS/EC2)"`
 	Region        string `json:"region" jsonschema:"required,description=AWS region (e.g. us-east-1)"`
+	AccountId     string `json:"accountId,omitempty" jsonschema:"description=AWS account ID for cross-account monitoring. Specify an account ID to filter metrics from a specific source account\\, or 'all' for all linked accounts."`
 }
 
 // listCloudWatchMetrics lists available metrics for a CloudWatch namespace
@@ -503,6 +515,9 @@ func listCloudWatchMetrics(ctx context.Context, args ListCloudWatchMetricsParams
 	params.Set("namespace", args.Namespace)
 	if args.Region != "" {
 		params.Set("region", args.Region)
+	}
+	if args.AccountId != "" {
+		params.Set("accountId", args.AccountId)
 	}
 
 	resourceURL := client.baseURL + "/api/datasources/uid/" + args.DatasourceUID + "/resources/metrics?" + params.Encode()
@@ -534,7 +549,7 @@ func listCloudWatchMetrics(ctx context.Context, args ListCloudWatchMetricsParams
 // ListCloudWatchMetrics is a tool for listing CloudWatch metrics
 var ListCloudWatchMetrics = mcpgrafana.MustTool(
 	"list_cloudwatch_metrics",
-	"List metrics for a CloudWatch namespace. Requires region. Use after list_cloudwatch_namespaces. NEXT: Use list_cloudwatch_dimensions\\, then query_cloudwatch.",
+	"List metrics for a CloudWatch namespace. Requires region. Supports cross-account monitoring via optional accountId parameter. Use after list_cloudwatch_namespaces. NEXT: Use list_cloudwatch_dimensions\\, then query_cloudwatch.",
 	listCloudWatchMetrics,
 	mcp.WithTitleAnnotation("List CloudWatch metrics"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -547,6 +562,7 @@ type ListCloudWatchDimensionsParams struct {
 	Namespace     string `json:"namespace" jsonschema:"required,description=CloudWatch namespace (e.g. AWS/ECS)"`
 	MetricName    string `json:"metricName" jsonschema:"required,description=Metric name (e.g. CPUUtilization)"`
 	Region        string `json:"region" jsonschema:"required,description=AWS region (e.g. us-east-1)"`
+	AccountId     string `json:"accountId,omitempty" jsonschema:"description=AWS account ID for cross-account monitoring. Specify an account ID to filter dimensions from a specific source account\\, or 'all' for all linked accounts."`
 }
 
 // listCloudWatchDimensions lists available dimension keys for a CloudWatch metric
@@ -562,6 +578,9 @@ func listCloudWatchDimensions(ctx context.Context, args ListCloudWatchDimensions
 	params.Set("metricName", args.MetricName)
 	if args.Region != "" {
 		params.Set("region", args.Region)
+	}
+	if args.AccountId != "" {
+		params.Set("accountId", args.AccountId)
 	}
 
 	resourceURL := client.baseURL + "/api/datasources/uid/" + args.DatasourceUID + "/resources/dimension-keys?" + params.Encode()
@@ -593,7 +612,7 @@ func listCloudWatchDimensions(ctx context.Context, args ListCloudWatchDimensions
 // ListCloudWatchDimensions is a tool for listing CloudWatch dimension keys
 var ListCloudWatchDimensions = mcpgrafana.MustTool(
 	"list_cloudwatch_dimensions",
-	"List dimension keys for a CloudWatch metric. Requires region. Use after list_cloudwatch_metrics. NEXT: Use query_cloudwatch with discovered dimensions.",
+	"List dimension keys for a CloudWatch metric. Requires region. Supports cross-account monitoring via optional accountId parameter. Use after list_cloudwatch_metrics. NEXT: Use query_cloudwatch with discovered dimensions.",
 	listCloudWatchDimensions,
 	mcp.WithTitleAnnotation("List CloudWatch dimensions"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/cloudwatch_test.go
+++ b/tools/cloudwatch_test.go
@@ -3,6 +3,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"net/url"
 	"testing"
 
@@ -25,6 +26,7 @@ func TestCloudWatchQueryParams_Validation(t *testing.T) {
 		Start:     "now-1h",
 		End:       "now",
 		Region:    "us-east-1",
+		AccountId: "123456789012",
 	}
 
 	assert.Equal(t, "test-uid", params.DatasourceUID)
@@ -37,6 +39,32 @@ func TestCloudWatchQueryParams_Validation(t *testing.T) {
 	assert.Equal(t, "now-1h", params.Start)
 	assert.Equal(t, "now", params.End)
 	assert.Equal(t, "us-east-1", params.Region)
+	assert.Equal(t, "123456789012", params.AccountId)
+}
+
+func TestCloudWatchQueryParams_AccountIdAll(t *testing.T) {
+	// Test that AccountId supports the "all" wildcard value
+	params := CloudWatchQueryParams{
+		DatasourceUID: "test-uid",
+		Namespace:     "AWS/EC2",
+		MetricName:    "CPUUtilization",
+		Region:        "us-east-1",
+		AccountId:     "all",
+	}
+
+	assert.Equal(t, "all", params.AccountId)
+}
+
+func TestCloudWatchQueryParams_AccountIdEmpty(t *testing.T) {
+	// Test that AccountId is optional and defaults to empty
+	params := CloudWatchQueryParams{
+		DatasourceUID: "test-uid",
+		Namespace:     "AWS/EC2",
+		MetricName:    "CPUUtilization",
+		Region:        "us-east-1",
+	}
+
+	assert.Empty(t, params.AccountId)
 }
 
 func TestCloudWatchQueryResult_Structure(t *testing.T) {
@@ -72,10 +100,12 @@ func TestListCloudWatchNamespacesParams_Structure(t *testing.T) {
 	params := ListCloudWatchNamespacesParams{
 		DatasourceUID: "test-uid",
 		Region:        "us-west-2",
+		AccountId:     "123456789012",
 	}
 
 	assert.Equal(t, "test-uid", params.DatasourceUID)
 	assert.Equal(t, "us-west-2", params.Region)
+	assert.Equal(t, "123456789012", params.AccountId)
 }
 
 func TestListCloudWatchMetricsParams_Structure(t *testing.T) {
@@ -83,11 +113,13 @@ func TestListCloudWatchMetricsParams_Structure(t *testing.T) {
 		DatasourceUID: "test-uid",
 		Namespace:     "AWS/EC2",
 		Region:        "eu-west-1",
+		AccountId:     "all",
 	}
 
 	assert.Equal(t, "test-uid", params.DatasourceUID)
 	assert.Equal(t, "AWS/EC2", params.Namespace)
 	assert.Equal(t, "eu-west-1", params.Region)
+	assert.Equal(t, "all", params.AccountId)
 }
 
 func TestListCloudWatchDimensionsParams_Structure(t *testing.T) {
@@ -96,12 +128,14 @@ func TestListCloudWatchDimensionsParams_Structure(t *testing.T) {
 		Namespace:     "AWS/RDS",
 		MetricName:    "DatabaseConnections",
 		Region:        "ap-southeast-1",
+		AccountId:     "987654321098",
 	}
 
 	assert.Equal(t, "test-uid", params.DatasourceUID)
 	assert.Equal(t, "AWS/RDS", params.Namespace)
 	assert.Equal(t, "DatabaseConnections", params.MetricName)
 	assert.Equal(t, "ap-southeast-1", params.Region)
+	assert.Equal(t, "987654321098", params.AccountId)
 }
 
 func TestCloudWatchQueryResult_Hints(t *testing.T) {
@@ -467,6 +501,80 @@ func TestCloudWatchURLEncoding(t *testing.T) {
 				assert.Contains(t, encoded, "Custom%23Namespace", "# should be percent-encoded")
 				assert.NotContains(t, encoded, "Custom#", "raw # should not appear in encoded query")
 			}
+		})
+	}
+}
+
+func TestCloudWatchQueryParams_JSONSerialization(t *testing.T) {
+	t.Run("accountId included when set", func(t *testing.T) {
+		params := CloudWatchQueryParams{
+			DatasourceUID: "test-uid",
+			Namespace:     "AWS/EC2",
+			MetricName:    "CPUUtilization",
+			Region:        "us-east-1",
+			AccountId:     "123456789012",
+		}
+
+		data, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		var raw map[string]interface{}
+		err = json.Unmarshal(data, &raw)
+		require.NoError(t, err)
+
+		assert.Equal(t, "123456789012", raw["accountId"])
+	})
+
+	t.Run("accountId omitted when empty", func(t *testing.T) {
+		params := CloudWatchQueryParams{
+			DatasourceUID: "test-uid",
+			Namespace:     "AWS/EC2",
+			MetricName:    "CPUUtilization",
+			Region:        "us-east-1",
+		}
+
+		data, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		var raw map[string]interface{}
+		err = json.Unmarshal(data, &raw)
+		require.NoError(t, err)
+
+		_, exists := raw["accountId"]
+		assert.False(t, exists, "accountId should be omitted from JSON when empty")
+	})
+}
+
+func TestCloudWatchAccountIdURLEncoding(t *testing.T) {
+	tests := []struct {
+		name      string
+		accountId string
+		wantParam string
+	}{
+		{
+			name:      "specific account ID",
+			accountId: "123456789012",
+			wantParam: "123456789012",
+		},
+		{
+			name:      "all accounts wildcard",
+			accountId: "all",
+			wantParam: "all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := url.Values{}
+			params.Set("region", "us-east-1")
+			if tt.accountId != "" {
+				params.Set("accountId", tt.accountId)
+			}
+
+			encoded := params.Encode()
+			parsed, err := url.ParseQuery(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantParam, parsed.Get("accountId"))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add optional `accountId` parameter to all four CloudWatch MCP tools (`query_cloudwatch`, `list_cloudwatch_namespaces`, `list_cloudwatch_metrics`, `list_cloudwatch_dimensions`) to enable cross-account monitoring queries
- Grafana's CloudWatch plugin natively supports `accountId` in queries, but the MCP tools did not expose it — monitoring account datasources could not query metrics from linked source accounts
- Accepts a specific AWS account ID (e.g. `123456789012`) or the special value `all` to query across all linked accounts

## Motivation

When using [CloudWatch cross-account observability](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html), a monitoring account datasource in Grafana needs to specify which source account(s) to query. The Grafana CloudWatch plugin already supports this via the `accountId` field in the query model (`CloudWatchMetricsQuery.AccountId`), but the MCP server tools didn't expose this parameter, making cross-account queries impossible through the MCP interface.

## Changes

**`tools/cloudwatch.go`:**
- Added `AccountId string` field (optional, `omitempty`) to `CloudWatchQueryParams`, `ListCloudWatchNamespacesParams`, `ListCloudWatchMetricsParams`, and `ListCloudWatchDimensionsParams`
- `query_cloudwatch`: conditionally includes `"accountId"` in the query payload sent to `/api/ds/query`
- Discovery tools (`list_cloudwatch_namespaces`, `list_cloudwatch_metrics`, `list_cloudwatch_dimensions`): pass `accountId` as a query parameter to resource APIs
- Updated tool descriptions to mention cross-account support

**`tools/cloudwatch_test.go`:**
- Updated existing struct tests to cover `AccountId` field
- Added `TestCloudWatchQueryParams_AccountIdAll` and `TestCloudWatchQueryParams_AccountIdEmpty`
- Added `TestCloudWatchQueryParams_JSONSerialization` — verifies `accountId` is present when set and omitted when empty
- Added `TestCloudWatchAccountIdURLEncoding` — verifies URL parameter encoding for account IDs

## Test plan

- [x] All existing unit tests pass
- [x] New unit tests cover JSON serialization (included/omitted) and URL encoding
- [x] Build compiles successfully
- [ ] Integration testing with a CloudWatch monitoring account datasource (requires cross-account setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CloudWatch queries/discovery requests are constructed by optionally injecting `accountId` into Grafana query payloads and resource URLs; mistakes could cause querying the wrong account(s) or no data returned. Scoped to CloudWatch tooling with added unit coverage, so overall risk is moderate.
> 
> **Overview**
> Adds an optional `accountId` parameter to the CloudWatch MCP tools (`query_cloudwatch`, `list_cloudwatch_namespaces`, `list_cloudwatch_metrics`, `list_cloudwatch_dimensions`) to enable Grafana CloudWatch cross-account monitoring.
> 
> When provided, `query_cloudwatch` now includes `accountId` in the `/api/ds/query` payload, and the discovery tools forward `accountId` as a URL query parameter to Grafana resource endpoints; tool help text is updated accordingly.
> 
> Unit tests are expanded to cover `accountId` struct presence, JSON `omitempty` behavior, and URL encoding/round-tripping (including the special value `all`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c73feeed7045c777c52e65906ff16da789e441a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->