### PR TITLE
fix(tools): return actionable errors for unsupported JSONPath syntax in patch operations

### DIFF
--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -251,7 +251,7 @@ var GetDashboardByUID = mcpgrafana.MustTool(
 
 var UpdateDashboard = mcpgrafana.MustTool(
 	"update_dashboard",
-	"Create or update a dashboard. Two modes: (1) Full JSON — provide 'dashboard' for new dashboards or complete replacements. (2) Patch — provide 'uid' + 'operations' to make targeted changes to an existing dashboard. One of these two modes is required; 'folderUid'\\, 'message'\\, and 'overwrite' are supplementary and do nothing on their own. Patch operations support JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'. Append to arrays with '/- ' syntax: '$.panels/- '. Remove by index: {\"op\": \"remove\"\\, \"path\": \"$.panels[2]\"}. Multiple removes on the same array are automatically reordered to avoid index-shifting issues.",
+	"Create or update a dashboard. Two modes: (1) Full JSON — provide 'dashboard' for new dashboards or complete replacements. (2) Patch — provide 'uid' + 'operations' to make targeted changes to an existing dashboard. One of these two modes is required; 'folderUid'\\, 'message'\\, and 'overwrite' are supplementary and do nothing on their own. Patch operations support JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'. Append to arrays with '/- ' syntax: '$.panels/- '. Remove by index: {\"op\": \"remove\"\\, \"path\": \"$.panels[2]\"}. Multiple removes on the same array are automatically reordered to avoid index-shifting issues. Note: only numeric array indices are supported in patch paths; filter expressions like [?(@.id==2)] and wildcards like [*] are not supported.",
 	updateDashboard,
 	mcp.WithTitleAnnotation("Create or update dashboard"),
 	mcp.WithDestructiveHintAnnotation(true),
@@ -475,6 +475,14 @@ func applyJSONPath(data map[string]interface{}, path string, value interface{}, 
 	// Remove the leading "$." if present
 	if len(path) > 2 && path[:2] == "$." {
 		path = path[2:]
+	}
+
+	// Detect unsupported JSONPath syntax and return actionable errors
+	if strings.Contains(path, "?(@") || strings.Contains(path, "?(") {
+		return fmt.Errorf("JSONPath filter expressions (e.g., [?(@.id==2)]) are not supported in patch operations. Use numeric array indices instead (e.g., $.panels[1]). Use get_dashboard_summary to find panel array indices")
+	}
+	if strings.Contains(path, "[*]") {
+		return fmt.Errorf("JSONPath wildcard expressions (e.g., [*]) are not supported in patch operations. Use numeric array indices instead (e.g., $.panels[0])")
 	}
 
 	// Split the path into segments

--- a/tools/dashboard_unit_test.go
+++ b/tools/dashboard_unit_test.go
@@ -473,3 +473,34 @@ func TestUpdateDashboard_ValidationErrors(t *testing.T) {
 		assert.Contains(t, err.Error(), "Do NOT retry")
 	})
 }
+
+func TestApplyJSONPath_UnsupportedSyntax(t *testing.T) {
+	data := map[string]interface{}{
+		"panels": []interface{}{
+			map[string]interface{}{"id": float64(1), "title": "Panel 1"},
+			map[string]interface{}{"id": float64(2), "title": "Panel 2"},
+		},
+	}
+
+	t.Run("filter expression returns actionable error", func(t *testing.T) {
+		err := applyJSONPath(data, `$.panels[?(@.id==2)].title`, "New Title", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "filter expressions")
+		assert.Contains(t, err.Error(), "not supported")
+		assert.Contains(t, err.Error(), "numeric array indices")
+	})
+
+	t.Run("wildcard expression returns actionable error", func(t *testing.T) {
+		err := applyJSONPath(data, `$.panels[*].title`, "New Title", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wildcard")
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("valid numeric index still works", func(t *testing.T) {
+		err := applyJSONPath(data, "$.panels[1].title", "New Title", false)
+		require.NoError(t, err)
+		panel := data["panels"].([]interface{})[1].(map[string]interface{})
+		assert.Equal(t, "New Title", panel["title"])
+	})
+}


### PR DESCRIPTION
## Summary

- Detects unsupported JSONPath filter expressions (`[?(@.id==2)]`) and wildcards (`[*]`) in `update_dashboard` patch operations and returns clear, actionable error messages instead of confusing "field is not an object" errors
- Updates the `update_dashboard` tool description to proactively note that only numeric array indices are supported in patch paths
- Adds unit tests for the new error detection

## Context

When using `update_dashboard` with patch operations, LLM agents naturally try JSONPath filter expressions like `$.panels[?(@.id==2)]` because they work in `get_dashboard_property`. The custom patch path parser silently misparses these and produces a confusing error with no indication that the syntax itself is unsupported. This wastes API calls and adds friction.

The fix detects unsupported syntax early in `applyJSONPath` and returns errors that tell the user exactly what to do instead (use numeric indices, use `get_dashboard_summary` to find them).

## Test plan

- [x] New tests pass: `go test ./tools/ -run TestApplyJSONPath_UnsupportedSyntax -v`
- [x] Existing tests unaffected: `go test ./tools/ -run TestApplyJSONPath -v`
- [x] Full suite has no new failures: `go test ./tools/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds early validation and clearer error messages for unsupported JSONPath constructs in `update_dashboard` patch paths, plus tests; no change to successful patch behavior.
> 
> **Overview**
> Improves `update_dashboard` patch UX by **detecting unsupported JSONPath filter (`[?()]`) and wildcard (`[*]`) syntax** in `applyJSONPath` and returning clear, actionable errors instead of downstream type errors.
> 
> Updates the tool description to document the numeric-index-only limitation, and adds unit coverage to ensure unsupported paths fail while numeric index paths still work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01fdbf1716312a9d35ad12d4d1b2896ab441b2c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->