### PR TITLE
Release v0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.6] - 2026-04-09
+
+### Added
+
+- Apply on-behalf-of authentication headers in the Grafana client transport chain, enabling delegated identity for API requests ([#728](https://github.com/grafana/mcp-grafana/pull/728))
+
+### Fixed
+
+- Preserve dashboard identity fields (`id`, `uid`, `version`) in patch mode to prevent accidental dashboard duplication ([#722](https://github.com/grafana/mcp-grafana/pull/722))
+
 ## [0.11.5] - 2026-04-09
 
 ### Added
@@ -125,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.11.6]: https://github.com/grafana/mcp-grafana/compare/v0.11.5...v0.11.6
 [0.11.5]: https://github.com/grafana/mcp-grafana/compare/v0.11.4...v0.11.5
 [0.11.4]: https://github.com/grafana/mcp-grafana/compare/v0.11.3...v0.11.4
 [0.11.3]: https://github.com/grafana/mcp-grafana/compare/v0.11.2...v0.11.3


### PR DESCRIPTION
## Summary

- Bump version to v0.11.6
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.11.6` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating release notes; no code or runtime behavior is modified.
> 
> **Overview**
> Adds a new `0.11.6` section to `CHANGELOG.md`, documenting one transport-layer auth enhancement (on-behalf-of headers) and one dashboard patch-mode fix (preserving `id`/`uid`/`version`).
> 
> Also adds the `v0.11.5...v0.11.6` comparison link for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911ba9349b7bd2b970e54b2cd80eca904d8e5ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->