### PR TITLE
Add Codex plugin quality gate CI

### DIFF
--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high


### PR DESCRIPTION
Adds a CI workflow to validate Codex plugin manifests using the [HOL Codex Plugin Scanner](https://github.com/hashgraph-online/codex-plugin-scanner).

This workflow runs automatically on any PR that modifies plugin files (\.codex-plugin/, skills/, .mcp.json) and ensures:
- Manifest structure is valid
- Skills are properly defined
- MCP configuration is correct
- Quality score meets the minimum threshold (80/100)

**Scanner:** [codex-plugin-scanner](https://github.com/hashgraph-online/codex-plugin-scanner) | [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new GitHub Actions workflow only, gating PRs that touch plugin-related files via an external scanner action and failing on high-severity findings or score < 80.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `plugin-quality-gate.yml`, that runs on pull requests affecting `.codex-plugin/**`, `skills/**`, or `.mcp.json`.
> 
> The workflow executes `hashgraph-online/hol-codex-plugin-scanner-action@v1` and fails the PR if the plugin scan score is below `80` or any *high* severity issue is reported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aac39410c8553e3558f2ee7a5c634c4f82d8ed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->