### PR TITLE
fix: fix get_panel_image error behind api proxy, with subpath grafana support, close #745

### DIFF
--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -83,6 +84,7 @@ type RenderTimeRange struct {
 
 func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallToolResult, error) {
 	config := mcpgrafana.GrafanaConfigFromContext(ctx)
+
 	baseURL := strings.TrimRight(config.URL, "/")
 
 	if baseURL == "" {
@@ -146,32 +148,75 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 		return nil, fmt.Errorf("failed to render image: HTTP %d - %s", resp.StatusCode, string(body))
 	}
 
-	// Read the image data
+	// Read the response body
 	imageData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read image data: %w", err)
 	}
 
-	// Return the image as base64 encoded data using MCP's image content type
-	base64Data := base64.StdEncoding.EncodeToString(imageData)
+	contentType := resp.Header.Get("Content-Type")
+	var base64Data string
+	mimeType := "image/png"
+
+	switch {
+	case strings.HasPrefix(contentType, "image/"):
+		base64Data = base64.StdEncoding.EncodeToString(imageData)
+		mimeType = strings.SplitN(contentType, ";", 2)[0]
+
+	case strings.HasPrefix(contentType, "application/json"):
+		// Some API proxies wrap the rendered image in a JSON envelope
+		// like {"base64": "<png-data>"}.
+		var envelope struct {
+			Base64 string `json:"base64"`
+		}
+		if err := json.Unmarshal(imageData, &envelope); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON render response: %w", err)
+		}
+		if envelope.Base64 == "" {
+			return nil, fmt.Errorf("render response JSON does not contain a 'base64' field")
+		}
+		base64Data = envelope.Base64
+
+	case strings.HasPrefix(contentType, "text/html"):
+		return nil, fmt.Errorf("render endpoint returned HTML instead of an image (likely an authentication or redirect issue). Verify that GRAFANA_URL is reachable with the configured credentials")
+
+	default:
+		return nil, fmt.Errorf("unexpected Content-Type from render endpoint: %s (expected image/png or application/json)", contentType)
+	}
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.ImageContent{
 				Type:     "image",
 				Data:     base64Data,
-				MIMEType: "image/png",
+				MIMEType: mimeType,
 			},
 		},
 	}, nil
+}
+
+// useLegacyRender reports whether the legacy /render/d-solo/ endpoint should
+// be used instead of the newer /render/d/?viewPanel= path. Set the
+// GRAFANA_RENDER_MODE environment variable to "legacy" to enable this for
+// Grafana instances where /render/d/ is unavailable (e.g. subpath deployments
+// or older Grafana versions).
+func useLegacyRender() bool {
+	return strings.EqualFold(os.Getenv("GRAFANA_RENDER_MODE"), "legacy")
 }
 
 func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 	// Strip trailing slashes from base URL for consistent URL construction
 	baseURL = strings.TrimRight(baseURL, "/")
 
-	// Build the render path
-	renderPath := fmt.Sprintf("/render/d/%s", args.DashboardUID)
+	legacy := useLegacyRender()
+
+	// Choose render path: d-solo (legacy, broader compatibility) vs d (modern).
+	var renderPath string
+	if args.PanelID != nil && legacy {
+		renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
+	} else {
+		renderPath = fmt.Sprintf("/render/d/%s", args.DashboardUID)
+	}
 
 	// Build query parameters
 	params := url.Values{}
@@ -195,9 +240,13 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 	}
 	params.Set("scale", strconv.Itoa(scale))
 
-	// Add panel ID if specified (for single panel rendering)
+	// d-solo uses "panelId", modern /d/ uses "viewPanel".
 	if args.PanelID != nil {
-		params.Set("viewPanel", strconv.Itoa(*args.PanelID))
+		if legacy {
+			params.Set("panelId", strconv.Itoa(*args.PanelID))
+		} else {
+			params.Set("viewPanel", strconv.Itoa(*args.PanelID))
+		}
 	}
 
 	// Add time range

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -273,6 +273,80 @@ func TestBuildRenderURL(t *testing.T) {
 	}
 }
 
+func TestBuildRenderURL_LegacyMode(t *testing.T) {
+	t.Setenv("GRAFANA_RENDER_MODE", "legacy")
+
+	tests := []struct {
+		name        string
+		baseURL     string
+		args        GetPanelImageParams
+		contains    []string
+		notContains []string
+	}{
+		{
+			name:    "Legacy mode uses d-solo for panel render",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				DashboardUID: "abc123",
+				PanelID:      intPtr(6),
+			},
+			contains: []string{
+				"http://localhost:3000/render/d-solo/abc123",
+				"panelId=6",
+				"width=1000",
+				"height=500",
+				"kiosk=true",
+			},
+			notContains: []string{
+				"viewPanel",
+				"/render/d/abc123",
+			},
+		},
+		{
+			name:    "Legacy mode full dashboard still uses /d/",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				DashboardUID: "abc123",
+			},
+			contains: []string{
+				"http://localhost:3000/render/d/abc123",
+			},
+			notContains: []string{
+				"d-solo",
+				"panelId",
+			},
+		},
+		{
+			name:    "Legacy mode with subpath base URL",
+			baseURL: "https://grafana.example.com/log_api/grafana/space",
+			args: GetPanelImageParams{
+				DashboardUID: "LmKXqOHIz",
+				PanelID:      intPtr(6),
+				Width:        intPtr(1000),
+				Height:       intPtr(500),
+			},
+			contains: []string{
+				"https://grafana.example.com/log_api/grafana/space/render/d-solo/LmKXqOHIz",
+				"panelId=6",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildRenderURL(tt.baseURL, tt.args)
+			require.NoError(t, err)
+
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+			for _, notExpected := range tt.notContains {
+				assert.NotContains(t, result, notExpected)
+			}
+		})
+	}
+}
+
 func TestGetPanelImage(t *testing.T) {
 	// Create a test PNG image (1x1 pixel)
 	testPNGData := []byte{
@@ -538,5 +612,108 @@ func TestGetPanelImage(t *testing.T) {
 		})
 
 		require.NoError(t, err)
+	})
+
+	t.Run("JSON envelope response from API proxy", func(t *testing.T) {
+		b64PNG := base64.StdEncoding.EncodeToString(testPNGData)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"base64":"` + b64PNG + `"}`))
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		result, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.Content, 1)
+
+		imageContent, ok := result.Content[0].(interface {
+			GetData() string
+			GetMimeType() string
+		})
+		if ok {
+			assert.Equal(t, "image/png", imageContent.GetMimeType())
+			decoded, err := base64.StdEncoding.DecodeString(imageContent.GetData())
+			require.NoError(t, err)
+			assert.Equal(t, testPNGData, decoded)
+		}
+	})
+
+	t.Run("JSON response without base64 field returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"error":"something went wrong"}`))
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		_, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base64")
+	})
+
+	t.Run("HTML response returns auth error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("<html><body>Login</body></html>"))
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		_, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTML")
+		assert.Contains(t, err.Error(), "authentication")
+	})
+
+	t.Run("Unexpected content type returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("unexpected"))
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		_, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected Content-Type")
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #745

The `get_panel_image` tool fails in two real-world deployment scenarios:

1. **API proxy environments** — Some reverse proxies / API gateways wrap the
   Grafana render response in a JSON envelope (`{"base64": "..."}`) instead of
   passing the raw PNG through. The tool previously assumed every 200 OK
   response was a raw image, producing corrupt output silently.

2. **Subpath / older Grafana deployments** — Grafana instances served under a
   subpath (e.g. `https://example.com/grafana/`) or running older versions may
   not support the `/render/d/?viewPanel=` endpoint, causing render failures
   with no workaround.

## Changes

### Content-Type aware response handling (`getPanelImage`)

- Inspect the `Content-Type` header and dispatch accordingly:
  | Content-Type | Behavior |
  |---|---|
  | `image/*` | Base64-encode raw bytes, preserve actual MIME type |
  | `application/json` | Unwrap `{"base64": "..."}` JSON envelope from API proxies |
  | `text/html` | Return actionable error (likely auth redirect) |
  | other | Return error with the unexpected Content-Type |
- Previously: blindly base64-encoded the body and hardcoded `image/png`.

### Legacy render mode (`buildRenderURL`)

- Add `GRAFANA_RENDER_MODE=legacy` environment variable opt-in.
- When enabled, panel renders use `/render/d-solo/{uid}?panelId=N` instead of
  `/render/d/{uid}?viewPanel=N`, which has broader compatibility with subpath
  deployments and older Grafana versions.
- Full dashboard renders (no panelId) are unaffected — always use `/render/d/`.

## Test plan

- [x] `TestBuildRenderURL_LegacyMode`: 3 cases covering d-solo path, full
  dashboard fallback, and subpath base URL
- [x] `TestGetPanelImage/JSON_envelope_response_from_API_proxy`: valid JSON
  envelope is correctly unwrapped
- [x] `TestGetPanelImage/JSON_response_without_base64_field`: missing field
  returns descriptive error
- [x] `TestGetPanelImage/HTML_response_returns_auth_error`: HTML detected as
  auth/redirect issue
- [x] `TestGetPanelImage/Unexpected_content_type_returns_error`: unknown
  Content-Type is rejected
- [x] All existing tests pass (modern mode behavior unchanged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how `get_panel_image` interprets successful render responses and how panel render URLs are constructed, which could affect compatibility across Grafana deployments. Behavior is gated for legacy mode via env var and covered by added unit tests.
> 
> **Overview**
> Fixes `get_panel_image` to be **Content-Type aware**: it now accepts `image/*` responses (preserving the MIME type), unwraps `application/json` responses that contain a `{ "base64": ... }` envelope, and returns clearer errors for `text/html` (auth/redirect) or unexpected content types.
> 
> Adds an opt-in **legacy render mode** via `GRAFANA_RENDER_MODE=legacy` that switches panel renders to `/render/d-solo/{uid}?panelId=...` (while keeping full-dashboard renders on `/render/d/{uid}`), improving compatibility with subpath and older Grafana setups. Unit tests cover the new URL behavior and the new response-handling branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144247051540178f93b10adf6f6718c4d62d512c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->