### PR TITLE
feat(tools): support PromQL queries against VictoriaMetrics datasources

### DIFF
--- a/tools/prom_backend.go
+++ b/tools/prom_backend.go
@@ -49,6 +49,8 @@ func backendForDatasource(ctx context.Context, uid string, projectOverride ...st
 	switch ds.Type {
 	case "stackdriver":
 		return newCloudMonitoringBackend(ctx, ds, proj)
+	case victoriaMetricsDatasourceType:
+		return newVictoriaMetricsBackend(ctx, uid, ds)
 	default:
 		// For prometheus, thanos, cortex, mimir, and any other Prometheus-compatible datasource,
 		// use the native Prometheus client via the datasource proxy.

--- a/tools/prom_backend.go
+++ b/tools/prom_backend.go
@@ -1,7 +1,9 @@
 package tools
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -197,6 +199,44 @@ func (rt *postToGetRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}
 
 	return rt.underlying.RoundTrip(cloned)
+}
+
+// doDSQuery posts payload to Grafana's /api/ds/query endpoint and decodes the
+// response. Shared by backends that route queries through the datasource query
+// API instead of a datasource-specific client.
+func doDSQuery(ctx context.Context, client *http.Client, baseURL string, payload map[string]interface{}) (*dsQueryResponse, error) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling query payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(body[:min(len(body), 1024)]))
+	}
+
+	var queryResp dsQueryResponse
+	if err := json.Unmarshal(body, &queryResp); err != nil {
+		return nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	return &queryResp, nil
 }
 
 func trimTrailingSlash(s string) string {

--- a/tools/prom_backend_cloudmonitoring.go
+++ b/tools/prom_backend_cloudmonitoring.go
@@ -1,7 +1,6 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -124,7 +123,7 @@ func (b *cloudMonitoringBackend) Query(ctx context.Context, expr string, queryTy
 		"to":      strconv.FormatInt(end.UnixMilli(), 10),
 	}
 
-	resp, err := b.doDSQuery(ctx, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +176,7 @@ func (b *cloudMonitoringBackend) LabelNames(ctx context.Context, matchers []stri
 		"to":      strconv.FormatInt(end.UnixMilli(), 10),
 	}
 
-	resp, err := b.doDSQuery(ctx, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
 	if err != nil {
 		return nil, fmt.Errorf("querying label names: %w", err)
 	}
@@ -282,48 +281,12 @@ func (b *cloudMonitoringBackend) labelValuesViaQuery(ctx context.Context, labelN
 		"to":      strconv.FormatInt(end.UnixMilli(), 10),
 	}
 
-	resp, err := b.doDSQuery(ctx, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
 	if err != nil {
 		return nil, fmt.Errorf("querying label values: %w", err)
 	}
 
 	return extractLabelValuesFromFrames(resp, labelName), nil
-}
-
-// doDSQuery executes a request against Grafana's /api/ds/query endpoint.
-func (b *cloudMonitoringBackend) doDSQuery(ctx context.Context, payload map[string]interface{}) (*dsQueryResponse, error) {
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := b.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(body[:min(len(body), 1024)]))
-	}
-
-	var queryResp dsQueryResponse
-	if err := json.Unmarshal(body, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-
-	return &queryResp, nil
 }
 
 // fetchMetricDescriptors calls the Cloud Monitoring plugin's /metricDescriptors/ resource endpoint.

--- a/tools/prom_backend_victoriametrics.go
+++ b/tools/prom_backend_victoriametrics.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/prometheus/common/model"
+)
+
+const victoriaMetricsDatasourceType = "victoriametrics-metrics-datasource"
+
+// victoriaMetricsBackend implements promBackend for the VictoriaMetrics
+// Grafana plugin (type: victoriametrics-metrics-datasource).
+//
+// Discovery endpoints (label names, label values, metric metadata) are served
+// correctly by the plugin's resource proxy and reuse the native Prometheus
+// backend. Only Query is overridden to go through Grafana's /api/ds/query
+// endpoint, because the plugin's resource proxy does not expose
+// /api/v1/query — hitting it returns the plugin's "Hello from VM data source!"
+// landing response and trips the Prometheus client's JSON parser.
+type victoriaMetricsBackend struct {
+	*prometheusBackend
+	httpClient    *http.Client
+	baseURL       string
+	datasourceUID string
+}
+
+func newVictoriaMetricsBackend(ctx context.Context, uid string, ds *models.DataSource) (*victoriaMetricsBackend, error) {
+	promBackend, err := newPrometheusBackend(ctx, uid, ds)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	baseURL := trimTrailingSlash(cfg.URL)
+
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create custom transport: %w", err)
+	}
+	transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
+
+	client := &http.Client{
+		Transport: mcpgrafana.NewUserAgentTransport(transport),
+		Timeout:   30 * time.Second,
+	}
+
+	return &victoriaMetricsBackend{
+		prometheusBackend: promBackend,
+		httpClient:        client,
+		baseURL:           baseURL,
+		datasourceUID:     ds.UID,
+	}, nil
+}
+
+// Query executes a PromQL/MetricsQL query via Grafana's /api/ds/query endpoint.
+//
+// The VictoriaMetrics plugin distinguishes instant vs range via two boolean
+// fields on the query payload (instant/range), unlike Prometheus where the
+// distinction is the URL path.
+func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, error) {
+	if start.IsZero() {
+		start = end
+	}
+	if end.IsZero() || end.Before(start) {
+		end = start
+	}
+
+	step := stepSeconds
+	if step == 0 {
+		step = 60
+	}
+
+	query := map[string]interface{}{
+		"refId": "A",
+		"datasource": map[string]string{
+			"type": victoriaMetricsDatasourceType,
+			"uid":  b.datasourceUID,
+		},
+		"expr":       expr,
+		"instant":    queryType == "instant",
+		"range":      queryType == "range",
+		"interval":   fmt.Sprintf("%ds", step),
+		"intervalMs": int64(step) * 1000,
+	}
+
+	payload := map[string]interface{}{
+		"queries": []interface{}{query},
+		"from":    strconv.FormatInt(start.UnixMilli(), 10),
+		"to":      strconv.FormatInt(end.UnixMilli(), 10),
+	}
+
+	resp, err := b.doDSQuery(ctx, payload)
+	if err != nil {
+		if queryType == "range" {
+			return nil, fmt.Errorf("querying VictoriaMetrics range: %w", err)
+		}
+		return nil, fmt.Errorf("querying VictoriaMetrics instant: %w", err)
+	}
+
+	return framesToPrometheusValue(resp, queryType)
+}
+
+// doDSQuery executes a request against Grafana's /api/ds/query endpoint.
+// Mirrors the Cloud Monitoring backend's helper of the same name; kept local
+// to avoid coupling the two backends.
+func (b *victoriaMetricsBackend) doDSQuery(ctx context.Context, payload map[string]interface{}) (*dsQueryResponse, error) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling query payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(body[:min(len(body), 1024)]))
+	}
+
+	var queryResp dsQueryResponse
+	if err := json.Unmarshal(body, &queryResp); err != nil {
+		return nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	return &queryResp, nil
+}

--- a/tools/prom_backend_victoriametrics.go
+++ b/tools/prom_backend_victoriametrics.go
@@ -46,11 +46,9 @@ func newVictoriaMetricsBackend(ctx context.Context, uid string, ds *models.DataS
 	if err != nil {
 		return nil, fmt.Errorf("failed to create custom transport: %w", err)
 	}
-	transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
-	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
 
 	client := &http.Client{
-		Transport: mcpgrafana.NewUserAgentTransport(transport),
+		Transport: transport,
 		Timeout:   30 * time.Second,
 	}
 

--- a/tools/prom_backend_victoriametrics.go
+++ b/tools/prom_backend_victoriametrics.go
@@ -18,14 +18,9 @@ import (
 const victoriaMetricsDatasourceType = "victoriametrics-metrics-datasource"
 
 // victoriaMetricsBackend implements promBackend for the VictoriaMetrics
-// Grafana plugin (type: victoriametrics-metrics-datasource).
-//
-// Discovery endpoints (label names, label values, metric metadata) are served
-// correctly by the plugin's resource proxy and reuse the native Prometheus
-// backend. Only Query is overridden to go through Grafana's /api/ds/query
-// endpoint, because the plugin's resource proxy does not expose
-// /api/v1/query — hitting it returns the plugin's "Hello from VM data source!"
-// landing response and trips the Prometheus client's JSON parser.
+// Grafana plugin. Discovery endpoints reuse the native Prometheus backend via
+// the resource proxy; Query is routed through /api/ds/query because the
+// plugin's resource proxy does not expose /api/v1/query.
 type victoriaMetricsBackend struct {
 	*prometheusBackend
 	httpClient    *http.Client
@@ -61,10 +56,7 @@ func newVictoriaMetricsBackend(ctx context.Context, uid string, ds *models.DataS
 }
 
 // Query executes a PromQL/MetricsQL query via Grafana's /api/ds/query endpoint.
-//
-// The VictoriaMetrics plugin distinguishes instant vs range via two boolean
-// fields on the query payload (instant/range), unlike Prometheus where the
-// distinction is the URL path.
+// The VM plugin signals instant vs range with two boolean fields on the payload.
 func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, error) {
 	if start.IsZero() {
 		start = end
@@ -99,18 +91,12 @@ func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryTy
 
 	resp, err := b.doDSQuery(ctx, payload)
 	if err != nil {
-		if queryType == "range" {
-			return nil, fmt.Errorf("querying VictoriaMetrics range: %w", err)
-		}
-		return nil, fmt.Errorf("querying VictoriaMetrics instant: %w", err)
+		return nil, fmt.Errorf("querying VictoriaMetrics %s: %w", queryType, err)
 	}
 
 	return framesToPrometheusValue(resp, queryType)
 }
 
-// doDSQuery executes a request against Grafana's /api/ds/query endpoint.
-// Mirrors the Cloud Monitoring backend's helper of the same name; kept local
-// to avoid coupling the two backends.
 func (b *victoriaMetricsBackend) doDSQuery(ctx context.Context, payload map[string]interface{}) (*dsQueryResponse, error) {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/tools/prom_backend_victoriametrics.go
+++ b/tools/prom_backend_victoriametrics.go
@@ -55,10 +55,17 @@ func newVictoriaMetricsBackend(ctx context.Context, uid string, ds *models.DataS
 // Query executes a PromQL/MetricsQL query via Grafana's /api/ds/query endpoint.
 // The VM plugin signals instant vs range with two boolean fields on the payload.
 func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, error) {
+	if queryType != "instant" && queryType != "range" {
+		return nil, fmt.Errorf("invalid query type: %s", queryType)
+	}
+
+	if start.IsZero() && end.IsZero() {
+		end = time.Now()
+	}
 	if start.IsZero() {
 		start = end
 	}
-	if end.IsZero() || end.Before(start) {
+	if end.Before(start) {
 		end = start
 	}
 

--- a/tools/prom_backend_victoriametrics.go
+++ b/tools/prom_backend_victoriametrics.go
@@ -1,11 +1,8 @@
 package tools
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -89,45 +86,10 @@ func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryTy
 		"to":      strconv.FormatInt(end.UnixMilli(), 10),
 	}
 
-	resp, err := b.doDSQuery(ctx, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
 	if err != nil {
 		return nil, fmt.Errorf("querying VictoriaMetrics %s: %w", queryType, err)
 	}
 
 	return framesToPrometheusValue(resp, queryType)
-}
-
-func (b *victoriaMetricsBackend) doDSQuery(ctx context.Context, payload map[string]interface{}) (*dsQueryResponse, error) {
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := b.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(body[:min(len(body), 1024)]))
-	}
-
-	var queryResp dsQueryResponse
-	if err := json.Unmarshal(body, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-
-	return &queryResp, nil
 }

--- a/tools/prom_backend_victoriametrics_test.go
+++ b/tools/prom_backend_victoriametrics_test.go
@@ -1,0 +1,180 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeVMServer captures the most recent /api/ds/query payload and returns a
+// canned dsQueryResponse so tests can assert payload shape and response decoding
+// independently.
+type fakeVMServer struct {
+	server      *httptest.Server
+	lastPayload map[string]interface{}
+	response    dsQueryResponse
+}
+
+func newFakeVMServer(t *testing.T, response dsQueryResponse) *fakeVMServer {
+	t.Helper()
+	f := &fakeVMServer{response: response}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/ds/query", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &f.lastPayload))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(f.response))
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func newTestVMBackend(t *testing.T, server *httptest.Server) *victoriaMetricsBackend {
+	t.Helper()
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: server.URL})
+	ds := &models.DataSource{UID: "vm-uid", Type: victoriaMetricsDatasourceType}
+	b, err := newVictoriaMetricsBackend(ctx, "vm-uid", ds)
+	require.NoError(t, err)
+	// Override baseURL on the test server (defensive — should already match).
+	b.baseURL = server.URL
+	return b
+}
+
+func TestVictoriaMetricsBackendQuery_PayloadShape(t *testing.T) {
+	cases := []struct {
+		name           string
+		queryType      string
+		wantInstant    bool
+		wantRange      bool
+		stepSeconds    int
+		wantInterval   string
+		wantIntervalMs float64
+	}{
+		{
+			name:           "instant query",
+			queryType:      "instant",
+			wantInstant:    true,
+			wantRange:      false,
+			stepSeconds:    0,
+			wantInterval:   "60s",
+			wantIntervalMs: 60000,
+		},
+		{
+			name:           "range query with step",
+			queryType:      "range",
+			wantInstant:    false,
+			wantRange:      true,
+			stepSeconds:    30,
+			wantInterval:   "30s",
+			wantIntervalMs: 30000,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
+				"A": {Frames: []dsQueryFrame{}},
+			}})
+			b := newTestVMBackend(t, fake.server)
+
+			start := time.Unix(1700000000, 0)
+			end := time.Unix(1700003600, 0)
+			_, err := b.Query(context.Background(), `up{job="prometheus"}`, tc.queryType, start, end, tc.stepSeconds)
+			require.NoError(t, err)
+
+			require.NotNil(t, fake.lastPayload)
+			queries, ok := fake.lastPayload["queries"].([]interface{})
+			require.True(t, ok, "payload should contain queries array")
+			require.Len(t, queries, 1)
+
+			q := queries[0].(map[string]interface{})
+			assert.Equal(t, "A", q["refId"])
+			assert.Equal(t, `up{job="prometheus"}`, q["expr"])
+			assert.Equal(t, tc.wantInstant, q["instant"])
+			assert.Equal(t, tc.wantRange, q["range"])
+			assert.Equal(t, tc.wantInterval, q["interval"])
+			assert.Equal(t, tc.wantIntervalMs, q["intervalMs"])
+
+			ds := q["datasource"].(map[string]interface{})
+			assert.Equal(t, victoriaMetricsDatasourceType, ds["type"])
+			assert.Equal(t, "vm-uid", ds["uid"])
+
+			assert.Equal(t, "1700000000000", fake.lastPayload["from"])
+			assert.Equal(t, "1700003600000", fake.lastPayload["to"])
+		})
+	}
+}
+
+func TestVictoriaMetricsBackendQuery_DecodesInstantResponse(t *testing.T) {
+	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
+		"A": {Frames: []dsQueryFrame{
+			{
+				Schema: dsQueryFrameSchema{
+					Name: "up",
+					Fields: []dsQueryFrameField{
+						{Name: "Time", Type: "time"},
+						{Name: "Value", Type: "number", Labels: map[string]string{"job": "prometheus"}},
+					},
+				},
+				Data: dsQueryFrameData{
+					Values: [][]interface{}{
+						{float64(1700000000000)},
+						{float64(1)},
+					},
+				},
+			},
+		}},
+	}})
+	b := newTestVMBackend(t, fake.server)
+
+	v, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
+	require.NoError(t, err)
+
+	vec, ok := v.(model.Vector)
+	require.True(t, ok)
+	require.Len(t, vec, 1)
+	assert.Equal(t, model.SampleValue(1), vec[0].Value)
+	assert.Equal(t, model.LabelValue("up"), vec[0].Metric["__name__"])
+	assert.Equal(t, model.LabelValue("prometheus"), vec[0].Metric["job"])
+}
+
+func TestVictoriaMetricsBackendQuery_PropagatesUpstreamError(t *testing.T) {
+	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
+		"A": {Error: "rate: bad expression"},
+	}})
+	b := newTestVMBackend(t, fake.server)
+
+	_, err := b.Query(context.Background(), "rate(", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rate: bad expression")
+}
+
+func TestVictoriaMetricsBackendQuery_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	t.Cleanup(server.Close)
+
+	b := newTestVMBackend(t, server)
+	_, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "querying VictoriaMetrics instant")
+	assert.Contains(t, err.Error(), "status 500")
+}

--- a/tools/prom_backend_victoriametrics_test.go
+++ b/tools/prom_backend_victoriametrics_test.go
@@ -154,6 +154,48 @@ func TestVictoriaMetricsBackendQuery_DecodesInstantResponse(t *testing.T) {
 	assert.Equal(t, model.LabelValue("prometheus"), vec[0].Metric["job"])
 }
 
+func TestVictoriaMetricsBackendQuery_DecodesRangeResponseAsMatrix(t *testing.T) {
+	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
+		"A": {Frames: []dsQueryFrame{
+			{
+				Schema: dsQueryFrameSchema{
+					Name: "up",
+					Fields: []dsQueryFrameField{
+						{Name: "Time", Type: "time"},
+						{Name: "Value", Type: "number", Labels: map[string]string{"job": "prometheus"}},
+					},
+				},
+				Data: dsQueryFrameData{
+					Values: [][]interface{}{
+						{float64(1700000000000), float64(1700000060000)},
+						{float64(1), float64(0)},
+					},
+				},
+			},
+		}},
+	}})
+	b := newTestVMBackend(t, fake.server)
+
+	v, err := b.Query(
+		context.Background(),
+		"up",
+		"range",
+		time.Unix(1700000000, 0),
+		time.Unix(1700000060, 0),
+		60,
+	)
+	require.NoError(t, err)
+
+	want := model.Matrix{{
+		Metric: model.Metric{"__name__": "up", "job": "prometheus"},
+		Values: []model.SamplePair{
+			{Timestamp: model.Time(1700000000000), Value: 1},
+			{Timestamp: model.Time(1700000060000), Value: 0},
+		},
+	}}
+	assert.Equal(t, want, v)
+}
+
 func TestVictoriaMetricsBackendQuery_PropagatesUpstreamError(t *testing.T) {
 	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
 		"A": {Error: "rate: bad expression"},

--- a/tools/prom_backend_victoriametrics_test.go
+++ b/tools/prom_backend_victoriametrics_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -205,6 +206,38 @@ func TestVictoriaMetricsBackendQuery_PropagatesUpstreamError(t *testing.T) {
 	_, err := b.Query(context.Background(), "rate(", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rate: bad expression")
+}
+
+func TestVictoriaMetricsBackendQuery_RejectsInvalidQueryType(t *testing.T) {
+	fake := newFakeVMServer(t, dsQueryResponse{})
+	b := newTestVMBackend(t, fake.server)
+
+	_, err := b.Query(context.Background(), "up", "bogus", time.Time{}, time.Unix(1700000000, 0), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid query type")
+	assert.Nil(t, fake.lastPayload, "should not hit the server with an invalid query type")
+}
+
+func TestVictoriaMetricsBackendQuery_DefaultsToNowWhenBothTimesZero(t *testing.T) {
+	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
+		"A": {Frames: []dsQueryFrame{}},
+	}})
+	b := newTestVMBackend(t, fake.server)
+
+	before := time.Now().UnixMilli()
+	_, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Time{}, 0)
+	require.NoError(t, err)
+	after := time.Now().UnixMilli()
+
+	require.NotNil(t, fake.lastPayload)
+	from, err := strconv.ParseInt(fake.lastPayload["from"].(string), 10, 64)
+	require.NoError(t, err)
+	to, err := strconv.ParseInt(fake.lastPayload["to"].(string), 10, 64)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, from, before)
+	assert.LessOrEqual(t, to, after)
+	assert.Equal(t, from, to, "both times default to the same now() value")
 }
 
 func TestVictoriaMetricsBackendQuery_HTTPError(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds support for `query_prometheus` (and `query_prometheus_histogram`) against datasources of type `victoriametrics-metrics-datasource` (the official VictoriaMetrics Grafana plugin).

Closes #766.

## Why

The native Prometheus backend talks to datasources via Grafana's `/api/datasources/uid/{uid}/resources/api/v1/query` proxy. The VictoriaMetrics plugin does **not** expose `/api/v1/query` on that path — it returns its plugin landing response (`Hello from VM data source!`), which trips the Prometheus client's JSON parser:

```
querying Prometheus range: bad_response: readObjectStart: expect { or n,
but found H, error found in #1 byte of ...|Hello from |...,
bigger context ...|Hello from VM data source!|...
```

Discovery endpoints (`list_prometheus_metric_names`, `list_prometheus_label_names`, `list_prometheus_label_values`) already work because the plugin serves them under different paths through the same proxy.

## Approach

This mirrors the fix used for Cloud Monitoring in #647: route queries through Grafana's generic `/api/ds/query` endpoint (the same path the Grafana frontend uses to talk to plugin-backed datasources). The new backend embeds `prometheusBackend` so label/metadata lookups continue to use the existing implementation; only `Query` is overridden.

The query payload matches the [`Query` struct in the VictoriaMetrics datasource plugin](https://github.com/VictoriaMetrics/victoriametrics-datasource/blob/main/pkg/plugin/query.go), with `instant` / `range` booleans rather than separate URL paths. All frame-to-Prometheus-value conversion (`framesToVector`, `framesToMatrix`) is reused unchanged from the Cloud Monitoring backend.

## What changed

- `tools/prom_backend.go` — add `victoriametrics-metrics-datasource` case to the backend selector.
- `tools/prom_backend_victoriametrics.go` — new backend (~150 LOC), embeds `prometheusBackend`, overrides only `Query`.
- `tools/prom_backend_victoriametrics_test.go` — unit tests covering payload shape (instant/range, step → interval/intervalMs), instant response decoding, upstream error propagation, and HTTP error handling.

## Test plan

- [x] `make lint-jsonschema` passes
- [x] `make test-unit` passes
- [x] Manually verified against a real Grafana + VictoriaMetrics datasource (instant, range, and `query_prometheus_histogram` all return correct results)
- [ ] Integration tests against a docker-composed VictoriaMetrics — happy to add if you want; would mirror the existing prometheus integration setup

## Notes

- VictoriaLogs (PR #634) is a different datasource type (`victoriametrics-logs-datasource`) and a different code path (Loki-equivalent tools), so this is independent.
- Could also add a Cursor-style migration test that hits the real plugin if you have a VM container in CI; otherwise the unit tests cover the contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new query execution path via `/api/ds/query` and refactors shared query plumbing, which could affect query behavior/error handling for Cloud Monitoring and the new VictoriaMetrics datasource type.
> 
> **Overview**
> Adds first-class support for datasources of type `victoriametrics-metrics-datasource` by introducing a new `victoriaMetricsBackend` that reuses the existing Prometheus backend for discovery but routes `Query` calls through Grafana’s generic `/api/ds/query` (building the plugin-specific payload and normalizing time/step defaults).
> 
> Refactors the Cloud Monitoring backend to reuse a new shared `doDSQuery` helper (moved to `prom_backend.go`) and adds unit tests covering VictoriaMetrics query payload shape, frame decoding to Prometheus `model.Value`, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc169a352486821d23188138a77d7ab037a4259a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->