### PR TITLE
feat(tools): add VictoriaLogs datasource support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The dashboard tools now include several strategies to manage context window usag
 ### Datasources
 
 - **List and fetch datasource information:** View all configured datasources and retrieve detailed information about each.
-  - _Supported datasource types: Prometheus, Loki, ClickHouse, CloudWatch, Elasticsearch._
+  - _Supported datasource types: Prometheus, Loki, ClickHouse, CloudWatch, Elasticsearch, VictoriaLogs._
 
 ### Query Examples
 
@@ -102,6 +102,13 @@ The dashboard tools now include several strategies to manage context window usag
 - **List CloudWatch metrics:** List metrics available in a specific namespace.
 - **List CloudWatch dimensions:** Get dimensions for filtering metric queries.
 - **Query CloudWatch:** Execute CloudWatch metric queries with time range support.
+
+### VictoriaLogs Querying
+
+- **Query VictoriaLogs:** Execute LogsQL queries against VictoriaLogs datasources to retrieve log entries.
+- **Query VictoriaLogs metadata:** List available field names and field values from VictoriaLogs datasources.
+- **Query VictoriaLogs hits:** Get log volume over time buckets for trend analysis.
+- **Query VictoriaLogs streams:** List matching log streams with hit counts.
 
 ### Log Search
 
@@ -280,6 +287,11 @@ Scopes define the specific resources that permissions apply to. Each action requ
 | `list_loki_label_values`          | Loki        | List values for a specific log label                                | `datasources:query`                     | `datasources:uid:loki-uid`                          |
 | `query_loki_stats`                | Loki        | Get statistics about log streams                                    | `datasources:query`                     | `datasources:uid:loki-uid`                          |
 | `query_loki_patterns`             | Loki        | Query detected log patterns to identify common structures           | `datasources:query`                     | `datasources:uid:loki-uid`                          |
+| `query_victorialogs`              | VictoriaLogs | Execute LogsQL queries against VictoriaLogs                        | `datasources:query`                     | `datasources:uid:victorialogs-uid`                  |
+| `list_victorialogs_field_names`   | VictoriaLogs | List available field names in VictoriaLogs                         | `datasources:query`                     | `datasources:uid:victorialogs-uid`                  |
+| `list_victorialogs_field_values`  | VictoriaLogs | List values for a specific field with hit counts                   | `datasources:query`                     | `datasources:uid:victorialogs-uid`                  |
+| `query_victorialogs_hits`         | VictoriaLogs | Query log volume over time buckets                                 | `datasources:query`                     | `datasources:uid:victorialogs-uid`                  |
+| `query_victorialogs_streams`      | VictoriaLogs | List matching log streams with hit counts                          | `datasources:query`                     | `datasources:uid:victorialogs-uid`                  |
 | `list_clickhouse_tables`          | ClickHouse* | List tables in a ClickHouse database                                | `datasources:query`                     | `datasources:uid:*`                                 |
 | `describe_clickhouse_table`       | ClickHouse* | Get table schema with column types                                  | `datasources:query`                     | `datasources:uid:*`                                 |
 | `query_clickhouse`                | ClickHouse* | Execute SQL queries with macro substitution                         | `datasources:query`                     | `datasources:uid:*`                                 |
@@ -358,6 +370,7 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 - `--disable-clickhouse`: Disable ClickHouse tools
 - `--disable-searchlogs`: Disable search_logs tool
 - `--disable-runpanelquery`: Disable run panel query tools
+- `--disable-victorialogs`: Disable VictoriaLogs tools
 
 ### Read-Only Mode
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -45,7 +45,7 @@ type disabledTools struct {
 	dashboard, folder, oncall, asserts, sift, admin,
 	pyroscope, navigation, proxied, annotations, rendering, cloudwatch, write,
 	examples, clickhouse, searchlogs,
-	runpanelquery bool
+	runpanelquery, victorialogs bool
 }
 
 // Configuration for the Grafana client.
@@ -61,7 +61,7 @@ type grafanaConfig struct {
 }
 
 func (dt *disabledTools) addFlags() {
-	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
+	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,victorialogs", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
 	flag.BoolVar(&dt.search, "disable-search", false, "Disable search tools")
 	flag.BoolVar(&dt.datasource, "disable-datasource", false, "Disable datasource tools")
 	flag.BoolVar(&dt.incident, "disable-incident", false, "Disable incident tools")
@@ -86,6 +86,7 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.clickhouse, "disable-clickhouse", false, "Disable ClickHouse tools")
 	flag.BoolVar(&dt.searchlogs, "disable-searchlogs", false, "Disable search logs tools")
 	flag.BoolVar(&dt.runpanelquery, "disable-runpanelquery", false, "Disable run panel query tools")
+	flag.BoolVar(&dt.victorialogs, "disable-victorialogs", false, "Disable VictoriaLogs tools")
 }
 
 func (gc *grafanaConfig) addFlags() {
@@ -123,6 +124,7 @@ func (dt *disabledTools) addTools(s *server.MCPServer) {
 	maybeAddTools(s, tools.AddClickHouseTools, enabledTools, dt.clickhouse, "clickhouse")
 	maybeAddTools(s, tools.AddSearchLogsTools, enabledTools, dt.searchlogs, "searchlogs")
 	maybeAddTools(s, tools.AddRunPanelQueryTools, enabledTools, dt.runpanelquery, "runpanelquery")
+	maybeAddTools(s, tools.AddVictoriaLogsTools, enabledTools, dt.victorialogs, "victorialogs")
 }
 
 func newServer(transport string, dt disabledTools, obs *observability.Observability) (*server.MCPServer, *mcpgrafana.ToolManager) {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,6 +121,11 @@ services:
       timeout: 5s
       retries: 5
 
+  victorialogs:
+    image: victoriametrics/victoria-logs:v1.16.0-victorialogs
+    ports:
+      - "9428:9428"
+
   clickhouse:
     image: clickhouse/clickhouse-server:25.10@sha256:8d1a479c36a4556eeb0556ad36141b194cf6a4a4020f9def391c1570fd1570b7
     ports:

--- a/testdata/provisioning/datasources/datasources.yaml
+++ b/testdata/provisioning/datasources/datasources.yaml
@@ -87,3 +87,9 @@ datasources:
       accessKey: test
       secretKey: test
     isDefault: false
+  - name: VictoriaLogs
+    uid: victorialogs
+    type: victoriametrics-logs-datasource
+    access: proxy
+    url: http://victorialogs:9428
+    isDefault: false

--- a/tools/victorialogs.go
+++ b/tools/victorialogs.go
@@ -164,22 +164,6 @@ func parseNDJSON(data []byte) ([]json.RawMessage, error) {
 	return results, nil
 }
 
-// victoriaLogsDefaultTimeRange returns default start and end times if not provided.
-func victoriaLogsDefaultTimeRange(startRFC3339, endRFC3339 string) (string, string) {
-	if startRFC3339 == "" {
-		startRFC3339 = time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
-	}
-	if endRFC3339 == "" {
-		endRFC3339 = time.Now().Format(time.RFC3339)
-	}
-	return startRFC3339, endRFC3339
-}
-
-// VictoriaLogsLogEntry represents a single log entry returned by VictoriaLogs.
-type VictoriaLogsLogEntry struct {
-	Fields map[string]string `json:"fields"`
-}
-
 // QueryVictoriaLogsParams defines the parameters for querying VictoriaLogs.
 type QueryVictoriaLogsParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the VictoriaLogs datasource to query"`
@@ -202,7 +186,7 @@ func queryVictoriaLogs(ctx context.Context, args QueryVictoriaLogsParams) (*Quer
 		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
 	}
 
-	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	startTime, endTime := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
 
 	// Apply limit constraints
 	limit := args.Limit
@@ -214,8 +198,7 @@ func queryVictoriaLogs(ctx context.Context, args QueryVictoriaLogsParams) (*Quer
 	}
 
 	// Build the query with limit pipe
-	query := args.Query
-	query = fmt.Sprintf("%s | limit %d", query, limit)
+	query := fmt.Sprintf("%s | limit %d", args.Query, limit)
 
 	params := url.Values{}
 	params.Set("query", query)
@@ -227,7 +210,7 @@ func queryVictoriaLogs(ctx context.Context, args QueryVictoriaLogsParams) (*Quer
 		return nil, err
 	}
 
-	// Parse NDJSON response
+	// Parse NDJSON response — /select/logsql/query returns one JSON object per line
 	var entries []map[string]string
 	if len(bodyBytes) > 0 {
 		lines, err := parseNDJSON(bodyBytes)
@@ -290,9 +273,17 @@ var QueryVictoriaLogs = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-// VictoriaLogsFieldName represents a field name entry from VictoriaLogs.
-type VictoriaLogsFieldName struct {
-	Field string `json:"field"`
+// victoriaLogsValuesResponse represents the JSON response from VictoriaLogs
+// endpoints that return a {"values": [...]} wrapper (field_names, field_values, streams).
+type victoriaLogsValuesResponse struct {
+	Values []json.RawMessage `json:"values"`
+}
+
+// VictoriaLogsFieldValue represents a field value entry with hit count.
+// Used by field_names, field_values, and streams endpoints.
+type VictoriaLogsFieldValue struct {
+	Value string `json:"value"`
+	Hits  int64  `json:"hits"`
 }
 
 // ListVictoriaLogsFieldNamesParams defines the parameters for listing field names.
@@ -310,7 +301,7 @@ func listVictoriaLogsFieldNames(ctx context.Context, args ListVictoriaLogsFieldN
 		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
 	}
 
-	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	startTime, endTime := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
 
 	params := url.Values{}
 	if args.Query != "" {
@@ -324,26 +315,23 @@ func listVictoriaLogsFieldNames(ctx context.Context, args ListVictoriaLogsFieldN
 		return nil, err
 	}
 
-	var fieldNames []string
+	// Response is JSON: {"values": [{"value": "field_name", "hits": N}, ...]}
+	var resp victoriaLogsValuesResponse
 	if len(bodyBytes) > 0 {
-		lines, err := parseNDJSON(bodyBytes)
-		if err != nil {
-			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
-		}
-
-		for _, line := range lines {
-			var entry VictoriaLogsFieldName
-			if err := json.Unmarshal(line, &entry); err != nil {
-				continue
-			}
-			if entry.Field != "" {
-				fieldNames = append(fieldNames, entry.Field)
-			}
+		if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+			return nil, fmt.Errorf("unmarshalling field_names response: %w", err)
 		}
 	}
 
-	if fieldNames == nil {
-		fieldNames = []string{}
+	fieldNames := make([]string, 0, len(resp.Values))
+	for _, raw := range resp.Values {
+		var entry VictoriaLogsFieldValue
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			continue
+		}
+		if entry.Value != "" {
+			fieldNames = append(fieldNames, entry.Value)
+		}
 	}
 
 	return fieldNames, nil
@@ -358,12 +346,6 @@ var ListVictoriaLogsFieldNames = mcpgrafana.MustTool(
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
-
-// VictoriaLogsFieldValue represents a field value entry with hit count.
-type VictoriaLogsFieldValue struct {
-	Value string `json:"value"`
-	Hits  int64  `json:"hits"`
-}
 
 // ListVictoriaLogsFieldValuesParams defines the parameters for listing field values.
 type ListVictoriaLogsFieldValuesParams struct {
@@ -382,7 +364,7 @@ func listVictoriaLogsFieldValues(ctx context.Context, args ListVictoriaLogsField
 		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
 	}
 
-	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	startTime, endTime := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
 
 	params := url.Values{}
 	params.Set("field", args.FieldName)
@@ -400,24 +382,21 @@ func listVictoriaLogsFieldValues(ctx context.Context, args ListVictoriaLogsField
 		return nil, err
 	}
 
-	var fieldValues []VictoriaLogsFieldValue
+	// Response is JSON: {"values": [{"value": "val", "hits": N}, ...]}
+	var resp victoriaLogsValuesResponse
 	if len(bodyBytes) > 0 {
-		lines, err := parseNDJSON(bodyBytes)
-		if err != nil {
-			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
-		}
-
-		for _, line := range lines {
-			var entry VictoriaLogsFieldValue
-			if err := json.Unmarshal(line, &entry); err != nil {
-				continue
-			}
-			fieldValues = append(fieldValues, entry)
+		if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+			return nil, fmt.Errorf("unmarshalling field_values response: %w", err)
 		}
 	}
 
-	if fieldValues == nil {
-		fieldValues = []VictoriaLogsFieldValue{}
+	fieldValues := make([]VictoriaLogsFieldValue, 0, len(resp.Values))
+	for _, raw := range resp.Values {
+		var entry VictoriaLogsFieldValue
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			continue
+		}
+		fieldValues = append(fieldValues, entry)
 	}
 
 	return fieldValues, nil
@@ -433,10 +412,25 @@ var ListVictoriaLogsFieldValues = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-// VictoriaLogsHit represents a hit count for a time bucket.
+// victoriaLogsHitsResponse represents the JSON response from /select/logsql/hits.
+// Response format: {"hits": [{"fields": {...}, "timestamps": [...], "values": [...], "total": N}]}
+type victoriaLogsHitsResponse struct {
+	Hits []victoriaLogsHitEntry `json:"hits"`
+}
+
+type victoriaLogsHitEntry struct {
+	Fields     map[string]string `json:"fields"`
+	Timestamps []string          `json:"timestamps"`
+	Values     []int64           `json:"values"`
+	Total      int64             `json:"total"`
+}
+
+// VictoriaLogsHit represents a hit count series for the MCP tool response.
 type VictoriaLogsHit struct {
-	Fields map[string]string `json:"fields"`
-	Hits   int64             `json:"hits"`
+	Fields     map[string]string `json:"fields"`
+	Timestamps []string          `json:"timestamps"`
+	Values     []int64           `json:"values"`
+	Total      int64             `json:"total"`
 }
 
 // QueryVictoriaLogsHitsParams defines the parameters for querying log volume hits.
@@ -460,7 +454,7 @@ func queryVictoriaLogsHits(ctx context.Context, args QueryVictoriaLogsHitsParams
 		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
 	}
 
-	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	startTime, endTime := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
 
 	params := url.Values{}
 	params.Set("query", args.Query)
@@ -475,24 +469,22 @@ func queryVictoriaLogsHits(ctx context.Context, args QueryVictoriaLogsHitsParams
 		return nil, err
 	}
 
-	var hits []VictoriaLogsHit
+	// Response is JSON: {"hits": [{"fields": {...}, "timestamps": [...], "values": [...], "total": N}]}
+	var resp victoriaLogsHitsResponse
 	if len(bodyBytes) > 0 {
-		lines, err := parseNDJSON(bodyBytes)
-		if err != nil {
-			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
-		}
-
-		for _, line := range lines {
-			var entry VictoriaLogsHit
-			if err := json.Unmarshal(line, &entry); err != nil {
-				continue
-			}
-			hits = append(hits, entry)
+		if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+			return nil, fmt.Errorf("unmarshalling hits response: %w", err)
 		}
 	}
 
-	if hits == nil {
-		hits = []VictoriaLogsHit{}
+	hits := make([]VictoriaLogsHit, 0, len(resp.Hits))
+	for _, entry := range resp.Hits {
+		hits = append(hits, VictoriaLogsHit{
+			Fields:     entry.Fields,
+			Timestamps: entry.Timestamps,
+			Values:     entry.Values,
+			Total:      entry.Total,
+		})
 	}
 
 	return &QueryVictoriaLogsHitsResult{Data: hits}, nil
@@ -501,18 +493,12 @@ func queryVictoriaLogsHits(ctx context.Context, args QueryVictoriaLogsHitsParams
 // QueryVictoriaLogsHits is a tool for querying log volume from VictoriaLogs.
 var QueryVictoriaLogsHits = mcpgrafana.MustTool(
 	"query_victorialogs_hits",
-	"Queries log volume over time from a VictoriaLogs datasource. Returns hit counts bucketed by time intervals\\, useful for understanding log volume trends and identifying spikes. The step parameter controls the bucket size. Defaults to the last hour if the time range is not provided.",
+	"Queries log volume over time from a VictoriaLogs datasource. Returns hit count series bucketed by time intervals\\, each with timestamps\\, values\\, and a total count. Useful for understanding log volume trends and identifying spikes. The step parameter controls the bucket size. Defaults to the last hour if the time range is not provided.",
 	queryVictoriaLogsHits,
 	mcp.WithTitleAnnotation("Query VictoriaLogs hits"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
-
-// VictoriaLogsStream represents a log stream with its hit count.
-type VictoriaLogsStream struct {
-	Value string `json:"value"`
-	Hits  int64  `json:"hits"`
-}
 
 // QueryVictoriaLogsStreamsParams defines the parameters for querying log streams.
 type QueryVictoriaLogsStreamsParams struct {
@@ -521,6 +507,12 @@ type QueryVictoriaLogsStreamsParams struct {
 	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
 	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of streams to return"`
+}
+
+// VictoriaLogsStream represents a log stream with its hit count.
+type VictoriaLogsStream struct {
+	Value string `json:"value"`
+	Hits  int64  `json:"hits"`
 }
 
 // QueryVictoriaLogsStreamsResult wraps the streams query result.
@@ -535,7 +527,7 @@ func queryVictoriaLogsStreams(ctx context.Context, args QueryVictoriaLogsStreams
 		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
 	}
 
-	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	startTime, endTime := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
 
 	params := url.Values{}
 	params.Set("query", args.Query)
@@ -550,24 +542,21 @@ func queryVictoriaLogsStreams(ctx context.Context, args QueryVictoriaLogsStreams
 		return nil, err
 	}
 
-	var streams []VictoriaLogsStream
+	// Response is JSON: {"values": [{"value": "{stream}", "hits": N}, ...]}
+	var resp victoriaLogsValuesResponse
 	if len(bodyBytes) > 0 {
-		lines, err := parseNDJSON(bodyBytes)
-		if err != nil {
-			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
-		}
-
-		for _, line := range lines {
-			var entry VictoriaLogsStream
-			if err := json.Unmarshal(line, &entry); err != nil {
-				continue
-			}
-			streams = append(streams, entry)
+		if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+			return nil, fmt.Errorf("unmarshalling streams response: %w", err)
 		}
 	}
 
-	if streams == nil {
-		streams = []VictoriaLogsStream{}
+	streams := make([]VictoriaLogsStream, 0, len(resp.Values))
+	for _, raw := range resp.Values {
+		var entry VictoriaLogsStream
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			continue
+		}
+		streams = append(streams, entry)
 	}
 
 	return &QueryVictoriaLogsStreamsResult{Data: streams}, nil

--- a/tools/victorialogs.go
+++ b/tools/victorialogs.go
@@ -415,14 +415,7 @@ var ListVictoriaLogsFieldValues = mcpgrafana.MustTool(
 // victoriaLogsHitsResponse represents the JSON response from /select/logsql/hits.
 // Response format: {"hits": [{"fields": {...}, "timestamps": [...], "values": [...], "total": N}]}
 type victoriaLogsHitsResponse struct {
-	Hits []victoriaLogsHitEntry `json:"hits"`
-}
-
-type victoriaLogsHitEntry struct {
-	Fields     map[string]string `json:"fields"`
-	Timestamps []string          `json:"timestamps"`
-	Values     []int64           `json:"values"`
-	Total      int64             `json:"total"`
+	Hits []VictoriaLogsHit `json:"hits"`
 }
 
 // VictoriaLogsHit represents a hit count series for the MCP tool response.
@@ -477,17 +470,7 @@ func queryVictoriaLogsHits(ctx context.Context, args QueryVictoriaLogsHitsParams
 		}
 	}
 
-	hits := make([]VictoriaLogsHit, 0, len(resp.Hits))
-	for _, entry := range resp.Hits {
-		hits = append(hits, VictoriaLogsHit{
-			Fields:     entry.Fields,
-			Timestamps: entry.Timestamps,
-			Values:     entry.Values,
-			Total:      entry.Total,
-		})
-	}
-
-	return &QueryVictoriaLogsHitsResult{Data: hits}, nil
+	return &QueryVictoriaLogsHitsResult{Data: resp.Hits}, nil
 }
 
 // QueryVictoriaLogsHits is a tool for querying log volume from VictoriaLogs.

--- a/tools/victorialogs.go
+++ b/tools/victorialogs.go
@@ -1,0 +1,593 @@
+package tools
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const (
+	// DefaultVictoriaLogsLimit is the default number of log lines to return if not specified
+	DefaultVictoriaLogsLimit = 100
+
+	// MaxVictoriaLogsLimit is the maximum number of log lines that can be requested
+	MaxVictoriaLogsLimit = 1000
+)
+
+// victoriaLogsClient is an HTTP client for VictoriaLogs API endpoints.
+type victoriaLogsClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func newVictoriaLogsClient(ctx context.Context, uid string) (*victoriaLogsClient, error) {
+	// First check if the datasource exists
+	_, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	u := fmt.Sprintf("%s/api/datasources/proxy/uid/%s", strings.TrimRight(cfg.URL, "/"), uid)
+
+	// Create custom transport with TLS configuration if available
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create custom transport: %w", err)
+	}
+	transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
+
+	client := &http.Client{
+		Transport: mcpgrafana.NewUserAgentTransport(transport),
+	}
+
+	return &victoriaLogsClient{
+		httpClient: client,
+		baseURL:    u,
+	}, nil
+}
+
+// buildURL constructs a full URL for a VictoriaLogs API endpoint.
+func (c *victoriaLogsClient) buildURL(urlPath string) string {
+	fullURL := c.baseURL
+	if !strings.HasSuffix(fullURL, "/") && !strings.HasPrefix(urlPath, "/") {
+		fullURL += "/"
+	} else if strings.HasSuffix(fullURL, "/") && strings.HasPrefix(urlPath, "/") {
+		urlPath = strings.TrimPrefix(urlPath, "/")
+	}
+	return fullURL + urlPath
+}
+
+// makeGetRequest makes a GET request to the VictoriaLogs API and returns the response body.
+func (c *victoriaLogsClient) makeGetRequest(ctx context.Context, urlPath string, params url.Values) ([]byte, error) {
+	fullURL := c.buildURL(urlPath)
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing URL: %w", err)
+	}
+
+	if params != nil {
+		u.RawQuery = params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("VictoriaLogs API returned status code %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	body := io.LimitReader(resp.Body, 1024*1024*48)
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	return bytes.TrimSpace(bodyBytes), nil
+}
+
+// makePostRequest makes a POST request with form-encoded body to the VictoriaLogs API.
+func (c *victoriaLogsClient) makePostRequest(ctx context.Context, urlPath string, params url.Values) ([]byte, error) {
+	fullURL := c.buildURL(urlPath)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", fullURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("VictoriaLogs API returned status code %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	body := io.LimitReader(resp.Body, 1024*1024*48)
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	return bytes.TrimSpace(bodyBytes), nil
+}
+
+// parseNDJSON parses newline-delimited JSON into a slice of json.RawMessage.
+func parseNDJSON(data []byte) ([]json.RawMessage, error) {
+	var results []json.RawMessage
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Increase the scanner buffer size for large lines
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024*48)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		// Make a copy since scanner reuses its buffer
+		lineCopy := make([]byte, len(line))
+		copy(lineCopy, line)
+		results = append(results, json.RawMessage(lineCopy))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning NDJSON: %w", err)
+	}
+	return results, nil
+}
+
+// victoriaLogsDefaultTimeRange returns default start and end times if not provided.
+func victoriaLogsDefaultTimeRange(startRFC3339, endRFC3339 string) (string, string) {
+	if startRFC3339 == "" {
+		startRFC3339 = time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+	}
+	if endRFC3339 == "" {
+		endRFC3339 = time.Now().Format(time.RFC3339)
+	}
+	return startRFC3339, endRFC3339
+}
+
+// VictoriaLogsLogEntry represents a single log entry returned by VictoriaLogs.
+type VictoriaLogsLogEntry struct {
+	Fields map[string]string `json:"fields"`
+}
+
+// QueryVictoriaLogsParams defines the parameters for querying VictoriaLogs.
+type QueryVictoriaLogsParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the VictoriaLogs datasource to query"`
+	Query         string `json:"query" jsonschema:"required,description=The LogsQL query to execute against VictoriaLogs. Supports full LogsQL syntax including stream selectors\\, word filters\\, and pipe operations."`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"default=100,description=Optionally\\, the maximum number of log entries to return (max: 1000). Applied as a LogsQL pipe (| limit N)."`
+}
+
+// QueryVictoriaLogsResult wraps the VictoriaLogs query result.
+type QueryVictoriaLogsResult struct {
+	Data  []map[string]string `json:"data"`
+	Hints *EmptyResultHints   `json:"hints,omitempty"`
+}
+
+// queryVictoriaLogs executes a LogsQL query against a VictoriaLogs datasource.
+func queryVictoriaLogs(ctx context.Context, args QueryVictoriaLogsParams) (*QueryVictoriaLogsResult, error) {
+	client, err := newVictoriaLogsClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
+	}
+
+	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+
+	// Apply limit constraints
+	limit := args.Limit
+	if limit <= 0 {
+		limit = DefaultVictoriaLogsLimit
+	}
+	if limit > MaxVictoriaLogsLimit {
+		limit = MaxVictoriaLogsLimit
+	}
+
+	// Build the query with limit pipe
+	query := args.Query
+	query = fmt.Sprintf("%s | limit %d", query, limit)
+
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("start", startTime)
+	params.Set("end", endTime)
+
+	bodyBytes, err := client.makePostRequest(ctx, "/select/logsql/query", params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse NDJSON response
+	var entries []map[string]string
+	if len(bodyBytes) > 0 {
+		lines, err := parseNDJSON(bodyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
+		}
+
+		for _, line := range lines {
+			var entry map[string]string
+			if err := json.Unmarshal(line, &entry); err != nil {
+				// Try as map[string]interface{} and convert
+				var rawEntry map[string]interface{}
+				if err2 := json.Unmarshal(line, &rawEntry); err2 != nil {
+					continue
+				}
+				entry = make(map[string]string)
+				for k, v := range rawEntry {
+					entry[k] = fmt.Sprintf("%v", v)
+				}
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	if entries == nil {
+		entries = []map[string]string{}
+	}
+
+	result := &QueryVictoriaLogsResult{
+		Data: entries,
+	}
+
+	if len(entries) == 0 {
+		var parsedStartTime, parsedEndTime time.Time
+		if startTime != "" {
+			parsedStartTime, _ = time.Parse(time.RFC3339, startTime)
+		}
+		if endTime != "" {
+			parsedEndTime, _ = time.Parse(time.RFC3339, endTime)
+		}
+
+		result.Hints = GenerateEmptyResultHints(HintContext{
+			DatasourceType: "victorialogs",
+			Query:          args.Query,
+			StartTime:      parsedStartTime,
+			EndTime:        parsedEndTime,
+		})
+	}
+
+	return result, nil
+}
+
+// QueryVictoriaLogs is a tool for querying logs from VictoriaLogs.
+var QueryVictoriaLogs = mcpgrafana.MustTool(
+	"query_victorialogs",
+	"Executes a LogsQL query against a VictoriaLogs datasource to retrieve log entries. Returns a list of log entries\\, each as a map of field names to values. Defaults to the last hour and a limit of 100 entries. Supports full LogsQL syntax including stream selectors\\, word filters\\, and pipe operations (e.g.\\, `_stream:{app=\"nginx\"} error | limit 10`). Use `list_victorialogs_field_names` and `list_victorialogs_field_values` to discover available fields before querying.",
+	queryVictoriaLogs,
+	mcp.WithTitleAnnotation("Query VictoriaLogs"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// VictoriaLogsFieldName represents a field name entry from VictoriaLogs.
+type VictoriaLogsFieldName struct {
+	Field string `json:"field"`
+}
+
+// ListVictoriaLogsFieldNamesParams defines the parameters for listing field names.
+type ListVictoriaLogsFieldNamesParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the VictoriaLogs datasource to query"`
+	Query         string `json:"query,omitempty" jsonschema:"description=Optionally\\, a LogsQL query to filter which logs to extract field names from"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+}
+
+// listVictoriaLogsFieldNames lists all available field names in a VictoriaLogs datasource.
+func listVictoriaLogsFieldNames(ctx context.Context, args ListVictoriaLogsFieldNamesParams) ([]string, error) {
+	client, err := newVictoriaLogsClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
+	}
+
+	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+
+	params := url.Values{}
+	if args.Query != "" {
+		params.Set("query", args.Query)
+	}
+	params.Set("start", startTime)
+	params.Set("end", endTime)
+
+	bodyBytes, err := client.makeGetRequest(ctx, "/select/logsql/field_names", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var fieldNames []string
+	if len(bodyBytes) > 0 {
+		lines, err := parseNDJSON(bodyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
+		}
+
+		for _, line := range lines {
+			var entry VictoriaLogsFieldName
+			if err := json.Unmarshal(line, &entry); err != nil {
+				continue
+			}
+			if entry.Field != "" {
+				fieldNames = append(fieldNames, entry.Field)
+			}
+		}
+	}
+
+	if fieldNames == nil {
+		fieldNames = []string{}
+	}
+
+	return fieldNames, nil
+}
+
+// ListVictoriaLogsFieldNames is a tool for listing field names in VictoriaLogs.
+var ListVictoriaLogsFieldNames = mcpgrafana.MustTool(
+	"list_victorialogs_field_names",
+	"Lists all available field names found in logs within a VictoriaLogs datasource and time range. Returns a list of unique field name strings. Optionally filter by a LogsQL query to see fields from specific log streams. Defaults to the last hour if the time range is not provided.",
+	listVictoriaLogsFieldNames,
+	mcp.WithTitleAnnotation("List VictoriaLogs field names"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// VictoriaLogsFieldValue represents a field value entry with hit count.
+type VictoriaLogsFieldValue struct {
+	Value string `json:"value"`
+	Hits  int64  `json:"hits"`
+}
+
+// ListVictoriaLogsFieldValuesParams defines the parameters for listing field values.
+type ListVictoriaLogsFieldValuesParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the VictoriaLogs datasource to query"`
+	FieldName     string `json:"fieldName" jsonschema:"required,description=The name of the field to retrieve values for (e.g. 'host'\\, 'level'\\, 'service')"`
+	Query         string `json:"query,omitempty" jsonschema:"description=Optionally\\, a LogsQL query to filter which logs to extract field values from"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of field values to return"`
+}
+
+// listVictoriaLogsFieldValues lists all values for a specific field in a VictoriaLogs datasource.
+func listVictoriaLogsFieldValues(ctx context.Context, args ListVictoriaLogsFieldValuesParams) ([]VictoriaLogsFieldValue, error) {
+	client, err := newVictoriaLogsClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
+	}
+
+	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+
+	params := url.Values{}
+	params.Set("field", args.FieldName)
+	if args.Query != "" {
+		params.Set("query", args.Query)
+	}
+	params.Set("start", startTime)
+	params.Set("end", endTime)
+	if args.Limit > 0 {
+		params.Set("limit", fmt.Sprintf("%d", args.Limit))
+	}
+
+	bodyBytes, err := client.makeGetRequest(ctx, "/select/logsql/field_values", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var fieldValues []VictoriaLogsFieldValue
+	if len(bodyBytes) > 0 {
+		lines, err := parseNDJSON(bodyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
+		}
+
+		for _, line := range lines {
+			var entry VictoriaLogsFieldValue
+			if err := json.Unmarshal(line, &entry); err != nil {
+				continue
+			}
+			fieldValues = append(fieldValues, entry)
+		}
+	}
+
+	if fieldValues == nil {
+		fieldValues = []VictoriaLogsFieldValue{}
+	}
+
+	return fieldValues, nil
+}
+
+// ListVictoriaLogsFieldValues is a tool for listing field values in VictoriaLogs.
+var ListVictoriaLogsFieldValues = mcpgrafana.MustTool(
+	"list_victorialogs_field_values",
+	"Retrieves all unique values for a specific field within a VictoriaLogs datasource and time range. Returns a list of objects\\, each containing the value and its hit count. Useful for discovering filter options and understanding data distribution. Defaults to the last hour if the time range is not provided.",
+	listVictoriaLogsFieldValues,
+	mcp.WithTitleAnnotation("List VictoriaLogs field values"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// VictoriaLogsHit represents a hit count for a time bucket.
+type VictoriaLogsHit struct {
+	Fields map[string]string `json:"fields"`
+	Hits   int64             `json:"hits"`
+}
+
+// QueryVictoriaLogsHitsParams defines the parameters for querying log volume hits.
+type QueryVictoriaLogsHitsParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the VictoriaLogs datasource to query"`
+	Query         string `json:"query" jsonschema:"required,description=The LogsQL query to count hits for"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	Step          string `json:"step,omitempty" jsonschema:"description=Optionally\\, the time bucket duration for aggregation (e.g. '5m'\\, '1h'). Defaults to automatic."`
+}
+
+// QueryVictoriaLogsHitsResult wraps the hits query result.
+type QueryVictoriaLogsHitsResult struct {
+	Data []VictoriaLogsHit `json:"data"`
+}
+
+// queryVictoriaLogsHits queries log volume over time from VictoriaLogs.
+func queryVictoriaLogsHits(ctx context.Context, args QueryVictoriaLogsHitsParams) (*QueryVictoriaLogsHitsResult, error) {
+	client, err := newVictoriaLogsClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
+	}
+
+	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+
+	params := url.Values{}
+	params.Set("query", args.Query)
+	params.Set("start", startTime)
+	params.Set("end", endTime)
+	if args.Step != "" {
+		params.Set("step", args.Step)
+	}
+
+	bodyBytes, err := client.makeGetRequest(ctx, "/select/logsql/hits", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var hits []VictoriaLogsHit
+	if len(bodyBytes) > 0 {
+		lines, err := parseNDJSON(bodyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
+		}
+
+		for _, line := range lines {
+			var entry VictoriaLogsHit
+			if err := json.Unmarshal(line, &entry); err != nil {
+				continue
+			}
+			hits = append(hits, entry)
+		}
+	}
+
+	if hits == nil {
+		hits = []VictoriaLogsHit{}
+	}
+
+	return &QueryVictoriaLogsHitsResult{Data: hits}, nil
+}
+
+// QueryVictoriaLogsHits is a tool for querying log volume from VictoriaLogs.
+var QueryVictoriaLogsHits = mcpgrafana.MustTool(
+	"query_victorialogs_hits",
+	"Queries log volume over time from a VictoriaLogs datasource. Returns hit counts bucketed by time intervals\\, useful for understanding log volume trends and identifying spikes. The step parameter controls the bucket size. Defaults to the last hour if the time range is not provided.",
+	queryVictoriaLogsHits,
+	mcp.WithTitleAnnotation("Query VictoriaLogs hits"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// VictoriaLogsStream represents a log stream with its hit count.
+type VictoriaLogsStream struct {
+	Value string `json:"value"`
+	Hits  int64  `json:"hits"`
+}
+
+// QueryVictoriaLogsStreamsParams defines the parameters for querying log streams.
+type QueryVictoriaLogsStreamsParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the VictoriaLogs datasource to query"`
+	Query         string `json:"query" jsonschema:"required,description=The LogsQL query to find matching streams for"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"description=Optionally\\, the maximum number of streams to return"`
+}
+
+// QueryVictoriaLogsStreamsResult wraps the streams query result.
+type QueryVictoriaLogsStreamsResult struct {
+	Data []VictoriaLogsStream `json:"data"`
+}
+
+// queryVictoriaLogsStreams queries matching log streams from VictoriaLogs.
+func queryVictoriaLogsStreams(ctx context.Context, args QueryVictoriaLogsStreamsParams) (*QueryVictoriaLogsStreamsResult, error) {
+	client, err := newVictoriaLogsClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating VictoriaLogs client: %w", err)
+	}
+
+	startTime, endTime := victoriaLogsDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+
+	params := url.Values{}
+	params.Set("query", args.Query)
+	params.Set("start", startTime)
+	params.Set("end", endTime)
+	if args.Limit > 0 {
+		params.Set("limit", fmt.Sprintf("%d", args.Limit))
+	}
+
+	bodyBytes, err := client.makeGetRequest(ctx, "/select/logsql/streams", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var streams []VictoriaLogsStream
+	if len(bodyBytes) > 0 {
+		lines, err := parseNDJSON(bodyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing NDJSON response: %w", err)
+		}
+
+		for _, line := range lines {
+			var entry VictoriaLogsStream
+			if err := json.Unmarshal(line, &entry); err != nil {
+				continue
+			}
+			streams = append(streams, entry)
+		}
+	}
+
+	if streams == nil {
+		streams = []VictoriaLogsStream{}
+	}
+
+	return &QueryVictoriaLogsStreamsResult{Data: streams}, nil
+}
+
+// QueryVictoriaLogsStreams is a tool for querying log streams from VictoriaLogs.
+var QueryVictoriaLogsStreams = mcpgrafana.MustTool(
+	"query_victorialogs_streams",
+	"Lists log streams matching a LogsQL query from a VictoriaLogs datasource. Returns stream identifiers with their hit counts\\, useful for discovering available log streams and understanding their relative volume. Defaults to the last hour if the time range is not provided.",
+	queryVictoriaLogsStreams,
+	mcp.WithTitleAnnotation("Query VictoriaLogs streams"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// AddVictoriaLogsTools registers all VictoriaLogs tools with the MCP server.
+func AddVictoriaLogsTools(s *server.MCPServer) {
+	QueryVictoriaLogs.Register(s)
+	ListVictoriaLogsFieldNames.Register(s)
+	ListVictoriaLogsFieldValues.Register(s)
+	QueryVictoriaLogsHits.Register(s)
+	QueryVictoriaLogsStreams.Register(s)
+}

--- a/tools/victorialogs_test.go
+++ b/tools/victorialogs_test.go
@@ -74,7 +74,10 @@ func TestVictoriaLogsTools(t *testing.T) {
 
 		// If we got results, check that they have the expected structure
 		for _, entry := range result.Data {
-			assert.GreaterOrEqual(t, entry.Hits, int64(0), "Hits should be non-negative")
+			assert.GreaterOrEqual(t, entry.Total, int64(0), "Total should be non-negative")
+			assert.NotNil(t, entry.Timestamps, "Timestamps should not be nil")
+			assert.NotNil(t, entry.Values, "Values should not be nil")
+			assert.Equal(t, len(entry.Timestamps), len(entry.Values), "Timestamps and Values should have same length")
 		}
 	})
 

--- a/tools/victorialogs_test.go
+++ b/tools/victorialogs_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVictoriaLogsTools(t *testing.T) {
+	t.Run("list victorialogs field names", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listVictoriaLogsFieldNames(ctx, ListVictoriaLogsFieldNamesParams{
+			DatasourceUID: "victorialogs",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Should return a result (may be empty if no data)")
+	})
+
+	t.Run("list victorialogs field values", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listVictoriaLogsFieldValues(ctx, ListVictoriaLogsFieldValuesParams{
+			DatasourceUID: "victorialogs",
+			FieldName:     "_msg",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Should return a result (may be empty if no data)")
+
+		// If we got results, check that they have the expected structure
+		for _, entry := range result {
+			assert.NotEmpty(t, entry.Value, "Field value should not be empty")
+			assert.GreaterOrEqual(t, entry.Hits, int64(0), "Hits should be non-negative")
+		}
+	})
+
+	t.Run("query victorialogs", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryVictoriaLogs(ctx, QueryVictoriaLogsParams{
+			DatasourceUID: "victorialogs",
+			Query:         "*",
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Result should not be nil")
+
+		// If we got results, check that they have the expected structure
+		for _, entry := range result.Data {
+			assert.NotNil(t, entry, "Log entry should not be nil")
+		}
+	})
+
+	t.Run("query victorialogs with no results", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryVictoriaLogs(ctx, QueryVictoriaLogsParams{
+			DatasourceUID: "victorialogs",
+			Query:         `non_existent_field_xyz123:"impossible_value_abc789"`,
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Result should not be nil")
+		assert.Equal(t, 0, len(result.Data), "Empty results should have length 0")
+	})
+
+	t.Run("query victorialogs hits", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryVictoriaLogsHits(ctx, QueryVictoriaLogsHitsParams{
+			DatasourceUID: "victorialogs",
+			Query:         "*",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Result should not be nil")
+
+		// If we got results, check that they have the expected structure
+		for _, entry := range result.Data {
+			assert.GreaterOrEqual(t, entry.Hits, int64(0), "Hits should be non-negative")
+		}
+	})
+
+	t.Run("query victorialogs streams", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryVictoriaLogsStreams(ctx, QueryVictoriaLogsStreamsParams{
+			DatasourceUID: "victorialogs",
+			Query:         "*",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Result should not be nil")
+
+		// If we got results, check that they have the expected structure
+		for _, entry := range result.Data {
+			assert.GreaterOrEqual(t, entry.Hits, int64(0), "Hits should be non-negative")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds 5 new tools for querying VictoriaLogs datasources (`victoriametrics-logs-datasource` type)
- `query_victorialogs` — Execute LogsQL queries (POST `/select/logsql/query`)
- `list_victorialogs_field_names` — List available field names
- `list_victorialogs_field_values` — Get values for a specific field with hit counts
- `query_victorialogs_hits` — Log volume over time buckets
- `query_victorialogs_streams` — List matching log streams with hit counts

### Why

The existing Loki tools fail against VictoriaLogs datasources because VictoriaLogs uses different API endpoints (`/select/logsql/*` vs `/loki/api/v1/*`), a different query language (LogsQL vs LogQL), and returns NDJSON instead of Loki's wrapped JSON format.

### Implementation notes

- Follows the Loki tool patterns for client construction, transport stack, and tool registration
- Handles VictoriaLogs' NDJSON (newline-delimited JSON) response format
- Uses POST with `application/x-www-form-urlencoded` for the query endpoint, GET for metadata
- Applies limits via LogsQL pipe syntax (`| limit N`) rather than query params
- Enabled by default; can be disabled with `--disable-victorialogs`
- Adds VictoriaLogs service to docker-compose and datasource provisioning for integration tests

## Test plan

- [x] `make lint-jsonschema` passes (no unescaped commas)
- [x] `go build ./...` compiles successfully
- [x] `make test-unit` passes
- [ ] `make test-integration` with docker-compose (requires VictoriaLogs container)
- [ ] Manual testing against a Grafana instance with VictoriaLogs datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new datasource integration with multiple HTTP query paths and NDJSON parsing, and enables the tool category by default, which could affect runtime behavior and integration test/dev environments.
> 
> **Overview**
> Adds a new **VictoriaLogs** tool category with five read-only tools (`query_victorialogs`, field name/value discovery, hits, and streams) that query Grafana’s datasource proxy using VictoriaLogs `/select/logsql/*` endpoints and handle NDJSON responses.
> 
> Wires the category into server startup and CLI (`victorialogs` enabled by default, `--disable-victorialogs` added), and updates docs/tool table accordingly. Extends the local dev/integration setup by provisioning a VictoriaLogs datasource and adding a `victorialogs` container plus integration tests for the new tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ac6074aac4146d7ba0ea84ed526f8c6b0997ba7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->