### PR TITLE
fix: include full query data in alert rule get response

### DIFF
--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -159,6 +159,7 @@ func mergeRuleDetail(provisioned *models.ProvisionedAlertRule, runtime *alerting
 	detail.IsPaused = provisioned.IsPaused
 	detail.NotificationSettings = provisioned.NotificationSettings
 	detail.Queries = extractQuerySummaries(provisioned.Data)
+	detail.Data = provisioned.Data
 
 	if runtime != nil {
 		detail.State = normalizeState(runtime.State)

--- a/tools/alerting_manage_rules_types.go
+++ b/tools/alerting_manage_rules_types.go
@@ -39,6 +39,7 @@ type alertRuleDetail struct {
 	IsPaused             bool                                  `json:"is_paused"`
 	NotificationSettings *models.AlertRuleNotificationSettings `json:"notification_settings,omitempty"`
 	Queries              []querySummary                        `json:"queries,omitempty"`
+	Data                 []*models.AlertQuery                  `json:"data,omitempty"`
 
 	KeepFiringFor               string  `json:"keep_firing_for,omitempty"`
 	Record                      *Record `json:"record,omitempty" `

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -850,6 +850,16 @@ func TestMergeRuleDetail(t *testing.T) {
 		require.Equal(t, "__expr__", detail.Queries[1].DatasourceUID)
 		require.Equal(t, "$A > 0", detail.Queries[1].Expression)
 
+		// Full query data should be preserved for round-tripping
+		require.Len(t, detail.Data, 2, "Data should contain full query models from provisioning API")
+		require.Equal(t, "A", detail.Data[0].RefID)
+		require.Equal(t, "prometheus-uid", detail.Data[0].DatasourceUID)
+		model0, ok := detail.Data[0].Model.(map[string]any)
+		require.True(t, ok, "Data[0].Model should be a map")
+		require.Equal(t, "up{job=\"api\"}", model0["expr"])
+		require.Equal(t, "B", detail.Data[1].RefID)
+		require.Equal(t, "__expr__", detail.Data[1].DatasourceUID)
+
 		// Runtime fields
 		require.Equal(t, "firing", detail.State)
 		require.Equal(t, "ok", detail.Health)
@@ -918,6 +928,55 @@ func TestMergeRuleDetail(t *testing.T) {
 		require.Equal(t, "ok", detail.Health, "the health status should match")
 		require.Equal(t, "recording", detail.Type, "the rule type should be 'recording'")
 		require.Equal(t, "2026-02-28T12:00:00Z", detail.LastEvaluation, "the last evaluation time should match formatted UTC time")
+	})
+
+	t.Run("Data preserves full Graphite query model for round-tripping", func(t *testing.T) {
+		title := "DLB Error Rate"
+		folderUID := "folder-1"
+		ruleGroup := "infra"
+		condition := "A"
+
+		graphiteModel := map[string]any{
+			"datasource": map[string]any{"type": "graphite", "uid": "000000004"},
+			"target":     "alias(asPercent(sumSeries(a), sumSeries(b)), 'error rate')",
+			"textEditor": true,
+			"intervalMs":  float64(1000),
+			"refId":      "C",
+		}
+
+		provisioned := &models.ProvisionedAlertRule{
+			UID:       "rule-graphite",
+			Title:     &title,
+			FolderUID: &folderUID,
+			RuleGroup: &ruleGroup,
+			Condition: &condition,
+			Data: []*models.AlertQuery{
+				{
+					RefID:         "C",
+					DatasourceUID: "000000004",
+					Model:         graphiteModel,
+				},
+			},
+		}
+
+		detail := mergeRuleDetail(provisioned, nil)
+
+		// Queries summary won't have the Graphite target (only expr/expression/query)
+		require.Len(t, detail.Queries, 1)
+		require.Equal(t, "C", detail.Queries[0].RefID)
+		require.Empty(t, detail.Queries[0].Expression, "querySummary does not capture Graphite target")
+
+		// But Data should have the full model for round-tripping
+		require.Len(t, detail.Data, 1, "Data must be populated with full query models")
+		require.Equal(t, "C", detail.Data[0].RefID)
+		require.Equal(t, "000000004", detail.Data[0].DatasourceUID)
+		model, ok := detail.Data[0].Model.(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "alias(asPercent(sumSeries(a), sumSeries(b)), 'error rate')", model["target"], "Graphite target must survive in Data")
+		require.Equal(t, true, model["textEditor"], "textEditor must survive in Data")
+		ds, ok := model["datasource"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "graphite", ds["type"])
 	})
 
 	t.Run("nil runtime leaves state fields empty", func(t *testing.T) {


### PR DESCRIPTION
## Summary

The `alerting_manage_rules` `get` operation returns only a `querySummary` (`ref_id`, `datasource_uid`, `expression`) for each query, discarding the full query model from the provisioning API. This makes `get` -> `update` round-trips silently lose datasource-specific fields for non-PromQL datasources (Graphite, OpenSearch, Elasticsearch, etc.).

Fixes #732

## Changes

- Add `Data []*models.AlertQuery` field to `alertRuleDetail` struct
- Populate `Data` from `provisioned.Data` in `mergeRuleDetail`, preserving full query models alongside the existing `Queries` summary
- Add unit test verifying Graphite model fields (`target`, `textEditor`, `datasource`) survive in the `Data` field
- Add assertions to existing `mergeRuleDetail` test verifying `Data` is populated for Prometheus queries

## Why both `Queries` and `Data`?

- `Queries` (summary) is compact and useful for LLM context — shows ref_id, datasource, and expression at a glance
- `Data` (full) contains the complete `models.AlertQuery` with all model fields, enabling safe round-trip updates

Removing `Queries` would be a breaking change for existing consumers. Adding `Data` alongside is backward-compatible.

## Test Plan

- [x] `go vet ./tools/` passes
- [x] `go test ./tools/` — all unit tests pass
- [x] JSON schema linter passes
- [x] New test: `TestMergeRuleDetail/Data_preserves_full_Graphite_query_model_for_round-tripping`
- [x] Extended test: existing `merges_provisioned_config_with_runtime_state` now verifies `Data` field

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive API response change that preserves existing `queries` behavior while returning additional `data` payload for round-tripping; main risk is unexpected larger responses for consumers that deserialize strictly.
> 
> **Overview**
> The `alerting_manage_rules` `get` response now includes full provisioning query payloads (`data: []*models.AlertQuery`) in addition to the existing compact `queries` summaries, preventing loss of datasource-specific query fields during `get` → `update` round-trips.
> 
> `mergeRuleDetail` now copies `provisioned.Data` into the new `alertRuleDetail.Data` field, and unit tests were extended to assert round-tripping for Prometheus queries and a Graphite query model (e.g., `target`, `textEditor`, `datasource`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bc6d447ed0471cde27eb613328c8b0664eaafa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->