### PR TITLE
ci: add CLA label automation

### DIFF
--- a/.github/workflows/cla-label.yml
+++ b/.github/workflows/cla-label.yml
@@ -1,0 +1,53 @@
+name: CLA Label
+
+on:
+  status: {}
+
+jobs:
+  label:
+    if: github.event.context == 'license/cla'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Label PRs based on CLA status
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { state, sha } = context.payload;
+
+            // Find PRs associated with this commit
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            });
+
+            for (const pr of prs) {
+              if (pr.state !== 'open') continue;
+
+              const addLabel = state === 'success' ? 'cla: yes' : 'cla: no';
+              const removeLabel = state === 'success' ? 'cla: no' : 'cla: yes';
+
+              // Add the appropriate label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [addLabel],
+              });
+
+              // Remove the opposite label if present
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: removeLabel,
+                });
+              } catch (e) {
+                // Label wasn't present, that's fine
+              }
+
+              console.log(`PR #${pr.number}: set "${addLabel}", removed "${removeLabel}"`);
+            }


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically labels PRs with `cla: yes` or `cla: no` based on the `license/cla` commit status from CLA Assistant
- Labels are swapped automatically when CLA status changes (e.g., when an author signs)
- Also backfilled labels on all 24 currently open PRs (15 signed, 9 unsigned)

## Test plan

- [x] Backfill script verified correct labeling on all open PRs
- [ ] Verify workflow triggers on next PR with a CLA status update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone GitHub Actions workflow that only updates PR labels based on an external `license/cla` status check, with no impact on runtime code or data handling.
> 
> **Overview**
> Automatically labels open PRs as **`cla: yes`** or **`cla: no`** whenever the `license/cla` commit status updates.
> 
> Adds a new workflow (`.github/workflows/cla-label.yml`) that finds PRs associated with the status’ commit SHA, applies the corresponding label, and removes the opposite label to keep CLA labeling in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8b47a3a8a5b83b2678faf65234ec745e38d5141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->