### PR TITLE
fix: reject malformed X-Grafana-URL header instead of panicking

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,26 @@ grafanaConfig := mcpgrafana.GrafanaConfig{
 contextFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
 ```
 
+**URL validation when wiring your own HTTP server:**
+
+When library consumers wire mcp-grafana's context functions into their own `http.Server`, install `ValidateGrafanaURLMiddleware` to reject malformed `X-Grafana-URL` headers with 400 Bad Request (matching the binary's behavior):
+
+```go
+mux.Handle(path, mcpgrafana.ValidateGrafanaURLMiddleware(yourMCPHandler))
+```
+
+When calling `NewGrafanaClient` directly (stdio or programmatic construction), pre-validate untrusted URLs to avoid a reachable panic:
+
+```go
+if err := mcpgrafana.ValidateGrafanaURL(urlFromHeader); err != nil {
+    http.Error(w, err.Error(), http.StatusBadRequest)
+    return
+}
+client := mcpgrafana.NewGrafanaClient(ctx, urlFromHeader, apiKey, nil)
+```
+
+Both patterns share `ValidateGrafanaURL` as the single validator.
+
 ### Server TLS Configuration (Streamable HTTP Transport Only)
 
 When using the streamable HTTP transport (`-t streamable-http`), you can configure the MCP server to serve HTTPS instead of HTTP. This is useful when you need to secure the connection between your MCP client and the server itself.

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -385,7 +385,10 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		if basePath == "" {
 			basePath = "/"
 		}
-		mux.Handle(basePath, observability.WrapHandler(srv, basePath))
+		mux.Handle(basePath, observability.WrapHandler(
+			mcpgrafana.ValidateGrafanaURLMiddleware(srv),
+			basePath,
+		))
 		mux.HandleFunc("/healthz", handleHealthz)
 		if obs.MetricsEnabled {
 			if obs.MetricsAddress == "" {
@@ -411,7 +414,10 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		}
 		srv := server.NewStreamableHTTPServer(s, opts...)
 		mux := http.NewServeMux()
-		mux.Handle(endpointPath, observability.WrapHandler(srv, endpointPath))
+		mux.Handle(endpointPath, observability.WrapHandler(
+			mcpgrafana.ValidateGrafanaURLMiddleware(srv),
+			endpointPath,
+		))
 		mux.HandleFunc("/healthz", handleHealthz)
 		if obs.MetricsEnabled {
 			if obs.MetricsAddress == "" {

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -43,6 +43,16 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 		return "", fmt.Errorf("grafana url not configured. Please set GRAFANA_URL environment variable or X-Grafana-URL header")
 	}
 
+	// Validate baseURL separately from the inbound X-Grafana-URL middleware:
+	// gc.PublicURL is populated by fetchPublicURL from Grafana's
+	// /api/frontend/settings appUrl response, which is not covered by the
+	// middleware at the HTTP transport boundary. A misconfigured Grafana can
+	// therefore return a malformed appUrl that flows into deeplink construction
+	// (e.g. http://%gg/d/<uid>) unless checked here.
+	if err := mcpgrafana.ValidateGrafanaURL(baseURL); err != nil {
+		return "", fmt.Errorf("grafana url is invalid: %w. Please set GRAFANA_URL environment variable or X-Grafana-URL header", err)
+	}
+
 	var deeplink string
 
 	switch strings.ToLower(args.ResourceType) {

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"testing"
 
@@ -250,4 +251,59 @@ func TestGenerateDeeplink(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "datasourceUid is required")
 	})
+}
+
+// TestGenerateDeeplink_RejectsMalformedBaseURL_ClientWithEmptyPublicURL
+// exercises the fall-through path where a GrafanaClient is attached but its
+// PublicURL is empty (/api/frontend/settings returned an empty or malformed
+// appUrl). generateDeeplink then reads config.URL, which may itself be
+// malformed. Without this guard, the malformed URL flows into the returned
+// deeplink (e.g. "http://%gg/d/abc123") with no error signal. Post-fix:
+// ValidateGrafanaURL catches the malformed baseURL and returns a structured
+// error wrapping ErrInvalidGrafanaURL.
+func TestGenerateDeeplink_RejectsMalformedBaseURL_ClientWithEmptyPublicURL(t *testing.T) {
+	grafanaCfg := mcpgrafana.GrafanaConfig{
+		URL: "http://%gg",
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	// Zero-value GrafanaClient: generateDeeplink only reads gc.PublicURL
+	// (empty), which is the code path we want to exercise. The test does
+	// not invoke any method on the client, so a zero value is equivalent to
+	// a real client whose fetchPublicURL call returned empty.
+	ctx = mcpgrafana.WithGrafanaClient(ctx, &mcpgrafana.GrafanaClient{})
+
+	params := GenerateDeeplinkParams{
+		ResourceType: "dashboard",
+		DashboardUID: stringPtr("abc123"),
+	}
+
+	_, err := generateDeeplink(ctx, params)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, mcpgrafana.ErrInvalidGrafanaURL),
+		"expected error to wrap ErrInvalidGrafanaURL, got: %v", err)
+	assert.Contains(t, err.Error(), "invalid",
+		"error message must include 'invalid' for operator/LLM readability; got %q", err.Error())
+}
+
+// TestGenerateDeeplink_RejectsMalformedBaseURL_NoClient covers the same bug
+// class but without any GrafanaClient attached to the context. Proves the
+// ValidateGrafanaURL guard fires on config.URL alone.
+func TestGenerateDeeplink_RejectsMalformedBaseURL_NoClient(t *testing.T) {
+	grafanaCfg := mcpgrafana.GrafanaConfig{
+		URL: "http://%gg",
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	params := GenerateDeeplinkParams{
+		ResourceType: "dashboard",
+		DashboardUID: stringPtr("abc123"),
+	}
+
+	_, err := generateDeeplink(ctx, params)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, mcpgrafana.ErrInvalidGrafanaURL),
+		"expected error to wrap ErrInvalidGrafanaURL, got: %v", err)
+	assert.Contains(t, err.Error(), "invalid",
+		"error message must include 'invalid' for operator/LLM readability; got %q", err.Error())
 }

--- a/validate_url.go
+++ b/validate_url.go
@@ -1,0 +1,69 @@
+package mcpgrafana
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ErrInvalidGrafanaURL is returned (wrapped) by ValidateGrafanaURL when the
+// input is not an absolute HTTP or HTTPS URL with a non-empty host. Detect
+// with errors.Is.
+//
+// The nav.go guard in tools/navigation.go:generateDeeplink wraps this
+// sentinel when config.URL is malformed (e.g. coming from a bad
+// /api/frontend/settings appUrl response), distinguishing that case from
+// missing-URL cases for callers that discriminate via errors.Is.
+var ErrInvalidGrafanaURL = errors.New("invalid Grafana URL")
+
+// ValidateGrafanaURL returns nil if u is an absolute HTTP or HTTPS URL with a
+// non-empty host. Trailing slashes are trimmed before validation so callers do
+// not need to pre-normalize; this is the single canonicalization point shared
+// by ValidateGrafanaURLMiddleware and the nav.go guard. On failure the
+// returned error wraps ErrInvalidGrafanaURL.
+//
+// url.Parse alone is too lenient: it accepts relative references (/foo),
+// unusual schemes (javascript:alert(1)), and URLs without a host (http://).
+// ParseRequestURI plus a scheme allow-list plus a host check is the standard
+// pattern for validating request-supplied URL headers.
+func ValidateGrafanaURL(u string) error {
+	u = strings.TrimRight(u, "/")
+	if u == "" {
+		return fmt.Errorf("%w: URL is empty", ErrInvalidGrafanaURL)
+	}
+	pu, err := url.ParseRequestURI(u)
+	if err != nil {
+		return fmt.Errorf("%w: %v (set a valid http:// or https:// URL)", ErrInvalidGrafanaURL, err)
+	}
+	if pu.Scheme != "http" && pu.Scheme != "https" {
+		return fmt.Errorf("%w: scheme %q not allowed (must be http or https)", ErrInvalidGrafanaURL, pu.Scheme)
+	}
+	if pu.Host == "" {
+		return fmt.Errorf("%w: URL has no host", ErrInvalidGrafanaURL)
+	}
+	return nil
+}
+
+// ValidateGrafanaURLMiddleware returns an http.Handler middleware that rejects
+// requests whose X-Grafana-URL header is present but fails ValidateGrafanaURL,
+// responding with 400 Bad Request. Requests without the header pass through
+// unchanged (downstream extractors apply the env-variable fallback).
+//
+// Library consumers that wire mcp-grafana's context functions into their own
+// http.Server should install this middleware to match the binary's defensive
+// behavior. Consumers that call NewGrafanaClient directly (stdio or
+// programmatic construction) should pre-validate the URL with
+// ValidateGrafanaURL instead.
+func ValidateGrafanaURLMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if raw := r.Header.Get(grafanaURLHeader); raw != "" {
+			if err := ValidateGrafanaURL(raw); err != nil {
+				http.Error(w, fmt.Sprintf("invalid X-Grafana-URL header: %v", err), http.StatusBadRequest)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/validate_url_test.go
+++ b/validate_url_test.go
@@ -1,0 +1,250 @@
+package mcpgrafana
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateGrafanaURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid inputs.
+		{"http with host+port", "http://localhost:3000", false},
+		{"https with host", "https://grafana.example.com", false},
+		{"https with host and path", "https://grafana.example.com/subpath", false},
+		{"http with port and path", "http://host:8000/api/mcp", false},
+		// url.ParseRequestURI lowercases the scheme, so the scheme-allow-list
+		// check below (pu.Scheme != "http" && != "https") accepts uppercase
+		// input without needing a separate case-fold. Documented so a future
+		// refactor that adds a strings.ToLower doesn't accidentally break
+		// this invariant.
+		{"uppercase scheme normalized by ParseRequestURI", "HTTP://host", false},
+
+		// Trim behavior (H1 trim consolidation).
+		{"http with single trailing slash", "http://grafana.example/", false},
+		{"http with multiple trailing slashes", "http://grafana.example///", false},
+
+		// Invalid inputs.
+		{"empty string", "", true},
+		{"slash-only trims to empty", "/", true},
+		{"plain text", "not a url", true},
+		{"invalid percent encoding", "http://%gg", true},
+		{"javascript scheme", "javascript:alert(1)", true},
+		{"file scheme", "file:///etc/passwd", true},
+		{"ftp scheme", "ftp://example.com", true},
+		{"scheme-relative", "//no-scheme.example.com", true},
+		{"relative path", "/relative/path", true},
+		{"http with empty host", "http://", true},
+		{"http with triple-slash and no host", "http:///path", true},
+		{"https with empty host", "https://", true},
+		{"control byte in URL", "http://host\x01", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ValidateGrafanaURL(tc.input)
+			if tc.wantErr {
+				require.Error(t, got, "expected an error for input %q", tc.input)
+				assert.True(t, errors.Is(got, ErrInvalidGrafanaURL),
+					"error must wrap ErrInvalidGrafanaURL for input %q; got %v", tc.input, got)
+			} else {
+				assert.NoError(t, got, "expected no error for input %q", tc.input)
+			}
+		})
+	}
+}
+
+func TestValidateGrafanaURLMiddleware(t *testing.T) {
+	cases := []struct {
+		name       string
+		setHeader  bool
+		headerVal  string
+		wantStatus int
+		wantCalled bool
+	}{
+		{"absent header passes through", false, "", http.StatusOK, true},
+		{"valid http header passes", true, "http://grafana.example", http.StatusOK, true},
+		{"valid https header passes", true, "https://grafana.example.com", http.StatusOK, true},
+		{"valid with trailing slash passes", true, "https://grafana.example.com/", http.StatusOK, true},
+		{"malformed percent encoding rejected", true, "http://%gg", http.StatusBadRequest, false},
+		{"javascript scheme rejected", true, "javascript:alert(1)", http.StatusBadRequest, false},
+		{"relative path rejected", true, "/relative", http.StatusBadRequest, false},
+		{"trim-to-empty slash rejected", true, "/", http.StatusBadRequest, false},
+		{"empty host rejected", true, "http://", http.StatusBadRequest, false},
+		{"CR-LF injection attempt rejected", true, "http://foo\r\nX-Injected: 1", http.StatusBadRequest, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.setHeader {
+				req.Header.Set(grafanaURLHeader, tc.headerVal)
+			}
+			rec := httptest.NewRecorder()
+			ValidateGrafanaURLMiddleware(next).ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.wantStatus, rec.Code, "unexpected status code")
+			assert.Equal(t, tc.wantCalled, called, "next handler call state mismatch")
+			if tc.wantStatus == http.StatusBadRequest {
+				assert.Contains(t, rec.Body.String(), "invalid X-Grafana-URL",
+					"rejection body must include the operator-visible error signal")
+			}
+		})
+	}
+
+	t.Run("duplicate header - first value is validated", func(t *testing.T) {
+		// Header.Get returns the first value. A caller that sends two
+		// X-Grafana-URL headers gets validated on the first; the second is
+		// ignored by standard Go http header semantics. Documented so a
+		// future reader knows the behavior is intentional, not accidental.
+		//
+		// Use Header.Add (not the raw map) so the key is stored under its
+		// canonical form (textproto.CanonicalMIMEHeaderKey). Raw map
+		// assignment with the non-canonical "X-Grafana-URL" key would leave
+		// the header invisible to Header.Get (which canonicalizes its
+		// lookup), and this test would pass for the wrong reason.
+		called := false
+		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Add(grafanaURLHeader, "http://ok.example")
+		req.Header.Add(grafanaURLHeader, "javascript:alert(1)")
+		rec := httptest.NewRecorder()
+		ValidateGrafanaURLMiddleware(next).ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.True(t, called)
+	})
+
+	t.Run("concurrent mixed under -race", func(t *testing.T) {
+		// Middleware is stateless by construction — no data race should
+		// surface. This test runs 20 concurrent requests through one
+		// middleware instance under go test -race to catch any accidental
+		// shared state introduced during review or future refactoring.
+		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		mw := ValidateGrafanaURLMiddleware(next)
+
+		mixed := []struct {
+			header     string
+			wantStatus int
+		}{
+			{"http://ok1.example", http.StatusOK},
+			{"http://%gg", http.StatusBadRequest},
+			{"https://ok2.example", http.StatusOK},
+			{"javascript:alert(1)", http.StatusBadRequest},
+			{"http://ok3.example:8000", http.StatusOK},
+			{"/", http.StatusBadRequest},
+			{"https://ok4.example/path", http.StatusOK},
+			{"file:///etc/passwd", http.StatusBadRequest},
+			{"http://ok5.example", http.StatusOK},
+			{"http://", http.StatusBadRequest},
+		}
+
+		var wg sync.WaitGroup
+		errs := make(chan string, 20)
+		for i := 0; i < 20; i++ {
+			tc := mixed[i%len(mixed)]
+			wg.Add(1)
+			go func(header string, wantStatus int) {
+				defer wg.Done()
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set(grafanaURLHeader, header)
+				rec := httptest.NewRecorder()
+				mw.ServeHTTP(rec, req)
+				if rec.Code != wantStatus {
+					errs <- "header " + header + ": got " + http.StatusText(rec.Code) + ", want " + http.StatusText(wantStatus)
+				}
+			}(tc.header, tc.wantStatus)
+		}
+		wg.Wait()
+		close(errs)
+		for e := range errs {
+			t.Error(e)
+		}
+	})
+}
+
+// Smoke coverage for ExtractGrafanaClientFromHeaders client construction.
+// These two tests exercise the extractor end-to-end (header parsing -> client
+// wiring -> real HTTP call against a test server) without depending on
+// sentinel-specific machinery.
+
+func TestExtractGrafanaClientFromHeaders_ValidURL(t *testing.T) {
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "test-token")
+
+	// hitCount tracks that the extractor wired a client pointed at THIS test
+	// server (not defaultGrafanaURL or anything else). A request counter is
+	// the cheapest durable assertion that the header-URL actually flowed
+	// through to client construction.
+	var hitCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"meta":{},"dashboard":{}}`))
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set(grafanaURLHeader, srv.URL)
+
+	ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
+	c := GrafanaClientFromContext(ctx)
+	require.NotNil(t, c, "extractor must attach a client when header URL is valid")
+
+	_, apiErr := c.Dashboards.GetDashboardByUID("any-uid")
+	// The call reaches the test server, which returns skeletal JSON. The
+	// openapi client may succeed or return a schema-mismatch error; either
+	// is acceptable. What's NOT acceptable is a URL-parse error, which
+	// would indicate the extractor wired garbage instead of the header URL.
+	if apiErr != nil {
+		assert.NotContains(t, apiErr.Error(), "parse",
+			"valid-header path must not produce a URL-parse error; got %v", apiErr)
+	}
+	assert.Greater(t, int(atomic.LoadInt32(&hitCount)), 0,
+		"extractor must wire a client that actually reaches the header-supplied URL")
+}
+
+func TestExtractGrafanaClientFromHeaders_NoHeader(t *testing.T) {
+	// No X-Grafana-URL header: extractor falls back to env, and env is empty
+	// so defaultGrafanaURL (http://localhost:3000) applies. Nothing is
+	// listening on :3000 during tests, so the client call MUST fail with a
+	// connection-level error (proving defaultGrafanaURL was used) and MUST
+	// NOT fail with a URL-parse error (which would mean the extractor
+	// produced garbage).
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
+	c := GrafanaClientFromContext(ctx)
+	require.NotNil(t, c, "extractor must attach a client even with no header")
+
+	_, apiErr := c.Dashboards.GetDashboardByUID("any-uid")
+	require.Error(t, apiErr,
+		"no-header path should fall back to defaultGrafanaURL and fail to connect")
+	assert.NotContains(t, apiErr.Error(), "parse",
+		"failure must be connection-level, not a URL-parse error; got %v", apiErr)
+}


### PR DESCRIPTION
Supersedes the sentinel-client approach. Per @sd2k's review: validates `X-Grafana-URL` at the HTTP middleware layer and returns 400 Bad Request on malformed input.

## Summary

- New exported `mcpgrafana.ValidateGrafanaURLMiddleware(next http.Handler) http.Handler`. Checks `X-Grafana-URL` on every request. Present-but-invalid: 400 Bad Request with error text. Absent or valid: passes through.
- Wired into both HTTP transports in `cmd/mcp-grafana/main.go` (SSE + streamable-http). stdio unaffected.
- Force-pushes the branch, superseding the prior sentinel-client revision. That earlier revision added ~300 LoC of sentinel HTTP-client machinery (`errorClientTransport`, `errorRoundTripper`, `newSentinelGrafanaClient`, `newSentinelIncidentClient`, `validateHeaderURL`, and their tests). None of that is needed with middleware at the transport boundary, and none of it is carried forward in this revision. The diff vs `main` shows the new approach directly, not deletions. The prior revision was only on the PR branch, never merged.
- Introduces `ValidateGrafanaURL` (consolidates trim internally) and `ErrInvalidGrafanaURL`. Both are used by the middleware and the nav guard.
- Adds a guard for the `config.URL` path in `tools/navigation.go:generateDeeplink` to match the middleware's guarantees on the `X-Grafana-URL` path. The guard protects `gc.PublicURL` (populated from Grafana's `/api/frontend/settings` `appUrl` response, not the caller's header), which middleware at the inbound boundary does not cover. Second commit on this branch.

## Behavioral matrix

| X-Grafana-URL | HTTP response |
|---|---|
| Absent | 200 (env fallback) |
| Valid http/https | 200 |
| Present but invalid | 400 Bad Request |
| Present but trims to empty (`/`) | 400 Bad Request (fail closed) |

## Library contract (README.md Programmatic Usage section updated)

- HTTP transports (SSE, streamable-http): middleware handles validation transparently.
- stdio transport: config from env; operators must set a valid `GRAFANA_URL`.
- Library consumers wiring mcp-grafana context-funcs into their own `http.Server`: install `ValidateGrafanaURLMiddleware` to match the binary's behavior.
- Library consumers using `NewGrafanaClient` directly (stdio or programmatic construction): pre-validate with `ValidateGrafanaURL` (the existing `NewGrafanaClient` docstring already notes this).
- Both patterns are shown in README "Programmatic Usage."

## Errors.Is contract change

`errors.Is(err, mcpgrafana.ErrInvalidGrafanaURL)` no longer triggers on HTTP-transport paths. Requests are rejected before extractors run. The sentinel is still returned by `ValidateGrafanaURL` itself (wrapped), so direct validation callers continue to detect it.

## Tests

- `TestValidateGrafanaURLMiddleware`: 12 cases (pass-through, rejection shapes, duplicate-header, CR-LF injection, 20-goroutine concurrency under `-race`).
- `TestValidateGrafanaURL`: 20 cases (scheme allow-list, host requirement, trim behavior).
- `TestExtractGrafanaClientFromHeaders_ValidURL` + `_NoHeader`: smoke coverage for client construction, with an httptest request counter proving the extractor wires a client at the header-supplied URL.
- `TestGenerateDeeplink_RejectsMalformedBaseURL_ClientWithEmptyPublicURL` + `_NoClient`: guard regression tests.

## Test plan

- [x] `make test-unit` passes
- [x] `make lint` reports 0 issues
- [x] Manual: valid/malformed/`/`-collapse/absent header behavior on both transports

## Follow-ups

- #776: `ValidateGrafanaURL` should reject embedded credentials (`user:pass@host`). Separate PR to follow this one.

## Closes

- #763 (extract-boundary, subsumed by middleware)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request handling for SSE/streamable HTTP by rejecting malformed `X-Grafana-URL` with `400`, which can affect clients that previously relied on permissive parsing; also adds URL validation to deeplink generation to prevent bad URLs from propagating.
> 
> **Overview**
> Prevents malformed `X-Grafana-URL` values from reaching Grafana client construction by introducing `ValidateGrafanaURL` (with `ErrInvalidGrafanaURL`) and an `ValidateGrafanaURLMiddleware` that returns **400 Bad Request** when the header is present but invalid.
> 
> Wires this middleware into the binary’s SSE and streamable-http handlers, and adds a separate base-URL validation guard in `tools/navigation.go` so deeplink generation errors out (instead of emitting malformed links) when `config.URL`/`PublicURL` is invalid. Updates README with guidance for library consumers and adds comprehensive unit tests for the validator, middleware, extractor smoke paths, and deeplink regression cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e97ee03015171d74e800a9d355bdff243cea400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->