### PR TITLE
fix: handle text/* content-type responses from Grafana API

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-openapi/runtime"
+	openapiclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/incident-go"
@@ -709,6 +711,17 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 
 	slog.Debug("Creating Grafana client", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", config.BasicAuth != nil, "org_id", cfg.OrgID, "timeout", timeout, "extra_headers_count", len(config.ExtraHeaders))
 	grafanaClient := client.NewHTTPClientWithConfig(strfmt.Default, cfg)
+
+	// Some Grafana versions (v12+) and reverse proxies return JSON responses
+	// with text/plain or text/html content-type headers. The default
+	// TextConsumer cannot deserialize these into typed Go structs. Override
+	// with JSONConsumer so the client can parse the response body correctly.
+	// See: https://github.com/grafana/mcp-grafana/issues/635
+	if rt, ok := grafanaClient.Transport.(*openapiclient.Runtime); ok {
+		jsonConsumer := runtime.JSONConsumer()
+		rt.Consumers[runtime.TextMime] = jsonConsumer
+		rt.Consumers[runtime.HTMLMime] = jsonConsumer
+	}
 
 	// Always enable HTTP tracing for context propagation (no-op when no exporter configured)
 	// Use reflection to wrap the transport without importing the runtime client package

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -1,6 +1,3 @@
-//go:build unit
-// +build unit
-
 package mcpgrafana
 
 import (
@@ -8,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/runtime/client"
@@ -645,6 +643,37 @@ func TestToolTracingInstrumentation(t *testing.T) {
 	})
 }
 
+func TestTextMimeConsumerOverride(t *testing.T) {
+	// Verify that NewGrafanaClient overrides text/plain and text/html consumers
+	// with JSON consumers so that responses with incorrect content-type headers
+	// (e.g. from Grafana v12 or reverse proxies) are still parsed correctly.
+	// See: https://github.com/grafana/mcp-grafana/issues/635
+	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
+	c := NewGrafanaClient(ctx, "http://localhost:3000", "test-api-key", nil)
+	require.NotNil(t, c)
+
+	rt, ok := c.Transport.(*client.Runtime)
+	require.True(t, ok, "expected Transport to be *client.Runtime")
+
+	// The text/plain and text/html consumers should no longer be the default
+	// TextConsumer. Verify by checking they can consume a JSON object into a
+	// map (TextConsumer would fail on this).
+	for _, mime := range []string{"text/plain", "text/html"} {
+		consumer, exists := rt.Consumers[mime]
+		require.True(t, exists, "consumer for %s should exist", mime)
+		require.NotNil(t, consumer, "consumer for %s should not be nil", mime)
+
+		// JSONConsumer can unmarshal into a map; TextConsumer cannot.
+		var result map[string]interface{}
+		err := consumer.Consume(
+			strings.NewReader(`{"status":"ok"}`),
+			&result,
+		)
+		assert.NoError(t, err, "consumer for %s should parse JSON", mime)
+		assert.Equal(t, "ok", result["status"], "consumer for %s should return parsed value", mime)
+	}
+}
+
 func TestHTTPTracingConfiguration(t *testing.T) {
 	t.Run("HTTP tracing always enabled for context propagation", func(t *testing.T) {
 		// Create context (HTTP tracing always enabled)
@@ -731,7 +760,6 @@ func assertHasAttribute(t *testing.T, attributes []attribute.KeyValue, key strin
 	}
 	t.Errorf("Expected attribute %s with value %s not found", key, expectedValue)
 }
-
 
 func TestExtraHeadersFromEnv(t *testing.T) {
 	t.Run("empty env returns nil", func(t *testing.T) {
@@ -1042,7 +1070,7 @@ func TestFetchPublicURL(t *testing.T) {
 		})
 
 		extraHeaders := map[string]string{
-			"X-Custom-Auth": "proxy-token-123",
+			"X-Custom-Auth":   "proxy-token-123",
 			"X-Forwarded-For": "10.0.0.1",
 		}
 		fetchPublicURL(context.Background(), ts.URL, "", nil, nil, extraHeaders)


### PR DESCRIPTION
Some Grafana versions (v12+) and reverse proxies return JSON responses with text/plain or text/html content-type headers instead of application/json. The go-swagger TextConsumer cannot deserialize these into typed Go structs, causing all read operations to fail with "TextConsumer/TextUnmarshaler" errors.

Override the text/plain and text/html consumers with JSONConsumer in NewGrafanaClient so the response body is parsed as JSON regardless of the content-type header.

Fixes #635
Supersedes #643.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OpenAPI client runtime consumers so `text/plain`/`text/html` responses are treated as JSON, which affects how all such responses are deserialized and could mask genuinely non-JSON text bodies.
> 
> **Overview**
> Fixes Grafana API read failures when Grafana v12+ (or proxies) return JSON bodies with `text/plain` or `text/html` content-types by overriding the OpenAPI runtime consumers in `NewGrafanaClient` to use `runtime.JSONConsumer()` for those MIME types.
> 
> Adds a unit test (`TestTextMimeConsumerOverride`) that asserts `text/plain`/`text/html` consumers can successfully unmarshal JSON, plus minor test cleanup/import changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74628c76f4e93209fb1a299635f1327f6f7a5c66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->