### PR TITLE
fix: extract Elasticsearch query field in alert rule summaries

### DIFF
--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -194,6 +194,8 @@ func extractQuerySummaries(data []*models.AlertQuery) []querySummary {
 				s.Expression = expr
 			} else if expr, ok := m["expression"].(string); ok && expr != "" {
 				s.Expression = expr
+			} else if query, ok := m["query"].(string); ok && query != "" {
+				s.Expression = query
 			}
 		}
 		summaries = append(summaries, s)

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -1330,3 +1330,86 @@ func TestConvertAlertQueries(t *testing.T) {
 		require.Equal(t, models.Duration(1800), result[0].RelativeTimeRange.To)
 	})
 }
+
+func TestExtractQuerySummaries(t *testing.T) {
+	t.Run("extracts expr field (Prometheus)", func(t *testing.T) {
+		data := []*models.AlertQuery{
+			{
+				RefID:         "A",
+				DatasourceUID: "prometheus-uid",
+				Model: map[string]any{
+					"expr": `up{job="grafana"}`,
+				},
+			},
+		}
+		summaries := extractQuerySummaries(data)
+		require.Len(t, summaries, 1)
+		require.Equal(t, `up{job="grafana"}`, summaries[0].Expression)
+	})
+
+	t.Run("extracts expression field (Grafana expression)", func(t *testing.T) {
+		data := []*models.AlertQuery{
+			{
+				RefID:         "B",
+				DatasourceUID: "__expr__",
+				Model: map[string]any{
+					"expression": "A",
+				},
+			},
+		}
+		summaries := extractQuerySummaries(data)
+		require.Len(t, summaries, 1)
+		require.Equal(t, "A", summaries[0].Expression)
+	})
+
+	t.Run("extracts query field (Elasticsearch)", func(t *testing.T) {
+		data := []*models.AlertQuery{
+			{
+				RefID:         "A",
+				DatasourceUID: "elasticsearch-uid",
+				Model: map[string]any{
+					"query": `app:"random-service" AND error`,
+				},
+			},
+		}
+		summaries := extractQuerySummaries(data)
+		require.Len(t, summaries, 1)
+		require.Equal(t, `app:"random-service" AND error`, summaries[0].Expression)
+	})
+
+	t.Run("returns nil for empty data", func(t *testing.T) {
+		summaries := extractQuerySummaries(nil)
+		require.Nil(t, summaries)
+	})
+
+	t.Run("handles mixed datasource types", func(t *testing.T) {
+		data := []*models.AlertQuery{
+			{
+				RefID:         "A",
+				DatasourceUID: "elasticsearch-uid",
+				Model: map[string]any{
+					"query": `app:"random-service" AND log.level:"ERROR"`,
+				},
+			},
+			{
+				RefID:         "B",
+				DatasourceUID: "__expr__",
+				Model: map[string]any{
+					"expression": "A",
+				},
+			},
+			{
+				RefID:         "C",
+				DatasourceUID: "__expr__",
+				Model: map[string]any{
+					"expression": "B",
+				},
+			},
+		}
+		summaries := extractQuerySummaries(data)
+		require.Len(t, summaries, 3)
+		require.Equal(t, `app:"random-service" AND log.level:"ERROR"`, summaries[0].Expression)
+		require.Equal(t, "A", summaries[1].Expression)
+		require.Equal(t, "B", summaries[2].Expression)
+	})
+}


### PR DESCRIPTION
## Summary

The `extractQuerySummaries` function in `alerting_manage_rules_handlers.go` currently checks for `expr` (Prometheus) and `expression` (Grafana expressions) fields when extracting query strings from alert rule models. However, Elasticsearch datasources store their Lucene query in a `query` field within the model, which was being silently dropped.

This causes the `alerting_manage_rules` tool to return empty expressions for Elasticsearch-based alert rules when using the `get` operation, making it impossible for MCP clients to retrieve the actual query used by the alert.

### Example

An Elasticsearch alert rule model looks like:

```yaml
query: >-
  app:"random-service" AND error AND NOT "No validation errors found"
datasource:
  type: elasticsearch
  uid: randomuid
```

Before this fix, the `queries` array in the response would only contain `ref_id` and `datasource_uid` — the query string was missing:

```json
{"ref_id": "A", "datasource_uid": "randomuid"}
```

After this fix:

```json
{"ref_id": "A", "datasource_uid": "randomuid", "expression": "app:\"random-service\" AND error AND NOT \"No validation errors found\""}
```

## Changes

- Added an `else if` branch in `extractQuerySummaries` to check for the `query` field (used by Elasticsearch datasources), mapping it to the existing `Expression` field on `querySummary`
- Added unit tests covering Prometheus (`expr`), Grafana expressions (`expression`), Elasticsearch (`query`), nil input, and mixed datasource types

## Test plan

- [x] Verified locally against a Grafana instance with Elasticsearch alert rules
- [x] Unit tests pass: `go test ./tools/ -run TestExtractQuerySummaries -v`
- [x] Existing unit and integration tests should not be affected (no behavioral change for `expr` or `expression` paths)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to alert rule summary extraction that only adds support for an additional model field, covered by targeted unit tests.
> 
> **Overview**
> Alert rule detail responses now preserve Elasticsearch/Lucene queries by having `extractQuerySummaries` fall back to the model’s `query` field when `expr`/`expression` are absent.
> 
> Adds unit tests for `extractQuerySummaries` covering Prometheus (`expr`), Grafana expressions (`expression`), Elasticsearch (`query`), nil input, and mixed query types to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad1bc07164c4e508999ed04f19a710160ad5dce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->