### PR TITLE
feat(tools): use typed struct instead of untyped models.AlertQuery

### DIFF
--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -298,12 +298,17 @@ func createAlertRule(ctx context.Context, args CreateAlertRuleParams) (*models.P
 		return nil, fmt.Errorf("create alert rule: invalid duration format %q: %w", args.For, err)
 	}
 
+	convertedData, err := convertAlertQueries(args.Data)
+	if err != nil {
+		return nil, fmt.Errorf("create alert rule: %w", err)
+	}
+
 	rule := &models.ProvisionedAlertRule{
 		Title:        &args.Title,
 		RuleGroup:    &args.RuleGroup,
 		FolderUID:    &args.FolderUID,
 		Condition:    &args.Condition,
-		Data:         args.Data,
+		Data:         convertedData,
 		NoDataState:  &args.NoDataState,
 		ExecErrState: &args.ExecErrState,
 		For:          func() *strfmt.Duration { d := strfmt.Duration(duration); return &d }(),
@@ -351,13 +356,18 @@ func updateAlertRule(ctx context.Context, args UpdateAlertRuleParams) (*models.P
 		return nil, fmt.Errorf("update alert rule: invalid duration format %q: %w", args.For, err)
 	}
 
+	convertedData, err := convertAlertQueries(args.Data)
+	if err != nil {
+		return nil, fmt.Errorf("update alert rule: %w", err)
+	}
+
 	rule := &models.ProvisionedAlertRule{
 		UID:          args.UID,
 		Title:        &args.Title,
 		RuleGroup:    &args.RuleGroup,
 		FolderUID:    &args.FolderUID,
 		Condition:    &args.Condition,
-		Data:         args.Data,
+		Data:         convertedData,
 		NoDataState:  &args.NoDataState,
 		ExecErrState: &args.ExecErrState,
 		For:          func() *strfmt.Duration { d := strfmt.Duration(duration); return &d }(),

--- a/tools/alerting_manage_rules_test.go
+++ b/tools/alerting_manage_rules_test.go
@@ -552,60 +552,36 @@ func TestManageRules_Create(t *testing.T) {
 	t.Run("create alert rule with valid parameters", func(t *testing.T) {
 		ctx := newTestContext()
 
-		sampleData := []*models.AlertQuery{
+		sampleData := []*AlertQuery{
 			{
-				RefID:     "A",
-				QueryType: "",
-				RelativeTimeRange: &models.RelativeTimeRange{
+				RefID:         "A",
+				DatasourceUID: "prometheus-uid",
+				RelativeTimeRange: &RelativeTimeRange{
 					From: 600,
 					To:   0,
 				},
-				DatasourceUID: "prometheus-uid",
-				Model: map[string]any{
-					"expr":          "up",
-					"hide":          false,
-					"intervalMs":    1000,
-					"maxDataPoints": 43200,
-					"refId":         "A",
+				Model: AlertQueryModel{
+					Expr: "up",
 				},
 			},
 			{
-				RefID:     "B",
-				QueryType: "",
-				RelativeTimeRange: &models.RelativeTimeRange{
-					From: 0,
-					To:   0,
-				},
+				RefID:         "B",
 				DatasourceUID: "__expr__",
-				Model: map[string]any{
-					"conditions": []any{
-						map[string]any{
-							"evaluator": map[string]any{
-								"params": []any{1},
-								"type":   "gt",
-							},
-							"operator": map[string]any{
-								"type": "and",
-							},
-							"query": map[string]any{
-								"params": []any{"A"},
-							},
-							"reducer": map[string]any{
-								"params": []any{},
-								"type":   "last",
-							},
-							"type": "query",
-						},
+				Model: AlertQueryModel{
+					Type:       "reduce",
+					Expression: "A",
+					Reducer:    "last",
+				},
+			},
+			{
+				RefID:         "C",
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "threshold",
+					Expression: "B",
+					Conditions: []AlertCondition{
+						{Evaluator: ConditionEvaluator{Type: "gt", Params: []float64{1}}},
 					},
-					"datasource": map[string]any{
-						"type": "__expr__",
-						"uid":  "__expr__",
-					},
-					"hide":          false,
-					"intervalMs":    1000,
-					"maxDataPoints": 43200,
-					"refId":         "B",
-					"type":          "classic_conditions",
 				},
 			},
 		}
@@ -621,7 +597,7 @@ func TestManageRules_Create(t *testing.T) {
 			Title:        "Test Created Alert Rule",
 			RuleGroup:    "test-group",
 			FolderUID:    "tests",
-			Condition:    "B",
+			Condition:    "C",
 			Data:         sampleData,
 			NoDataState:  "OK",
 			ExecErrState: "OK",
@@ -641,6 +617,197 @@ func TestManageRules_Create(t *testing.T) {
 		require.Equal(t, testUID, created.UID)
 		require.Equal(t, "Test Created Alert Rule", *created.Title)
 		require.Equal(t, "test-group", *created.RuleGroup)
+	})
+
+	t.Run("create alert rule with reduce and threshold expressions", func(t *testing.T) {
+		ctx := newTestContext()
+
+		data := []*AlertQuery{
+			{
+				RefID:         "A",
+				DatasourceUID: "prometheus",
+				RelativeTimeRange: &RelativeTimeRange{
+					From: 600,
+					To:   0,
+				},
+				Model: AlertQueryModel{
+					Expr: "vector(1)",
+				},
+			},
+			{
+				RefID:         "B",
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "reduce",
+					Expression: "A",
+					Reducer:    "last",
+				},
+			},
+			{
+				RefID:         "C",
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "threshold",
+					Expression: "B",
+					Conditions: []AlertCondition{
+						{Evaluator: ConditionEvaluator{Type: "gt", Params: []float64{0}}},
+					},
+				},
+			},
+		}
+
+		testUID := "test_create_reduce_threshold"
+		t.Cleanup(func() {
+			manageRulesReadWrite(ctx, ManageRulesReadWriteParams{Operation: "delete", RuleUID: testUID}) //nolint:errcheck
+		})
+
+		result, err := manageRulesReadWrite(ctx, ManageRulesReadWriteParams{
+			Operation:    "create",
+			RuleUID:      testUID,
+			Title:        "Test Reduce+Threshold Rule",
+			RuleGroup:    "test-group",
+			FolderUID:    "tests",
+			Condition:    "C",
+			Data:         data,
+			NoDataState:  "OK",
+			ExecErrState: "OK",
+			For:          "5m",
+			OrgID:        1,
+		})
+		require.NoError(t, err)
+
+		created, ok := result.(*models.ProvisionedAlertRule)
+		require.True(t, ok)
+		require.Equal(t, testUID, created.UID)
+		require.Equal(t, "Test Reduce+Threshold Rule", *created.Title)
+		require.Len(t, created.Data, 3)
+		require.Equal(t, "A", created.Data[0].RefID)
+		require.Equal(t, "B", created.Data[1].RefID)
+		require.Equal(t, "C", created.Data[2].RefID)
+	})
+
+	t.Run("create alert rule with math expression", func(t *testing.T) {
+		ctx := newTestContext()
+
+		data := []*AlertQuery{
+			{
+				RefID:         "A",
+				DatasourceUID: "prometheus",
+				RelativeTimeRange: &RelativeTimeRange{
+					From: 600,
+					To:   0,
+				},
+				Model: AlertQueryModel{
+					Expr: "vector(1)",
+				},
+			},
+			{
+				RefID:         "B",
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "reduce",
+					Expression: "A",
+					Reducer:    "last",
+				},
+			},
+			{
+				RefID:         "C",
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "math",
+					Expression: "$B > 0",
+				},
+			},
+		}
+
+		testUID := "test_create_math_expr"
+		t.Cleanup(func() {
+			manageRulesReadWrite(ctx, ManageRulesReadWriteParams{Operation: "delete", RuleUID: testUID}) //nolint:errcheck
+		})
+
+		result, err := manageRulesReadWrite(ctx, ManageRulesReadWriteParams{
+			Operation:    "create",
+			RuleUID:      testUID,
+			Title:        "Test Math Expression Rule",
+			RuleGroup:    "test-group",
+			FolderUID:    "tests",
+			Condition:    "C",
+			Data:         data,
+			NoDataState:  "OK",
+			ExecErrState: "OK",
+			For:          "5m",
+			OrgID:        1,
+		})
+		require.NoError(t, err)
+
+		created, ok := result.(*models.ProvisionedAlertRule)
+		require.True(t, ok)
+		require.Equal(t, testUID, created.UID)
+		require.Equal(t, "Test Math Expression Rule", *created.Title)
+		require.Len(t, created.Data, 3)
+	})
+
+	t.Run("create alert rule with auto-assigned RefIDs", func(t *testing.T) {
+		ctx := newTestContext()
+
+		data := []*AlertQuery{
+			{
+				DatasourceUID: "prometheus",
+				RelativeTimeRange: &RelativeTimeRange{
+					From: 600,
+					To:   0,
+				},
+				Model: AlertQueryModel{
+					Expr: "vector(1)",
+				},
+			},
+			{
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "reduce",
+					Expression: "A",
+					Reducer:    "last",
+				},
+			},
+			{
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "threshold",
+					Expression: "B",
+					Conditions: []AlertCondition{
+						{Evaluator: ConditionEvaluator{Type: "gt", Params: []float64{0}}},
+					},
+				},
+			},
+		}
+
+		testUID := "test_create_auto_refid"
+		t.Cleanup(func() {
+			manageRulesReadWrite(ctx, ManageRulesReadWriteParams{Operation: "delete", RuleUID: testUID}) //nolint:errcheck
+		})
+
+		result, err := manageRulesReadWrite(ctx, ManageRulesReadWriteParams{
+			Operation:    "create",
+			RuleUID:      testUID,
+			Title:        "Test Auto RefID Rule",
+			RuleGroup:    "test-group",
+			FolderUID:    "tests",
+			Condition:    "C",
+			Data:         data,
+			NoDataState:  "OK",
+			ExecErrState: "OK",
+			For:          "5m",
+			OrgID:        1,
+		})
+		require.NoError(t, err)
+
+		created, ok := result.(*models.ProvisionedAlertRule)
+		require.True(t, ok)
+		require.Equal(t, testUID, created.UID)
+		require.Len(t, created.Data, 3)
+		require.Equal(t, "A", created.Data[0].RefID)
+		require.Equal(t, "B", created.Data[1].RefID)
+		require.Equal(t, "C", created.Data[2].RefID)
 	})
 
 	t.Run("create alert rule with missing required fields", func(t *testing.T) {
@@ -672,21 +839,16 @@ func TestManageRules_Update(t *testing.T) {
 	t.Run("update existing alert rule", func(t *testing.T) {
 		ctx := newTestContext()
 
-		sampleData := []*models.AlertQuery{
+		sampleData := []*AlertQuery{
 			{
-				RefID:     "A",
-				QueryType: "",
-				RelativeTimeRange: &models.RelativeTimeRange{
+				RefID:         "A",
+				DatasourceUID: "prometheus-uid",
+				RelativeTimeRange: &RelativeTimeRange{
 					From: 600,
 					To:   0,
 				},
-				DatasourceUID: "prometheus-uid",
-				Model: map[string]any{
-					"expr":          "up",
-					"hide":          false,
-					"intervalMs":    1000,
-					"maxDataPoints": 43200,
-					"refId":         "A",
+				Model: AlertQueryModel{
+					Expr: "up",
 				},
 			},
 		}
@@ -751,7 +913,7 @@ func TestManageRules_Update(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "tests",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{},
+			Data:         []*AlertQuery{},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -777,21 +939,16 @@ func TestManageRules_Delete(t *testing.T) {
 	t.Run("delete existing alert rule", func(t *testing.T) {
 		ctx := newTestContext()
 
-		sampleData := []*models.AlertQuery{
+		sampleData := []*AlertQuery{
 			{
-				RefID:     "A",
-				QueryType: "",
-				RelativeTimeRange: &models.RelativeTimeRange{
+				RefID:         "A",
+				DatasourceUID: "prometheus-uid",
+				RelativeTimeRange: &RelativeTimeRange{
 					From: 600,
 					To:   0,
 				},
-				DatasourceUID: "prometheus-uid",
-				Model: map[string]any{
-					"expr":          "up",
-					"hide":          false,
-					"intervalMs":    1000,
-					"maxDataPoints": 43200,
-					"refId":         "A",
+				Model: AlertQueryModel{
+					Expr: "up",
 				},
 			},
 		}
@@ -865,61 +1022,37 @@ func TestManageRules_Delete(t *testing.T) {
 }
 
 // createTestAlertQueries creates sample alert query data for testing DisableProvenance
-func createTestAlertQueries() []*models.AlertQuery {
-	return []*models.AlertQuery{
+func createTestAlertQueries() []*AlertQuery {
+	return []*AlertQuery{
 		{
-			RefID:     "A",
-			QueryType: "",
-			RelativeTimeRange: &models.RelativeTimeRange{
+			RefID:         "A",
+			DatasourceUID: "prometheus",
+			RelativeTimeRange: &RelativeTimeRange{
 				From: 600,
 				To:   0,
 			},
-			DatasourceUID: "prometheus",
-			Model: map[string]any{
-				"expr":          "vector(1)",
-				"hide":          false,
-				"intervalMs":    1000,
-				"maxDataPoints": 43200,
-				"refId":         "A",
+			Model: AlertQueryModel{
+				Expr: "vector(1)",
 			},
 		},
 		{
-			RefID:     "B",
-			QueryType: "",
-			RelativeTimeRange: &models.RelativeTimeRange{
-				From: 0,
-				To:   0,
-			},
+			RefID:         "B",
 			DatasourceUID: "__expr__",
-			Model: map[string]any{
-				"conditions": []any{
-					map[string]any{
-						"evaluator": map[string]any{
-							"params": []any{0},
-							"type":   "gt",
-						},
-						"operator": map[string]any{
-							"type": "and",
-						},
-						"query": map[string]any{
-							"params": []any{"A"},
-						},
-						"reducer": map[string]any{
-							"params": []any{},
-							"type":   "last",
-						},
-						"type": "query",
-					},
+			Model: AlertQueryModel{
+				Type:       "reduce",
+				Expression: "A",
+				Reducer:    "last",
+			},
+		},
+		{
+			RefID:         "C",
+			DatasourceUID: "__expr__",
+			Model: AlertQueryModel{
+				Type:       "threshold",
+				Expression: "B",
+				Conditions: []AlertCondition{
+					{Evaluator: ConditionEvaluator{Type: "gt", Params: []float64{0}}},
 				},
-				"datasource": map[string]any{
-					"type": "__expr__",
-					"uid":  "__expr__",
-				},
-				"hide":          false,
-				"intervalMs":    1000,
-				"maxDataPoints": 43200,
-				"refId":         "B",
-				"type":          "classic_conditions",
 			},
 		},
 	}
@@ -942,7 +1075,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:        "Test Provenance Default",
 			RuleGroup:    "test-group",
 			FolderUID:    "tests",
-			Condition:    "B",
+			Condition:    "C",
 			Data:         sampleData,
 			NoDataState:  "OK",
 			ExecErrState: "OK",
@@ -975,7 +1108,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:             "Test Provenance True",
 			RuleGroup:         "test-group",
 			FolderUID:         "tests",
-			Condition:         "B",
+			Condition:         "C",
 			Data:              sampleData,
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
@@ -1008,7 +1141,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:             "Test Provenance False",
 			RuleGroup:         "test-group",
 			FolderUID:         "tests",
-			Condition:         "B",
+			Condition:         "C",
 			Data:              sampleData,
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
@@ -1040,7 +1173,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:        "Test Update Provenance Default",
 			RuleGroup:    "test-group",
 			FolderUID:    "tests",
-			Condition:    "B",
+			Condition:    "C",
 			Data:         sampleData,
 			NoDataState:  "OK",
 			ExecErrState: "OK",
@@ -1056,7 +1189,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:        "Test Update Provenance Default - Updated",
 			RuleGroup:    "test-group",
 			FolderUID:    "tests",
-			Condition:    "B",
+			Condition:    "C",
 			Data:         sampleData,
 			NoDataState:  "OK",
 			ExecErrState: "OK",
@@ -1087,7 +1220,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:        "Test Update Provenance",
 			RuleGroup:    "test-group",
 			FolderUID:    "tests",
-			Condition:    "B",
+			Condition:    "C",
 			Data:         sampleData,
 			NoDataState:  "OK",
 			ExecErrState: "OK",
@@ -1104,7 +1237,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:             "Test Update Provenance - Updated",
 			RuleGroup:         "test-group",
 			FolderUID:         "tests",
-			Condition:         "B",
+			Condition:         "C",
 			Data:              sampleData,
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
@@ -1136,7 +1269,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:        "Test Update Provenance False",
 			RuleGroup:    "test-group",
 			FolderUID:    "tests",
-			Condition:    "B",
+			Condition:    "C",
 			Data:         sampleData,
 			NoDataState:  "OK",
 			ExecErrState: "OK",
@@ -1153,7 +1286,7 @@ func TestManageRules_DisableProvenance(t *testing.T) {
 			Title:             "Test Update Provenance False - Updated",
 			RuleGroup:         "test-group",
 			FolderUID:         "tests",
-			Condition:         "B",
+			Condition:         "C",
 			Data:              sampleData,
 			NoDataState:       "OK",
 			ExecErrState:      "OK",

--- a/tools/alerting_manage_rules_types.go
+++ b/tools/alerting_manage_rules_types.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -40,9 +41,9 @@ type alertRuleDetail struct {
 	Annotations  map[string]string `json:"annotations,omitempty"`
 	Labels       map[string]string `json:"labels,omitempty"`
 
-	IsPaused             bool                                      `json:"is_paused"`
-	NotificationSettings *models.AlertRuleNotificationSettings      `json:"notification_settings,omitempty"`
-	Queries              []querySummary                             `json:"queries,omitempty"`
+	IsPaused             bool                                  `json:"is_paused"`
+	NotificationSettings *models.AlertRuleNotificationSettings `json:"notification_settings,omitempty"`
+	Queries              []querySummary                        `json:"queries,omitempty"`
 
 	State          string  `json:"state"`
 	Health         string  `json:"health"`
@@ -58,20 +59,113 @@ type querySummary struct {
 	Expression    string `json:"expression,omitempty"`
 }
 
+type RelativeTimeRange struct {
+	From int64 `json:"from" jsonschema:"description=Seconds before eval time (e.g. 600 = 10m ago)"`
+	To   int64 `json:"to" jsonschema:"description=Seconds before eval time (0 = now)"`
+}
+
+type AlertQuery struct {
+	RefID             string             `json:"refId,omitempty" jsonschema:"description=Query identifier (e.g. 'A'). Auto-assigned from position if omitted."`
+	DatasourceUID     string             `json:"datasourceUid" jsonschema:"required,description=Datasource UID (e.g. 'grafanacloud-prom'\\, 'grafanacloud-logs') for data queries\\, or '__expr__' for expressions that transform other queries (reduce\\, threshold\\, math)."`
+	RelativeTimeRange *RelativeTimeRange `json:"relativeTimeRange,omitempty" jsonschema:"description=Time range relative to eval time. Defaults to {from:600\\,to:0} for non-expression queries."`
+	QueryType         string             `json:"queryType,omitempty" jsonschema:"description=Optional datasource-specific query type (e.g. 'instant'\\, 'range'). Usually left empty."`
+	Model             AlertQueryModel    `json:"model" jsonschema:"required,description=Query model. For data sources: set expr. For expressions: set type and expression."`
+}
+
+type AlertQueryModel struct {
+	Expr string `json:"expr,omitempty" jsonschema:"description=Query expression (PromQL\\, LogQL\\, etc.)"`
+
+	// Server-side expressions only (when datasourceUid is __expr__).
+	Type       string           `json:"type,omitempty" jsonschema:"description=Expression type (only for __expr__ datasource): math\\, reduce\\, threshold"`
+	Expression string           `json:"expression,omitempty" jsonschema:"description=Expression ref or formula. For reduce/threshold: ref like 'A'. For math: '$A > 0'."`
+	Reducer    string           `json:"reducer,omitempty" jsonschema:"description=Reducer for reduce expressions: last\\, mean\\, min\\, max\\, sum\\, count"`
+	Conditions []AlertCondition `json:"conditions,omitempty" jsonschema:"description=Conditions for threshold expressions"`
+}
+
+type AlertCondition struct {
+	Evaluator ConditionEvaluator `json:"evaluator" jsonschema:"description=Threshold evaluator"`
+}
+
+type ConditionEvaluator struct {
+	Type   string    `json:"type" jsonschema:"required,description=Evaluator: gt\\, lt\\, within_range\\, outside_range\\, no_value"`
+	Params []float64 `json:"params" jsonschema:"required,description=Threshold value(s)"`
+}
+
+// indexToRefID converts a zero-based index to a letter-based representation,
+// matching the Grafana UI logic.
+// 0 -> "A", 1 -> "B", ..., 25 -> "Z", 26 -> "AA", 27 -> "AB", ...
+func indexToRefID(i int) string {
+	result := ""
+	for {
+		result = string(rune('A'+i%26)) + result
+		i = i/26 - 1
+		if i < 0 {
+			break
+		}
+	}
+	return result
+}
+
+// convertAlertQueries converts typed AlertQuery slice to the models.AlertQuery
+// slice expected by the Grafana API. It auto-assigns RefIDs and default RelativeTimeRange.
+func convertAlertQueries(queries []*AlertQuery) ([]*models.AlertQuery, error) {
+	result := make([]*models.AlertQuery, 0, len(queries))
+	for i, q := range queries {
+		if q == nil {
+			return nil, fmt.Errorf("query at index %d is nil", i)
+		}
+		refID := q.RefID
+		if refID == "" {
+			refID = indexToRefID(i)
+		}
+
+		var rtr *models.RelativeTimeRange
+		if q.RelativeTimeRange != nil {
+			rtr = &models.RelativeTimeRange{
+				From: models.Duration(q.RelativeTimeRange.From),
+				To:   models.Duration(q.RelativeTimeRange.To),
+			}
+		} else if q.DatasourceUID != "__expr__" {
+			rtr = &models.RelativeTimeRange{
+				From: 600,
+				To:   0,
+			}
+		}
+
+		modelBytes, err := json.Marshal(q.Model)
+		if err != nil {
+			return nil, fmt.Errorf("marshal model for query %s: %w", refID, err)
+		}
+		modelMap := make(map[string]any)
+		if err := json.Unmarshal(modelBytes, &modelMap); err != nil {
+			return nil, fmt.Errorf("unmarshal model for query %s: %w", refID, err)
+		}
+
+		result = append(result, &models.AlertQuery{
+			RefID:             refID,
+			DatasourceUID:     q.DatasourceUID,
+			RelativeTimeRange: rtr,
+			QueryType:         q.QueryType,
+			Model:             modelMap,
+		})
+	}
+	return result, nil
+}
+
 type CreateAlertRuleParams struct {
-	Title             string               `json:"title" jsonschema:"required,description=The title of the alert rule"`
-	RuleGroup         string               `json:"ruleGroup" jsonschema:"required,description=The rule group name"`
-	FolderUID         string               `json:"folderUID" jsonschema:"required,description=The folder UID where the rule will be created"`
-	Condition         string               `json:"condition" jsonschema:"required,description=The query condition identifier (e.g. 'A'\\, 'B')"`
-	Data              []*models.AlertQuery `json:"data" jsonschema:"required,description=Array of query data objects"`
-	NoDataState       string               `json:"noDataState" jsonschema:"required,description=State when no data (NoData\\, Alerting\\, OK)"`
-	ExecErrState      string               `json:"execErrState" jsonschema:"required,description=State on execution error (NoData\\, Alerting\\, OK)"`
-	For               string               `json:"for" jsonschema:"required,description=Duration before alert fires (e.g. '5m')"`
-	Annotations       map[string]string    `json:"annotations,omitempty" jsonschema:"description=Optional annotations"`
-	Labels            map[string]string    `json:"labels,omitempty" jsonschema:"description=Optional labels"`
-	UID               *string              `json:"uid,omitempty" jsonschema:"description=Optional UID for the alert rule"`
-	OrgID             int64                `json:"orgID" jsonschema:"required,description=The organization ID"`
-	DisableProvenance *bool                `json:"disableProvenance,omitempty" jsonschema:"description=If true\\, the alert will remain editable in the Grafana UI (sets X-Disable-Provenance header). If false\\, the alert will be marked with provenance 'api' and locked from UI editing. Defaults to true."`
+	Title             string            `json:"title" jsonschema:"required,description=The title of the alert rule"`
+	RuleGroup         string            `json:"ruleGroup" jsonschema:"required,description=The rule group name"`
+	FolderUID         string            `json:"folderUID" jsonschema:"required,description=The folder UID where the rule will be created"`
+	Condition         string            `json:"condition" jsonschema:"required,description=The query condition identifier (e.g. 'A'\\, 'B')"`
+	Data              []*AlertQuery     `json:"data" jsonschema:"required,description=Array of alert query objects. Example: [{datasourceUid: 'prometheus'\\, model: {expr: 'vector(1)'}}\\, {datasourceUid: '__expr__'\\, model: {type: 'threshold'\\, expression: 'A'\\, conditions: [{evaluator: {type: 'gt'\\, params: [1]}}]}}]. RefID and relativeTimeRange are auto-assigned if omitted."`
+	NoDataState       string            `json:"noDataState" jsonschema:"required,description=State when no data (NoData\\, Alerting\\, OK)"`
+	ExecErrState      string            `json:"execErrState" jsonschema:"required,description=State on execution error (NoData\\, Alerting\\, OK)"`
+	For               string            `json:"for" jsonschema:"required,description=Duration before alert fires (e.g. '5m')"`
+	Annotations       map[string]string `json:"annotations,omitempty" jsonschema:"description=Optional annotations"`
+	Labels            map[string]string `json:"labels,omitempty" jsonschema:"description=Optional labels"`
+	UID               *string           `json:"uid,omitempty" jsonschema:"description=Optional UID for the alert rule"`
+	OrgID             int64             `json:"orgID" jsonschema:"required,description=The organization ID"`
+	DisableProvenance *bool             `json:"disableProvenance,omitempty" jsonschema:"description=If true\\, the alert will remain editable in the Grafana UI (sets X-Disable-Provenance header). If false\\, the alert will be marked with provenance 'api' and locked from UI editing. Defaults to true."`
 }
 
 func (p CreateAlertRuleParams) validate() error {
@@ -106,19 +200,19 @@ func (p CreateAlertRuleParams) validate() error {
 }
 
 type UpdateAlertRuleParams struct {
-	UID               string               `json:"uid" jsonschema:"required,description=The UID of the alert rule to update"`
-	Title             string               `json:"title" jsonschema:"required,description=The title of the alert rule"`
-	RuleGroup         string               `json:"ruleGroup" jsonschema:"required,description=The rule group name"`
-	FolderUID         string               `json:"folderUID" jsonschema:"required,description=The folder UID where the rule will be created"`
-	Condition         string               `json:"condition" jsonschema:"required,description=The query condition identifier (e.g. 'A'\\, 'B')"`
-	Data              []*models.AlertQuery `json:"data" jsonschema:"required,description=Array of query data objects"`
-	NoDataState       string               `json:"noDataState" jsonschema:"required,description=State when no data (NoData\\, Alerting\\, OK)"`
-	ExecErrState      string               `json:"execErrState" jsonschema:"required,description=State on execution error (NoData\\, Alerting\\, OK)"`
-	For               string               `json:"for" jsonschema:"required,description=Duration before alert fires (e.g. '5m')"`
-	Annotations       map[string]string    `json:"annotations,omitempty" jsonschema:"description=Optional annotations"`
-	Labels            map[string]string    `json:"labels,omitempty" jsonschema:"description=Optional labels"`
-	OrgID             int64                `json:"orgID" jsonschema:"required,description=The organization ID"`
-	DisableProvenance *bool                `json:"disableProvenance,omitempty" jsonschema:"description=If true\\, the alert will remain editable in the Grafana UI (sets X-Disable-Provenance header). If false\\, the alert will be marked with provenance 'api' and locked from UI editing. Defaults to true."`
+	UID               string            `json:"uid" jsonschema:"required,description=The UID of the alert rule to update"`
+	Title             string            `json:"title" jsonschema:"required,description=The title of the alert rule"`
+	RuleGroup         string            `json:"ruleGroup" jsonschema:"required,description=The rule group name"`
+	FolderUID         string            `json:"folderUID" jsonschema:"required,description=The folder UID where the rule will be created"`
+	Condition         string            `json:"condition" jsonschema:"required,description=The query condition identifier (e.g. 'A'\\, 'B')"`
+	Data              []*AlertQuery     `json:"data" jsonschema:"required,description=Array of alert query objects. RefID and relativeTimeRange are auto-assigned if omitted."`
+	NoDataState       string            `json:"noDataState" jsonschema:"required,description=State when no data (NoData\\, Alerting\\, OK)"`
+	ExecErrState      string            `json:"execErrState" jsonschema:"required,description=State on execution error (NoData\\, Alerting\\, OK)"`
+	For               string            `json:"for" jsonschema:"required,description=Duration before alert fires (e.g. '5m')"`
+	Annotations       map[string]string `json:"annotations,omitempty" jsonschema:"description=Optional annotations"`
+	Labels            map[string]string `json:"labels,omitempty" jsonschema:"description=Optional labels"`
+	OrgID             int64             `json:"orgID" jsonschema:"required,description=The organization ID"`
+	DisableProvenance *bool             `json:"disableProvenance,omitempty" jsonschema:"description=If true\\, the alert will remain editable in the Grafana UI (sets X-Disable-Provenance header). If false\\, the alert will be marked with provenance 'api' and locked from UI editing. Defaults to true."`
 }
 
 func (p UpdateAlertRuleParams) validate() error {
@@ -205,25 +299,25 @@ func (p ManageRulesReadParams) validate() error {
 
 // ManageRulesReadWriteParams is the param struct for the read-write version of alerting_manage_rules.
 type ManageRulesReadWriteParams struct {
-	Operation         string               `json:"operation" jsonschema:"required,enum=list,enum=get,enum=versions,enum=create,enum=update,enum=delete,description=The operation to perform: 'list'\\, 'get'\\, 'versions'\\, 'create'\\, 'update'\\, or 'delete'. To create a rule\\, use operation 'create' and provide all required fields in a single call. To update a rule\\, first use 'get' to retrieve its full configuration\\, then 'update' with all required fields plus your changes."`
-	RuleUID           string               `json:"rule_uid,omitempty" jsonschema:"description=The UID of the alert rule (required for 'get'\\, 'versions'\\, 'update'\\, 'delete'; optional for 'create')"`
-	RuleLimit         int                  `json:"rule_limit,omitempty" jsonschema:"default=200,description=Maximum number of rules to return (default 200\\, max 200). Requires Grafana 12.4+ (for 'list' operation)"`
-	DatasourceUID     *string              `json:"datasource_uid,omitempty" jsonschema:"description=Optional: UID of a Prometheus or Loki datasource to query for datasource-managed alert rules (for 'list' operation)"`
-	LabelSelectors    []Selector           `json:"label_selectors,omitempty" jsonschema:"description=Label matchers to filter alert rules (for 'list' operation)"`
-	LimitAlerts       int                  `json:"limit_alerts,omitempty" jsonschema:"description=Limit alert instances per rule. For list: 0 omits alerts. For get: <=0 defaults to 200. Max 200."`
-	SearchFolder      string               `json:"search_folder,omitempty" jsonschema:"description=Search folders by path using partial matching (for 'list' operation). Requires Grafana 12.4+. Mutually exclusive with folder_uid when used for filtering."`
-	Title             string               `json:"title,omitempty" jsonschema:"description=The title of the alert rule (required for 'create'\\, 'update')"`
-	RuleGroup         string               `json:"rule_group,omitempty" jsonschema:"description=The rule group name (required for 'create'\\, 'update')"`
-	FolderUID         string               `json:"folder_uid,omitempty" jsonschema:"description=The folder UID. For 'list': filter by exact folder UID (mutually exclusive with search_folder). For 'create'/'update': the folder to store the rule in (required)."`
-	Condition         string               `json:"condition,omitempty" jsonschema:"description=The query condition identifier\\, e.g. 'A'\\, 'B' (required for 'create'\\, 'update')"`
-	Data              []*models.AlertQuery `json:"data,omitempty" jsonschema:"description=Array of alert query objects (required for 'create' and 'update'). Example: [{refId: 'A'\\, datasourceUid: 'prometheus'\\, relativeTimeRange: {from: 600\\, to: 0}\\, model: {expr: 'vector(1)'\\, refId: 'A'}}]. Use datasourceUid '__expr__' for server-side expressions. The 'condition' field must reference one of the refIds."`
-	NoDataState       string               `json:"no_data_state,omitempty" jsonschema:"description=State when no data: NoData\\, Alerting\\, OK (required for 'create'\\, 'update')"`
-	ExecErrState      string               `json:"exec_err_state,omitempty" jsonschema:"description=State on execution error: NoData\\, Alerting\\, OK (required for 'create'\\, 'update')"`
-	For               string               `json:"for,omitempty" jsonschema:"description=Duration before alert fires\\, e.g. '5m' (required for 'create'\\, 'update')"`
-	Annotations       map[string]string    `json:"annotations,omitempty" jsonschema:"description=Optional annotations for the alert rule"`
-	Labels            map[string]string    `json:"labels,omitempty" jsonschema:"description=Optional labels for the alert rule"`
-	OrgID             int64                `json:"org_id,omitempty" jsonschema:"description=The organization ID (required for 'create'\\, 'update')"`
-	DisableProvenance *bool                `json:"disable_provenance,omitempty" jsonschema:"description=If true\\, the alert remains editable in the Grafana UI (sets X-Disable-Provenance header). Defaults to true."`
+	Operation         string            `json:"operation" jsonschema:"required,enum=list,enum=get,enum=versions,enum=create,enum=update,enum=delete,description=The operation to perform: 'list'\\, 'get'\\, 'versions'\\, 'create'\\, 'update'\\, or 'delete'. To create a rule\\, use operation 'create' and provide all required fields in a single call. To update a rule\\, first use 'get' to retrieve its full configuration\\, then 'update' with all required fields plus your changes."`
+	RuleUID           string            `json:"rule_uid,omitempty" jsonschema:"description=The UID of the alert rule (required for 'get'\\, 'versions'\\, 'update'\\, 'delete'; optional for 'create')"`
+	RuleLimit         int               `json:"rule_limit,omitempty" jsonschema:"default=200,description=Maximum number of rules to return (default 200\\, max 200). Requires Grafana 12.4+ (for 'list' operation)"`
+	DatasourceUID     *string           `json:"datasource_uid,omitempty" jsonschema:"description=Optional: UID of a Prometheus or Loki datasource to query for datasource-managed alert rules (for 'list' operation)"`
+	LabelSelectors    []Selector        `json:"label_selectors,omitempty" jsonschema:"description=Label matchers to filter alert rules (for 'list' operation)"`
+	LimitAlerts       int               `json:"limit_alerts,omitempty" jsonschema:"description=Limit alert instances per rule. For list: 0 omits alerts. For get: <=0 defaults to 200. Max 200."`
+	SearchFolder      string            `json:"search_folder,omitempty" jsonschema:"description=Search folders by path using partial matching (for 'list' operation). Requires Grafana 12.4+. Mutually exclusive with folder_uid when used for filtering."`
+	Title             string            `json:"title,omitempty" jsonschema:"description=The title of the alert rule (required for 'create'\\, 'update')"`
+	RuleGroup         string            `json:"rule_group,omitempty" jsonschema:"description=The rule group name (required for 'create'\\, 'update')"`
+	FolderUID         string            `json:"folder_uid,omitempty" jsonschema:"description=The folder UID. For 'list': filter by exact folder UID (mutually exclusive with search_folder). For 'create'/'update': the folder to store the rule in (required)."`
+	Condition         string            `json:"condition,omitempty" jsonschema:"description=The query condition identifier\\, e.g. 'A'\\, 'B' (required for 'create'\\, 'update')"`
+	Data              []*AlertQuery     `json:"data,omitempty" jsonschema:"description=Array of alert query objects (required for 'create' and 'update'). Example: [{datasourceUid: 'prometheus'\\, model: {expr: 'vector(1)'}}\\, {datasourceUid: '__expr__'\\, model: {type: 'threshold'\\, expression: 'A'\\, conditions: [{evaluator: {type: 'gt'\\, params: [1]}}]}}]. RefID and relativeTimeRange are auto-assigned if omitted. Use datasourceUid '__expr__' for server-side expressions. The 'condition' field must reference one of the refIds."`
+	NoDataState       string            `json:"no_data_state,omitempty" jsonschema:"description=State when no data: NoData\\, Alerting\\, OK (required for 'create'\\, 'update')"`
+	ExecErrState      string            `json:"exec_err_state,omitempty" jsonschema:"description=State on execution error: NoData\\, Alerting\\, OK (required for 'create'\\, 'update')"`
+	For               string            `json:"for,omitempty" jsonschema:"description=Duration before alert fires\\, e.g. '5m' (required for 'create'\\, 'update')"`
+	Annotations       map[string]string `json:"annotations,omitempty" jsonschema:"description=Optional annotations for the alert rule"`
+	Labels            map[string]string `json:"labels,omitempty" jsonschema:"description=Optional labels for the alert rule"`
+	OrgID             int64             `json:"org_id,omitempty" jsonschema:"description=The organization ID (required for 'create'\\, 'update')"`
+	DisableProvenance *bool             `json:"disable_provenance,omitempty" jsonschema:"description=If true\\, the alert remains editable in the Grafana UI (sets X-Disable-Provenance header). Defaults to true."`
 }
 
 func (p ManageRulesReadWriteParams) validate() error {
@@ -298,4 +392,3 @@ func (p ManageRulesReadWriteParams) toUpdateParams() UpdateAlertRuleParams {
 		DisableProvenance: p.DisableProvenance,
 	}
 }
-

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -18,7 +18,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -33,7 +33,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -49,7 +49,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			Title:        "Test Rule",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -65,7 +65,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			Title:        "Test Rule",
 			RuleGroup:    "test-group",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -81,7 +81,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			Title:        "Test Rule",
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -114,7 +114,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			ExecErrState: "OK",
 			For:          "5m",
 			OrgID:        1,
@@ -130,7 +130,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:   "test-group",
 			FolderUID:   "test-folder",
 			Condition:   "A",
-			Data:        []*models.AlertQuery{{RefID: "A"}},
+			Data:        []*AlertQuery{{RefID: "A"}},
 			NoDataState: "OK",
 			For:         "5m",
 			OrgID:       1,
@@ -146,7 +146,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			OrgID:        1,
@@ -162,7 +162,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -180,7 +180,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:         "test-group",
 			FolderUID:         "test-folder",
 			Condition:         "A",
-			Data:              []*models.AlertQuery{{RefID: "A"}},
+			Data:              []*AlertQuery{{RefID: "A"}},
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
 			For:               "5m",
@@ -198,7 +198,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:         "test-group",
 			FolderUID:         "test-folder",
 			Condition:         "A",
-			Data:              []*models.AlertQuery{{RefID: "A"}},
+			Data:              []*AlertQuery{{RefID: "A"}},
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
 			For:               "5m",
@@ -215,7 +215,7 @@ func TestCreateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:         "test-group",
 			FolderUID:         "test-folder",
 			Condition:         "A",
-			Data:              []*models.AlertQuery{{RefID: "A"}},
+			Data:              []*AlertQuery{{RefID: "A"}},
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
 			For:               "5m",
@@ -235,7 +235,7 @@ func TestUpdateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -251,7 +251,7 @@ func TestUpdateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -269,7 +269,7 @@ func TestUpdateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -288,7 +288,7 @@ func TestUpdateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:         "test-group",
 			FolderUID:         "test-folder",
 			Condition:         "A",
-			Data:              []*models.AlertQuery{{RefID: "A"}},
+			Data:              []*AlertQuery{{RefID: "A"}},
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
 			For:               "5m",
@@ -307,7 +307,7 @@ func TestUpdateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:         "test-group",
 			FolderUID:         "test-folder",
 			Condition:         "A",
-			Data:              []*models.AlertQuery{{RefID: "A"}},
+			Data:              []*AlertQuery{{RefID: "A"}},
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
 			For:               "5m",
@@ -325,7 +325,7 @@ func TestUpdateAlertRuleParams_Validate(t *testing.T) {
 			RuleGroup:         "test-group",
 			FolderUID:         "test-folder",
 			Condition:         "A",
-			Data:              []*models.AlertQuery{{RefID: "A"}},
+			Data:              []*AlertQuery{{RefID: "A"}},
 			NoDataState:       "OK",
 			ExecErrState:      "OK",
 			For:               "5m",
@@ -363,7 +363,7 @@ func TestBuiltInValidationCatchesInvalidData(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "InvalidValue", // Invalid enum
 			ExecErrState: "OK",
 			For:          "5m",
@@ -381,7 +381,7 @@ func TestBuiltInValidationCatchesInvalidData(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "BadValue", // Invalid enum
 			For:          "5m",
@@ -404,7 +404,7 @@ func TestBuiltInValidationCatchesInvalidData(t *testing.T) {
 			RuleGroup:    "test-group",
 			FolderUID:    "test-folder",
 			Condition:    "A",
-			Data:         []*models.AlertQuery{{RefID: "A"}},
+			Data:         []*AlertQuery{{RefID: "A"}},
 			NoDataState:  "OK",
 			ExecErrState: "OK",
 			For:          "5m",
@@ -504,7 +504,7 @@ func TestManageRulesReadWriteParams_Validate(t *testing.T) {
 		RuleGroup:    "test-group",
 		FolderUID:    "test-folder",
 		Condition:    "A",
-		Data:         []*models.AlertQuery{{RefID: "A"}},
+		Data:         []*AlertQuery{{RefID: "A"}},
 		NoDataState:  "OK",
 		ExecErrState: "OK",
 		For:          "5m",
@@ -518,7 +518,7 @@ func TestManageRulesReadWriteParams_Validate(t *testing.T) {
 		RuleGroup:    "test-group",
 		FolderUID:    "test-folder",
 		Condition:    "A",
-		Data:         []*models.AlertQuery{{RefID: "A"}},
+		Data:         []*AlertQuery{{RefID: "A"}},
 		NoDataState:  "OK",
 		ExecErrState: "OK",
 		For:          "5m",
@@ -572,7 +572,7 @@ func TestManageRulesReadWriteParams_Validate(t *testing.T) {
 				RuleGroup:    "test-group",
 				FolderUID:    "test-folder",
 				Condition:    "A",
-				Data:         []*models.AlertQuery{{RefID: "A"}},
+				Data:         []*AlertQuery{{RefID: "A"}},
 				NoDataState:  "OK",
 				ExecErrState: "OK",
 				For:          "5m",
@@ -587,7 +587,7 @@ func TestManageRulesReadWriteParams_Validate(t *testing.T) {
 				Title:        "Test Rule",
 				FolderUID:    "test-folder",
 				Condition:    "A",
-				Data:         []*models.AlertQuery{{RefID: "A"}},
+				Data:         []*AlertQuery{{RefID: "A"}},
 				NoDataState:  "OK",
 				ExecErrState: "OK",
 				For:          "5m",
@@ -607,7 +607,7 @@ func TestManageRulesReadWriteParams_Validate(t *testing.T) {
 				RuleGroup:    "test-group",
 				FolderUID:    "test-folder",
 				Condition:    "A",
-				Data:         []*models.AlertQuery{{RefID: "A"}},
+				Data:         []*AlertQuery{{RefID: "A"}},
 				NoDataState:  "OK",
 				ExecErrState: "OK",
 				For:          "5m",
@@ -668,7 +668,7 @@ func TestManageRulesReadWriteParams_ToCreateParams(t *testing.T) {
 			RuleGroup:         "test-group",
 			FolderUID:         "test-folder",
 			Condition:         "B",
-			Data:              []*models.AlertQuery{{RefID: "A"}, {RefID: "B"}},
+			Data:              []*AlertQuery{{RefID: "A"}, {RefID: "B"}},
 			NoDataState:       "Alerting",
 			ExecErrState:      "OK",
 			For:               "10m",
@@ -717,7 +717,7 @@ func TestManageRulesReadWriteParams_ToUpdateParams(t *testing.T) {
 			RuleGroup:         "updated-group",
 			FolderUID:         "updated-folder",
 			Condition:         "A",
-			Data:              []*models.AlertQuery{{RefID: "A"}},
+			Data:              []*AlertQuery{{RefID: "A"}},
 			NoDataState:       "NoData",
 			ExecErrState:      "Alerting",
 			For:               "15m",
@@ -1124,5 +1124,125 @@ func TestFindRuleInResponse(t *testing.T) {
 		require.Equal(t, "Modified", resp.Data.RuleGroups[0].Rules[1].Name)
 		// Restore
 		resp.Data.RuleGroups[0].Rules[1].Name = "Rule Two"
+	})
+}
+
+func TestConvertAlertQueries(t *testing.T) {
+	t.Run("auto-assigns RefID from index when empty", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{DatasourceUID: "prometheus", Model: AlertQueryModel{Expr: "up"}},
+			{DatasourceUID: "__expr__", Model: AlertQueryModel{Type: "math", Expression: "$A > 0"}},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		require.Equal(t, "A", result[0].RefID)
+		require.Equal(t, "B", result[1].RefID)
+	})
+
+	t.Run("preserves explicit RefID", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{RefID: "X", DatasourceUID: "prometheus", Model: AlertQueryModel{Expr: "up"}},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.Equal(t, "X", result[0].RefID)
+	})
+
+	t.Run("defaults RelativeTimeRange for non-expression queries", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{DatasourceUID: "prometheus", Model: AlertQueryModel{Expr: "up"}},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.NotNil(t, result[0].RelativeTimeRange)
+		require.Equal(t, models.Duration(600), result[0].RelativeTimeRange.From)
+		require.Equal(t, models.Duration(0), result[0].RelativeTimeRange.To)
+	})
+
+	t.Run("does not default RelativeTimeRange for __expr__ queries", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{DatasourceUID: "__expr__", Model: AlertQueryModel{Type: "math", Expression: "$A > 0"}},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.Nil(t, result[0].RelativeTimeRange)
+	})
+
+	t.Run("handles empty model", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{DatasourceUID: "prometheus", Model: AlertQueryModel{}},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, "A", result[0].RefID)
+	})
+
+	t.Run("mixed data source and expression queries", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{
+				DatasourceUID:     "prometheus",
+				RelativeTimeRange: &RelativeTimeRange{From: 300, To: 0},
+				Model:             AlertQueryModel{Expr: "up{job=\"api\"}"},
+			},
+			{
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "reduce",
+					Expression: "A",
+					Reducer:    "last",
+				},
+			},
+			{
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type:       "threshold",
+					Expression: "B",
+					Conditions: []AlertCondition{
+						{Evaluator: ConditionEvaluator{Type: "gt", Params: []float64{0.95}}},
+					},
+				},
+			},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+
+		// Data source query
+		require.Equal(t, "A", result[0].RefID)
+		require.Equal(t, "prometheus", result[0].DatasourceUID)
+		require.NotNil(t, result[0].RelativeTimeRange)
+		require.Equal(t, models.Duration(300), result[0].RelativeTimeRange.From)
+
+		// Reduce expression
+		require.Equal(t, "B", result[1].RefID)
+		require.Equal(t, "__expr__", result[1].DatasourceUID)
+		require.Nil(t, result[1].RelativeTimeRange)
+
+		// Threshold expression
+		require.Equal(t, "C", result[2].RefID)
+		require.Equal(t, "__expr__", result[2].DatasourceUID)
+	})
+
+	t.Run("empty input returns empty output", func(t *testing.T) {
+		result, err := convertAlertQueries(nil)
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("preserves explicit RelativeTimeRange", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{
+				DatasourceUID:     "prometheus",
+				RelativeTimeRange: &RelativeTimeRange{From: 3600, To: 1800},
+				Model:             AlertQueryModel{Expr: "up"},
+			},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.NotNil(t, result[0].RelativeTimeRange)
+		require.Equal(t, models.Duration(3600), result[0].RelativeTimeRange.From)
+		require.Equal(t, models.Duration(1800), result[0].RelativeTimeRange.To)
 	})
 }


### PR DESCRIPTION
https://github.com/grafana/mcp-grafana/pull/619#issuecomment-4004522919

> don't seem flaky

said I about the new tests and they are failing 😅 

---

Description of the data fields in the [new consolidated alerting tool](https://github.com/grafana/mcp-grafana/pull/619) was just `Array of query data objects` with no guidance on the required structure. Since `models.AlertQuery.Model` is `interface{}`, the jsonschema reflector emits bare `true` for it, giving LLMs no type information about the model field. This caused e2e test `test_create_alert_rule` to be flaky, especially with gpt-4o model.

Replaced `models.AlertQuery` in tool params with a types `AlertQuery` struct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts schema/field descriptions (no runtime logic changes), so behavior and data handling remain unchanged.
> 
> **Overview**
> Updates the `ManageRulesReadWriteParams.Data` jsonschema description in `tools/alerting_manage_rules_types.go` to include a concrete `models.AlertQuery` example (including `refId`, `datasourceUid`, `relativeTimeRange`, and `model`), plus guidance on using `__expr__` for server-side expressions and requiring `condition` to reference an existing `refId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23beecbba67db393fa9ec233109a70706cb59c86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->