### PR TITLE
chore: add Make targets for local token analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,18 @@ PHONY: run-streamable-http
 run-streamable-http: ## Run the MCP server in StreamableHTTP mode.
 	$(GRAFANA_ENV) $(OTEL_ENV) go run ./cmd/mcp-grafana --transport streamable-http --log-level debug --debug --metrics --enabled-tools $(ENABLED_TOOLS)
 
+define check_mcp_tokens
+	@command -v mcp-tokens >/dev/null 2>&1 || { echo "Error: mcp-tokens is not installed. Install it from https://github.com/sd2k/mcp-tokens"; exit 1; }
+endef
+
 .PHONY: token-baseline
 token-baseline: build ## Generate a token baseline for the MCP server.
+	$(check_mcp_tokens)
 	mcp-tokens analyze --format json --all-providers --output baseline.json -- ./dist/mcp-grafana
 
 .PHONY: token-check
 token-check: build ## Compare token usage against the baseline.
+	$(check_mcp_tokens)
 	mcp-tokens analyze --baseline baseline.json --threshold-percent 5 -- ./dist/mcp-grafana
 
 .PHONY: run-test-services


### PR DESCRIPTION
## Summary

- Adds `make token-baseline` to generate a token baseline JSON file (mirrors the `token-baseline.yml` CI workflow)
- Adds `make token-check` to compare current token usage against the baseline with a 5% threshold (mirrors the `token-check.yml` CI workflow)
- Both targets depend on `build` so the binary is always fresh

These let contributors on forks (where CI token workflows can't run due to missing secrets) run token analysis locally. Requires `mcp-tokens` CLI to be installed.

## Test plan

- [ ] Run `make token-baseline` and verify `baseline.json` is generated
- [ ] Run `make token-check` and verify it compares against the baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Makefile-only changes that add optional local tooling and do not affect runtime code paths. Main risk is minor contributor friction if `mcp-tokens`/`baseline.json` are missing when running the new targets.
> 
> **Overview**
> Adds `make token-baseline` and `make token-check` to run local token usage analysis against the built `dist/mcp-grafana` binary.
> 
> Both targets gate execution on the `mcp-tokens` CLI being installed and use `baseline.json` for baseline generation/comparison (5% threshold).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db07ce9ab209b07a1df15ac1fa4ab4b4354940c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->