### PR TITLE
Add Graphite datasource support with query and metric browsing tools

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -44,7 +44,7 @@ type disabledTools struct {
 	prometheus, loki, elasticsearch, alerting,
 	dashboard, folder, oncall, asserts, sift, admin,
 	pyroscope, navigation, proxied, annotations, rendering, cloudwatch, write,
-	examples, clickhouse, searchlogs,
+	examples, clickhouse, searchlogs, graphite,
 	runpanelquery bool
 }
 
@@ -64,7 +64,7 @@ type grafanaConfig struct {
 }
 
 func (dt *disabledTools) addFlags() {
-	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
+	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,graphite", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
 	flag.BoolVar(&dt.search, "disable-search", false, "Disable search tools")
 	flag.BoolVar(&dt.datasource, "disable-datasource", false, "Disable datasource tools")
 	flag.BoolVar(&dt.incident, "disable-incident", false, "Disable incident tools")
@@ -89,6 +89,7 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.clickhouse, "disable-clickhouse", false, "Disable ClickHouse tools")
 	flag.BoolVar(&dt.searchlogs, "disable-searchlogs", false, "Disable search logs tools")
 	flag.BoolVar(&dt.runpanelquery, "disable-runpanelquery", false, "Disable run panel query tools")
+	flag.BoolVar(&dt.graphite, "disable-graphite", false, "Disable Graphite tools")
 }
 
 func (gc *grafanaConfig) addFlags() {
@@ -129,6 +130,7 @@ func (dt *disabledTools) addTools(s *server.MCPServer) {
 	maybeAddTools(s, tools.AddClickHouseTools, enabledTools, dt.clickhouse, "clickhouse")
 	maybeAddTools(s, tools.AddSearchLogsTools, enabledTools, dt.searchlogs, "searchlogs")
 	maybeAddTools(s, tools.AddRunPanelQueryTools, enabledTools, dt.runpanelquery, "runpanelquery")
+	maybeAddTools(s, tools.AddGraphiteTools, enabledTools, dt.graphite, "graphite")
 }
 
 func newServer(transport string, dt disabledTools, obs *observability.Observability, sessionIdleTimeoutMinutes int) (*server.MCPServer, *mcpgrafana.ToolManager, *mcpgrafana.SessionManager) {

--- a/tools/graphite.go
+++ b/tools/graphite.go
@@ -1,0 +1,362 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const (
+	// GraphiteDatasourceType is the type identifier for Graphite datasources
+	GraphiteDatasourceType = "graphite"
+
+	graphiteResponseLimitBytes = 1024 * 1024 * 10 // 10MB
+)
+
+// GraphiteClient handles queries to a Graphite datasource via Grafana proxy
+type GraphiteClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func newGraphiteClient(ctx context.Context, uid string) (*GraphiteClient, error) {
+	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
+	if err != nil {
+		return nil, err
+	}
+	if ds.Type != GraphiteDatasourceType {
+		return nil, fmt.Errorf("datasource %s is of type %s, not %s", uid, ds.Type, GraphiteDatasourceType)
+	}
+
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	grafanaURL := strings.TrimRight(cfg.URL, "/")
+	resourcesBase, proxyBase := datasourceProxyPaths(uid)
+	baseURL := grafanaURL + proxyBase
+
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create custom transport: %w", err)
+	}
+	transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
+
+	// Wrap with fallback transport: try /proxy first, fall back to /resources
+	// on 403/500 for compatibility with different managed Grafana deployments.
+	var rt http.RoundTripper = mcpgrafana.NewUserAgentTransport(transport)
+	rt = newDatasourceFallbackTransport(rt, proxyBase, resourcesBase)
+
+	client := &http.Client{Transport: rt}
+	return &GraphiteClient{httpClient: client, baseURL: baseURL}, nil
+}
+
+// doGet performs a GET request to the Graphite API via the Grafana proxy
+func (c *GraphiteClient) doGet(ctx context.Context, path string, params url.Values) ([]byte, error) {
+	fullURL := strings.TrimRight(c.baseURL, "/") + path
+	if len(params) > 0 {
+		fullURL += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("graphite API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, graphiteResponseLimitBytes))
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	return data, nil
+}
+
+// GraphiteDatapoint is a single metric sample. Value is nil when Graphite
+// reports no data for that timestamp (null in the JSON response).
+type GraphiteDatapoint struct {
+	Value     *float64 `json:"value"`
+	Timestamp int64    `json:"timestamp"`
+}
+
+// GraphiteSeries is a metric series as returned by the Graphite render API.
+type GraphiteSeries struct {
+	Target     string             `json:"target"`
+	Tags       map[string]string  `json:"tags,omitempty"`
+	Datapoints []GraphiteDatapoint `json:"datapoints"`
+}
+
+// graphiteRawSeries is the wire format for the Graphite render API response.
+// Each datapoint is [value_or_null, unix_timestamp].
+type graphiteRawSeries struct {
+	Target     string              `json:"target"`
+	Tags       map[string]string   `json:"tags,omitempty"`
+	Datapoints [][]json.RawMessage `json:"datapoints"`
+}
+
+// parseGraphiteDatapoints converts the raw render API datapoints to typed values.
+func parseGraphiteDatapoints(raw [][]json.RawMessage) []GraphiteDatapoint {
+	pts := make([]GraphiteDatapoint, 0, len(raw))
+	for _, pair := range raw {
+		if len(pair) < 2 {
+			continue
+		}
+		var ts int64
+		if err := json.Unmarshal(pair[1], &ts); err != nil {
+			continue
+		}
+		var val *float64
+		if string(pair[0]) != "null" {
+			var f float64
+			if err := json.Unmarshal(pair[0], &f); err == nil {
+				val = &f
+			}
+		}
+		pts = append(pts, GraphiteDatapoint{Value: val, Timestamp: ts})
+	}
+	return pts
+}
+
+// parseGraphiteTime converts a time string to a value Graphite's render API
+// accepts for its `from`/`until` parameters.
+//
+//   - Empty string → returned as-is (caller should supply a default).
+//   - Graphite relative formats ("-1h", "-24h", "now", …) → passed through unchanged.
+//   - RFC 3339 strings → converted to a Unix timestamp (integer seconds).
+func parseGraphiteTime(s string) string {
+	if s == "" || s == "now" || strings.HasPrefix(s, "-") {
+		return s
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		// Unknown format — pass through and let Graphite decide.
+		return s
+	}
+	return strconv.FormatInt(t.Unix(), 10)
+}
+
+// QueryGraphiteParams defines the parameters for querying a Graphite datasource.
+type QueryGraphiteParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the Graphite datasource to query"`
+	Target        string `json:"target" jsonschema:"required,description=The Graphite target expression to evaluate (e.g. 'servers.web*.cpu.load5'\\, 'sumSeries(app.*.requests)'\\, 'seriesByTag(\\'name=cpu.load\\')')"`
+	From          string `json:"from,omitempty" jsonschema:"description=Start of the time range. Accepts RFC3339 (e.g. '2024-01-01T00:00:00Z') or Graphite relative times (e.g. '-1h'\\, '-24h'). Defaults to '-1h'."`
+	Until         string `json:"until,omitempty" jsonschema:"description=End of the time range. Accepts RFC3339 or Graphite relative times (e.g. 'now'). Defaults to 'now'."`
+	MaxDataPoints int    `json:"maxDataPoints,omitempty" jsonschema:"description=Optional maximum number of data points per series. Graphite consolidates data when the requested range exceeds this value."`
+}
+
+// QueryGraphiteResult wraps a Graphite render query result with optional hints.
+type QueryGraphiteResult struct {
+	Series []*GraphiteSeries `json:"series"`
+	Hints  *EmptyResultHints `json:"hints,omitempty"`
+}
+
+func queryGraphite(ctx context.Context, args QueryGraphiteParams) (*QueryGraphiteResult, error) {
+	client, err := newGraphiteClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating graphite client: %w", err)
+	}
+
+	from := args.From
+	if from == "" {
+		from = "-1h"
+	}
+	until := args.Until
+	if until == "" {
+		until = "now"
+	}
+
+	params := url.Values{}
+	params.Set("target", args.Target)
+	params.Set("from", parseGraphiteTime(from))
+	params.Set("until", parseGraphiteTime(until))
+	params.Set("format", "json")
+	if args.MaxDataPoints > 0 {
+		params.Set("maxDataPoints", strconv.Itoa(args.MaxDataPoints))
+	}
+
+	data, err := client.doGet(ctx, "/render", params)
+	if err != nil {
+		return nil, fmt.Errorf("querying graphite render API: %w", err)
+	}
+
+	var rawSeries []graphiteRawSeries
+	if err := json.Unmarshal(data, &rawSeries); err != nil {
+		return nil, fmt.Errorf("parsing graphite render response: %w", err)
+	}
+
+	series := make([]*GraphiteSeries, 0, len(rawSeries))
+	for _, rs := range rawSeries {
+		series = append(series, &GraphiteSeries{
+			Target:     rs.Target,
+			Tags:       rs.Tags,
+			Datapoints: parseGraphiteDatapoints(rs.Datapoints),
+		})
+	}
+
+	result := &QueryGraphiteResult{Series: series}
+	if len(series) == 0 {
+		var startTime, endTime time.Time
+		if t, err := time.Parse(time.RFC3339, args.From); err == nil {
+			startTime = t
+		}
+		if t, err := time.Parse(time.RFC3339, args.Until); err == nil {
+			endTime = t
+		}
+		result.Hints = GenerateEmptyResultHints(HintContext{
+			DatasourceType: GraphiteDatasourceType,
+			Query:          args.Target,
+			StartTime:      startTime,
+			EndTime:        endTime,
+		})
+	}
+	return result, nil
+}
+
+// QueryGraphite is the MCP tool for querying a Graphite datasource.
+var QueryGraphite = mcpgrafana.MustTool(
+	"query_graphite",
+	"WORKFLOW: list_graphite_metrics -> query_graphite.\n\nExecutes a Graphite render API query against a Graphite datasource and returns matching metric series with their datapoints. Supports the full Graphite target expression language including wildcard patterns (e.g. 'servers.web*.cpu.load5'), aggregation functions (e.g. 'sumSeries(app.*.requests)'), and tag-based queries (e.g. 'seriesByTag(\\'name=cpu.load\\')'). Datapoints with no recorded value are returned with a null value field. Time range defaults to the last hour if not specified.",
+	queryGraphite,
+	mcp.WithTitleAnnotation("Query Graphite metrics"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// GraphiteMetricNode is a node in the Graphite metric hierarchy as returned
+// by the find API.
+type GraphiteMetricNode struct {
+	// ID is the full dotted path of this node (e.g. "servers.web01.cpu").
+	ID string `json:"id"`
+	// Text is the last segment of the path (e.g. "cpu").
+	Text string `json:"text"`
+	// Leaf indicates whether this node is an actual metric (true) or a
+	// branch that can be expanded further (false).
+	Leaf bool `json:"leaf"`
+	// Expandable indicates whether this node has children.
+	Expandable bool `json:"expandable"`
+}
+
+// graphiteRawMetricNode is the wire format returned by Graphite's find API;
+// leaf and expandable are encoded as integers (0 or 1).
+type graphiteRawMetricNode struct {
+	ID         string `json:"id"`
+	Text       string `json:"text"`
+	Leaf       int    `json:"leaf"`
+	Expandable int    `json:"expandable"`
+}
+
+// ListGraphiteMetricsParams defines the parameters for the list_graphite_metrics tool.
+type ListGraphiteMetricsParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the Graphite datasource to query"`
+	Query         string `json:"query" jsonschema:"required,description=Metric path pattern to search. Use '*' as a wildcard at any level (e.g. '*' lists top-level nodes\\, 'servers.*' lists all servers\\, 'servers.web01.*' lists all metrics under web01)."`
+}
+
+func listGraphiteMetrics(ctx context.Context, args ListGraphiteMetricsParams) ([]GraphiteMetricNode, error) {
+	client, err := newGraphiteClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating graphite client: %w", err)
+	}
+
+	query := args.Query
+	if query == "" {
+		query = "*"
+	}
+
+	params := url.Values{}
+	params.Set("query", query)
+
+	data, err := client.doGet(ctx, "/metrics/find", params)
+	if err != nil {
+		return nil, fmt.Errorf("listing graphite metrics: %w", err)
+	}
+
+	var rawNodes []graphiteRawMetricNode
+	if err := json.Unmarshal(data, &rawNodes); err != nil {
+		return nil, fmt.Errorf("parsing graphite metrics response: %w", err)
+	}
+
+	nodes := make([]GraphiteMetricNode, 0, len(rawNodes))
+	for _, rn := range rawNodes {
+		nodes = append(nodes, GraphiteMetricNode{
+			ID:         rn.ID,
+			Text:       rn.Text,
+			Leaf:       rn.Leaf == 1,
+			Expandable: rn.Expandable == 1,
+		})
+	}
+	return nodes, nil
+}
+
+// ListGraphiteMetrics is the MCP tool for browsing the Graphite metric tree.
+var ListGraphiteMetrics = mcpgrafana.MustTool(
+	"list_graphite_metrics",
+	"Discover available metric paths in a Graphite datasource by browsing the metric tree. Returns nodes matching the query pattern\\, each indicating whether it is a leaf metric (has data) or an expandable branch (has children). Use '*' as a wildcard at any level to enumerate the tree (e.g. '*' → top-level nodes\\, 'servers.*' → all second-level nodes under 'servers'). Drill down progressively to find the full metric path before querying with query_graphite.",
+	listGraphiteMetrics,
+	mcp.WithTitleAnnotation("List Graphite metrics"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// ListGraphiteTagsParams defines the parameters for the list_graphite_tags tool.
+type ListGraphiteTagsParams struct {
+	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the Graphite datasource to query"`
+	Prefix        string `json:"prefix,omitempty" jsonschema:"description=Optional prefix to filter tag names (e.g. 'env' returns tags whose name starts with 'env')."`
+}
+
+func listGraphiteTags(ctx context.Context, args ListGraphiteTagsParams) ([]string, error) {
+	client, err := newGraphiteClient(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating graphite client: %w", err)
+	}
+
+	params := url.Values{}
+	if args.Prefix != "" {
+		params.Set("tagPrefix", args.Prefix)
+	}
+
+	data, err := client.doGet(ctx, "/tags", params)
+	if err != nil {
+		return nil, fmt.Errorf("listing graphite tags: %w", err)
+	}
+
+	var tags []string
+	if err := json.Unmarshal(data, &tags); err != nil {
+		return nil, fmt.Errorf("parsing graphite tags response: %w", err)
+	}
+	return tags, nil
+}
+
+// ListGraphiteTags is the MCP tool for listing tag names in a tagged Graphite instance.
+var ListGraphiteTags = mcpgrafana.MustTool(
+	"list_graphite_tags",
+	"List available tag names in a Graphite datasource that uses tag-based metrics. Returns a list of tag name strings (e.g. [\"name\"\\, \"env\"\\, \"region\"]). These tags can be used to build tag-based target expressions for query_graphite (e.g. seriesByTag('name=cpu.load\\,env=prod')). Optionally filter by a prefix. Requires Graphite to be configured with tag support.",
+	listGraphiteTags,
+	mcp.WithTitleAnnotation("List Graphite tags"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// AddGraphiteTools registers all Graphite tools with the MCP server.
+func AddGraphiteTools(mcp *server.MCPServer) {
+	QueryGraphite.Register(mcp)
+	ListGraphiteMetrics.Register(mcp)
+	ListGraphiteTags.Register(mcp)
+}

--- a/tools/graphite_unit_test.go
+++ b/tools/graphite_unit_test.go
@@ -1,0 +1,340 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- parseGraphiteTime ---
+
+func TestParseGraphiteTime(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string passes through",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "now passes through",
+			input: "now",
+			want:  "now",
+		},
+		{
+			name:  "relative -1h passes through",
+			input: "-1h",
+			want:  "-1h",
+		},
+		{
+			name:  "relative -24h passes through",
+			input: "-24h",
+			want:  "-24h",
+		},
+		{
+			name:  "RFC3339 is converted to unix timestamp",
+			input: "2024-01-01T00:00:00Z",
+			want:  "1704067200",
+		},
+		{
+			name:  "unknown format passes through",
+			input: "12:00_20240101",
+			want:  "12:00_20240101",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseGraphiteTime(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// --- parseGraphiteDatapoints ---
+
+func TestParseGraphiteDatapoints(t *testing.T) {
+	t.Run("normal values", func(t *testing.T) {
+		raw := [][]json.RawMessage{
+			{json.RawMessage("1.5"), json.RawMessage("1704067200")},
+			{json.RawMessage("2.0"), json.RawMessage("1704067260")},
+		}
+		pts := parseGraphiteDatapoints(raw)
+		require.Len(t, pts, 2)
+		require.NotNil(t, pts[0].Value)
+		assert.InDelta(t, 1.5, *pts[0].Value, 1e-9)
+		assert.Equal(t, int64(1704067200), pts[0].Timestamp)
+		require.NotNil(t, pts[1].Value)
+		assert.InDelta(t, 2.0, *pts[1].Value, 1e-9)
+	})
+
+	t.Run("null value becomes nil pointer", func(t *testing.T) {
+		raw := [][]json.RawMessage{
+			{json.RawMessage("null"), json.RawMessage("1704067200")},
+		}
+		pts := parseGraphiteDatapoints(raw)
+		require.Len(t, pts, 1)
+		assert.Nil(t, pts[0].Value)
+		assert.Equal(t, int64(1704067200), pts[0].Timestamp)
+	})
+
+	t.Run("mix of null and non-null values", func(t *testing.T) {
+		raw := [][]json.RawMessage{
+			{json.RawMessage("null"), json.RawMessage("1704067200")},
+			{json.RawMessage("3.14"), json.RawMessage("1704067260")},
+			{json.RawMessage("null"), json.RawMessage("1704067320")},
+		}
+		pts := parseGraphiteDatapoints(raw)
+		require.Len(t, pts, 3)
+		assert.Nil(t, pts[0].Value)
+		require.NotNil(t, pts[1].Value)
+		assert.InDelta(t, 3.14, *pts[1].Value, 1e-9)
+		assert.Nil(t, pts[2].Value)
+	})
+
+	t.Run("empty input returns empty slice", func(t *testing.T) {
+		pts := parseGraphiteDatapoints(nil)
+		assert.Empty(t, pts)
+	})
+
+	t.Run("malformed pairs are skipped", func(t *testing.T) {
+		raw := [][]json.RawMessage{
+			{json.RawMessage("1.0")}, // only one element — no timestamp
+			{json.RawMessage("2.0"), json.RawMessage("1704067200")},
+		}
+		pts := parseGraphiteDatapoints(raw)
+		require.Len(t, pts, 1)
+		assert.Equal(t, int64(1704067200), pts[0].Timestamp)
+	})
+}
+
+// --- queryGraphite handler (via doGet) ---
+
+func TestQueryGraphite_DoGet_ParsesRenderResponse(t *testing.T) {
+	renderResp := []graphiteRawSeries{
+		{
+			Target: "servers.web01.cpu.load5",
+			Datapoints: [][]json.RawMessage{
+				{json.RawMessage("0.5"), json.RawMessage("1704067200")},
+				{json.RawMessage("null"), json.RawMessage("1704067260")},
+				{json.RawMessage("1.2"), json.RawMessage("1704067320")},
+			},
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/render", r.URL.Path)
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "servers.web01.cpu.load5", r.URL.Query().Get("target"))
+		assert.Equal(t, "json", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(renderResp)
+	}))
+	t.Cleanup(ts.Close)
+
+	client := &GraphiteClient{
+		httpClient: http.DefaultClient,
+		baseURL:    ts.URL,
+	}
+
+	params := url.Values{}
+	params.Set("target", "servers.web01.cpu.load5")
+	params.Set("from", "-1h")
+	params.Set("until", "now")
+	params.Set("format", "json")
+
+	data, err := client.doGet(context.Background(), "/render", params)
+	require.NoError(t, err)
+
+	var series []graphiteRawSeries
+	require.NoError(t, json.Unmarshal(data, &series))
+	require.Len(t, series, 1)
+	assert.Equal(t, "servers.web01.cpu.load5", series[0].Target)
+
+	pts := parseGraphiteDatapoints(series[0].Datapoints)
+	require.Len(t, pts, 3)
+	require.NotNil(t, pts[0].Value)
+	assert.InDelta(t, 0.5, *pts[0].Value, 1e-9)
+	assert.Nil(t, pts[1].Value)
+	require.NotNil(t, pts[2].Value)
+	assert.InDelta(t, 1.2, *pts[2].Value, 1e-9)
+}
+
+func TestQueryGraphite_EmptyResult_HasHints(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(ts.Close)
+
+	client := &GraphiteClient{
+		httpClient: http.DefaultClient,
+		baseURL:    ts.URL,
+	}
+
+	ctx := context.Background()
+	data, err := client.doGet(ctx, "/render", nil)
+	require.NoError(t, err)
+
+	var rawSeries []graphiteRawSeries
+	require.NoError(t, json.Unmarshal(data, &rawSeries))
+	assert.Empty(t, rawSeries)
+
+	// Simulate the handler building hints for an empty result
+	hints := GenerateEmptyResultHints(HintContext{
+		DatasourceType: GraphiteDatasourceType,
+		Query:          "nonexistent.metric.*",
+		StartTime:      time.Now().Add(-time.Hour),
+		EndTime:        time.Now(),
+	})
+	require.NotNil(t, hints)
+	assert.NotEmpty(t, hints.Summary)
+	assert.NotEmpty(t, hints.PossibleCauses)
+	assert.NotEmpty(t, hints.SuggestedActions)
+}
+
+// --- listGraphiteMetrics handler ---
+
+func TestListGraphiteMetrics_ParsesNodes(t *testing.T) {
+	rawNodes := []graphiteRawMetricNode{
+		{ID: "servers", Text: "servers", Leaf: 0, Expandable: 1},
+		{ID: "cpu.load5", Text: "load5", Leaf: 1, Expandable: 0},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/metrics/find", r.URL.Path)
+		assert.Equal(t, "servers.*", r.URL.Query().Get("query"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rawNodes)
+	}))
+	t.Cleanup(ts.Close)
+
+	client := &GraphiteClient{
+		httpClient: http.DefaultClient,
+		baseURL:    ts.URL,
+	}
+
+	ctx := context.Background()
+	params := url.Values{}
+	params.Set("query", "servers.*")
+
+	data, err := client.doGet(ctx, "/metrics/find", params)
+	require.NoError(t, err)
+
+	var nodes []graphiteRawMetricNode
+	require.NoError(t, json.Unmarshal(data, &nodes))
+	require.Len(t, nodes, 2)
+
+	parsed := make([]GraphiteMetricNode, 0, len(nodes))
+	for _, n := range nodes {
+		parsed = append(parsed, GraphiteMetricNode{
+			ID:         n.ID,
+			Text:       n.Text,
+			Leaf:       n.Leaf == 1,
+			Expandable: n.Expandable == 1,
+		})
+	}
+	assert.False(t, parsed[0].Leaf)
+	assert.True(t, parsed[0].Expandable)
+	assert.True(t, parsed[1].Leaf)
+	assert.False(t, parsed[1].Expandable)
+}
+
+// --- listGraphiteTags handler ---
+
+func TestListGraphiteTags_ReturnsTags(t *testing.T) {
+	tags := []string{"env", "name", "region", "server"}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/tags", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tags)
+	}))
+	t.Cleanup(ts.Close)
+
+	client := &GraphiteClient{
+		httpClient: http.DefaultClient,
+		baseURL:    ts.URL,
+	}
+
+	ctx := context.Background()
+	data, err := client.doGet(ctx, "/tags", nil)
+	require.NoError(t, err)
+
+	var result []string
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Equal(t, tags, result)
+}
+
+func TestListGraphiteTags_WithPrefix(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "env", r.URL.Query().Get("tagPrefix"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]string{"env"})
+	}))
+	t.Cleanup(ts.Close)
+
+	client := &GraphiteClient{
+		httpClient: http.DefaultClient,
+		baseURL:    ts.URL,
+	}
+
+	ctx := context.Background()
+	params := url.Values{}
+	params.Set("tagPrefix", "env")
+
+	data, err := client.doGet(ctx, "/tags", params)
+	require.NoError(t, err)
+
+	var result []string
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Equal(t, []string{"env"}, result)
+}
+
+func TestListGraphiteTags_EmptyList(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(ts.Close)
+
+	client := &GraphiteClient{
+		httpClient: http.DefaultClient,
+		baseURL:    ts.URL,
+	}
+
+	data, err := client.doGet(context.Background(), "/tags", nil)
+	require.NoError(t, err)
+
+	var result []string
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Empty(t, result)
+}
+
+// --- doGet error handling ---
+
+func TestGraphiteClient_DoGet_NonOKStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ts.Close)
+
+	client := &GraphiteClient{
+		httpClient: http.DefaultClient,
+		baseURL:    ts.URL,
+	}
+
+	_, err := client.doGet(context.Background(), "/render", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}

--- a/tools/hints.go
+++ b/tools/hints.go
@@ -73,6 +73,11 @@ func GenerateEmptyResultHints(ctx HintContext) *EmptyResultHints {
 		hints.PossibleCauses = getCloudWatchCauses(ctx)
 		hints.SuggestedActions = getCloudWatchActions(ctx)
 
+	case "graphite":
+		hints.Summary = "The Graphite query returned no metric series for the specified target and time range."
+		hints.PossibleCauses = getGraphiteCauses(ctx)
+		hints.SuggestedActions = getGraphiteActions(ctx)
+
 	default:
 		hints.Summary = "The query returned no data for the specified parameters."
 		hints.PossibleCauses = getGenericCauses()
@@ -198,6 +203,36 @@ func getCloudWatchActions(ctx HintContext) []string {
 		"Use list_cloudwatch_dimensions to verify dimension values",
 		"Try expanding the time range - CloudWatch data may have ingestion delays",
 	}
+}
+
+// getGraphiteCauses returns possible causes for empty Graphite results
+func getGraphiteCauses(ctx HintContext) []string {
+	causes := []string{
+		"The target expression may not match any metric paths",
+		"No data was recorded for the specified time range",
+		"The time range may be outside the data retention period for this metric",
+		"Wildcard patterns may not expand to any existing metrics",
+	}
+	if strings.Contains(ctx.Query, "seriesByTag") {
+		causes = append(causes, "Tag values in seriesByTag() may not match any tagged series")
+	}
+	if strings.Contains(ctx.Query, "sumSeries") || strings.Contains(ctx.Query, "averageSeries") {
+		causes = append(causes, "Aggregation functions return no data when the inner target matches nothing")
+	}
+	return causes
+}
+
+// getGraphiteActions returns suggested actions for empty Graphite results
+func getGraphiteActions(ctx HintContext) []string {
+	actions := []string{
+		"Use list_graphite_metrics to browse and verify the metric path exists",
+		"Try a simpler wildcard pattern (e.g. '*') to confirm the top-level namespace",
+		"Expand the time range — the metric may have data in a different period",
+	}
+	if strings.Contains(ctx.Query, "seriesByTag") {
+		actions = append(actions, "Use list_graphite_tags to verify tag names and values")
+	}
+	return actions
 }
 
 // getGenericCauses returns generic causes for empty results


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for querying and exploring Graphite datasources through three new MCP tools: `query_graphite`, `list_graphite_metrics`, and `list_graphite_tags`.

## Key Changes

- **New Graphite client implementation** (`tools/graphite.go`):
  - `GraphiteClient` handles HTTP requests to Graphite APIs via Grafana's datasource proxy
  - Supports authentication via access tokens, ID tokens, API keys, and basic auth
  - Implements fallback transport for compatibility with different managed Grafana deployments
  - Includes response size limiting (10MB) for safety

- **Three new MCP tools**:
  - `query_graphite`: Executes Graphite render API queries with support for target expressions, wildcard patterns, aggregation functions, and tag-based queries. Returns metric series with datapoints and generates helpful hints for empty results.
  - `list_graphite_metrics`: Browses the Graphite metric tree hierarchy using the find API, supporting wildcard patterns to discover available metrics
  - `list_graphite_tags`: Lists available tag names in tagged Graphite instances for use in tag-based queries

- **Comprehensive unit tests** (`tools/graphite_unit_test.go`):
  - Tests for time format parsing (RFC3339 to Unix timestamp conversion, relative time formats)
  - Tests for datapoint parsing including null value handling
  - Tests for render API response parsing
  - Tests for metric node parsing with leaf/expandable flags
  - Tests for tag listing with optional prefix filtering
  - Error handling tests for non-OK HTTP responses

- **Enhanced hint generation** (`tools/hints.go`):
  - Added Graphite-specific empty result hints with contextual causes and suggested actions
  - Detects tag-based queries and aggregation functions to provide targeted suggestions

- **Tool registration** (`cmd/mcp-grafana/main.go`):
  - Added `graphite` flag to disable Graphite tools if needed
  - Integrated `AddGraphiteTools()` into server initialization

## Notable Implementation Details

- Time parsing supports both RFC3339 format (converted to Unix timestamps) and Graphite relative formats (e.g., "-1h", "now") passed through unchanged
- Datapoints with null values are represented as nil pointers in the response
- Empty results trigger contextual hint generation based on query patterns (e.g., seriesByTag, aggregation functions)
- Default time range is 1 hour if not specified
- Metric browsing uses wildcard patterns for progressive tree traversal

https://claude.ai/code/session_01VGabt5Q5tRfaMtCKvm9JYQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new datasource integration that proxies authenticated HTTP requests through Grafana and introduces new query parsing/response handling; main risk is correctness and compatibility of the proxy endpoints and Graphite API semantics.
> 
> **Overview**
> Adds **Graphite datasource support** to the MCP server, including new tools for querying and discovery: `query_graphite` (render API), `list_graphite_metrics` (metric tree via find API), and `list_graphite_tags` (tag names).
> 
> Registers the new tool category in the CLI (`enabled-tools` default now includes `graphite`, plus `--disable-graphite`) and extends empty-result hinting with Graphite-specific causes/actions. Includes unit tests covering time/datapoint parsing, API response parsing, and non-OK HTTP handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9bd2e42c8a2e25027ce849ba0867bfa370ee95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->