### PR TITLE
feat(loki): support categorized labels from Loki >= 3.0

### DIFF
--- a/tools/loki.go
+++ b/tools/loki.go
@@ -119,6 +119,10 @@ func (c *Client) makeRequest(ctx context.Context, method, urlPath string, params
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
+	// Request categorized labels so Loki returns structured metadata and
+	// parsed labels separately from stream/index labels (Loki >= 3.0).
+	req.Header.Set("X-Loki-Response-Encoding-Flags", "categorize-labels")
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
@@ -320,8 +324,9 @@ type LokiMetricSample struct {
 type lokiQueryResponse struct {
 	Status string `json:"status"`
 	Data   struct {
-		ResultType string          `json:"resultType"` // "streams", "vector", or "matrix"
-		Result     json.RawMessage `json:"result"`     // Unmarshal based on resultType
+		ResultType    string          `json:"resultType"`              // "streams", "vector", or "matrix"
+		EncodingFlags []string        `json:"encodingFlags,omitempty"` // e.g. ["categorize-labels"]
+		Result        json.RawMessage `json:"result"`                  // Unmarshal based on resultType
 		// Stats is a pointer so we can distinguish "stats missing" (nil) from "stats present with zero values"
 		Stats *struct {
 			Summary struct {
@@ -329,6 +334,24 @@ type lokiQueryResponse struct {
 			} `json:"summary"`
 		} `json:"stats,omitempty"`
 	} `json:"data"`
+}
+
+// categorizedLabels is the third element of a log entry's values array when
+// Loki responds with the categorize-labels encoding flag.
+type categorizedLabels struct {
+	StructuredMetadata map[string]string `json:"structuredMetadata,omitempty"`
+	Parsed             map[string]string `json:"parsed,omitempty"`
+}
+
+// hasCategorizeLabelsFlag reports whether the response included the
+// "categorize-labels" encoding flag from Loki >= 3.0.
+func hasCategorizeLabelsFlag(flags []string) bool {
+	for _, f := range flags {
+		if f == "categorize-labels" {
+			return true
+		}
+	}
+	return false
 }
 
 // MetricValue represents a single metric data point with timestamp and value
@@ -480,13 +503,18 @@ type QueryLokiLogsResult struct {
 	Metadata *QueryMetadata    `json:"metadata,omitempty"`
 }
 
-// LogEntry represents a single log entry or metric sample with metadata
+// LogEntry represents a single log entry or metric sample with metadata.
+// When Loki returns categorized labels (via X-Loki-Response-Encoding-Flags),
+// Labels contains only stream/index labels, while StructuredMetadata and
+// Parsed carry the remaining label categories per entry.
 type LogEntry struct {
-	Timestamp string            `json:"timestamp,omitempty"`
-	Line      string            `json:"line,omitempty"`   // For log queries
-	Value     *float64          `json:"value,omitempty"`  // For instant metric queries
-	Values    []MetricValue     `json:"values,omitempty"` // For range metric queries
-	Labels    map[string]string `json:"labels"`
+	Timestamp          string            `json:"timestamp,omitempty"`
+	Line               string            `json:"line,omitempty"`              // For log queries
+	Value              *float64          `json:"value,omitempty"`             // For instant metric queries
+	Values             []MetricValue     `json:"values,omitempty"`            // For range metric queries
+	Labels             map[string]string `json:"labels"`                      // Stream / index labels
+	StructuredMetadata map[string]string `json:"structuredMetadata,omitempty"` // Structured metadata labels (Loki >= 3.0)
+	Parsed             map[string]string `json:"parsed,omitempty"`            // Parser-extracted labels (Loki >= 3.0)
 }
 
 // enforceLogLimit ensures a log limit value is within acceptable bounds
@@ -592,6 +620,11 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 			return nil, fmt.Errorf("parsing streams result: %w", err)
 		}
 
+		// Check if Loki returned categorized labels (Loki >= 3.0).
+		// When present, values[2] is a JSON object with "structuredMetadata"
+		// and "parsed" maps; stream.Stream contains only index labels.
+		categorized := hasCategorizeLabelsFlag(response.Data.EncodingFlags)
+
 		for _, stream := range streams {
 			for _, value := range stream.Values {
 				if len(value) >= 2 {
@@ -601,11 +634,22 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 						continue // Skip invalid log lines
 					}
 
-					entries = append(entries, LogEntry{
+					entry := LogEntry{
 						Timestamp: string(value[0]), // Nanoseconds as string
 						Line:      logLine,
 						Labels:    stream.Stream,
-					})
+					}
+
+					// Parse categorized labels from the optional third element.
+					if categorized && len(value) >= 3 {
+						var cats categorizedLabels
+						if err := json.Unmarshal(value[2], &cats); err == nil {
+							entry.StructuredMetadata = cats.StructuredMetadata
+							entry.Parsed = cats.Parsed
+						}
+					}
+
+					entries = append(entries, entry)
 				}
 			}
 		}

--- a/tools/loki_unit_test.go
+++ b/tools/loki_unit_test.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnforceLogLimit(t *testing.T) {
@@ -82,4 +84,105 @@ func TestEnforceLogLimit(t *testing.T) {
 			assert.Equal(t, tc.expectedLimit, result)
 		})
 	}
+}
+
+func TestHasCategorizeLabelsFlag(t *testing.T) {
+	assert.True(t, hasCategorizeLabelsFlag([]string{"categorize-labels"}))
+	assert.True(t, hasCategorizeLabelsFlag([]string{"other", "categorize-labels"}))
+	assert.False(t, hasCategorizeLabelsFlag(nil))
+	assert.False(t, hasCategorizeLabelsFlag([]string{}))
+	assert.False(t, hasCategorizeLabelsFlag([]string{"other"}))
+}
+
+func TestCategorizedLabelsParsing(t *testing.T) {
+	// Simulate a Loki response with categorize-labels encoding flag.
+	// values[2] carries the categorized labels object.
+	rawResponse := `{
+		"status": "success",
+		"data": {
+			"resultType": "streams",
+			"encodingFlags": ["categorize-labels"],
+			"result": [
+				{
+					"stream": {"app": "frontend", "namespace": "default"},
+					"values": [
+						[
+							"1693996529000222496",
+							"level=info msg=\"request handled\"",
+							{
+								"structuredMetadata": {"traceID": "abc123", "service_name": "web"},
+								"parsed": {"level": "info", "msg": "request handled"}
+							}
+						],
+						[
+							"1693996530000000000",
+							"level=error msg=\"timeout\"",
+							{
+								"structuredMetadata": {"traceID": "def456"},
+								"parsed": {"level": "error"}
+							}
+						]
+					]
+				}
+			]
+		}
+	}`
+
+	var response lokiQueryResponse
+	require.NoError(t, json.Unmarshal([]byte(rawResponse), &response))
+
+	assert.Equal(t, "streams", response.Data.ResultType)
+	assert.True(t, hasCategorizeLabelsFlag(response.Data.EncodingFlags))
+
+	// Parse streams
+	var streams []LokiLogStream
+	require.NoError(t, json.Unmarshal(response.Data.Result, &streams))
+	require.Len(t, streams, 1)
+
+	stream := streams[0]
+	// Stream labels should only contain index labels
+	assert.Equal(t, map[string]string{"app": "frontend", "namespace": "default"}, stream.Stream)
+	require.Len(t, stream.Values, 2)
+
+	// First entry — parse the third element
+	require.Len(t, stream.Values[0], 3)
+	var cats1 categorizedLabels
+	require.NoError(t, json.Unmarshal(stream.Values[0][2], &cats1))
+	assert.Equal(t, map[string]string{"traceID": "abc123", "service_name": "web"}, cats1.StructuredMetadata)
+	assert.Equal(t, map[string]string{"level": "info", "msg": "request handled"}, cats1.Parsed)
+
+	// Second entry
+	var cats2 categorizedLabels
+	require.NoError(t, json.Unmarshal(stream.Values[1][2], &cats2))
+	assert.Equal(t, map[string]string{"traceID": "def456"}, cats2.StructuredMetadata)
+	assert.Equal(t, map[string]string{"level": "error"}, cats2.Parsed)
+}
+
+func TestCategorizedLabelsBackwardCompat(t *testing.T) {
+	// Without the encoding flag, values only have 2 elements (old Loki).
+	rawResponse := `{
+		"status": "success",
+		"data": {
+			"resultType": "streams",
+			"result": [
+				{
+					"stream": {"app": "backend"},
+					"values": [
+						["1693996529000222496", "some log line"]
+					]
+				}
+			]
+		}
+	}`
+
+	var response lokiQueryResponse
+	require.NoError(t, json.Unmarshal([]byte(rawResponse), &response))
+
+	assert.False(t, hasCategorizeLabelsFlag(response.Data.EncodingFlags))
+
+	var streams []LokiLogStream
+	require.NoError(t, json.Unmarshal(response.Data.Result, &streams))
+	require.Len(t, streams, 1)
+	require.Len(t, streams[0].Values, 1)
+	require.Len(t, streams[0].Values[0], 2) // Only timestamp + line, no third element
 }


### PR DESCRIPTION
## Summary
- Set `X-Loki-Response-Encoding-Flags: categorize-labels` request header so Loki >= 3.0 returns structured metadata and parsed labels separately from stream/index labels.
- Add `StructuredMetadata` and `Parsed` fields to `LogEntry`, giving consumers richer per-entry context (e.g. traceID, parsed level) without polluting stream labels.
- Backward compatible — when the encoding flag is absent (older Loki), behavior is unchanged.

## Test plan
- [x] `TestHasCategorizeLabelsFlag` — flag detection helper (true/false/nil/empty)
- [x] `TestCategorizedLabelsParsing` — full round-trip with structuredMetadata + parsed maps
- [x] `TestCategorizedLabelsBackwardCompat` — old Loki response without encoding flag
- [ ] Integration test with a real Loki >= 3.0 instance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Loki query request/response handling and the `LogEntry` output schema, which may affect downstream consumers expecting labels-only metadata. Backward compatibility is attempted via conditional parsing, but behavior depends on Loki version and response shape.
> 
> **Overview**
> Adds Loki 3.0 *categorized labels* support by sending `X-Loki-Response-Encoding-Flags: categorize-labels` on requests and reading `encodingFlags` from query responses.
> 
> For `streams` results, parses the optional third `values[...]` element into new per-entry `structuredMetadata` and `parsed` fields on `LogEntry`, leaving `labels` as stream/index labels only, with unit tests covering flag detection, parsing, and backward compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b584c652bcb1f62251a2000890e84a11fb9dc191. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->