### PR TITLE
fix: remove unused orgId param and warn on missing org ID

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -640,7 +640,8 @@ func doFetchPublicURL(ctx context.Context, grafanaURL, apiKey string, auth *url.
 // NewGrafanaClient creates a Grafana client with the provided URL and API key.
 // The client is automatically configured with the correct HTTP scheme, debug settings from context, custom TLS configuration if present, and OpenTelemetry instrumentation for distributed tracing.
 // It also fetches the Grafana instance's public URL from /api/frontend/settings for use in deep link generation.
-func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.Userinfo, orgId int64) *GrafanaClient {
+// The org ID is read from the GrafanaConfig in the context, which should be set by ExtractGrafanaInfoFromEnv or ExtractGrafanaInfoFromHeaders before calling this function.
+func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.Userinfo) *GrafanaClient {
 	cfg := client.DefaultTransportConfig()
 
 	var parsedURL *url.URL
@@ -762,19 +763,23 @@ var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Conte
 		grafanaURL = defaultGrafanaURL
 	}
 	auth := userAndPassFromEnv()
-	orgId := orgIdFromEnv()
-	grafanaClient := NewGrafanaClient(ctx, grafanaURL, apiKey, auth, orgId)
+	grafanaClient := NewGrafanaClient(ctx, grafanaURL, apiKey, auth)
 	return WithGrafanaClient(ctx, grafanaClient)
 }
 
 // ExtractGrafanaClientFromHeaders is a HTTPContextFunc that creates and injects a Grafana client into the context.
 // It prioritizes configuration from HTTP headers (X-Grafana-URL, X-Grafana-API-Key) over environment variables for multi-tenant scenarios.
 var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
+	config := GrafanaConfigFromContext(ctx)
+	if config.OrgID == 0 {
+		slog.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
+	}
+
 	// Extract transport config from request headers, and set it on the context.
-	u, apiKey, basicAuth, orgId := extractKeyGrafanaInfoFromReq(req)
+	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req)
 	slog.Debug("Creating Grafana client", "url", u, "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil)
 
-	grafanaClient := NewGrafanaClient(ctx, u, apiKey, basicAuth, orgId)
+	grafanaClient := NewGrafanaClient(ctx, u, apiKey, basicAuth)
 	return WithGrafanaClient(ctx, grafanaClient)
 }
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -641,7 +641,7 @@ func TestHTTPTracingConfiguration(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), config)
 
 		// Create Grafana client
-		client := NewGrafanaClient(ctx, "http://localhost:3000", "test-api-key", nil, 0)
+		client := NewGrafanaClient(ctx, "http://localhost:3000", "test-api-key", nil)
 		require.NotNil(t, client)
 
 		// Verify the client was created successfully (should not panic)
@@ -656,7 +656,7 @@ func TestHTTPTracingConfiguration(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), config)
 
 		// Create Grafana client (should not panic even without OTEL configured)
-		client := NewGrafanaClient(ctx, "http://localhost:3000", "test-api-key", nil, 0)
+		client := NewGrafanaClient(ctx, "http://localhost:3000", "test-api-key", nil)
 		require.NotNil(t, client)
 
 		// Verify the client was created successfully
@@ -897,7 +897,7 @@ func TestNewGrafanaClientOrgIDTransport(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
 			OrgID: 99,
 		})
-		c := NewGrafanaClient(ctx, ts.URL, "test-key", nil, 99)
+		c := NewGrafanaClient(ctx, ts.URL, "test-key", nil)
 		require.NotNil(t, c)
 
 		// Make a real request through the client
@@ -917,7 +917,7 @@ func TestNewGrafanaClientOrgIDTransport(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
 			OrgID: 0,
 		})
-		c := NewGrafanaClient(ctx, ts.URL, "test-key", nil, 0)
+		c := NewGrafanaClient(ctx, ts.URL, "test-key", nil)
 		require.NotNil(t, c)
 
 		_, _ = c.Search.Search(nil, nil)
@@ -1102,7 +1102,7 @@ func TestNewGrafanaClientFetchesPublicURL(t *testing.T) {
 		})
 
 		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
-		gc := NewGrafanaClient(ctx, ts.URL, "test-key", nil, 0)
+		gc := NewGrafanaClient(ctx, ts.URL, "test-key", nil)
 		assert.Equal(t, "https://public.grafana.example.com", gc.PublicURL)
 	})
 
@@ -1117,7 +1117,7 @@ func TestNewGrafanaClientFetchesPublicURL(t *testing.T) {
 		})
 
 		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
-		gc := NewGrafanaClient(ctx, ts.URL, "test-key", nil, 0)
+		gc := NewGrafanaClient(ctx, ts.URL, "test-key", nil)
 		assert.Equal(t, "", gc.PublicURL)
 	})
 }

--- a/tools/cloud_testing_utils.go
+++ b/tools/cloud_testing_utils.go
@@ -42,7 +42,7 @@ func createCloudTestContext(t *testing.T, testName, urlEnv, apiKeyEnv string) co
 		t.Skipf("Neither %s nor %s environment variables are set, skipping cloud %s integration tests", serviceAccountTokenEnv, apiKeyEnv, testName)
 	}
 
-	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey, nil, 0)
+	client := mcpgrafana.NewGrafanaClient(ctx, grafanaURL, grafanaApiKey, nil)
 
 	config := mcpgrafana.GrafanaConfig{
 		URL:    grafanaURL,


### PR DESCRIPTION
## Summary
- Removed the unused `orgId int64` parameter from `NewGrafanaClient` — it was silently discarded since the function reads `config.OrgID` from the context instead, which could mislead callers
- Added a `slog.Warn` in `ExtractGrafanaClientFromHeaders` when no org ID is found in headers or env vars, helping users diagnose intermittent org ID issues in SSE/HTTP mode

Ref #640 — a user reported that the org ID fix from #649 still doesn't work consistently. The likely cause is their MCP client not sending `X-Grafana-Org-Id` on every SSE POST, and not having `GRAFANA_ORG_ID` set as a fallback. The new warning log will make this much easier to diagnose.

## Test plan
- [x] Existing unit tests updated and passing
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a small but potentially breaking API change: `NewGrafanaClient`’s signature changes, so downstream callers must update. Runtime behavior is mostly unchanged aside from an added warning log when no org ID is configured for header-based requests.
> 
> **Overview**
> Removes the unused `orgId` parameter from `NewGrafanaClient`, making org selection consistently come from `GrafanaConfig` in the passed `context` rather than from a misleading call-site argument.
> 
> Adds a `slog.Warn` in `ExtractGrafanaClientFromHeaders` when no org ID is found (neither `X-Grafana-Org-Id` nor `GRAFANA_ORG_ID`), to help diagnose multi-tenant/SSE cases where requests fall back to the default org; updates unit + cloud integration test helpers for the new client constructor signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f99988508d59e2a817ce2b261562cf2263e0820. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->