### PR TITLE
Fix parallel tool call handling in test utils

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -90,6 +90,7 @@ async def run_llm_tool_loop(
     response = await acompletion(model=model, messages=messages, tools=tools)
 
     while response.choices and response.choices[0].message.tool_calls:
+        messages.append(response.choices[0].message)
         for tool_call in response.choices[0].message.tool_calls:
             tool_name = tool_call.function.name
             args = (
@@ -101,7 +102,6 @@ async def run_llm_tool_loop(
                 mcp_client, tool_name, args
             )
             tools_called.append(mcp_tc)
-            messages.append(response.choices[0].message)
             messages.append(
                 Message(role="tool", tool_call_id=tool_call.id, content=result_text)
             )


### PR DESCRIPTION
When running tests, I noticed that sometimes they fail with a 400 from Anthropic when multiple tools are used. When an LLM returns multiple `tool_use` blocks in one response, the response message was appended once per tool call instead of once before all tool results, causing the Anthropic API to reject it with an error:

```
litellm.exceptions.BadRequestError: litellm.BadRequestError: AnthropicException - 
{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "messages.3: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_019hSh4d2Y1nmLT3ydyhzPEi. Each `tool_use` block must have a corresponding `tool_result` block in the next message."
  },
  "request_id": "req_011CYjcwZjZjXC6eaN148vsY"
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts message history ordering to satisfy Anthropic tool-use requirements; low blast radius and no production logic impacted.
> 
> **Overview**
> Fixes `tests/utils.py` `run_llm_tool_loop` to append the assistant message containing `tool_calls` **once per LLM response** (before iterating tool calls) instead of once per tool invocation.
> 
> This ensures tool results are recorded immediately after the corresponding tool-use blocks, preventing 400 errors from Anthropic when multiple tool calls are returned in a single assistant message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 253e66426d63b6de60ceb59d59777bd3eef58993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->