### PR TITLE
fix: propagate trace context through OnCall, ClickHouse, and CloudWatch tools

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -267,6 +267,15 @@ type GrafanaConfig struct {
 	BaseTransport http.RoundTripper
 }
 
+// HTTPTransport returns the base HTTP transport for this config.
+// If BaseTransport is set it is returned; otherwise http.DefaultTransport.
+func (c GrafanaConfig) HTTPTransport() http.RoundTripper {
+	if c.BaseTransport != nil {
+		return c.BaseTransport
+	}
+	return http.DefaultTransport
+}
+
 const (
 	// DefaultGrafanaClientTimeout is the default timeout for Grafana HTTP client requests.
 	DefaultGrafanaClientTimeout = 10 * time.Second

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -15,6 +15,7 @@ import (
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -108,10 +109,14 @@ func newClickHouseClient(ctx context.Context, uid string) (*clickHouseClient, er
 	baseURL := strings.TrimRight(cfg.URL, "/")
 
 	// Create custom transport with TLS configuration if available
-	var transport = http.DefaultTransport
+	transport := cfg.HTTPTransport()
 	if tlsConfig := cfg.TLSConfig; tlsConfig != nil {
+		base, ok := transport.(*http.Transport)
+		if !ok {
+			base = http.DefaultTransport.(*http.Transport).Clone()
+		}
 		var err error
-		transport, err = tlsConfig.HTTPTransport(transport.(*http.Transport))
+		transport, err = tlsConfig.HTTPTransport(base)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create custom transport: %w", err)
 		}
@@ -121,7 +126,7 @@ func newClickHouseClient(ctx context.Context, uid string) (*clickHouseClient, er
 	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
 
 	client := &http.Client{
-		Transport: mcpgrafana.NewUserAgentTransport(transport),
+		Transport: otelhttp.NewTransport(mcpgrafana.NewUserAgentTransport(transport)),
 	}
 
 	return &clickHouseClient{

--- a/tools/cloudwatch.go
+++ b/tools/cloudwatch.go
@@ -15,6 +15,7 @@ import (
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -96,10 +97,14 @@ func newCloudWatchClient(ctx context.Context, uid string) (*cloudWatchClient, er
 	baseURL := strings.TrimRight(cfg.URL, "/")
 
 	// Create custom transport with TLS configuration if available
-	var transport = http.DefaultTransport
+	transport := cfg.HTTPTransport()
 	if tlsConfig := cfg.TLSConfig; tlsConfig != nil {
+		base, ok := transport.(*http.Transport)
+		if !ok {
+			base = http.DefaultTransport.(*http.Transport).Clone()
+		}
 		var err error
-		transport, err = tlsConfig.HTTPTransport(transport.(*http.Transport))
+		transport, err = tlsConfig.HTTPTransport(base)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create custom transport: %w", err)
 		}
@@ -109,7 +114,7 @@ func newCloudWatchClient(ctx context.Context, uid string) (*cloudWatchClient, er
 	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
 
 	client := &http.Client{
-		Transport: mcpgrafana.NewUserAgentTransport(transport),
+		Transport: otelhttp.NewTransport(mcpgrafana.NewUserAgentTransport(transport)),
 	}
 
 	return &cloudWatchClient{

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -14,6 +14,7 @@ import (
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // getOnCallURLFromSettings retrieves the OnCall API URL from the Grafana settings endpoint.
@@ -43,7 +44,8 @@ func getOnCallURLFromSettings(ctx context.Context, cfg mcpgrafana.GrafanaConfig)
 	// Add user agent for tracking
 	req.Header.Set("User-Agent", mcpgrafana.UserAgent())
 
-	resp, err := http.DefaultClient.Do(req)
+	httpClient := &http.Client{Transport: otelhttp.NewTransport(cfg.HTTPTransport())}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetching settings: %w", err)
 	}
@@ -106,15 +108,11 @@ func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
 			}
 			if httpClientField.IsValid() && httpClientField.CanSet() {
 				if httpClient, ok := httpClientField.Interface().(*http.Client); ok {
-					// Wrap the transport with user agent
-					if httpClient.Transport == nil {
-						httpClient.Transport = http.DefaultTransport
-					}
-					transport := httpClient.Transport
+					transport := cfg.HTTPTransport()
 					if len(cfg.ExtraHeaders) > 0 {
 						transport = mcpgrafana.NewExtraHeadersRoundTripper(transport, cfg.ExtraHeaders)
 					}
-					httpClient.Transport = mcpgrafana.NewUserAgentTransport(transport)
+					httpClient.Transport = otelhttp.NewTransport(mcpgrafana.NewUserAgentTransport(transport))
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- OnCall tools used `http.DefaultClient` / `http.DefaultTransport` for the IRM settings fetch and the amixr-api-go-client, bypassing the otelhttp-instrumented transport. Same pattern in ClickHouse and CloudWatch tool clients.
- Adds `GrafanaConfig.HTTPTransport()` helper that returns `BaseTransport` if set (e.g. with pre-configured tracing from cloud-mcp) or falls back to `http.DefaultTransport`.
- All three tool files now wrap their final HTTP client transport with `otelhttp.NewTransport()`, so downstream requests carry W3C `traceparent` headers and create child spans.

## Context

Discovered while debugging a 401 on the IRM settings fetch (`/api/plugins/grafana-irm-app/settings`) from the cloud MCP server — the last visible span was `tools/call list_oncall_schedules` with nothing downstream because the HTTP client wasn't instrumented.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test -short ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTTP transport construction and TLS wrapping for multiple tool clients; a mis-wrapped `RoundTripper` could change connection behavior or break custom transports, though the change is localized to client setup.
> 
> **Overview**
> Ensures outbound HTTP requests made by the OnCall, ClickHouse, and CloudWatch tools are **OpenTelemetry-instrumented** so trace context (`traceparent`) propagates and downstream spans are created.
> 
> Introduces `GrafanaConfig.HTTPTransport()` to consistently select `BaseTransport` (when provided) or fall back to `http.DefaultTransport`, and updates the tool clients to build TLS-capable transports safely (cloning a `*http.Transport` when needed) before wrapping the final transport with `otelhttp.NewTransport()` plus existing auth/org/user-agent/header middleware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea86035aed35ef4aeb4d50caa37d45e506d0e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->