### PR TITLE
fix: encode Basic Auth per RFC 7617 in proxied_client.go

### DIFF
--- a/proxied_client.go
+++ b/proxied_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"sync"
 
 	mcp_client "github.com/mark3labs/mcp-go/client"
@@ -22,6 +23,17 @@ type ProxiedClient struct {
 	mutex          sync.RWMutex
 }
 
+// basicAuthHeader encodes credentials per RFC 7617:
+// base64(username ":" password) with raw bytes, matching
+// (*http.Request).SetBasicAuth in the standard library. url.Userinfo.String()
+// percent-escapes reserved characters per RFC 3986, which is wrong here —
+// passwords containing ':', '@', '/', '%', or space would be double-encoded
+// on the wire and rejected by spec-compliant Basic Auth parsers.
+func basicAuthHeader(u *url.Userinfo) string {
+	password, _ := u.Password()
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(u.Username()+":"+password))
+}
+
 // NewProxiedClient creates a new connection to a remote MCP server
 func NewProxiedClient(ctx context.Context, datasourceUID, datasourceName, datasourceType, mcpEndpoint string) (*ProxiedClient, error) {
 	// Get Grafana config for authentication
@@ -32,8 +44,7 @@ func NewProxiedClient(ctx context.Context, datasourceUID, datasourceName, dataso
 	if config.APIKey != "" {
 		headers["Authorization"] = "Bearer " + config.APIKey
 	} else if config.BasicAuth != nil {
-		auth := config.BasicAuth.String()
-		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+		headers["Authorization"] = basicAuthHeader(config.BasicAuth)
 	}
 
 	// Add org ID header if configured

--- a/proxied_client_test.go
+++ b/proxied_client_test.go
@@ -1,0 +1,71 @@
+package mcpgrafana
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBasicAuthHeaderEncoding verifies that basicAuthHeader produces the
+// same bytes as (*http.Request).SetBasicAuth — base64(username ":" password)
+// with raw bytes per RFC 7617. Regression test for the bug where
+// url.Userinfo.String() was used, which percent-escapes reserved characters
+// per RFC 3986 and breaks Basic Auth for passwords containing ':', '@',
+// '/', '%', or space.
+func TestBasicAuthHeaderEncoding(t *testing.T) {
+	cases := []struct {
+		name, username, password, want string
+	}{
+		{
+			name:     "plain ASCII",
+			username: "admin",
+			password: "password",
+			want:     "Basic YWRtaW46cGFzc3dvcmQ=",
+		},
+		{
+			name:     "colon in password",
+			username: "admin",
+			password: "p:w0rd",
+			want:     "Basic YWRtaW46cDp3MHJk",
+		},
+		{
+			name:     "at sign in password",
+			username: "admin",
+			password: "p@ssw0rd",
+			want:     "Basic YWRtaW46cEBzc3cwcmQ=",
+		},
+		{
+			name:     "percent in password",
+			username: "admin",
+			password: "p%w0rd",
+			want:     "Basic YWRtaW46cCV3MHJk",
+		},
+		{
+			name:     "space in password",
+			username: "admin",
+			password: "pw 0rd",
+			want:     "Basic YWRtaW46cHcgMHJk",
+		},
+		{
+			name:     "slash in password",
+			username: "admin",
+			password: "p/w0rd",
+			want:     "Basic YWRtaW46cC93MHJk",
+		},
+		{
+			name:     "empty password",
+			username: "admin",
+			password: "",
+			want:     "Basic YWRtaW46",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := url.UserPassword(tc.username, tc.password)
+			got := basicAuthHeader(u)
+			assert.Equal(t, tc.want, got,
+				"basicAuthHeader must produce raw base64(user:password) per RFC 7617, not percent-encoded userinfo")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the fix discussed in #757: `proxied_client.go` was building the Basic Auth header via `(*url.Userinfo).String()`, which percent-escapes reserved characters per RFC 3986. RFC 7617 wants raw `username ":" password` bytes. See #757 for the full walkthrough of the spec deviation, observable impact, and precedent elsewhere in the codebase.

## What changed

- Extracted `basicAuthHeader(u *url.Userinfo) string` helper that mirrors `(*http.Request).SetBasicAuth`'s encoding.
- `NewProxiedClient` now calls the helper instead of the inline `config.BasicAuth.String()` path.
- New `proxied_client_test.go` with `TestBasicAuthHeaderEncoding`: 7 subtests covering plain ASCII, colon/at/percent/space/slash in password, empty password. Each asserts an exact expected base64 byte string so regressions fail loudly in either direction.

## Test plan

- [x] `make test-unit` passes (including the 7 new subtests)
- [x] `make lint` shows 0 issues (golangci-lint + jsonschema linter)
- [ ] Manual verification of the byte-level change against a Tempo proxied datasource with a password containing `:` (out of scope for a stdlib-pure unit test, but welcome suggestions if maintainers want integration coverage)

Closes #757

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Basic Auth headers are generated for proxied MCP connections, which could affect connectivity to servers that previously (incorrectly) tolerated percent-encoded credentials. Scope is small and covered by new unit tests for special-character passwords.
> 
> **Overview**
> Fixes Basic Auth header construction in `NewProxiedClient` by replacing `url.Userinfo.String()`-based encoding with a dedicated `basicAuthHeader` helper that base64-encodes raw `username:password` bytes per RFC 7617.
> 
> Adds `proxied_client_test.go` with regression cases for reserved characters (e.g., `:`, `@`, `%`, space, `/`) and empty passwords to ensure the Authorization header bytes match the standard library behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af28e4d6e5984f162525a9401953f983c1da60c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->