### PR TITLE
fix: use correct cloud monitoring test datasource uid

### DIFF
--- a/tools/cloudmonitoring_cloud_test.go
+++ b/tools/cloudmonitoring_cloud_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const cloudMonitoringTestDatasourceUID = "dehw4r7w7o0lcd"
+const cloudMonitoringTestDatasourceUID = "gcmimpersonation-ds-m"
 
 func createCloudMonitoringTestContext(t *testing.T) context.Context {
 	t.Helper()
@@ -52,7 +52,7 @@ func TestCloudMonitoringQuery(t *testing.T) {
 		result, err := queryPrometheus(ctx, QueryPrometheusParams{
 			DatasourceUID: cloudMonitoringTestDatasourceUID,
 			Expr:          `compute_googleapis_com:instance:cpu:utilization`,
-			EndTime:     "now",
+			EndTime:       "now",
 			QueryType:     "instant",
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only change that swaps a hardcoded datasource UID (plus trivial formatting), with no production code impact.
> 
> **Overview**
> Updates `tools/cloudmonitoring_cloud_test.go` to use the correct Cloud Monitoring test datasource UID (`gcmimpersonation-ds-m`) so the cloud integration tests run against the intended Grafana datasource.
> 
> Includes a minor whitespace/alignment tweak in the instant query parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4105ca05ca43b952b334d61f3d3830d2412acaf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->