### PR TITLE
fix: register ephemeral sessions to fix horizontal scaling of proxied tools

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -136,8 +136,10 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 		mcpgrafana.WithSessionTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute),
 	)
 
-	// Declare variable for ToolManager that will be initialized after server creation
+	// Declare variables that will be initialized after server creation.
+	// The hooks below capture these by pointer, so they must be declared first.
 	var stm *mcpgrafana.ToolManager
+	var s *server.MCPServer
 
 	// Create hooks
 	hooks := &server.Hooks{
@@ -149,9 +151,24 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 	// (stdio mode is handled by InitializeAndRegisterServerTools; per-session tools
 	// are not supported).
 	if transport != "stdio" && !dt.proxied {
+		// ensureSessionRegistered registers an ephemeral session in MCPServer.sessions
+		// if it's not already there. This is needed for horizontal scaling: when a
+		// request lands on a pod that didn't handle the initialize call, the SDK
+		// creates an ephemeral session that isn't registered, causing AddSessionTools
+		// to fail with ErrSessionNotFound. RegisterSession uses LoadOrStore
+		// internally, so this is a no-op for already-registered sessions.
+		ensureSessionRegistered := func(ctx context.Context) {
+			if s != nil {
+				if session := server.ClientSessionFromContext(ctx); session != nil {
+					_ = s.RegisterSession(ctx, session)
+				}
+			}
+		}
+
 		// OnBeforeListTools: Discover, connect, and register tools
 		hooks.OnBeforeListTools = []server.OnBeforeListToolsFunc{
 			func(ctx context.Context, id any, request *mcp.ListToolsRequest) {
+				ensureSessionRegistered(ctx)
 				if stm != nil {
 					if session := server.ClientSessionFromContext(ctx); session != nil {
 						stm.InitializeAndRegisterProxiedTools(ctx, session)
@@ -163,6 +180,7 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 		// OnBeforeCallTool: Fallback in case client calls tool without listing first
 		hooks.OnBeforeCallTool = []server.OnBeforeCallToolFunc{
 			func(ctx context.Context, id any, request *mcp.CallToolRequest) {
+				ensureSessionRegistered(ctx)
 				if stm != nil {
 					if session := server.ClientSessionFromContext(ctx); session != nil {
 						stm.InitializeAndRegisterProxiedTools(ctx, session)
@@ -175,7 +193,7 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 	// Merge observability hooks with existing hooks
 	hooks = observability.MergeHooks(hooks, obs.MCPHooks())
 
-	s := server.NewMCPServer("mcp-grafana", mcpgrafana.Version(),
+	s = server.NewMCPServer("mcp-grafana", mcpgrafana.Version(),
 		server.WithInstructions(`
 This server provides access to your Grafana instance and the surrounding ecosystem.
 
@@ -202,6 +220,10 @@ Note that some of these capabilities may be disabled. Do not try to use features
 
 	// Initialize ToolManager now that server is created
 	stm = mcpgrafana.NewToolManager(sm, s, mcpgrafana.WithProxiedTools(!dt.proxied))
+
+	// Give the SessionManager a reference to the MCPServer so the reaper can
+	// unregister sessions from the SDK's internal session map.
+	sm.SetMCPServer(s)
 
 	dt.addTools(s)
 	return s, stm, sm

--- a/session.go
+++ b/session.go
@@ -89,6 +89,22 @@ type SessionManager struct {
 	reaperDone chan struct{}
 	closeOnce  sync.Once
 	metrics    sessionMetrics
+
+	// mcpServer is an optional reference to the MCP server, used to unregister
+	// sessions from the SDK's internal session map when they are reaped. This
+	// prevents a memory leak when sessions are registered via RegisterSession
+	// in horizontal scaling scenarios (where ephemeral sessions are registered
+	// so that AddSessionTools can find them).
+	mcpServer *server.MCPServer
+}
+
+// SetMCPServer sets the MCP server reference for session cleanup. When set,
+// the reaper will call MCPServer.UnregisterSession for reaped sessions to
+// prevent a memory leak in the SDK's internal session map.
+func (sm *SessionManager) SetMCPServer(s *server.MCPServer) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	sm.mcpServer = s
 }
 
 func NewSessionManager(opts ...SessionManagerOption) *SessionManager {
@@ -215,6 +231,7 @@ func (sm *SessionManager) reapStaleSessions() {
 	sm.mutex.Lock()
 	var stale []*SessionState
 	var staleIDs []string
+	mcpSrv := sm.mcpServer
 	for id, state := range sm.sessions {
 		if now.Sub(state.lastActivity) > sm.sessionTTL {
 			stale = append(stale, state)
@@ -232,8 +249,15 @@ func (sm *SessionManager) reapStaleSessions() {
 		slog.Info("Reaping stale sessions", "count", len(stale), "session_ids", staleIDs)
 	}
 
-	for _, state := range stale {
+	ctx := context.Background()
+	for i, state := range stale {
 		cleanupSessionState(state)
+		// Also unregister from MCPServer.sessions to prevent a memory leak.
+		// Sessions may have been registered there via RegisterSession in the
+		// OnBeforeListTools/OnBeforeCallTool hooks for horizontal scaling support.
+		if mcpSrv != nil {
+			mcpSrv.UnregisterSession(ctx, staleIDs[i])
+		}
 	}
 }
 

--- a/session_horizontal_scaling_test.go
+++ b/session_horizontal_scaling_test.go
@@ -1,0 +1,207 @@
+package mcpgrafana
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSessionWithTools implements both server.ClientSession and server.SessionWithTools
+// for testing the horizontal scaling fix where AddSessionTools needs to find
+// the session in MCPServer.sessions.
+type mockSessionWithTools struct {
+	id            string
+	notifChannel  chan mcp.JSONRPCNotification
+	isInitialized bool
+	tools         map[string]server.ServerTool
+	mu            sync.RWMutex
+}
+
+func newMockSessionWithTools(id string) *mockSessionWithTools {
+	return &mockSessionWithTools{
+		id:           id,
+		notifChannel: make(chan mcp.JSONRPCNotification, 10),
+		tools:        make(map[string]server.ServerTool),
+	}
+}
+
+func (m *mockSessionWithTools) SessionID() string {
+	return m.id
+}
+
+func (m *mockSessionWithTools) NotificationChannel() chan<- mcp.JSONRPCNotification {
+	return m.notifChannel
+}
+
+func (m *mockSessionWithTools) Initialize() {
+	m.isInitialized = true
+}
+
+func (m *mockSessionWithTools) Initialized() bool {
+	return m.isInitialized
+}
+
+func (m *mockSessionWithTools) GetSessionTools() map[string]server.ServerTool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cp := make(map[string]server.ServerTool, len(m.tools))
+	for k, v := range m.tools {
+		cp[k] = v
+	}
+	return cp
+}
+
+func (m *mockSessionWithTools) SetSessionTools(tools map[string]server.ServerTool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tools = tools
+}
+
+// TestRegisterSessionFixesAddSessionTools verifies the core fix for issue #749:
+// when an ephemeral session is registered in MCPServer.sessions via RegisterSession,
+// AddSessionTools succeeds instead of returning ErrSessionNotFound.
+func TestRegisterSessionFixesAddSessionTools(t *testing.T) {
+	t.Run("AddSessionTools fails without RegisterSession", func(t *testing.T) {
+		s := server.NewMCPServer("test", "1.0.0")
+		session := newMockSessionWithTools("unregistered-session")
+
+		err := s.AddSessionTools(session.SessionID(), server.ServerTool{
+			Tool:    mcp.NewTool("test-tool"),
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { return nil, nil },
+		})
+		assert.Error(t, err, "AddSessionTools should fail for unregistered session")
+	})
+
+	t.Run("AddSessionTools succeeds after RegisterSession", func(t *testing.T) {
+		s := server.NewMCPServer("test", "1.0.0")
+		session := newMockSessionWithTools("cross-pod-session")
+
+		// Simulate what the fix does: register the ephemeral session
+		err := s.RegisterSession(context.Background(), session)
+		require.NoError(t, err)
+
+		// Now AddSessionTools should succeed
+		err = s.AddSessionTools(session.SessionID(), server.ServerTool{
+			Tool:    mcp.NewTool("tempo_traceql-search"),
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { return nil, nil },
+		})
+		assert.NoError(t, err, "AddSessionTools should succeed after RegisterSession")
+
+		// Verify the tool was actually registered
+		tools := session.GetSessionTools()
+		assert.Contains(t, tools, "tempo_traceql-search")
+	})
+
+	t.Run("RegisterSession is idempotent for already-registered sessions", func(t *testing.T) {
+		s := server.NewMCPServer("test", "1.0.0")
+		session := newMockSessionWithTools("existing-session")
+
+		// First registration
+		err := s.RegisterSession(context.Background(), session)
+		require.NoError(t, err)
+
+		// Second registration should return ErrSessionExists but not panic
+		err = s.RegisterSession(context.Background(), session)
+		assert.Error(t, err, "Second RegisterSession should return error")
+
+		// AddSessionTools should still work
+		err = s.AddSessionTools(session.SessionID(), server.ServerTool{
+			Tool:    mcp.NewTool("test-tool"),
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { return nil, nil },
+		})
+		assert.NoError(t, err)
+	})
+}
+
+// TestReaperUnregistersFromMCPServer verifies that the session reaper also
+// cleans up sessions from MCPServer.sessions when SetMCPServer has been called.
+func TestReaperUnregistersFromMCPServer(t *testing.T) {
+	t.Run("reaper cleans up MCPServer sessions", func(t *testing.T) {
+		s := server.NewMCPServer("test", "1.0.0")
+
+		sm := NewSessionManager(
+			WithSessionTTL(50 * time.Millisecond),
+		)
+		sm.SetMCPServer(s)
+		defer sm.Close()
+
+		session := newMockSessionWithTools("reap-me")
+
+		// Register in both the application SessionManager and MCPServer
+		sm.CreateSession(context.Background(), session)
+		err := s.RegisterSession(context.Background(), session)
+		require.NoError(t, err)
+
+		// Add a tool to prove the session is registered
+		err = s.AddSessionTools(session.SessionID(), server.ServerTool{
+			Tool:    mcp.NewTool("test-tool"),
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { return nil, nil },
+		})
+		require.NoError(t, err)
+
+		// Wait for the session to become stale and be reaped
+		time.Sleep(200 * time.Millisecond)
+
+		// Session should be removed from both managers
+		_, exists := sm.GetSession("reap-me")
+		assert.False(t, exists, "Session should be removed from SessionManager")
+
+		// Verify the session is gone from MCPServer too by trying to add tools
+		err = s.AddSessionTools("reap-me", server.ServerTool{
+			Tool:    mcp.NewTool("another-tool"),
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) { return nil, nil },
+		})
+		assert.Error(t, err, "Session should be unregistered from MCPServer after reaping")
+	})
+
+	t.Run("reaper works without MCPServer reference", func(t *testing.T) {
+		sm := NewSessionManager(
+			WithSessionTTL(50 * time.Millisecond),
+		)
+		// Deliberately NOT calling sm.SetMCPServer()
+		defer sm.Close()
+
+		session := &mockClientSession{id: "no-mcp-server"}
+		sm.CreateSession(context.Background(), session)
+
+		// Wait for reaping
+		time.Sleep(200 * time.Millisecond)
+
+		_, exists := sm.GetSession("no-mcp-server")
+		assert.False(t, exists, "Session should still be reaped without MCPServer reference")
+	})
+}
+
+// TestSetMCPServer verifies the SetMCPServer method.
+func TestSetMCPServer(t *testing.T) {
+	t.Run("SetMCPServer sets the reference", func(t *testing.T) {
+		sm := NewSessionManager()
+		defer sm.Close()
+
+		s := server.NewMCPServer("test", "1.0.0")
+		sm.SetMCPServer(s)
+
+		sm.mutex.RLock()
+		assert.Equal(t, s, sm.mcpServer)
+		sm.mutex.RUnlock()
+	})
+
+	t.Run("SetMCPServer can be called with nil", func(t *testing.T) {
+		sm := NewSessionManager()
+		defer sm.Close()
+
+		s := server.NewMCPServer("test", "1.0.0")
+		sm.SetMCPServer(s)
+		sm.SetMCPServer(nil)
+
+		sm.mutex.RLock()
+		assert.Nil(t, sm.mcpServer)
+		sm.mutex.RUnlock()
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #749. When running mcp-grafana in `streamable-http` mode with multiple Kubernetes replicas, proxied tools (e.g., Tempo) silently fail when a request lands on a pod that didn't handle the `initialize` call.

**Root cause:** The mcp-go SDK creates an ephemeral `streamableHttpSession` for POST requests with unknown session IDs, but never registers it in `MCPServer.sessions`. When `InitializeAndRegisterProxiedTools` calls `AddSessionTools`, it fails with `ErrSessionNotFound` because the session isn't in the map.

**Fix:** Call `MCPServer.RegisterSession` in the `OnBeforeListTools` and `OnBeforeCallTool` hooks before registering proxied tools. This ensures the ephemeral session is in the SDK's session map so `AddSessionTools` succeeds. `RegisterSession` uses `LoadOrStore` internally, so it's a no-op for already-registered sessions.

Also adds `SessionManager.SetMCPServer` so the session reaper can call `UnregisterSession` for reaped sessions, preventing a memory leak in the SDK's session map.

## Changes

- `cmd/mcp-grafana/main.go`: Add `ensureSessionRegistered` helper called in both tool hooks before proxied tool initialization
- `session.go`: Add `mcpServer` field and `SetMCPServer` method to `SessionManager`; reaper now calls `MCPServer.UnregisterSession` for reaped sessions
- `session_horizontal_scaling_test.go`: Tests verifying the fix (RegisterSession enables AddSessionTools, reaper cleans up MCPServer sessions)

## Test plan

- [x] New unit tests verify `AddSessionTools` fails without `RegisterSession` and succeeds with it
- [x] New unit tests verify the reaper calls `UnregisterSession` when `SetMCPServer` is set
- [x] All existing tests pass (`go test ./...`)
- [x] `golangci-lint run` passes with 0 issues
- [x] `go vet ./...` passes
- [x] Race detector clean on new tests
- [ ] Integration testing with multiple replicas in Kubernetes (requires manual verification by reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP session registration/reaping and per-request hooks, which can impact tool availability and session lifecycle across transports. Risk is mitigated by being scoped to proxied-tools paths and covered by new unit tests.
> 
> **Overview**
> Ensures proxied tools work when `streamable-http` requests hit a different replica than the one that handled `initialize`, by registering any ephemeral session in `MCPServer.sessions` during `OnBeforeListTools`/`OnBeforeCallTool` before calling `InitializeAndRegisterProxiedTools`.
> 
> Adds `SessionManager.SetMCPServer` so the idle-session reaper also calls `MCPServer.UnregisterSession` for reaped sessions, preventing leaked entries in the SDK’s internal session map, and introduces focused tests covering both the cross-pod registration behavior and reaper cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b926b3d0bcb6877e1af662eadb2835677daca43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->