### PR TITLE
feat: add accept header for api proxy for rendering, close #745

### DIFF
--- a/k8s_resource_test.go
+++ b/k8s_resource_test.go
@@ -76,6 +76,7 @@ func TestNewResourceRegistry(t *testing.T) {
 		g := reg.GetGroup("dashboard.grafana.app")
 		if g == nil {
 			t.Fatal("expected non-nil group")
+			return
 		}
 		if g.Name != "dashboard.grafana.app" {
 			t.Errorf("Name = %q, want %q", g.Name, "dashboard.grafana.app")

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -130,6 +130,10 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 	// Add user agent
 	req.Header.Set("User-Agent", mcpgrafana.UserAgent())
 
+	// Prefer raw image bytes so API gateways (e.g. Kong) that inspect
+	// Accept to decide response format return the PNG directly.
+	req.Header.Set("Accept", "image/*")
+
 	// Execute request
 	resp, err := httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #745

The `get_panel_image` tool does not set an `Accept` header when requesting
rendered images from Grafana. Some API gateways (e.g. Kong, Envoy, AWS API
Gateway) inspect the `Accept` header to decide whether to pass through the
upstream response as-is or wrap it in a JSON envelope. Without an explicit
`Accept: image/*`, gateways may default to wrapping the binary PNG response
in JSON, causing the tool to receive unexpected content.

## Changes

Set `Accept: image/*` on the render HTTP request so that content-negotiation
aware proxies return the raw PNG bytes directly.

## Test plan

- Existing `TestGetPanelImage` tests continue to pass (the mock servers are
  unaffected by the added header)
- Verified in production behind an API gateway that previously wrapped the
  response in JSON — with the `Accept` header, the gateway now returns
  `image/png` directly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single request header to influence content negotiation and a tiny test tweak; no auth, persistence, or core logic changes.
> 
> **Overview**
> `get_panel_image` now sends `Accept: image/*` when requesting rendered images so content-negotiation proxies return raw PNG bytes instead of wrapping responses.
> 
> Also tweaks `k8s_resource_test.go` to `return` after a `t.Fatal` in `TestNewResourceRegistry`’s `GetGroup` subtest to satisfy control-flow/lint expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc35c8c05213c58759ad9f89e33d38421db62de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->