### PR TITLE
feat(rendering): support image legacy d-solo render mode, close #750

### DIFF
--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -18,11 +17,6 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-)
-
-const (
-	grafanaRenderModeEnvVar = "GRAFANA_RENDER_MODE"
-	renderModeLegacy        = "legacy"
 )
 
 // StringOrSlice is a type that can be unmarshaled from either a JSON string
@@ -180,18 +174,17 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 	// Strip trailing slashes from base URL for consistent URL construction
 	baseURL = strings.TrimRight(baseURL, "/")
 
-	// Build the render path
-	renderPath := fmt.Sprintf("/render/d/%s", args.DashboardUID)
-	panelParamKey := "viewPanel"
-
-	// Use solo path and panel ID parameter for single panel rendering in legacy mode
-	if args.PanelID != nil && strings.EqualFold(os.Getenv(grafanaRenderModeEnvVar), renderModeLegacy) {
-		renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
-		panelParamKey = "panelId"
-	}
-
 	// Build query parameters
 	params := url.Values{}
+
+	// Single-panel renders use the purpose-built /d-solo route (lighter than loading
+	// the full dashboard with viewPanel). Full dashboard renders use /d as default.
+	renderPath := fmt.Sprintf("/render/d/%s", args.DashboardUID)
+
+	if args.PanelID != nil {
+		renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
+		params.Set("panelId", strconv.Itoa(*args.PanelID))
+	}
 
 	// Set dimensions
 	width := 1000
@@ -211,11 +204,6 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 		scale = *args.Scale
 	}
 	params.Set("scale", strconv.Itoa(scale))
-
-	// Add panel ID if specified (for single panel rendering)
-	if args.PanelID != nil {
-		params.Set(panelParamKey, strconv.Itoa(*args.PanelID))
-	}
 
 	// Add time range
 	if args.TimeRange != nil {

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,11 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+const (
+	grafanaRenderModeEnvVar = "GRAFANA_RENDER_MODE"
+	renderModeLegacy        = "legacy"
 )
 
 // StringOrSlice is a type that can be unmarshaled from either a JSON string
@@ -176,6 +182,13 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 
 	// Build the render path
 	renderPath := fmt.Sprintf("/render/d/%s", args.DashboardUID)
+	panelParamKey := "viewPanel"
+
+	// Use solo path and panel ID parameter for single panel rendering in legacy mode
+	if args.PanelID != nil && strings.EqualFold(os.Getenv(grafanaRenderModeEnvVar), renderModeLegacy) {
+		renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
+		panelParamKey = "panelId"
+	}
 
 	// Build query parameters
 	params := url.Values{}
@@ -201,7 +214,7 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 
 	// Add panel ID if specified (for single panel rendering)
 	if args.PanelID != nil {
-		params.Set("viewPanel", strconv.Itoa(*args.PanelID))
+		params.Set(panelParamKey, strconv.Itoa(*args.PanelID))
 	}
 
 	// Add time range

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -151,7 +151,6 @@ func TestBuildRenderURL(t *testing.T) {
 		name        string
 		baseURL     string
 		args        GetPanelImageParams
-		renderMode  string
 		contains    []string
 		notContains []string
 	}{
@@ -170,7 +169,7 @@ func TestBuildRenderURL(t *testing.T) {
 			},
 		},
 		{
-			name:    "Panel render with custom dimensions (default mode)",
+			name:    "Panel render with custom dimensions uses d-solo path",
 			baseURL: "http://localhost:3000",
 			args: GetPanelImageParams{
 				DashboardUID: "abc123",
@@ -179,27 +178,10 @@ func TestBuildRenderURL(t *testing.T) {
 				Height:       intPtr(600),
 			},
 			contains: []string{
-				"http://localhost:3000/render/d/abc123",
-				"viewPanel=5",
-				"width=800",
-				"height=600",
-			},
-			notContains: []string{
-				"/d-solo/",
-				"panelId=",
-			},
-		},
-		{
-			name:       "Panel render with legacy mode uses d-solo",
-			baseURL:    "http://localhost:3000",
-			renderMode: "legacy",
-			args: GetPanelImageParams{
-				DashboardUID: "abc123",
-				PanelID:      intPtr(5),
-			},
-			contains: []string{
 				"http://localhost:3000/render/d-solo/abc123",
 				"panelId=5",
+				"width=800",
+				"height=600",
 			},
 			notContains: []string{
 				"/render/d/abc123",
@@ -286,10 +268,6 @@ func TestBuildRenderURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.renderMode != "" {
-				t.Setenv(grafanaRenderModeEnvVar, tt.renderMode)
-			}
-
 			result, err := buildRenderURL(tt.baseURL, tt.args)
 			require.NoError(t, err)
 
@@ -358,35 +336,7 @@ func TestGetPanelImage(t *testing.T) {
 		}
 	})
 
-	t.Run("Panel image with specific panel ID", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "5", r.URL.Query().Get("viewPanel"))
-
-			w.Header().Set("Content-Type", "image/png")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(testPNGData)
-		}))
-		defer server.Close()
-
-		grafanaCfg := mcpgrafana.GrafanaConfig{
-			URL:    server.URL,
-			APIKey: "test-api-key",
-		}
-		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
-
-		panelID := 5
-		result, err := getPanelImage(ctx, GetPanelImageParams{
-			DashboardUID: "test-dash",
-			PanelID:      &panelID,
-		})
-
-		require.NoError(t, err)
-		require.NotNil(t, result)
-	})
-
-	t.Run("Panel image with legacy mode uses d-solo path and panelId param", func(t *testing.T) {
-		t.Setenv(grafanaRenderModeEnvVar, "legacy")
-
+	t.Run("Panel image with specific panel ID uses d-solo path and panelId param", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Contains(t, r.URL.Path, "/render/d-solo/test-dash")
 			assert.Equal(t, "5", r.URL.Query().Get("panelId"))

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -148,10 +148,12 @@ func TestGetPanelImageParams_UnmarshalVariables(t *testing.T) {
 
 func TestBuildRenderURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		baseURL  string
-		args     GetPanelImageParams
-		contains []string
+		name        string
+		baseURL     string
+		args        GetPanelImageParams
+		renderMode  string
+		contains    []string
+		notContains []string
 	}{
 		{
 			name:    "Basic dashboard render",
@@ -168,7 +170,7 @@ func TestBuildRenderURL(t *testing.T) {
 			},
 		},
 		{
-			name:    "Panel render with custom dimensions",
+			name:    "Panel render with custom dimensions (default mode)",
 			baseURL: "http://localhost:3000",
 			args: GetPanelImageParams{
 				DashboardUID: "abc123",
@@ -181,6 +183,27 @@ func TestBuildRenderURL(t *testing.T) {
 				"viewPanel=5",
 				"width=800",
 				"height=600",
+			},
+			notContains: []string{
+				"/d-solo/",
+				"panelId=",
+			},
+		},
+		{
+			name:       "Panel render with legacy mode uses d-solo",
+			baseURL:    "http://localhost:3000",
+			renderMode: "legacy",
+			args: GetPanelImageParams{
+				DashboardUID: "abc123",
+				PanelID:      intPtr(5),
+			},
+			contains: []string{
+				"http://localhost:3000/render/d-solo/abc123",
+				"panelId=5",
+			},
+			notContains: []string{
+				"/render/d/abc123",
+				"viewPanel=",
 			},
 		},
 		{
@@ -263,11 +286,18 @@ func TestBuildRenderURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.renderMode != "" {
+				t.Setenv(grafanaRenderModeEnvVar, tt.renderMode)
+			}
+
 			result, err := buildRenderURL(tt.baseURL, tt.args)
 			require.NoError(t, err)
 
 			for _, expected := range tt.contains {
 				assert.Contains(t, result, expected)
+			}
+			for _, unexpected := range tt.notContains {
+				assert.NotContains(t, result, unexpected)
 			}
 		})
 	}
@@ -331,6 +361,35 @@ func TestGetPanelImage(t *testing.T) {
 	t.Run("Panel image with specific panel ID", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "5", r.URL.Query().Get("viewPanel"))
+
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(testPNGData)
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		panelID := 5
+		result, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+			PanelID:      &panelID,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("Panel image with legacy mode uses d-solo path and panelId param", func(t *testing.T) {
+		t.Setenv(grafanaRenderModeEnvVar, "legacy")
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Contains(t, r.URL.Path, "/render/d-solo/test-dash")
+			assert.Equal(t, "5", r.URL.Query().Get("panelId"))
 
 			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

- Add `GRAFANA_RENDER_MODE` environment variable to control single panel render path
- When set to `legacy`, use `/render/d-solo/{uid}?panelId={id}` instead of `/render/d/{uid}?viewPanel={id}`
- Default behavior is unchanged; full dashboard rendering is unaffected

Closes #750 

## Test plan

- [x] Unit test: `buildRenderURL` verifies legacy mode produces `/d-solo/` path with `panelId` param
- [x] Unit test: default mode still produces `/d/` path with `viewPanel` param (with `notContains` assertions)
- [x] Integration test: end-to-end `getPanelImage` verifies HTTP request path and query params in legacy mode
- [x] All existing tests pass with no regressions


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the URL/parameter used for single-panel Grafana renders, which could break image rendering against Grafana instances expecting the previous `viewPanel` behavior. Covered by updated unit and integration tests, but still impacts a key external integration point.
> 
> **Overview**
> Single-panel image rendering now uses Grafana’s dedicated ` /render/d-solo/{uid}` endpoint with a `panelId` query parameter instead of rendering the full dashboard via `/render/d/{uid}` with `viewPanel`.
> 
> Tests were updated to assert the new path/param and to explicitly ensure the old `/render/d` + `viewPanel` form is not used for panel renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f574e9a9793e0474720d2408876a7dd99b17af50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->