### PR TITLE
fix(tools): support multi-value dashboard variables in get_panel_image

### DIFF
--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,22 +12,68 @@ import (
 	"strings"
 	"time"
 
+	"github.com/invopop/jsonschema"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
+// StringOrSlice is a type that can be unmarshaled from either a JSON string
+// or an array of strings. This allows dashboard variables to support both
+// single-value (e.g., "prometheus") and multi-value (e.g., ["server1", "server2"])
+// inputs.
+type StringOrSlice []string
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// It accepts both a JSON string and a JSON array of strings.
+func (s *StringOrSlice) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal as a single string first.
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*s = StringOrSlice{single}
+		return nil
+	}
+
+	// Try to unmarshal as an array of strings.
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return fmt.Errorf("variables value must be a string or array of strings, got: %s", string(data))
+	}
+	*s = StringOrSlice(arr)
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// A single-element slice is marshaled as a plain string for backward compatibility.
+func (s StringOrSlice) MarshalJSON() ([]byte, error) {
+	if len(s) == 1 {
+		return json.Marshal(s[0])
+	}
+	return json.Marshal([]string(s))
+}
+
+// JSONSchema implements the jsonschema.customSchemaGetterType interface so that
+// the schema reflector emits a union type: either a string or an array of strings.
+func (StringOrSlice) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{Type: "array", Items: &jsonschema.Schema{Type: "string"}},
+		},
+	}
+}
+
 type GetPanelImageParams struct {
-	DashboardUID string            `json:"dashboardUid" jsonschema:"required,description=The UID of the dashboard containing the panel"`
-	PanelID      *int              `json:"panelId,omitempty" jsonschema:"description=The ID of the panel to render. If omitted\\, the entire dashboard is rendered"`
-	Width        *int              `json:"width,omitempty" jsonschema:"description=Width of the rendered image in pixels. Defaults to 1000"`
-	Height       *int              `json:"height,omitempty" jsonschema:"description=Height of the rendered image in pixels. Defaults to 500"`
-	TimeRange    *RenderTimeRange  `json:"timeRange,omitempty" jsonschema:"description=Time range for the rendered image"`
-	Variables    map[string]string `json:"variables,omitempty" jsonschema:"description=Dashboard variables to apply (e.g.\\, {\"var-datasource\": \"prometheus\"})"`
-	Theme        *string           `json:"theme,omitempty" jsonschema:"description=Theme for the rendered image: light or dark. Defaults to dark"`
-	Scale        *int              `json:"scale,omitempty" jsonschema:"description=Scale factor for the image (1-3). Defaults to 1"`
-	Timeout      *int              `json:"timeout,omitempty" jsonschema:"description=Rendering timeout in seconds. Defaults to 60"`
+	DashboardUID string                   `json:"dashboardUid" jsonschema:"required,description=The UID of the dashboard containing the panel"`
+	PanelID      *int                     `json:"panelId,omitempty" jsonschema:"description=The ID of the panel to render. If omitted\\, the entire dashboard is rendered"`
+	Width        *int                     `json:"width,omitempty" jsonschema:"description=Width of the rendered image in pixels. Defaults to 1000"`
+	Height       *int                     `json:"height,omitempty" jsonschema:"description=Height of the rendered image in pixels. Defaults to 500"`
+	TimeRange    *RenderTimeRange         `json:"timeRange,omitempty" jsonschema:"description=Time range for the rendered image"`
+	Variables    map[string]StringOrSlice `json:"variables,omitempty" jsonschema:"description=Dashboard variables to apply. Values can be a single string or an array of strings for multi-value variables (e.g.\\, {\"var-datasource\": \"prometheus\"\\, \"var-instance\": [\"server1\"\\, \"server2\"]})"`
+	Theme        *string                  `json:"theme,omitempty" jsonschema:"description=Theme for the rendered image: light or dark. Defaults to dark"`
+	Scale        *int                     `json:"scale,omitempty" jsonschema:"description=Scale factor for the image (1-3). Defaults to 1"`
+	Timeout      *int                     `json:"timeout,omitempty" jsonschema:"description=Rendering timeout in seconds. Defaults to 60"`
 }
 
 type RenderTimeRange struct {
@@ -168,9 +215,11 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 		params.Set("theme", *args.Theme)
 	}
 
-	// Add dashboard variables
-	for key, value := range args.Variables {
-		params.Set(key, value)
+	// Add dashboard variables (supports multi-value via params.Add)
+	for key, values := range args.Variables {
+		for _, v := range values {
+			params.Add(key, v)
+		}
 	}
 
 	// Add kiosk mode options for cleaner rendering

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -5,6 +5,7 @@ package tools
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,6 +18,132 @@ import (
 
 func intPtr(i int) *int {
 	return &i
+}
+
+func TestStringOrSlice_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected StringOrSlice
+		wantErr  bool
+	}{
+		{
+			name:     "Single string value",
+			input:    `"prometheus"`,
+			expected: StringOrSlice{"prometheus"},
+		},
+		{
+			name:     "Array with single value",
+			input:    `["prometheus"]`,
+			expected: StringOrSlice{"prometheus"},
+		},
+		{
+			name:     "Array with multiple values",
+			input:    `["server1", "server2", "server3"]`,
+			expected: StringOrSlice{"server1", "server2", "server3"},
+		},
+		{
+			name:     "Empty array",
+			input:    `[]`,
+			expected: StringOrSlice{},
+		},
+		{
+			name:    "Invalid type (number)",
+			input:   `42`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid type (object)",
+			input:   `{"key": "value"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result StringOrSlice
+			err := json.Unmarshal([]byte(tt.input), &result)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStringOrSlice_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    StringOrSlice
+		expected string
+	}{
+		{
+			name:     "Single value marshals as string",
+			input:    StringOrSlice{"prometheus"},
+			expected: `"prometheus"`,
+		},
+		{
+			name:     "Multiple values marshal as array",
+			input:    StringOrSlice{"server1", "server2"},
+			expected: `["server1","server2"]`,
+		},
+		{
+			name:     "Empty slice marshals as empty array",
+			input:    StringOrSlice{},
+			expected: `[]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestGetPanelImageParams_UnmarshalVariables(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]StringOrSlice
+	}{
+		{
+			name:  "Single string values (backward compatible)",
+			input: `{"dashboardUid": "abc", "variables": {"var-datasource": "prometheus", "var-host": "server01"}}`,
+			expected: map[string]StringOrSlice{
+				"var-datasource": {"prometheus"},
+				"var-host":       {"server01"},
+			},
+		},
+		{
+			name:  "Multi-value array",
+			input: `{"dashboardUid": "abc", "variables": {"var-instance": ["172.16.31.129", "172.16.32.99"]}}`,
+			expected: map[string]StringOrSlice{
+				"var-instance": {"172.16.31.129", "172.16.32.99"},
+			},
+		},
+		{
+			name:  "Mixed single and multi-value",
+			input: `{"dashboardUid": "abc", "variables": {"var-datasource": "prometheus", "var-instance": ["server1", "server2"]}}`,
+			expected: map[string]StringOrSlice{
+				"var-datasource": {"prometheus"},
+				"var-instance":   {"server1", "server2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var params GetPanelImageParams
+			err := json.Unmarshal([]byte(tt.input), &params)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, params.Variables)
+		})
+	}
 }
 
 func TestBuildRenderURL(t *testing.T) {
@@ -83,18 +210,32 @@ func TestBuildRenderURL(t *testing.T) {
 			},
 		},
 		{
-			name:    "With variables",
+			name:    "With single-value variables",
 			baseURL: "http://localhost:3000",
 			args: GetPanelImageParams{
 				DashboardUID: "abc123",
-				Variables: map[string]string{
-					"var-datasource": "prometheus",
-					"var-host":       "server01",
+				Variables: map[string]StringOrSlice{
+					"var-datasource": {"prometheus"},
+					"var-host":       {"server01"},
 				},
 			},
 			contains: []string{
 				"var-datasource=prometheus",
 				"var-host=server01",
+			},
+		},
+		{
+			name:    "With multi-value variables",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				DashboardUID: "abc123",
+				Variables: map[string]StringOrSlice{
+					"var-instance": {"172.16.31.129", "172.16.32.99"},
+				},
+			},
+			contains: []string{
+				"var-instance=172.16.31.129",
+				"var-instance=172.16.32.99",
 			},
 		},
 		{
@@ -339,8 +480,36 @@ func TestGetPanelImage(t *testing.T) {
 
 		_, err := getPanelImage(ctx, GetPanelImageParams{
 			DashboardUID: "test-dash",
-			Variables: map[string]string{
-				"var-datasource": "prometheus",
+			Variables: map[string]StringOrSlice{
+				"var-datasource": {"prometheus"},
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("With multi-value dashboard variables", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Multi-value variables should appear as multiple query params
+			values := r.URL.Query()["var-instance"]
+			assert.ElementsMatch(t, []string{"172.16.31.129", "172.16.32.99"}, values)
+
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(testPNGData)
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		_, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+			Variables: map[string]StringOrSlice{
+				"var-instance": {"172.16.31.129", "172.16.32.99"},
 			},
 		})
 


### PR DESCRIPTION
## Summary

- Introduces a `StringOrSlice` custom type for the `Variables` field in `GetPanelImageParams` that accepts both a JSON string (`"prometheus"`) and an array of strings (`["server1", "server2"]`)
- Updates URL construction to use `params.Add` so multi-value variables produce repeated query parameters (e.g., `var-instance=server1&var-instance=server2`)
- Maintains full backward compatibility — single string values continue to work as before

## Test plan

- [x] Unit tests for `StringOrSlice` unmarshal/marshal (string, array, invalid types)
- [x] Unit tests for `GetPanelImageParams` unmarshal with mixed single/multi-value variables
- [x] Unit tests for `buildRenderURL` with multi-value variables
- [x] Integration-style test verifying multi-value query params arrive at the HTTP server
- [x] All existing tests continue to pass
- [x] `go vet` and `golangci-lint` clean

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `get_panel_image` input contract and URL query construction for dashboard variables, which could affect existing callers and rendered URLs (though single-value behavior is intended to remain compatible). Coverage is improved with new unit/integration-style tests.
> 
> **Overview**
> `get_panel_image` now supports **multi-value dashboard variables** by changing `GetPanelImageParams.Variables` to `map[string]StringOrSlice`, where values can be provided as either a JSON string or an array of strings (with JSON schema updated accordingly).
> 
> `buildRenderURL` switches from `params.Set` to `params.Add` for variables so multi-select values are sent as repeated query parameters, and the test suite is expanded to cover marshaling/unmarshaling and end-to-end query behavior for both single and multi-value variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a9e4534d2a8f786ccfd9cb7b2cf602a9639ba17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->