### PR TITLE
chore(ci): migrate to docker-build-push-image action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,11 +65,12 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
       - name: Build and Push to Docker Hub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@e7a3275d4c4978a3514801ec55708f1c599a6906
+        uses: grafana/shared-workflows/actions/docker-build-push-image@21ae57f82e5256e5a418406388926d4ba24bccf2 # docker-build-push-image/v0.3.2
         with:
           context: .
           file: ./Dockerfile
-          repository: grafana/mcp-grafana
+          dockerhub-repository: grafana/mcp-grafana
+          registries: dockerhub
           platforms: ${{ needs.prepare.outputs.platforms }}
           tags: |
             ${{ needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.is_stable == 'true' && 'latest' || '' }}
@@ -85,11 +86,12 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
       - name: Build and Push Alpine to Docker Hub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@e7a3275d4c4978a3514801ec55708f1c599a6906
+        uses: grafana/shared-workflows/actions/docker-build-push-image@21ae57f82e5256e5a418406388926d4ba24bccf2 # docker-build-push-image/v0.3.2
         with:
           context: .
           file: ./Dockerfile.alpine
-          repository: grafana/mcp-grafana
+          dockerhub-repository: grafana/mcp-grafana
+          registries: dockerhub
           platforms: ${{ needs.prepare.outputs.platforms }}
           tags: |
             ${{ needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.is_stable == 'true' && 'alpine' || '' }}


### PR DESCRIPTION
Migrates from the deprecated `build-push-to-dockerhub` action to the unified [`docker-build-push-image`](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image) action.

## What This Changes

- Updated action references from `build-push-to-dockerhub` to `docker-build-push-image@v0.3.2`
- Renamed `repository` input to `dockerhub-repository`
- Added `registries: dockerhub` input

Applies to both the standard and alpine Docker build steps.

## References

- [docker-build-push-image docs](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image)
- [Migration guide](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating-from-push-to-gar-docker)
- [Repo migration tracking issue](https://github.com/grafana/deployment_tools/issues/390404)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that swaps a shared GitHub Action and renames inputs; main risk is misconfigured image publishing/tags rather than runtime behavior.
> 
> **Overview**
> Migrates the GitHub Actions Docker publishing workflow from the deprecated `build-push-to-dockerhub` action to `docker-build-push-image@v0.3.2` for both the standard and Alpine image builds.
> 
> Updates inputs to match the new action (`repository` -> `dockerhub-repository`) and explicitly sets `registries: dockerhub`, while preserving the existing tag-based tagging and conditional push behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e08225d82e2167f5dbcc64c6be4c357e7450ca61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->