### PR TITLE
feat: add settings for Grafana URL, Token, and OrgID for gemini CLI

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -5,5 +5,25 @@
     "grafana": {
       "command": "${extensionPath}${/}mcp-grafana"
     }
-  }
+  },
+  "settings": [
+    {
+      "name": "Grafana URL",
+      "description": "The base URL of your Grafana instance (e.g., https://grafana.example.com)",
+      "envVar": "GRAFANA_URL",
+      "required": true
+    },
+    {
+      "name": "Service Account Token",
+      "description": "Your Grafana Service Account Token (glsa_...)",
+      "envVar": "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+      "required": true,
+      "sensitive": true
+    },
+    {
+      "name": "Organization ID",
+      "description": "The Grafana Organization ID to use",
+      "envVar": "GRAFANA_ORG_ID"
+    }
+  ]
 }


### PR DESCRIPTION
Add the configuration schema for the Gemini CLI extension to enable easy setup of Grafana connection parameters. These settings map to the GRAFANA_URL, GRAFANA_SERVICE_ACCOUNT_TOKEN, and GRAFANA_ORG_ID environment variables used by the server.

The settings can be specified by users with `gemini extensions config grafana`. Secrets will be stored securely in an OS keychain.