### PR TITLE
fix(tools): use UTC in TestParseRelativeTime to avoid DST flakiness

### DIFF
--- a/tools/prometheus_unit_test.go
+++ b/tools/prometheus_unit_test.go
@@ -104,13 +104,13 @@ func TestParseRelativeTime(t *testing.T) {
 				diff := result.Sub(now)
 				assert.Less(t, diff.Abs(), 2*time.Second, "Time difference should be less than 2 seconds")
 			} else if tc.isMonthCase {
-				// For month calculations, use proper calendar arithmetic
-				expected := now.AddDate(0, -1, 0)
+				// The datemath library (used by parseTime) defaults to UTC for
+				// calendar arithmetic, so use UTC to avoid DST differences.
+				expected := now.UTC().AddDate(0, -1, 0)
 				diff := result.Sub(expected)
 				assert.Less(t, diff.Abs(), 2*time.Second, "Time difference should be less than 2 seconds")
 			} else if tc.isYearCase {
-				// For year calculations, use proper calendar arithmetic
-				expected := now.AddDate(-1, 0, 0)
+				expected := now.UTC().AddDate(-1, 0, 0)
 				diff := result.Sub(expected)
 				assert.Less(t, diff.Abs(), 2*time.Second, "Time difference should be less than 2 seconds")
 			} else {


### PR DESCRIPTION
## Summary

`TestParseRelativeTime/now-1M` fails when the local timezone has a DST transition within the past month (e.g., US spring-forward on March 8).

**Root cause:** The [`go-datemath`](https://github.com/jszwedko/go-datemath) library, used internally by `parseTime` via Grafana's [`gtime.TimeRange.ParseFrom`](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/backend/gtime/time_range.go), [defaults to `time.UTC`](https://github.com/jszwedko/go-datemath/blob/640a500621d6/datemath.go#L200) when no location is specified. The test, however, was computing its expected value using `now.AddDate(0, -1, 0)` in **local time**. Go's [`time.AddDate`](https://pkg.go.dev/time#Time.AddDate) preserves wall-clock time across timezone changes, so when a DST transition (±1 hour) falls within the month/year window, the local-time and UTC calculations diverge by exactly 1 hour — exceeding the test's 2-second tolerance.

**Fix:** Use `now.UTC().AddDate(...)` in the test's month/year assertions to match the datemath library's behavior.

## Test plan

- [x] `go test -count=1 -tags unit ./tools/` passes (including `TestParseRelativeTime/now-1M`)
- [x] Full unit suite `go test -count=1 -tags unit ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that aligns expectations with UTC calendar arithmetic, without modifying production time parsing logic.
> 
> **Overview**
> **Stabilizes relative-time unit tests across DST boundaries.**
> 
> `TestParseRelativeTime` now computes expected values for month/year cases using `now.UTC().AddDate(...)` instead of local-time `AddDate`, matching the UTC-based calendar arithmetic used by `parseTime`’s datemath parsing and preventing 1-hour DST-induced failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 908852caf49e9208b2f7d21d83358271fc63d396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->