### PR TITLE
fix: handle text/* content-type responses from Grafana API

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-openapi/runtime"
+	openapiclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/incident-go"
@@ -564,6 +566,17 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 
 	slog.Debug("Creating Grafana client", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", config.BasicAuth != nil, "org_id", cfg.OrgID, "timeout", timeout, "extra_headers_count", len(config.ExtraHeaders))
 	grafanaClient := client.NewHTTPClientWithConfig(strfmt.Default, cfg)
+
+	// Some Grafana versions (v12+) and reverse proxies return JSON responses
+	// with text/plain or text/html content-type headers. The default
+	// TextConsumer cannot deserialize these into typed Go structs. Override
+	// with JSONConsumer so the client can parse the response body correctly.
+	// See: https://github.com/grafana/mcp-grafana/issues/635
+	if rt, ok := grafanaClient.Transport.(*openapiclient.Runtime); ok {
+		jsonConsumer := runtime.JSONConsumer()
+		rt.Consumers[runtime.TextMime] = jsonConsumer
+		rt.Consumers[runtime.HTMLMime] = jsonConsumer
+	}
 
 	// Always enable HTTP tracing for context propagation (no-op when no exporter configured)
 	// Use reflection to wrap the transport without importing the runtime client package

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -6,6 +6,7 @@ package mcpgrafana
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/runtime/client"
@@ -630,6 +631,37 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		assertHasAttribute(t, attributes, "mcp.method.name", "tools/call")
 		assertHasAttribute(t, attributes, "gen_ai.tool.call.arguments", `{"safeData":"debug-value"}`)
 	})
+}
+
+func TestTextMimeConsumerOverride(t *testing.T) {
+	// Verify that NewGrafanaClient overrides text/plain and text/html consumers
+	// with JSON consumers so that responses with incorrect content-type headers
+	// (e.g. from Grafana v12 or reverse proxies) are still parsed correctly.
+	// See: https://github.com/grafana/mcp-grafana/issues/635
+	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
+	c := NewGrafanaClient(ctx, "http://localhost:3000", "test-api-key", nil, 0)
+	require.NotNil(t, c)
+
+	rt, ok := c.Transport.(*client.Runtime)
+	require.True(t, ok, "expected Transport to be *client.Runtime")
+
+	// The text/plain and text/html consumers should no longer be the default
+	// TextConsumer. Verify by checking they can consume a JSON object into a
+	// map (TextConsumer would fail on this).
+	for _, mime := range []string{"text/plain", "text/html"} {
+		consumer, exists := rt.Consumers[mime]
+		require.True(t, exists, "consumer for %s should exist", mime)
+		require.NotNil(t, consumer, "consumer for %s should not be nil", mime)
+
+		// JSONConsumer can unmarshal into a map; TextConsumer cannot.
+		var result map[string]interface{}
+		err := consumer.Consume(
+			strings.NewReader(`{"status":"ok"}`),
+			&result,
+		)
+		assert.NoError(t, err, "consumer for %s should parse JSON", mime)
+		assert.Equal(t, "ok", result["status"], "consumer for %s should return parsed value", mime)
+	}
 }
 
 func TestHTTPTracingConfiguration(t *testing.T) {


### PR DESCRIPTION
## Summary

- Override `text/plain` and `text/html` consumers with `JSONConsumer` in `NewGrafanaClient` so JSON responses with incorrect content-type headers are parsed correctly
- Adds unit test verifying the consumer override works

## Problem

All read operations (`list_datasources`, `search_dashboards`, `get_dashboard_by_uid`, etc.) fail with:

```
(*models.DataSourceList) is not supported by the TextConsumer,
can be resolved by supporting TextUnmarshaler interface
```

This happens when the Grafana API (v12+) or a reverse proxy returns JSON with `Content-Type: text/plain` or `text/html` instead of `application/json`. The go-swagger default `TextConsumer` cannot deserialize these responses into typed Go structs.

## Fix

After creating the Grafana HTTP client, override the `text/plain` and `text/html` entries in `rt.Consumers` with `runtime.JSONConsumer()`. This is a 4-line change in `NewGrafanaClient`. The override is safe because:

1. The Grafana API only returns JSON, so text/* responses are always JSON with a wrong header
2. If the body is genuinely non-JSON, `JSONConsumer` returns a clear parse error (no worse than the current `TextConsumer` crash)

## Test plan

- [x] New unit test `TestTextMimeConsumerOverride` verifies both `text/plain` and `text/html` consumers can parse JSON
- [x] Full unit test suite passes (`go test -tags unit ./...`)
- [x] `go build ./...` clean

Fixes #635

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted client-side parsing change plus a unit test; risk is limited to how the OpenAPI client consumes `text/*` responses.
> 
> **Overview**
> Fixes Grafana API read failures when JSON responses are returned with `text/plain`/`text/html` content-types (e.g., Grafana v12+ or reverse proxies) by overriding the OpenAPI runtime consumers in `NewGrafanaClient` to use `runtime.JSONConsumer()` for those MIME types.
> 
> Adds a unit test (`TestTextMimeConsumerOverride`) that asserts the overridden consumers can successfully unmarshal JSON into a map for both `text/plain` and `text/html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42d2a237bff27a3e7103db9db6426622d2b81a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->