### PR TITLE
fix(tools): fix generate_deeplink for explore resource type

### DIFF
--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -13,12 +14,13 @@ import (
 )
 
 type GenerateDeeplinkParams struct {
-	ResourceType  string            `json:"resourceType" jsonschema:"required,description=Type of resource: dashboard\\, panel\\, or explore"`
-	DashboardUID  *string           `json:"dashboardUid,omitempty" jsonschema:"description=Dashboard UID (required for dashboard and panel types)"`
-	DatasourceUID *string           `json:"datasourceUid,omitempty" jsonschema:"description=Datasource UID (required for explore type)"`
-	PanelID       *int              `json:"panelId,omitempty" jsonschema:"description=Panel ID (required for panel type)"`
-	QueryParams   map[string]string `json:"queryParams,omitempty" jsonschema:"description=Additional query parameters"`
-	TimeRange     *TimeRange        `json:"timeRange,omitempty" jsonschema:"description=Time range for the link"`
+	ResourceType  string                   `json:"resourceType" jsonschema:"required,description=Type of resource: dashboard\\, panel\\, or explore"`
+	DashboardUID  *string                  `json:"dashboardUid,omitempty" jsonschema:"description=Dashboard UID (required for dashboard and panel types)"`
+	DatasourceUID *string                  `json:"datasourceUid,omitempty" jsonschema:"description=Datasource UID (required for explore type)"`
+	PanelID       *int                     `json:"panelId,omitempty" jsonschema:"description=Panel ID (required for panel type)"`
+	Queries       []map[string]interface{} `json:"queries,omitempty" jsonschema:"description=List of query objects for explore links (e.g. [{\"refId\":\"A\"\\,\"expr\":\"up\"}])"`
+	QueryParams   map[string]string        `json:"queryParams,omitempty" jsonschema:"description=Additional URL query parameters (for dashboard/panel types)"`
+	TimeRange     *TimeRange               `json:"timeRange,omitempty" jsonschema:"description=Time range for the link"`
 }
 
 type TimeRange struct {
@@ -42,6 +44,7 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 			return "", fmt.Errorf("dashboardUid is required for dashboard links")
 		}
 		deeplink = fmt.Sprintf("%s/d/%s", baseURL, *args.DashboardUID)
+
 	case "panel":
 		if args.DashboardUID == nil {
 			return "", fmt.Errorf("dashboardUid is required for panel links")
@@ -50,14 +53,46 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 			return "", fmt.Errorf("panelId is required for panel links")
 		}
 		deeplink = fmt.Sprintf("%s/d/%s?viewPanel=%d", baseURL, *args.DashboardUID, *args.PanelID)
+
 	case "explore":
 		if args.DatasourceUID == nil {
 			return "", fmt.Errorf("datasourceUid is required for explore links")
 		}
+
+		// Build the full explore state inside `left` — Grafana Explore reads
+		// datasource, queries, and range all from this single JSON object.
+		exploreState := map[string]interface{}{
+			"datasource": *args.DatasourceUID,
+		}
+		if len(args.Queries) > 0 {
+			exploreState["queries"] = args.Queries
+		}
+		if args.TimeRange != nil {
+			rangeObj := map[string]string{}
+			if args.TimeRange.From != "" {
+				rangeObj["from"] = args.TimeRange.From
+			}
+			if args.TimeRange.To != "" {
+				rangeObj["to"] = args.TimeRange.To
+			}
+			if len(rangeObj) > 0 {
+				exploreState["range"] = rangeObj
+			}
+		}
+
+		leftJSON, err := json.Marshal(exploreState)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal explore state: %w", err)
+		}
+
 		params := url.Values{}
-		exploreState := fmt.Sprintf(`{"datasource":"%s"}`, *args.DatasourceUID)
-		params.Set("left", exploreState)
+		params.Set("left", string(leftJSON))
 		deeplink = fmt.Sprintf("%s/explore?%s", baseURL, params.Encode())
+
+		// For explore, time range is already embedded in `left` — skip the
+		// generic time range block below by clearing it.
+		args.TimeRange = nil
+
 	default:
 		return "", fmt.Errorf("unsupported resource type: %s. Supported types are: dashboard, panel, explore", args.ResourceType)
 	}
@@ -96,7 +131,7 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 
 var GenerateDeeplink = mcpgrafana.MustTool(
 	"generate_deeplink",
-	"Generate deeplink URLs for Grafana resources. Supports dashboards (requires dashboardUid), panels (requires dashboardUid and panelId), and Explore queries (requires datasourceUid). Optionally accepts time range and additional query parameters.",
+	"Generate deeplink URLs for Grafana resources. Supports dashboards (requires dashboardUid), panels (requires dashboardUid and panelId), and Explore queries (requires datasourceUid and optionally queries). For explore links, the time range and queries are embedded inside the Grafana explore state.",
 	generateDeeplink,
 	mcp.WithTitleAnnotation("Generate navigation deeplink"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +46,7 @@ func TestGenerateDeeplink(t *testing.T) {
 		assert.Equal(t, "http://localhost:3000/d/dash-123?viewPanel=5", result)
 	})
 
-	t.Run("Explore deeplink", func(t *testing.T) {
+	t.Run("Explore deeplink basic", func(t *testing.T) {
 		params := GenerateDeeplinkParams{
 			ResourceType:  "explore",
 			DatasourceUID: stringPtr("prometheus-uid"),
@@ -57,7 +58,59 @@ func TestGenerateDeeplink(t *testing.T) {
 		assert.Contains(t, result, "prometheus-uid")
 	})
 
-	t.Run("With time range", func(t *testing.T) {
+	t.Run("Explore deeplink with time range inside left JSON", func(t *testing.T) {
+		params := GenerateDeeplinkParams{
+			ResourceType:  "explore",
+			DatasourceUID: stringPtr("prometheus-uid"),
+			TimeRange: &TimeRange{
+				From: "now-1h",
+				To:   "now",
+			},
+		}
+
+		result, err := generateDeeplink(ctx, params)
+		require.NoError(t, err)
+
+		u, err := url.Parse(result)
+		require.NoError(t, err)
+
+		leftRaw := u.Query().Get("left")
+		require.NotEmpty(t, leftRaw)
+
+		// Range must be inside `left`, not as top-level URL params.
+		assert.Contains(t, leftRaw, `"range"`)
+		assert.Contains(t, leftRaw, "now-1h")
+		assert.Contains(t, leftRaw, "now")
+		assert.Empty(t, u.Query().Get("from"), "from should not be a top-level URL param for explore")
+		assert.Empty(t, u.Query().Get("to"), "to should not be a top-level URL param for explore")
+
+		// There must be exactly one `left` param.
+		assert.Len(t, u.Query()["left"], 1)
+	})
+
+	t.Run("Explore deeplink with queries", func(t *testing.T) {
+		params := GenerateDeeplinkParams{
+			ResourceType:  "explore",
+			DatasourceUID: stringPtr("prometheus-uid"),
+			Queries: []map[string]interface{}{
+				{"refId": "A", "expr": "up"},
+			},
+			TimeRange: &TimeRange{From: "now-1h", To: "now"},
+		}
+
+		result, err := generateDeeplink(ctx, params)
+		require.NoError(t, err)
+
+		u, err := url.Parse(result)
+		require.NoError(t, err)
+
+		leftRaw := u.Query().Get("left")
+		assert.Contains(t, leftRaw, `"queries"`)
+		assert.Contains(t, leftRaw, `"expr"`)
+		assert.Contains(t, leftRaw, "up")
+	})
+
+	t.Run("With time range on dashboard", func(t *testing.T) {
 		params := GenerateDeeplinkParams{
 			ResourceType: "dashboard",
 			DashboardUID: stringPtr("abc123"),


### PR DESCRIPTION
The explore deeplink was broken in three ways:

- The `left` URL param only contained `{"datasource":"uid"}`, missing queries and time range. Grafana Explore reads all state (datasource, queries, range) from this single JSON object.
- Time range was appended as top-level `&from=&to=` URL params, which Grafana Explore ignores entirely.
- There was no way to pass queries, so the link always opened with an empty query editor.

Fix by building the full explore state JSON inside `left` (datasource + queries + range) and adding a `queries` field to `GenerateDeeplinkParams` so callers can pass PromQL/LogQL expressions directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to URL construction for the Explore resource type with added test coverage; minimal blast radius outside deeplink formatting.
> 
> **Overview**
> Fixes `generate_deeplink` for Grafana *Explore* by building a full Explore state JSON (datasource + optional queries + optional range) and encoding it into the `left` URL param, instead of appending `from`/`to` as top-level query parameters.
> 
> Extends `GenerateDeeplinkParams` with a new `Queries` field for Explore links and updates tests to validate range/queries are embedded in `left` and that no extra time params are added for Explore.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efa3938740cae0010468e13710bf17ba7320b83a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->