### PR TITLE
Add docs publishing workflow

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -1,0 +1,23 @@
+name: publish-technical-documentation-next
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/sources/**"
+  workflow_dispatch:
+jobs:
+  sync:
+    if: github.repository == 'grafana/mcp-grafana'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1 # zizmor: ignore[unpinned-uses]
+        with:
+          website_directory: content/docs/mcp-grafana/next

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # Default owners is the Machine Learning team.
 * @grafana/machine-learning
 
+.github/workflows/publish-technical-documentation-next.yml @grafana/docs-tooling


### PR DESCRIPTION
On every push to main that modifies the docs sources, sync them to the website repository.

The first sync has already been done in https://github.com/grafana/website/pull/30358.

I'll need a repo admin to give write access to the repo for @grafana/docs-tooling if you want to delegate us ownership of this file.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
