### PR TITLE
Fix naming in makefile for docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,4 +10,4 @@ include docs.mk
 
 .PHONY: test
 test:
-	docker run -v $(CURDIR)/sources:/hugo/content/docs/mcp-server/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'exec make hugo'
+	docker run -v $(CURDIR)/sources:/hugo/content/docs/mcp-grafana/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'exec make hugo'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single docs build/test command now mounts generated sources under the correct `mcp-grafana` Hugo content path, affecting only the docs build container invocation.
> 
> **Overview**
> Fixes the docs `make test` Docker invocation to mount `docs/sources` into the Hugo content directory for `mcp-grafana` instead of `mcp-server`, aligning the build output path with this repository’s documentation namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 801e18ad0556294b3c8fa1194d2f08e0b6c56ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->