### PR TITLE
Enhance client cache key with forwarded headers support

### DIFF
--- a/client_cache.go
+++ b/client_cache.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/grafana/incident-go"
@@ -18,17 +20,18 @@ import (
 
 const clientCacheMeterName = "mcp-grafana"
 
-// clientCacheKey uniquely identifies a client by its credentials and target.
+// clientCacheKey uniquely identifies a client by its credentials, target, and forwarded headers.
 type clientCacheKey struct {
-	url      string
-	apiKey   string
-	username string
-	password string
-	orgID    int64
+	url             string
+	apiKey          string
+	username        string
+	password        string
+	orgID           int64
+	forwardedHeaders string // sorted, serialized forwarded headers for cache differentiation
 }
 
-// cacheKeyFromRequest builds a clientCacheKey from request-derived credentials.
-func cacheKeyFromRequest(grafanaURL, apiKey string, basicAuth *url.Userinfo, orgID int64) clientCacheKey {
+// cacheKeyFromRequest builds a clientCacheKey from request-derived credentials and forwarded headers.
+func cacheKeyFromRequest(grafanaURL, apiKey string, basicAuth *url.Userinfo, orgID int64, req *http.Request) clientCacheKey {
 	key := clientCacheKey{
 		url:    grafanaURL,
 		apiKey: apiKey,
@@ -38,6 +41,24 @@ func cacheKeyFromRequest(grafanaURL, apiKey string, basicAuth *url.Userinfo, org
 		key.username = basicAuth.Username()
 		key.password, _ = basicAuth.Password()
 	}
+	if req != nil {
+		headers := forwardedHeadersFromRequest(req)
+		if len(headers) > 0 {
+			names := make([]string, 0, len(headers))
+			for k := range headers {
+				names = append(names, k)
+			}
+			sort.Strings(names)
+			var sb strings.Builder
+			for _, k := range names {
+				sb.WriteString(k)
+				sb.WriteByte('=')
+				sb.WriteString(headers[k])
+				sb.WriteByte(',')
+			}
+			key.forwardedHeaders = sb.String()
+		}
+	}
 	return key
 }
 
@@ -45,7 +66,7 @@ func cacheKeyFromRequest(grafanaURL, apiKey string, basicAuth *url.Userinfo, org
 func (k clientCacheKey) String() string {
 	hasKey := k.apiKey != ""
 	hasBasic := k.username != ""
-	return fmt.Sprintf("url=%s apiKey=%t basicAuth=%t orgID=%d", k.url, hasKey, hasBasic, k.orgID)
+	return fmt.Sprintf("url=%s apiKey=%t basicAuth=%t orgID=%d forwardedHeaders=%s", k.url, hasKey, hasBasic, k.orgID, k.forwardedHeaders)
 }
 
 // clientCacheMetrics holds OTel instruments for cache observability.
@@ -252,7 +273,7 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 		}
 
 		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req)
-		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID)
+		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		grafanaClient := cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {
 			slog.Debug("Creating new Grafana client (cache miss)", "url", u, "api_key_hash", hashAPIKey(apiKey))
@@ -267,7 +288,7 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 func extractIncidentClientCached(cache *ClientCache) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req)
-		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID)
+		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID, req)
 
 		incidentClient := cache.GetOrCreateIncidentClient(key, func() *incident.Client {
 			incidentURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/v1/", grafanaURL)

--- a/client_cache_test.go
+++ b/client_cache_test.go
@@ -110,12 +110,15 @@ func TestClientCache_DifferentCredentials(t *testing.T) {
 	defer cache.Close()
 
 	keys := []clientCacheKey{
-		{url: "http://host1:3000", apiKey: "key1", orgID: 1},
-		{url: "http://host1:3000", apiKey: "key2", orgID: 1},       // different key
-		{url: "http://host1:3000", apiKey: "key1", orgID: 2},       // different org
-		{url: "http://host2:3000", apiKey: "key1", orgID: 1},       // different url
-		{url: "http://host1:3000", apiKey: "key1", orgID: 1},       // same as first
+		{url: "http://host1:3000", apiKey: "key1", orgID: 1, forwardedHeaders: "X-WEBAUTH-USER=admin"}, // base key
+		{url: "http://host1:3000", apiKey: "key2", orgID: 1, forwardedHeaders: "X-WEBAUTH-USER=admin"},       // different key
+		{url: "http://host1:3000", apiKey: "key1", orgID: 2, forwardedHeaders: "X-WEBAUTH-USER=admin"},       // different org
+		{url: "http://host2:3000", apiKey: "key1", orgID: 1, forwardedHeaders: "X-WEBAUTH-USER=admin"},       // different url
+		{url: "http://host1:3000", apiKey: "key1", orgID: 1, forwardedHeaders: "X-WEBAUTH-USER=admin"},       // same as first
+		{url: "http://host1:3000", apiKey: "key1", orgID: 1, forwardedHeaders: "X-WEBAUTH-USER=john.doe"}, // different user
 	}
+
+	const numUniqueKeys = 5
 
 	clients := make([]*GrafanaClient, len(keys))
 	for i, key := range keys {
@@ -130,17 +133,18 @@ func TestClientCache_DifferentCredentials(t *testing.T) {
 	assert.NotSame(t, clients[0], clients[1])
 	assert.NotSame(t, clients[0], clients[2])
 	assert.NotSame(t, clients[0], clients[3])
+	assert.NotSame(t, clients[0], clients[5])
 
 	g, _ := cache.Size()
-	assert.Equal(t, 4, g) // 4 unique keys
+	assert.Equal(t, numUniqueKeys, g) // 5 unique keys
 }
 
 func TestCacheKeyFromRequest(t *testing.T) {
-	key1 := cacheKeyFromRequest("http://localhost:3000", "key1", nil, 1)
-	key2 := cacheKeyFromRequest("http://localhost:3000", "key1", nil, 1)
+	key1 := cacheKeyFromRequest("http://localhost:3000", "key1", nil, 1, nil)
+	key2 := cacheKeyFromRequest("http://localhost:3000", "key1", nil, 1, nil)
 	assert.Equal(t, key1, key2)
 
-	key3 := cacheKeyFromRequest("http://localhost:3000", "key1", url.UserPassword("admin", "pass"), 1)
+	key3 := cacheKeyFromRequest("http://localhost:3000", "key1", url.UserPassword("admin", "pass"), 1, nil)
 	assert.NotEqual(t, key1, key3)
 
 	assert.Equal(t, "admin", key3.username)


### PR DESCRIPTION
- Added forwardedHeaders field to clientCacheKey for better differentiation.
- Updated cacheKeyFromRequest function to include request headers.
- Modified tests to account for new forwardedHeaders functionality.

Fixes a bug when even when using forwarded headers, same Grafana client (the first one) will be used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Grafana/Incident clients are keyed in the shared cache by incorporating forwarded request headers, which can alter client reuse patterns and increase cache cardinality. Risk is mainly behavioral/performance (more distinct cached clients) rather than security-critical logic changes.
> 
> **Overview**
> Fixes incorrect client reuse when *forwarded headers* are used by including them in the `clientCacheKey`.
> 
> `cacheKeyFromRequest` now accepts the incoming `*http.Request`, extracts forwarded headers, sorts/serializes them into a stable `forwardedHeaders` string, and both Grafana and Incident client extraction paths pass the request through so cache entries are differentiated per forwarded-header identity. Tests are updated to assert distinct clients are created when forwarded header values differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba5d3eccb612f7e164443e1d1706664b7b9cfcaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->