### PR TITLE
fix: preserve extra model fields in AlertQueryModel for non-PromQL datasources

### DIFF
--- a/tools/alerting_manage_rules_types.go
+++ b/tools/alerting_manage_rules_types.go
@@ -71,18 +71,134 @@ type AlertQuery struct {
 	Model             AlertQueryModel    `json:"model" jsonschema:"required,description=Query model. For data sources: set expr. For expressions: set type and expression."`
 }
 
+// AlertQueryModel represents the query model for an alert query.
+// It has typed fields for common PromQL/expression properties, plus an Extra
+// map that preserves all additional datasource-specific fields (e.g. Graphite
+// "target", "datasource", "textEditor") that would otherwise be silently
+// dropped during JSON round-tripping.
 type AlertQueryModel struct {
 	Expr string `json:"expr,omitempty" jsonschema:"description=Query expression (PromQL\\, LogQL\\, etc.)"`
 
 	// Server-side expressions only (when datasourceUid is __expr__).
-	Type       string           `json:"type,omitempty" jsonschema:"description=Expression type (only for __expr__ datasource): math\\, reduce\\, threshold"`
+	Type       string           `json:"type,omitempty" jsonschema:"description=Expression type (only for __expr__ datasource): math\\, reduce\\, threshold\\, classic_conditions"`
 	Expression string           `json:"expression,omitempty" jsonschema:"description=Expression ref or formula. For reduce/threshold: ref like 'A'. For math: '$A > 0'."`
 	Reducer    string           `json:"reducer,omitempty" jsonschema:"description=Reducer for reduce expressions: last\\, mean\\, min\\, max\\, sum\\, count"`
-	Conditions []AlertCondition `json:"conditions,omitempty" jsonschema:"description=Conditions for threshold expressions"`
+	Conditions []AlertCondition `json:"conditions,omitempty" jsonschema:"description=Conditions for threshold or classic_conditions expressions"`
+
+	// Extra captures all additional model fields not explicitly typed above
+	// (e.g. Graphite "target", "datasource", "textEditor", "intervalMs",
+	// "maxDataPoints", "refId", etc.). This ensures datasource-specific
+	// fields survive JSON round-tripping through convertAlertQueries.
+	Extra map[string]any `json:"-"`
 }
 
+// MarshalJSON implements custom JSON marshaling that merges typed fields with
+// Extra overflow fields, ensuring datasource-specific properties are preserved.
+func (m AlertQueryModel) MarshalJSON() ([]byte, error) {
+	result := make(map[string]any)
+
+	// Start with extra fields as the base
+	for k, v := range m.Extra {
+		result[k] = v
+	}
+
+	// Overlay typed fields (they take precedence over Extra)
+	if m.Expr != "" {
+		result["expr"] = m.Expr
+	}
+	if m.Type != "" {
+		result["type"] = m.Type
+	}
+	if m.Expression != "" {
+		result["expression"] = m.Expression
+	}
+	if m.Reducer != "" {
+		result["reducer"] = m.Reducer
+	}
+	if len(m.Conditions) > 0 {
+		result["conditions"] = m.Conditions
+	}
+
+	return json.Marshal(result)
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling that populates typed fields
+// and stores all remaining fields in Extra.
+func (m *AlertQueryModel) UnmarshalJSON(data []byte) error {
+	// Unmarshal everything into a generic map first
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Extract known typed fields. If a known key exists but has an unexpected
+	// type (e.g. null, number, object instead of string), fall through to
+	// Extra so the value is preserved in the round-trip rather than silently
+	// dropped.
+	knownConsumed := make(map[string]bool)
+
+	if v, ok := raw["expr"].(string); ok {
+		m.Expr = v
+		knownConsumed["expr"] = true
+	}
+	if v, ok := raw["type"].(string); ok {
+		m.Type = v
+		knownConsumed["type"] = true
+	}
+	if v, ok := raw["expression"].(string); ok {
+		m.Expression = v
+		knownConsumed["expression"] = true
+	}
+	if v, ok := raw["reducer"].(string); ok {
+		m.Reducer = v
+		knownConsumed["reducer"] = true
+	}
+	if v, ok := raw["conditions"]; ok {
+		condBytes, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("marshal conditions: %w", err)
+		}
+		if err := json.Unmarshal(condBytes, &m.Conditions); err != nil {
+			return fmt.Errorf("unmarshal conditions: %w", err)
+		}
+		knownConsumed["conditions"] = true
+	}
+
+	// Store all remaining fields in Extra — including known keys whose
+	// type assertion failed above, so no value is silently lost.
+	m.Extra = make(map[string]any)
+	for k, v := range raw {
+		if !knownConsumed[k] {
+			m.Extra[k] = v
+		}
+	}
+
+	return nil
+}
+
+// AlertCondition represents a condition within a classic_conditions or threshold expression.
+// It includes the full set of fields used by classic_conditions (evaluator, operator, query, reducer).
 type AlertCondition struct {
-	Evaluator ConditionEvaluator `json:"evaluator" jsonschema:"description=Threshold evaluator"`
+	Evaluator ConditionEvaluator  `json:"evaluator" jsonschema:"description=Threshold evaluator"`
+	Operator  *ConditionOperator  `json:"operator,omitempty" jsonschema:"description=Logical operator (and/or) for combining conditions"`
+	Query     *ConditionQuery     `json:"query,omitempty" jsonschema:"description=Query reference for classic_conditions (contains params with RefID)"`
+	Reducer   *ConditionReducer   `json:"reducer,omitempty" jsonschema:"description=Reducer for classic_conditions (avg\\, sum\\, min\\, max\\, count\\, last\\, median)"`
+}
+
+// ConditionOperator represents the logical operator in a classic_conditions condition.
+type ConditionOperator struct {
+	Type string `json:"type" jsonschema:"description=Logical operator type: and\\, or"`
+}
+
+// ConditionQuery represents the query reference in a classic_conditions condition.
+type ConditionQuery struct {
+	Params []string `json:"params" jsonschema:"description=Query parameters\\, typically contains the RefID of the referenced query (e.g. ['C'])"`
+}
+
+// ConditionReducer represents the reducer in a classic_conditions condition.
+type ConditionReducer struct {
+	Type   string   `json:"type" jsonschema:"description=Reducer type: avg\\, sum\\, min\\, max\\, count\\, last\\, median"`
+	Params []string `json:"params,omitempty" jsonschema:"description=Optional reducer parameters"`
 }
 
 type ConditionEvaluator struct {

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -1329,6 +1329,157 @@ func TestConvertAlertQueries(t *testing.T) {
 		require.Equal(t, models.Duration(3600), result[0].RelativeTimeRange.From)
 		require.Equal(t, models.Duration(1800), result[0].RelativeTimeRange.To)
 	})
+
+	t.Run("preserves extra model fields for Graphite queries", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{
+				RefID:         "C",
+				DatasourceUID: "000000004",
+				RelativeTimeRange: &RelativeTimeRange{From: 300, To: 0},
+				Model: AlertQueryModel{
+					Extra: map[string]any{
+						"datasource": map[string]any{"type": "graphite", "uid": "000000004"},
+						"target":     "alias(asPercent(sumSeries(a), sumSeries(b)), 'error rate')",
+						"textEditor": true,
+						"refId":      "C",
+					},
+				},
+			},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, "C", result[0].RefID)
+
+		model := result[0].Model.(map[string]any)
+		require.Equal(t, "alias(asPercent(sumSeries(a), sumSeries(b)), 'error rate')", model["target"])
+		require.Equal(t, true, model["textEditor"])
+		ds, ok := model["datasource"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "graphite", ds["type"])
+	})
+
+	t.Run("preserves classic_conditions with operator, query, and reducer", func(t *testing.T) {
+		queries := []*AlertQuery{
+			{
+				RefID:         "A",
+				DatasourceUID: "__expr__",
+				Model: AlertQueryModel{
+					Type: "classic_conditions",
+					Conditions: []AlertCondition{
+						{
+							Evaluator: ConditionEvaluator{Type: "gt", Params: []float64{0.1}},
+							Operator:  &ConditionOperator{Type: "and"},
+							Query:     &ConditionQuery{Params: []string{"C"}},
+							Reducer:   &ConditionReducer{Type: "avg"},
+						},
+					},
+				},
+			},
+		}
+		result, err := convertAlertQueries(queries)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+
+		model := result[0].Model.(map[string]any)
+		conditions, ok := model["conditions"].([]any)
+		require.True(t, ok)
+		require.Len(t, conditions, 1)
+
+		cond := conditions[0].(map[string]any)
+		// Verify evaluator
+		evaluator := cond["evaluator"].(map[string]any)
+		require.Equal(t, "gt", evaluator["type"])
+		// Verify operator is preserved
+		operator := cond["operator"].(map[string]any)
+		require.Equal(t, "and", operator["type"])
+		// Verify query params (RefID reference) is preserved
+		query := cond["query"].(map[string]any)
+		params := query["params"].([]any)
+		require.Equal(t, "C", params[0])
+		// Verify reducer is preserved
+		reducer := cond["reducer"].(map[string]any)
+		require.Equal(t, "avg", reducer["type"])
+	})
+}
+
+func TestAlertQueryModel_JSONRoundTrip(t *testing.T) {
+	t.Run("round-trips Graphite model without data loss", func(t *testing.T) {
+		input := `{
+			"datasource": {"type": "graphite", "uid": "000000004"},
+			"target": "alias(asPercent(a, b), 'rate')",
+			"textEditor": true,
+			"intervalMs": 1000,
+			"maxDataPoints": 43200,
+			"refCount": 0,
+			"refId": "C"
+		}`
+
+		var model AlertQueryModel
+		err := json.Unmarshal([]byte(input), &model)
+		require.NoError(t, err)
+
+		// Typed fields should be empty (Graphite doesn't use them)
+		require.Empty(t, model.Expr)
+		require.Empty(t, model.Type)
+
+		// Extra should have all Graphite-specific fields
+		require.Equal(t, "alias(asPercent(a, b), 'rate')", model.Extra["target"])
+		require.Equal(t, true, model.Extra["textEditor"])
+		require.Equal(t, float64(1000), model.Extra["intervalMs"])
+
+		// Re-marshal and verify no data loss
+		output, err := json.Marshal(model)
+		require.NoError(t, err)
+
+		var roundTripped map[string]any
+		err = json.Unmarshal(output, &roundTripped)
+		require.NoError(t, err)
+
+		require.Equal(t, "alias(asPercent(a, b), 'rate')", roundTripped["target"])
+		require.Equal(t, true, roundTripped["textEditor"])
+		require.Equal(t, float64(1000), roundTripped["intervalMs"])
+	})
+
+	t.Run("round-trips classic_conditions with all fields", func(t *testing.T) {
+		input := `{
+			"type": "classic_conditions",
+			"conditions": [
+				{
+					"evaluator": {"type": "gt", "params": [0.1]},
+					"operator": {"type": "and"},
+					"query": {"params": ["C"]},
+					"reducer": {"type": "avg"}
+				}
+			]
+		}`
+
+		var model AlertQueryModel
+		err := json.Unmarshal([]byte(input), &model)
+		require.NoError(t, err)
+		require.Equal(t, "classic_conditions", model.Type)
+		require.Len(t, model.Conditions, 1)
+		require.NotNil(t, model.Conditions[0].Operator)
+		require.Equal(t, "and", model.Conditions[0].Operator.Type)
+		require.NotNil(t, model.Conditions[0].Query)
+		require.Equal(t, []string{"C"}, model.Conditions[0].Query.Params)
+		require.NotNil(t, model.Conditions[0].Reducer)
+		require.Equal(t, "avg", model.Conditions[0].Reducer.Type)
+
+		// Re-marshal
+		output, err := json.Marshal(model)
+		require.NoError(t, err)
+
+		var roundTripped map[string]any
+		err = json.Unmarshal(output, &roundTripped)
+		require.NoError(t, err)
+
+		conditions := roundTripped["conditions"].([]any)
+		cond := conditions[0].(map[string]any)
+		query := cond["query"].(map[string]any)
+		params := query["params"].([]any)
+		require.Equal(t, "C", params[0])
+	})
 }
 
 func TestExtractQuerySummaries(t *testing.T) {


### PR DESCRIPTION
## Summary

`AlertQueryModel` only has typed fields for PromQL-style queries (`expr`, `type`, `expression`, `reducer`, `conditions`). Fields specific to other datasources like Graphite (`target`, `datasource`, `textEditor`) and classic_conditions fields (`operator`, `query`, `reducer`) are silently dropped during JSON round-tripping in `convertAlertQueries()`.

This causes alert rules created via the MCP tool to fail with:
```
[sse.parseError] failed to parse expression [A]: condition 1 is missing the query RefID argument
```

Fixes #731

## Changes

- Add `Extra map[string]any` to `AlertQueryModel` with custom `MarshalJSON`/`UnmarshalJSON` to preserve all datasource-specific fields that aren't explicitly typed
- Add missing `Operator`, `Query`, `Reducer` fields to `AlertCondition` for classic_conditions support
- Add unit tests for:
  - Graphite model field preservation through `convertAlertQueries`
  - Classic_conditions with operator/query/reducer round-tripping
  - Full JSON round-trip tests for both Graphite and classic_conditions models

## Affected Datasources

Any datasource that uses model fields beyond `expr`:
- **Graphite** (`target`, `datasource`, `textEditor`)
- **Classic conditions** (`query.params`, `operator`, `reducer`)
- Likely also: CloudWatch, Elasticsearch, InfluxDB, etc.

## Test Plan

- [ ] Existing unit tests pass
- [ ] New `TestAlertQueryModel_JSONRoundTrip` tests verify no data loss
- [ ] New `convertAlertQueries` tests verify Graphite and classic_conditions preservation
- [ ] Integration test: create alert rule with Graphite datasource via MCP tool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces custom JSON marshal/unmarshal for `AlertQueryModel`, which changes how alert query models are serialized for all datasources; bugs here could alter or drop fields sent to the Grafana API. Covered by new unit tests, but still touches core request payload construction in `convertAlertQueries`.
> 
> **Overview**
> Fixes alert rule creation/update for non-PromQL datasources by preventing datasource-specific `model` fields from being lost when building Grafana API payloads.
> 
> `AlertQueryModel` now keeps an `Extra` field and custom `MarshalJSON`/`UnmarshalJSON` to round-trip unknown model properties, and `AlertCondition` is expanded to support `classic_conditions` (`operator`, `query`, `reducer`). Adds unit tests verifying Graphite field preservation through `convertAlertQueries` and full JSON round-trip coverage for Graphite and `classic_conditions` models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1385deff6712cb2092e62d52c4f5b319a71a9ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->