### PR TITLE
fix(mcpgrafana): validate X-Grafana-URL at extract boundary

### DIFF
--- a/client_cache.go
+++ b/client_cache.go
@@ -244,11 +244,21 @@ func hashAPIKey(key string) string {
 }
 
 // extractGrafanaClientCached creates an httpContextFunc that uses the cache.
+// If X-Grafana-URL is present but malformed or uses a non-HTTP(S) scheme, a
+// sentinel client is attached to the context instead of invoking
+// NewGrafanaClient (which would panic on url.Parse failure). The sentinel is
+// not cached: caching it would let a single bad caller poison a cache slot
+// keyed by their malformed URL.
 func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		config := GrafanaConfigFromContext(ctx)
 		if config.OrgID == 0 {
 			slog.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
+		}
+
+		if err := validateHeaderURL(req); err != nil {
+			slog.Warn("rejecting malformed X-Grafana-URL header, attaching sentinel Grafana client", "error", err)
+			return WithGrafanaClient(ctx, newSentinelGrafanaClient(err))
 		}
 
 		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req)
@@ -264,8 +274,14 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 }
 
 // extractIncidentClientCached creates an httpContextFunc that uses the cache.
+// Same sentinel-on-bad-URL behavior as extractGrafanaClientCached.
 func extractIncidentClientCached(cache *ClientCache) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
+		if err := validateHeaderURL(req); err != nil {
+			slog.Warn("rejecting malformed X-Grafana-URL header, attaching sentinel incident client", "error", err)
+			return WithIncidentClient(ctx, newSentinelIncidentClient(err))
+		}
+
 		grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req)
 		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID)
 

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -725,6 +725,13 @@ func doFetchPublicURL(ctx context.Context, grafanaURL, apiKey string, auth *url.
 // The client is automatically configured with the correct HTTP scheme, debug settings from context, custom TLS configuration if present, and OpenTelemetry instrumentation for distributed tracing.
 // It also fetches the Grafana instance's public URL from /api/frontend/settings for use in deep link generation.
 // The org ID is read from the GrafanaConfig in the context, which should be set by ExtractGrafanaInfoFromEnv or ExtractGrafanaInfoFromHeaders before calling this function.
+//
+// NewGrafanaClient panics if grafanaURL is present but not parseable by
+// url.Parse. This is safe for operator-supplied configuration (env vars,
+// CLI flags) where loud startup failure is preferable to silently running
+// against the wrong host. Library consumers that pass untrusted input
+// (request headers, user input) must validate first via ValidateGrafanaURL
+// to avoid a reachable panic.
 func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.Userinfo) *GrafanaClient {
 	cfg := client.DefaultTransportConfig()
 
@@ -878,10 +885,18 @@ var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Conte
 
 // ExtractGrafanaClientFromHeaders is a HTTPContextFunc that creates and injects a Grafana client into the context.
 // It prioritizes configuration from HTTP headers (X-Grafana-URL, X-Grafana-API-Key) over environment variables for multi-tenant scenarios.
+// If X-Grafana-URL is present but malformed or uses a non-HTTP(S) scheme, a sentinel client
+// is attached to the context instead; tool handlers receive ErrInvalidGrafanaURL from the
+// client's API methods rather than having NewGrafanaClient panic on url.Parse failure.
 var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	config := GrafanaConfigFromContext(ctx)
 	if config.OrgID == 0 {
 		slog.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
+	}
+
+	if err := validateHeaderURL(req); err != nil {
+		slog.Warn("rejecting malformed X-Grafana-URL header, attaching sentinel Grafana client", "error", err)
+		return WithGrafanaClient(ctx, newSentinelGrafanaClient(err))
 	}
 
 	// Extract transport config from request headers, and set it on the context.
@@ -945,7 +960,15 @@ var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Cont
 
 // ExtractIncidentClientFromHeaders is a HTTPContextFunc that creates and injects a Grafana Incident client into the context.
 // It uses HTTP headers for configuration with environment variable fallbacks, enabling per-request incident management configuration.
+// If X-Grafana-URL is present but malformed or uses a non-HTTP(S) scheme, a sentinel
+// client is attached instead; incident-tool handlers surface ErrInvalidGrafanaURL from
+// HTTP calls rather than building an incident URL from garbage.
 var ExtractIncidentClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
+	if err := validateHeaderURL(req); err != nil {
+		slog.Warn("rejecting malformed X-Grafana-URL header, attaching sentinel incident client", "error", err)
+		return WithIncidentClient(ctx, newSentinelIncidentClient(err))
+	}
+
 	grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req)
 	incidentURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/v1/", grafanaURL)
 	client := incident.NewClient(incidentURL, apiKey)

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -551,13 +551,41 @@ type httpContextFunc func(ctx context.Context, req *http.Request) context.Contex
 // ExtractGrafanaInfoFromHeaders is a HTTPContextFunc that extracts Grafana configuration from HTTP request headers.
 // It reads X-Grafana-URL and X-Grafana-API-Key headers, falling back to environment variables if headers are not present.
 // Headers listed in GRAFANA_FORWARD_HEADERS are copied from the incoming request and merged with GRAFANA_EXTRA_HEADERS.
+//
+// When X-Grafana-URL is present but fails ValidateGrafanaURL (malformed, non-http(s)
+// scheme, missing host, or trims to empty), the header is rejected and config.URL
+// is left empty. This is fail-closed: the function does NOT fall back to env on a
+// present-but-invalid header, because silently substituting env would mask the
+// caller's mistake. Absent header still falls back to env. A slog.Warn names the
+// rejection so operators can diagnose bad deployments from logs.
 var ExtractGrafanaInfoFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
+	// extractKeyGrafanaInfoFromReq is called unconditionally because we need
+	// apiKey, basicAuth, and orgID on every path (including the invalid-URL
+	// path). Its `u` return is used only on the valid or absent header paths.
 	u, apiKey, basicAuth, orgID := extractKeyGrafanaInfoFromReq(req)
 
 	// Get existing config or create a new one.
 	// This will respect the existing debug flag, if set.
 	config := GrafanaConfigFromContext(ctx)
-	config.URL = u
+
+	rawHeader := req.Header.Get(grafanaURLHeader)
+	if rawHeader != "" {
+		// Present header: validate the trimmed RAW header, not `u`. `u` can
+		// be env-sourced when the raw header trims to empty (e.g. "/"), so
+		// validating `u` would silently accept an env URL when the header
+		// itself was bad. Validating the raw-trimmed header keeps fail-closed.
+		if err := ValidateGrafanaURL(strings.TrimRight(rawHeader, "/")); err != nil {
+			slog.Warn("rejecting malformed X-Grafana-URL header, leaving config.URL empty", "error", err)
+			config.URL = ""
+		} else {
+			config.URL = u
+		}
+	} else {
+		// Absent header: u is already the env-fallback URL (or empty) as
+		// returned by extractKeyGrafanaInfoFromReq. Pass through unchanged.
+		config.URL = u
+	}
+
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
 	config.OrgID = orgID

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -2,10 +2,12 @@ package mcpgrafana
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-openapi/runtime/client"
@@ -1307,4 +1309,99 @@ func TestNewGrafanaClientFetchesPublicURL(t *testing.T) {
 		gc := NewGrafanaClient(ctx, ts.URL, "test-key", nil)
 		assert.Equal(t, "", gc.PublicURL)
 	})
+}
+
+// capturingHandler is a test-local slog.Handler that records every slog.Record
+// passed through it. Used by TestExtractGrafanaInfoFromHeaders_URLValidation to
+// assert that the new warn-on-bad-header path emits the expected WARN record.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *capturingHandler) warnRejectionCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var n int
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn && strings.Contains(r.Message, "rejecting malformed X-Grafana-URL header") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestExtractGrafanaInfoFromHeaders_URLValidation covers the inline header
+// validation added to ExtractGrafanaInfoFromHeaders. The six cases cover the
+// full product of (valid | invalid | absent | trim-collapse) x (env present |
+// env absent), plus the critical regression case (e) where a literal "/"
+// header would, under the old trim-then-empty-check logic, silently fall back
+// to env. Each sub-test runs with t.Setenv-scoped env vars so it is hermetic
+// regardless of the developer's shell env.
+func TestExtractGrafanaInfoFromHeaders_URLValidation(t *testing.T) {
+	cases := []struct {
+		name            string
+		header          string // "" means no X-Grafana-URL header set at all
+		setHeader       bool
+		env             string // value for GRAFANA_URL env; "" means unset
+		wantURL         string
+		wantWarnCount   int
+	}{
+		{name: "valid header, env present", header: "http://grafana.example", setHeader: true, env: "http://env.example", wantURL: "http://grafana.example", wantWarnCount: 0},
+		{name: "invalid header, env present", header: "http://%gg", setHeader: true, env: "http://env.example", wantURL: "", wantWarnCount: 1},
+		{name: "absent header, env present", header: "", setHeader: false, env: "http://env.example", wantURL: "http://env.example", wantWarnCount: 0},
+		// Note: "absent header, absent env" resolves to defaultGrafanaURL
+		// (http://localhost:3000) via extractKeyGrafanaInfoFromEnv, not "".
+		// The only paths that produce an empty config.URL are the fail-closed
+		// branches (invalid + trim-collapse below).
+		{name: "absent header, env absent (default applies)", header: "", setHeader: false, env: "", wantURL: defaultGrafanaURL, wantWarnCount: 0},
+		{name: "slash header (trim-collapse), env present", header: "/", setHeader: true, env: "http://env.example", wantURL: "", wantWarnCount: 1},
+		{name: "valid header, env absent", header: "http://grafana.example", setHeader: true, env: "", wantURL: "http://grafana.example", wantWarnCount: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Hermetic env setup: GRAFANA_URL is the only env var
+			// extractKeyGrafanaInfoFromReq consults for URL fallback, but
+			// clear the auth-token vars too so a developer-set env does not
+			// leak into assertions on other config fields via future tests.
+			t.Setenv("GRAFANA_URL", tc.env)
+			t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+			t.Setenv("GRAFANA_API_KEY", "")
+
+			// Install capturing slog.Handler as the process default so
+			// the WARN emitted inside ExtractGrafanaInfoFromHeaders is
+			// captured. Restore after the subtest via t.Cleanup. No
+			// t.Parallel, matching the slog.SetDefault-mutation pattern
+			// established by observability_test.go:TestSetup_SlowLogSurvivesStrictGlobal.
+			prev := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(prev) })
+			h := &capturingHandler{}
+			slog.SetDefault(slog.New(h))
+
+			req, err := http.NewRequest("GET", "http://example.com", nil)
+			require.NoError(t, err)
+			if tc.setHeader {
+				req.Header.Set(grafanaURLHeader, tc.header)
+			}
+
+			ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
+			cfg := GrafanaConfigFromContext(ctx)
+
+			assert.Equal(t, tc.wantURL, cfg.URL, "config.URL")
+			assert.Equal(t, tc.wantWarnCount, h.warnRejectionCount(), "warn count")
+		})
+	}
 }

--- a/sentinel_client.go
+++ b/sentinel_client.go
@@ -1,0 +1,128 @@
+package mcpgrafana
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	"github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/incident-go"
+)
+
+// ErrInvalidGrafanaURL is returned by tool handlers when the caller-supplied
+// X-Grafana-URL header was malformed or used a non-HTTP(S) scheme, so the
+// request could not be associated with a valid Grafana instance. It is
+// surfaced via sentinel *GrafanaClient / *incident.Client values attached to
+// the request context, so tool handlers receive a structured error from
+// their normal API-call error path rather than nil-dereffing on a missing
+// client.
+//
+// Detect with errors.Is(err, ErrInvalidGrafanaURL). The wrapped parse error
+// is rendered with %v, not %w, so errors.As cannot unwrap the underlying
+// *url.Error. This is intentional: the sentinel is the stable contract;
+// callers should not depend on the inner error type.
+//
+// Fires only on the HTTP header-based transport path (SSE / streamable-http).
+// Callers that invoke NewGrafanaClient directly with an invalid URL still
+// panic. Use ValidateGrafanaURL to validate URLs before passing to
+// NewGrafanaClient from library code.
+var ErrInvalidGrafanaURL = errors.New("invalid X-Grafana-URL header")
+
+// ValidateGrafanaURL returns nil if u parses as an absolute HTTP or HTTPS URL
+// with a non-empty host. It is exported so library consumers can validate
+// URLs before passing them to NewGrafanaClient (which panics on invalid
+// input). On failure the returned error wraps ErrInvalidGrafanaURL.
+//
+// url.Parse alone is too lenient: it accepts relative references (/foo),
+// unusual schemes (javascript:alert(1)), and URLs without a host (http://).
+// ParseRequestURI plus a scheme allow-list plus a host check is the standard
+// pattern for validating request-supplied URL headers.
+func ValidateGrafanaURL(u string) error {
+	pu, err := url.ParseRequestURI(u)
+	if err != nil {
+		return fmt.Errorf("%w: %v (set a valid http:// or https:// URL)", ErrInvalidGrafanaURL, err)
+	}
+	if pu.Scheme != "http" && pu.Scheme != "https" {
+		return fmt.Errorf("%w: scheme %q not allowed (must be http or https)", ErrInvalidGrafanaURL, pu.Scheme)
+	}
+	if pu.Host == "" {
+		return fmt.Errorf("%w: URL has no host", ErrInvalidGrafanaURL)
+	}
+	return nil
+}
+
+// validateHeaderURL returns an error if the request's X-Grafana-URL header is
+// present but malformed or non-http(s). It returns nil when the header is
+// absent (callers fall back to the env-configured URL downstream) or valid.
+func validateHeaderURL(req *http.Request) error {
+	u := strings.TrimRight(req.Header.Get(grafanaURLHeader), "/")
+	if u == "" {
+		return nil
+	}
+	return ValidateGrafanaURL(u)
+}
+
+// errorClientTransport implements runtime.ClientTransport. Every operation
+// returns the configured error. Used to back sentinel Grafana clients that
+// stand in for a real client when the request's X-Grafana-URL header failed
+// validation.
+type errorClientTransport struct {
+	err error
+}
+
+// Submit satisfies runtime.ClientTransport.
+func (t *errorClientTransport) Submit(*runtime.ClientOperation) (interface{}, error) {
+	return nil, t.err
+}
+
+// newSentinelGrafanaClient returns a *GrafanaClient whose openapi-backed API
+// methods all return err. The openapi client's generated SetTransport
+// propagates the sentinel transport to every sub-resource (Dashboards,
+// Datasources, ...), so any tool handler that calls a method on the returned
+// client receives err from its normal error-return path.
+//
+// If err is nil the sentinel would silently return (nil, nil) from every API
+// call, a hidden nil-panic setup for callers. Substitute ErrInvalidGrafanaURL
+// so the sentinel always propagates a detectable failure.
+func newSentinelGrafanaClient(err error) *GrafanaClient {
+	if err == nil {
+		err = ErrInvalidGrafanaURL
+	}
+	c := client.NewHTTPClient(strfmt.Default)
+	c.SetTransport(&errorClientTransport{err: err})
+	return &GrafanaClient{
+		GrafanaHTTPAPI: c,
+	}
+}
+
+// errorRoundTripper implements http.RoundTripper, returning the configured
+// error for every request. Used to back sentinel incident-go clients, which
+// expose an http.Client rather than a typed runtime.ClientTransport.
+type errorRoundTripper struct {
+	err error
+}
+
+// RoundTrip satisfies http.RoundTripper.
+func (t *errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.err
+}
+
+// newSentinelIncidentClient returns a *incident.Client whose HTTP calls all
+// fail with err. The URL passed to incident.NewClient is never used in
+// practice because the sentinel RoundTripper short-circuits before any
+// request is issued.
+//
+// If err is nil the sentinel would return (nil, nil) from every call. See
+// newSentinelGrafanaClient for the rationale; the same substitution applies.
+func newSentinelIncidentClient(err error) *incident.Client {
+	if err == nil {
+		err = ErrInvalidGrafanaURL
+	}
+	c := incident.NewClient("http://invalid.sentinel", "")
+	c.HTTPClient.Transport = &errorRoundTripper{err: err}
+	return c
+}

--- a/sentinel_client_test.go
+++ b/sentinel_client_test.go
@@ -1,0 +1,395 @@
+package mcpgrafana
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/grafana/incident-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateGrafanaURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid inputs.
+		{"http with host+port", "http://localhost:3000", false},
+		{"https with host", "https://grafana.example.com", false},
+		{"https with host and path", "https://grafana.example.com/subpath", false},
+		{"http with port and path", "http://host:8000/api/mcp", false},
+		{"uppercase scheme is normalized by ParseRequestURI", "HTTP://host", false},
+
+		// Invalid inputs.
+		{"empty string", "", true},
+		{"plain text", "not a url", true},
+		{"invalid percent encoding", "http://%gg", true},
+		{"javascript scheme", "javascript:alert(1)", true},
+		{"file scheme", "file:///etc/passwd", true},
+		{"ftp scheme", "ftp://example.com", true},
+		{"scheme-relative", "//no-scheme.example.com", true},
+		{"relative path", "/relative/path", true},
+		{"http with empty host", "http://", true},
+		{"http with triple-slash and no host", "http:///path", true},
+		{"https with empty host", "https://", true},
+		{"control byte in URL", "http://host\x01", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ValidateGrafanaURL(tc.input)
+			if tc.wantErr {
+				require.Error(t, got, "expected an error for input %q", tc.input)
+				assert.True(t, errors.Is(got, ErrInvalidGrafanaURL),
+					"error must wrap ErrInvalidGrafanaURL for input %q; got %v", tc.input, got)
+			} else {
+				assert.NoError(t, got, "expected no error for input %q", tc.input)
+			}
+		})
+	}
+}
+
+func TestValidateHeaderURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		setHdr  bool
+		value   string
+		wantErr bool
+	}{
+		{"absent header (no Set call)", false, "", false},
+		{"empty header", true, "", false},
+		{"empty header with trailing slash", true, "/", false}, // TrimRight("/", "/") = ""
+		{"valid http", true, "http://localhost:3000", false},
+		{"valid https with trailing slash", true, "https://grafana.example.com/", false},
+		{"valid with nested path", true, "https://example.com/subpath/api", false},
+		{"malformed percent encoding", true, "http://%gg", true},
+		{"non-http scheme", true, "file:///etc/passwd", true},
+		{"no host", true, "http://", true},
+		{"relative path", true, "/relative", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			require.NoError(t, err)
+			if tc.setHdr {
+				req.Header.Set(grafanaURLHeader, tc.value)
+			}
+			got := validateHeaderURL(req)
+			if tc.wantErr {
+				require.Error(t, got)
+				assert.True(t, errors.Is(got, ErrInvalidGrafanaURL),
+					"error must wrap ErrInvalidGrafanaURL; got %v", got)
+			} else {
+				assert.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestSentinelGrafanaClient_PublicURLIsEmpty(t *testing.T) {
+	// navigation.go and proxied_tools.go read c.PublicURL or check gc != nil
+	// patterns. The sentinel must present as non-nil with empty PublicURL so
+	// conditional-access branches short-circuit cleanly rather than trying
+	// to dereference a partially-populated struct.
+	c := newSentinelGrafanaClient(errors.New("boom"))
+	require.NotNil(t, c)
+	assert.Empty(t, c.PublicURL,
+		"sentinel PublicURL must be empty so `gc != nil && gc.PublicURL != \"\"` checks short-circuit")
+}
+
+func TestSentinelGrafanaClient_ReturnsError(t *testing.T) {
+	t.Run("API method returns the configured error", func(t *testing.T) {
+		want := errors.New("boom")
+		c := newSentinelGrafanaClient(want)
+
+		// Any sub-resource call should route through the sentinel transport.
+		// GetDashboardByUID is representative: it's a simple GET that doesn't
+		// depend on request-body serialization, so any error from Submit
+		// surfaces directly as the returned error.
+		_, err := c.Dashboards.GetDashboardByUID("any-uid")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, want),
+			"sub-resource call must surface the sentinel error; got %v", err)
+	})
+
+	t.Run("nil err is substituted with ErrInvalidGrafanaURL", func(t *testing.T) {
+		// Guards against a footgun: if a future caller passes nil, the
+		// sentinel must still produce a detectable error rather than
+		// silently returning (nil, nil) from every API call.
+		c := newSentinelGrafanaClient(nil)
+		_, err := c.Dashboards.GetDashboardByUID("any-uid")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInvalidGrafanaURL),
+			"nil-err sentinel must substitute ErrInvalidGrafanaURL; got %v", err)
+	})
+}
+
+func TestSentinelIncidentClient_ReturnsError(t *testing.T) {
+	t.Run("HTTP request returns the configured error", func(t *testing.T) {
+		want := errors.New("boom")
+		c := newSentinelIncidentClient(want)
+
+		// Exercise HTTPClient directly: the sentinel RoundTripper
+		// short-circuits any request before it reaches a real server.
+		req, err := http.NewRequest(http.MethodGet, "http://any.example/api/v1/x", nil)
+		require.NoError(t, err)
+		_, err = c.HTTPClient.Do(req)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, want),
+			"HTTP call must surface the sentinel error; got %v", err)
+	})
+
+	t.Run("typed incident service method returns the configured error", func(t *testing.T) {
+		// Mirror the pattern in tools/incident.go:20-21 — wrap the client
+		// in incident.NewIncidentsService and call a typed method. Proves
+		// the sentinel RoundTripper intercepts at the layer tool handlers
+		// actually use, not just raw HTTPClient.Do.
+		want := errors.New("boom")
+		c := newSentinelIncidentClient(want)
+		is := incident.NewIncidentsService(c)
+		_, err := is.QueryIncidentPreviews(context.Background(),
+			incident.QueryIncidentPreviewsRequest{
+				Query: incident.IncidentPreviewsQuery{Limit: 10},
+			})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, want),
+			"typed incident service method must surface the sentinel error; got %v", err)
+	})
+
+	t.Run("nil err is substituted with ErrInvalidGrafanaURL", func(t *testing.T) {
+		c := newSentinelIncidentClient(nil)
+		req, err := http.NewRequest(http.MethodGet, "http://any.example/api/v1/x", nil)
+		require.NoError(t, err)
+		_, err = c.HTTPClient.Do(req)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInvalidGrafanaURL),
+			"nil-err sentinel must substitute ErrInvalidGrafanaURL; got %v", err)
+	})
+}
+
+func TestExtractGrafanaClientFromHeaders_InvalidURL(t *testing.T) {
+	// extractKeyGrafanaInfoFromReq pulls GRAFANA_URL from env as a fallback;
+	// neutralize that so a bad header is the only input.
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+
+	cases := []struct {
+		name   string
+		header string
+	}{
+		{"malformed percent encoding", "http://%gg"},
+		{"non-http scheme", "file:///etc/passwd"},
+		{"empty host", "http://"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			require.NoError(t, err)
+			req.Header.Set(grafanaURLHeader, tc.header)
+
+			ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
+			c := GrafanaClientFromContext(ctx)
+			require.NotNil(t, c, "client must be attached even on validation failure")
+
+			// Sentinel surfaces ErrInvalidGrafanaURL from any API call.
+			_, apiErr := c.Dashboards.GetDashboardByUID("any-uid")
+			require.Error(t, apiErr)
+			assert.True(t, errors.Is(apiErr, ErrInvalidGrafanaURL),
+				"sentinel client must surface ErrInvalidGrafanaURL; got %v", apiErr)
+		})
+	}
+}
+
+func TestExtractGrafanaClientFromHeaders_ValidURL(t *testing.T) {
+	// When the header is valid, the extractor must attach a real client,
+	// not a sentinel. We can't easily invoke the real client without a
+	// Grafana instance, but we can assert that the client is NOT returning
+	// ErrInvalidGrafanaURL on a direct call (which would prove it's a
+	// sentinel).
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "test-token")
+
+	// Use an httptest server so the request actually goes somewhere and
+	// produces a real HTTP error we can distinguish from the sentinel error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"meta":{},"dashboard":{}}`))
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set(grafanaURLHeader, srv.URL)
+
+	ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
+	c := GrafanaClientFromContext(ctx)
+	require.NotNil(t, c)
+
+	_, apiErr := c.Dashboards.GetDashboardByUID("any-uid")
+	// Real client may succeed or return a parse/shape error from the canned
+	// response, but must not return the sentinel error.
+	if apiErr != nil {
+		assert.False(t, errors.Is(apiErr, ErrInvalidGrafanaURL),
+			"valid URL path must attach a real client, not a sentinel; got sentinel error")
+	}
+}
+
+func TestExtractGrafanaClientFromHeaders_NoHeader(t *testing.T) {
+	// No X-Grafana-URL header: falls back to env URL (defaultGrafanaURL if
+	// env is empty). Must NOT be a sentinel.
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
+	c := GrafanaClientFromContext(ctx)
+	require.NotNil(t, c)
+
+	// Calling the real client will fail with a connection error
+	// (defaultGrafanaURL points at localhost:3000), but not with the
+	// sentinel error.
+	_, apiErr := c.Dashboards.GetDashboardByUID("any-uid")
+	if apiErr != nil {
+		assert.False(t, errors.Is(apiErr, ErrInvalidGrafanaURL),
+			"no-header path must attach a real client, not a sentinel; got sentinel error")
+	}
+}
+
+func TestExtractIncidentClientFromHeaders_InvalidURL(t *testing.T) {
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set(grafanaURLHeader, "http://%gg")
+
+	ctx := ExtractIncidentClientFromHeaders(context.Background(), req)
+	c := IncidentClientFromContext(ctx)
+	require.NotNil(t, c, "incident client must be attached even on validation failure")
+
+	apiReq, err := http.NewRequest(http.MethodGet, "http://any.example/api/v1/x", nil)
+	require.NoError(t, err)
+	_, err = c.HTTPClient.Do(apiReq)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidGrafanaURL),
+		"sentinel incident client must surface ErrInvalidGrafanaURL; got %v", err)
+}
+
+func TestExtractGrafanaClientCached_DoesNotPoisonCacheWithSentinel(t *testing.T) {
+	// A request with a malformed X-Grafana-URL must not create a cache
+	// entry. Subsequent requests with a valid URL must get a real client,
+	// not a cached sentinel.
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "test-token")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"meta":{},"dashboard":{}}`))
+	}))
+	defer srv.Close()
+
+	cache := NewClientCache()
+	defer cache.Close()
+	extractor := extractGrafanaClientCached(cache)
+
+	// First: malformed URL.
+	badReq, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	badReq.Header.Set(grafanaURLHeader, "http://%gg")
+	badCtx := extractor(context.Background(), badReq)
+	badClient := GrafanaClientFromContext(badCtx)
+	require.NotNil(t, badClient)
+
+	grafanaCount, _ := cache.Size()
+	assert.Zero(t, grafanaCount, "sentinel must not be cached")
+
+	// Then: valid URL.
+	goodReq, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	goodReq.Header.Set(grafanaURLHeader, srv.URL)
+	goodCtx := extractor(context.Background(), goodReq)
+	goodClient := GrafanaClientFromContext(goodCtx)
+	require.NotNil(t, goodClient)
+
+	// Valid client must NOT be a sentinel.
+	_, apiErr := goodClient.Dashboards.GetDashboardByUID("any-uid")
+	if apiErr != nil {
+		assert.False(t, errors.Is(apiErr, ErrInvalidGrafanaURL),
+			"valid URL path must attach a real client after a cache miss from a bad-URL request; got sentinel error")
+	}
+}
+
+func TestExtractGrafanaClientCached_ConcurrentMixedURLs(t *testing.T) {
+	// Race-detector sanity check: N goroutines fire requests through the
+	// cached extractor, alternating valid and invalid headers. No races,
+	// no nil clients, sentinels on bad requests only.
+	t.Setenv("GRAFANA_URL", "")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "test-token")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cache := NewClientCache()
+	defer cache.Close()
+	extractor := extractGrafanaClientCached(cache)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		bad := i%2 == 0
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			if err != nil {
+				t.Errorf("new request: %v", err)
+				return
+			}
+			if bad {
+				req.Header.Set(grafanaURLHeader, "http://%gg")
+			} else {
+				req.Header.Set(grafanaURLHeader, srv.URL)
+			}
+			ctx := extractor(context.Background(), req)
+			c := GrafanaClientFromContext(ctx)
+			if c == nil {
+				t.Errorf("nil client")
+				return
+			}
+			_, apiErr := c.Dashboards.GetDashboardByUID("any-uid")
+			if bad {
+				if !errors.Is(apiErr, ErrInvalidGrafanaURL) {
+					t.Errorf("bad URL path must return sentinel error, got %v", apiErr)
+				}
+			} else {
+				if apiErr != nil && errors.Is(apiErr, ErrInvalidGrafanaURL) {
+					t.Errorf("valid URL path must not return sentinel error")
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestErrInvalidGrafanaURL_ActionableMessageText(t *testing.T) {
+	// Lock in the error message text the MCP client eventually sees. This
+	// is a regression guard: if someone rewords the hint, this test flags
+	// it so we notice and decide intentionally.
+	err := ValidateGrafanaURL("http://%gg")
+	require.Error(t, err)
+	msg := err.Error()
+	assert.True(t, strings.Contains(msg, "invalid X-Grafana-URL header"),
+		"error text must contain the sentinel prefix; got %q", msg)
+	assert.True(t, strings.Contains(msg, "http://") || strings.Contains(msg, "https://"),
+		"error text should include an actionable hint naming http(s); got %q", msg)
+}

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -43,6 +43,15 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 		return "", fmt.Errorf("grafana url not configured. Please set GRAFANA_URL environment variable or X-Grafana-URL header")
 	}
 
+	// Guard against a malformed URL flowing through config.URL when
+	// X-Grafana-URL was rejected by the client extractor. The sentinel client
+	// has empty PublicURL so this path reads config.URL, which
+	// ExtractGrafanaInfoFromHeaders sets unconditionally from the raw header.
+	// Without this guard, generated deeplinks embed garbage (e.g. http://%gg/d/<uid>).
+	if err := mcpgrafana.ValidateGrafanaURL(baseURL); err != nil {
+		return "", fmt.Errorf("grafana url is invalid: %w. Please set GRAFANA_URL environment variable or X-Grafana-URL header", err)
+	}
+
 	var deeplink string
 
 	switch strings.ToLower(args.ResourceType) {

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"testing"
 
@@ -250,4 +251,63 @@ func TestGenerateDeeplink(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "datasourceUid is required")
 	})
+}
+
+// TestGenerateDeeplink_RejectsMalformedBaseURL_WithSentinelClient exercises
+// the exact runtime state produced by the IMP-2 fix
+// (sentinel_client.go:newSentinelGrafanaClient): a *GrafanaClient is attached
+// to the context with an empty PublicURL, and config.URL still holds the raw
+// malformed X-Grafana-URL header value because ExtractGrafanaInfoFromHeaders
+// sets config.URL unconditionally before the client extractor validates.
+// Pre-fix: generateDeeplink returns a garbage deeplink like
+// "http://%gg/d/abc123" to the LLM with no error signal. Post-fix:
+// ValidateGrafanaURL guard catches the malformed baseURL and returns a
+// structured error wrapping ErrInvalidGrafanaURL.
+func TestGenerateDeeplink_RejectsMalformedBaseURL_WithSentinelClient(t *testing.T) {
+	grafanaCfg := mcpgrafana.GrafanaConfig{
+		URL: "http://%gg",
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	// Zero-value GrafanaClient stands in for the real sentinel from IMP-2.
+	// generateDeeplink only reads gc.PublicURL (empty string, matching the
+	// sentinel's empty PublicURL), which is the code path we want to
+	// exercise. newSentinelGrafanaClient is package-private to mcpgrafana;
+	// the zero-value is equivalent for this test because generateDeeplink
+	// never invokes a method on the client. If future changes to
+	// generateDeeplink add a method call, this test needs to switch to a
+	// real sentinel (and newSentinelGrafanaClient will need to be
+	// exported, or a test-only helper added).
+	ctx = mcpgrafana.WithGrafanaClient(ctx, &mcpgrafana.GrafanaClient{})
+
+	params := GenerateDeeplinkParams{
+		ResourceType: "dashboard",
+		DashboardUID: stringPtr("abc123"),
+	}
+
+	_, err := generateDeeplink(ctx, params)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, mcpgrafana.ErrInvalidGrafanaURL),
+		"expected error to wrap ErrInvalidGrafanaURL, got: %v", err)
+}
+
+// TestGenerateDeeplink_RejectsMalformedBaseURL_NoClient covers the same bug
+// class but without any GrafanaClient attached to the context. Proves the
+// ValidateGrafanaURL guard fires on config.URL alone, not only when the
+// sentinel-style zero client is present.
+func TestGenerateDeeplink_RejectsMalformedBaseURL_NoClient(t *testing.T) {
+	grafanaCfg := mcpgrafana.GrafanaConfig{
+		URL: "http://%gg",
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	params := GenerateDeeplinkParams{
+		ResourceType: "dashboard",
+		DashboardUID: stringPtr("abc123"),
+	}
+
+	_, err := generateDeeplink(ctx, params)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, mcpgrafana.ErrInvalidGrafanaURL),
+		"expected error to wrap ErrInvalidGrafanaURL, got: %v", err)
 }


### PR DESCRIPTION
> **Depends on PR #762.** This PR builds on `ValidateGrafanaURL` from #762 and will not compile/merge cleanly on its own. Please land #762 first, then merge this against the rebased base. If you want to squash-merge both in sequence, this PR is fine to merge second; if you want to rebase-merge, this PR's branch will auto-rebase onto #762's merged state.

## Summary

`ExtractGrafanaInfoFromHeaders` previously wrote `config.URL` unconditionally from the raw `X-Grafana-URL` header, even when the URL was malformed. PR #762 closed the client-side failure path via sentinel clients; this PR closes the operator-visibility gap at the config boundary.

## What changed

In `mcpgrafana.go::ExtractGrafanaInfoFromHeaders`, if the raw `X-Grafana-URL` header is present, the trimmed value is validated inline via `ValidateGrafanaURL` (the helper introduced in #762). On error: `slog.Warn` naming the rejection + `config.URL = ""` (fail-closed). On absent header: existing env-fallback behavior unchanged.

Semantic matrix (new):

| X-Grafana-URL | Behavior |
|---------------|----------|
| Valid http/https | `config.URL` set from header |
| Present but invalid (e.g. `http://%gg`) | `config.URL = ""`, WARN emitted |
| Present but trims to empty (e.g. `/`) | `config.URL = ""`, WARN emitted (fail closed, NOT env fallback) |
| Absent | `config.URL` from `GRAFANA_URL` env, else `defaultGrafanaURL` |

## Why inline, not via `validateHeaderURL`

`validateHeaderURL` from #762 has four existing callers (two grafana client extractors + two incident client extractors, cached and uncached variants). Its current contract is "trimmed-empty implies absent," which the client extractors depend on. This PR wants the opposite semantic ("present-but-trim-empty implies invalid") so a literal `/` header is rejected rather than silently falling back to env. Expressing that inline keeps the two call-site semantics separate and legible; modifying `validateHeaderURL` would silently shift behavior across all four callers with no test coverage for that shift.

## Tests

`TestExtractGrafanaInfoFromHeaders_URLValidation` is table-driven with six cases:

- valid header + env
- invalid header (`http://%gg`) + env produces `""`, WARN
- absent header + env produces env
- absent header + absent env produces `defaultGrafanaURL` (`http://localhost:3000`, via existing fallback)
- `/` header + env produces `""`, WARN (the trim-collapse regression guard)
- valid header + absent env

Each sub-case uses `t.Setenv` for hermetic env state. WARN capture via a test-local `capturingHandler` installed as `slog.Default()` with `t.Cleanup` restore. No `t.Parallel`.

## Test plan

- [x] `make test-unit` passes
- [x] `make lint` reports 0 issues
- [x] Manual verification: valid / malformed / `/` / absent-header cases all produce expected behavior + stderr WARN on the two fail-closed paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-header handling for Grafana/Incident client/config extraction to reject malformed `X-Grafana-URL` values and return sentinel errors instead of panicking or generating bad links, which may alter behavior for misconfigured callers.
> 
> **Overview**
> Adds strict validation for caller-supplied `X-Grafana-URL` and makes header-based flows **fail-closed** when the header is present but invalid (including trim-to-empty cases like `/`), emitting `slog.Warn` and leaving `config.URL` empty rather than silently falling back to env.
> 
> Client extractors (cached and uncached, Grafana and Incident) now attach **non-cached sentinel clients** on invalid headers so downstream tool calls consistently surface `ErrInvalidGrafanaURL` instead of triggering `NewGrafanaClient` panics. Deeplink generation now validates its chosen base URL to avoid returning malformed links.
> 
> Adds comprehensive unit tests for URL validation, sentinel client behavior, cache non-poisoning, concurrent mixed valid/invalid requests, and WARN-log emission on rejected headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5814a8745b9b0ac7d299bb9152109c2788950cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->