### PR TITLE
Release v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2026-03-12
+
+### Added
+
+- Support panel filtering and template variable substitution in `get_dashboard_panel_queries` for more targeted query extraction ([#539](https://github.com/grafana/mcp-grafana/pull/539))
+- New `alerting_manage_routing` tool for managing notification policies, contact points, and time intervals in a single unified tool ([#618](https://github.com/grafana/mcp-grafana/pull/618))
+- Add `accountId` parameter to CloudWatch tools for cross-account monitoring support ([#616](https://github.com/grafana/mcp-grafana/pull/616))
+
+### Fixed
+
+- Add `OrgIDRoundTripper` to the Grafana client transport chain so organization ID is correctly sent on all requests ([#649](https://github.com/grafana/mcp-grafana/pull/649))
+
+### Changed
+
+- Consolidate alerting rule tools into a single `alerting_manage_rules` tool for simpler discovery ([#619](https://github.com/grafana/mcp-grafana/pull/619))
+- Use typed struct for alert query parameters instead of untyped `models.AlertQuery` ([#630](https://github.com/grafana/mcp-grafana/pull/630))
+- Add server-side filtering support to alerting client for more efficient rule queries (Grafana 10.0+) ([#612](https://github.com/grafana/mcp-grafana/pull/612))
+
 ## [0.11.2] - 2026-02-24
 
 ### Changed
@@ -56,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.11.3]: https://github.com/grafana/mcp-grafana/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/grafana/mcp-grafana/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/grafana/mcp-grafana/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/grafana/mcp-grafana/compare/v0.10.0...v0.11.0


### PR DESCRIPTION
## Summary

- Bump version to v0.11.3
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.11.3` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog; no code paths or runtime behavior are modified.
> 
> **Overview**
> Documents the `0.11.3` release in `CHANGELOG.md`, including new capabilities like panel filtering/template variable substitution for `get_dashboard_panel_queries`, a unified `alerting_manage_routing` tool, and cross-account CloudWatch support via an `accountId` parameter.
> 
> Also records alerting-related changes (consolidated `alerting_manage_rules`, typed alert query parameters, server-side rule filtering) and a fix to ensure org IDs are sent on all Grafana client requests, and adds the `v0.11.2...v0.11.3` compare link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f371ef0b65058e90de64cd3ea524969dd5529b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->