### PR TITLE
fix(prometheus): support GET-only datasources in query tools

### DIFF
--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -107,6 +107,11 @@ func (p *prometheusDatasourceHTTPMethodRoundTripper) RoundTrip(req *http.Request
 		return p.base.RoundTrip(req)
 	}
 
+	contentType := strings.ToLower(req.Header.Get("Content-Type"))
+	if req.Body != nil && contentType != "" && !strings.HasPrefix(contentType, "application/x-www-form-urlencoded") {
+		return p.base.RoundTrip(req)
+	}
+
 	bodyBytes := []byte{}
 	if req.Body != nil {
 		var err error
@@ -122,19 +127,21 @@ func (p *prometheusDatasourceHTTPMethodRoundTripper) RoundTrip(req *http.Request
 	converted.Body = nil
 	converted.GetBody = nil
 	converted.ContentLength = 0
-	converted.Header = req.Header.Clone()
 	converted.Header.Del("Content-Type")
 	converted.Header.Del("Content-Length")
 
-	query := converted.URL.Query()
-	if values, parseErr := url.ParseQuery(string(bodyBytes)); parseErr == nil {
-		for key, vals := range values {
-			for _, val := range vals {
-				query.Add(key, val)
-			}
-		}
-		converted.URL.RawQuery = query.Encode()
+	values, parseErr := url.ParseQuery(string(bodyBytes))
+	if parseErr != nil {
+		return nil, fmt.Errorf("parsing form body for GET conversion: %w", parseErr)
 	}
+
+	query := converted.URL.Query()
+	for key, vals := range values {
+		for _, val := range vals {
+			query.Add(key, val)
+		}
+	}
+	converted.URL.RawQuery = query.Encode()
 
 	return p.base.RoundTrip(converted)
 }

--- a/tools/prometheus_unit_test.go
+++ b/tools/prometheus_unit_test.go
@@ -32,31 +32,98 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 func TestPrometheusDatasourceHTTPMethodRoundTripper(t *testing.T) {
-	var gotMethod string
-	var gotQuery string
+	t.Run("converts form POST body into GET query", func(t *testing.T) {
+		var gotMethod string
+		var gotQuery string
 
-	rt := &prometheusDatasourceHTTPMethodRoundTripper{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		gotMethod = r.Method
-		gotQuery = r.URL.RawQuery
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("ok")),
-			Header:     make(http.Header),
-		}, nil
-	})}
+		rt := &prometheusDatasourceHTTPMethodRoundTripper{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotMethod = r.Method
+			gotQuery = r.URL.RawQuery
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+			}, nil
+		})}
 
-	req, err := http.NewRequest(http.MethodPost, "http://example.test/api/datasources/uid/abc/resources/api/v1/query", strings.NewReader("query=up&time=1234"))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req, err := http.NewRequest(http.MethodPost, "http://example.test/api/datasources/uid/abc/resources/api/v1/query", strings.NewReader("query=up&time=1234"))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := rt.RoundTrip(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	_, _ = io.ReadAll(resp.Body)
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.ReadAll(resp.Body)
 
-	assert.Equal(t, http.MethodGet, gotMethod)
-	assert.Contains(t, gotQuery, "query=up")
-	assert.Contains(t, gotQuery, "time=1234")
+		assert.Equal(t, http.MethodGet, gotMethod)
+		assert.Contains(t, gotQuery, "query=up")
+		assert.Contains(t, gotQuery, "time=1234")
+	})
+
+	t.Run("keeps non-form POST requests unchanged", func(t *testing.T) {
+		var gotMethod string
+
+		rt := &prometheusDatasourceHTTPMethodRoundTripper{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotMethod = r.Method
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+			}, nil
+		})}
+
+		req, err := http.NewRequest(http.MethodPost, "http://example.test/api/datasources/uid/abc/resources/api/v1/query", strings.NewReader(`{"query":"up"}`))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.ReadAll(resp.Body)
+
+		assert.Equal(t, http.MethodPost, gotMethod)
+	})
+
+	t.Run("converts nil-body POST to GET", func(t *testing.T) {
+		var gotMethod string
+
+		rt := &prometheusDatasourceHTTPMethodRoundTripper{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotMethod = r.Method
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+			}, nil
+		})}
+
+		req, err := http.NewRequest(http.MethodPost, "http://example.test/api/datasources/uid/abc/resources/api/v1/query", nil)
+		require.NoError(t, err)
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.ReadAll(resp.Body)
+
+		assert.Equal(t, http.MethodGet, gotMethod)
+	})
+
+	t.Run("returns clear parse error for invalid form body", func(t *testing.T) {
+		rt := &prometheusDatasourceHTTPMethodRoundTripper{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Header:     make(http.Header),
+			}, nil
+		})}
+
+		req, err := http.NewRequest(http.MethodPost, "http://example.test/api/datasources/uid/abc/resources/api/v1/query", strings.NewReader("query=%zz"))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		_, err = rt.RoundTrip(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing form body for GET conversion")
+	})
 }
 
 func TestParseRelativeTime(t *testing.T) {


### PR DESCRIPTION
## Summary
- read datasource `jsonData.httpMethod` in `promClientFromContext`
- when the datasource is configured for `GET`, wrap the Prometheus client transport to convert outgoing form-encoded POST requests into GET requests against the datasource resources endpoint
- keep existing behavior unchanged for POST-configured datasources
- add focused unit tests for method detection and POST→GET conversion behavior

## Testing
- `go test ./tools -run 'TestDatasourcePrometheusHTTPMethod|TestPrometheusDatasourceHTTPMethodRoundTripper'`

## Related
Fixes #632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Prometheus requests are sent for GET-configured datasources by rewriting HTTP methods and bodies, which could affect query compatibility or edge cases around request encoding; POST-configured datasources are unchanged.
> 
> **Overview**
> Prometheus tooling now respects datasource `jsonData.httpMethod`: when configured for `GET`, `promClientFromContext` wraps the Prometheus client transport to transparently convert form-encoded `POST` requests into `GET` requests with equivalent query parameters.
> 
> Adds unit coverage for method detection defaults and for the POST→GET conversion behavior (including non-form POST passthrough and invalid form error handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f199f4b2e3a86652096536922c49e90a32cf39bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->