### PR TITLE
fix: include full query data in alert rule get response

### DIFF
--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -158,7 +158,6 @@ func mergeRuleDetail(provisioned *models.ProvisionedAlertRule, runtime *alerting
 
 	detail.IsPaused = provisioned.IsPaused
 	detail.NotificationSettings = provisioned.NotificationSettings
-	detail.Queries = extractQuerySummaries(provisioned.Data)
 	detail.Data = provisioned.Data
 
 	if runtime != nil {
@@ -178,30 +177,6 @@ func normalizeState(state string) string {
 		return "normal"
 	}
 	return state
-}
-
-func extractQuerySummaries(data []*models.AlertQuery) []querySummary {
-	if len(data) == 0 {
-		return nil
-	}
-	summaries := make([]querySummary, 0, len(data))
-	for _, q := range data {
-		s := querySummary{
-			RefID:         q.RefID,
-			DatasourceUID: q.DatasourceUID,
-		}
-		if m, ok := q.Model.(map[string]any); ok {
-			if expr, ok := m["expr"].(string); ok && expr != "" {
-				s.Expression = expr
-			} else if expr, ok := m["expression"].(string); ok && expr != "" {
-				s.Expression = expr
-			} else if query, ok := m["query"].(string); ok && query != "" {
-				s.Expression = query
-			}
-		}
-		summaries = append(summaries, s)
-	}
-	return summaries
 }
 
 func findRuleInResponse(resp *rulesResponse, uid string) *alertingRule {

--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -159,6 +159,7 @@ func mergeRuleDetail(provisioned *models.ProvisionedAlertRule, runtime *alerting
 	detail.IsPaused = provisioned.IsPaused
 	detail.NotificationSettings = provisioned.NotificationSettings
 	detail.Queries = extractQuerySummaries(provisioned.Data)
+	detail.Data = provisioned.Data
 
 	if runtime != nil {
 		detail.State = normalizeState(runtime.State)

--- a/tools/alerting_manage_rules_test.go
+++ b/tools/alerting_manage_rules_test.go
@@ -500,13 +500,12 @@ func TestManageRules_Get(t *testing.T) {
 		require.False(t, detail.IsPaused)
 		require.Nil(t, detail.NotificationSettings)
 
-		// Queries extracted from provisioned data
-		require.Len(t, detail.Queries, 2)
-		require.Equal(t, "A", detail.Queries[0].RefID)
-		require.Equal(t, "prometheus", detail.Queries[0].DatasourceUID)
-		require.Equal(t, "vector(1)", detail.Queries[0].Expression)
-		require.Equal(t, "B", detail.Queries[1].RefID)
-		require.Equal(t, "__expr__", detail.Queries[1].DatasourceUID)
+		// Full query data preserved for round-tripping
+		require.Len(t, detail.Data, 2)
+		require.Equal(t, "A", detail.Data[0].RefID)
+		require.Equal(t, "prometheus", detail.Data[0].DatasourceUID)
+		require.Equal(t, "B", detail.Data[1].RefID)
+		require.Equal(t, "__expr__", detail.Data[1].DatasourceUID)
 
 		// Runtime state from Prometheus rules API
 		require.Equal(t, "alerting", detail.Type)

--- a/tools/alerting_manage_rules_types.go
+++ b/tools/alerting_manage_rules_types.go
@@ -38,7 +38,6 @@ type alertRuleDetail struct {
 
 	IsPaused             bool                                  `json:"is_paused"`
 	NotificationSettings *models.AlertRuleNotificationSettings `json:"notification_settings,omitempty"`
-	Queries              []querySummary                        `json:"queries,omitempty"`
 	Data                 []*models.AlertQuery                  `json:"data,omitempty"`
 
 	KeepFiringFor               string  `json:"keep_firing_for,omitempty"`
@@ -51,12 +50,6 @@ type alertRuleDetail struct {
 	LastEvaluation string  `json:"last_evaluation,omitempty"`
 	LastError      string  `json:"last_error,omitempty"`
 	Alerts         []alert `json:"alerts,omitempty"`
-}
-
-type querySummary struct {
-	RefID         string `json:"ref_id"`
-	DatasourceUID string `json:"datasource_uid"`
-	Expression    string `json:"expression,omitempty"`
 }
 
 type RelativeTimeRange struct {

--- a/tools/alerting_manage_rules_types.go
+++ b/tools/alerting_manage_rules_types.go
@@ -39,6 +39,7 @@ type alertRuleDetail struct {
 	IsPaused             bool                                  `json:"is_paused"`
 	NotificationSettings *models.AlertRuleNotificationSettings `json:"notification_settings,omitempty"`
 	Queries              []querySummary                        `json:"queries,omitempty"`
+	Data                 []*models.AlertQuery                  `json:"data,omitempty"`
 
 	KeepFiringFor               string  `json:"keep_firing_for,omitempty"`
 	Record                      *Record `json:"record,omitempty" `

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -842,13 +842,6 @@ func TestMergeRuleDetail(t *testing.T) {
 		require.True(t, detail.IsPaused)
 		require.NotNil(t, detail.NotificationSettings)
 		require.Equal(t, "slack-notifications", *detail.NotificationSettings.Receiver)
-		require.Len(t, detail.Queries, 2)
-		require.Equal(t, "A", detail.Queries[0].RefID)
-		require.Equal(t, "prometheus-uid", detail.Queries[0].DatasourceUID)
-		require.Equal(t, "up{job=\"api\"}", detail.Queries[0].Expression)
-		require.Equal(t, "B", detail.Queries[1].RefID)
-		require.Equal(t, "__expr__", detail.Queries[1].DatasourceUID)
-		require.Equal(t, "$A > 0", detail.Queries[1].Expression)
 
 		// Full query data should be preserved for round-tripping
 		require.Len(t, detail.Data, 2, "Data should contain full query models from provisioning API")
@@ -918,11 +911,6 @@ func TestMergeRuleDetail(t *testing.T) {
 		require.Equal(t, "A", *detail.Record.From, "the from identifier in recording config should match")
 		require.Equal(t, "cpu_usage_avg", *detail.Record.Metric, "the target metric name in recording config should match")
 
-		require.Len(t, detail.Queries, 1, "the queries slice should have length 1")
-		require.Equal(t, "A", detail.Queries[0].RefID, "the query refID should match")
-		require.Equal(t, "prometheus-uid", detail.Queries[0].DatasourceUID, "the query datasource UID should match")
-		require.Equal(t, "avg(up{job=\"api\"})", detail.Queries[0].Expression, "the query expression should match")
-
 		// Runtime fields
 		require.Equal(t, "normal", detail.State, "the rule state should be normalized from inactive to normal")
 		require.Equal(t, "ok", detail.Health, "the health status should match")
@@ -961,12 +949,7 @@ func TestMergeRuleDetail(t *testing.T) {
 
 		detail := mergeRuleDetail(provisioned, nil)
 
-		// Queries summary won't have the Graphite target (only expr/expression/query)
-		require.Len(t, detail.Queries, 1)
-		require.Equal(t, "C", detail.Queries[0].RefID)
-		require.Empty(t, detail.Queries[0].Expression, "querySummary does not capture Graphite target")
-
-		// But Data should have the full model for round-tripping
+		// Data should have the full model for round-tripping
 		require.Len(t, detail.Data, 1, "Data must be populated with full query models")
 		require.Equal(t, "C", detail.Data[0].RefID)
 		require.Equal(t, "000000004", detail.Data[0].DatasourceUID)
@@ -998,7 +981,6 @@ func TestMergeRuleDetail(t *testing.T) {
 		require.Nil(t, detail.Alerts)
 		require.False(t, detail.IsPaused)
 		require.Nil(t, detail.NotificationSettings)
-		require.Nil(t, detail.Queries)
 	})
 
 	t.Run("provisioned with nil pointer fields", func(t *testing.T) {
@@ -1541,85 +1523,3 @@ func TestAlertQueryModel_JSONRoundTrip(t *testing.T) {
 	})
 }
 
-func TestExtractQuerySummaries(t *testing.T) {
-	t.Run("extracts expr field (Prometheus)", func(t *testing.T) {
-		data := []*models.AlertQuery{
-			{
-				RefID:         "A",
-				DatasourceUID: "prometheus-uid",
-				Model: map[string]any{
-					"expr": `up{job="grafana"}`,
-				},
-			},
-		}
-		summaries := extractQuerySummaries(data)
-		require.Len(t, summaries, 1)
-		require.Equal(t, `up{job="grafana"}`, summaries[0].Expression)
-	})
-
-	t.Run("extracts expression field (Grafana expression)", func(t *testing.T) {
-		data := []*models.AlertQuery{
-			{
-				RefID:         "B",
-				DatasourceUID: "__expr__",
-				Model: map[string]any{
-					"expression": "A",
-				},
-			},
-		}
-		summaries := extractQuerySummaries(data)
-		require.Len(t, summaries, 1)
-		require.Equal(t, "A", summaries[0].Expression)
-	})
-
-	t.Run("extracts query field (Elasticsearch)", func(t *testing.T) {
-		data := []*models.AlertQuery{
-			{
-				RefID:         "A",
-				DatasourceUID: "elasticsearch-uid",
-				Model: map[string]any{
-					"query": `app:"random-service" AND error`,
-				},
-			},
-		}
-		summaries := extractQuerySummaries(data)
-		require.Len(t, summaries, 1)
-		require.Equal(t, `app:"random-service" AND error`, summaries[0].Expression)
-	})
-
-	t.Run("returns nil for empty data", func(t *testing.T) {
-		summaries := extractQuerySummaries(nil)
-		require.Nil(t, summaries)
-	})
-
-	t.Run("handles mixed datasource types", func(t *testing.T) {
-		data := []*models.AlertQuery{
-			{
-				RefID:         "A",
-				DatasourceUID: "elasticsearch-uid",
-				Model: map[string]any{
-					"query": `app:"random-service" AND log.level:"ERROR"`,
-				},
-			},
-			{
-				RefID:         "B",
-				DatasourceUID: "__expr__",
-				Model: map[string]any{
-					"expression": "A",
-				},
-			},
-			{
-				RefID:         "C",
-				DatasourceUID: "__expr__",
-				Model: map[string]any{
-					"expression": "B",
-				},
-			},
-		}
-		summaries := extractQuerySummaries(data)
-		require.Len(t, summaries, 3)
-		require.Equal(t, `app:"random-service" AND log.level:"ERROR"`, summaries[0].Expression)
-		require.Equal(t, "A", summaries[1].Expression)
-		require.Equal(t, "B", summaries[2].Expression)
-	})
-}

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -850,6 +850,16 @@ func TestMergeRuleDetail(t *testing.T) {
 		require.Equal(t, "__expr__", detail.Queries[1].DatasourceUID)
 		require.Equal(t, "$A > 0", detail.Queries[1].Expression)
 
+		// Full query data should be preserved for round-tripping
+		require.Len(t, detail.Data, 2, "Data should contain full query models from provisioning API")
+		require.Equal(t, "A", detail.Data[0].RefID)
+		require.Equal(t, "prometheus-uid", detail.Data[0].DatasourceUID)
+		model0, ok := detail.Data[0].Model.(map[string]any)
+		require.True(t, ok, "Data[0].Model should be a map")
+		require.Equal(t, "up{job=\"api\"}", model0["expr"])
+		require.Equal(t, "B", detail.Data[1].RefID)
+		require.Equal(t, "__expr__", detail.Data[1].DatasourceUID)
+
 		// Runtime fields
 		require.Equal(t, "firing", detail.State)
 		require.Equal(t, "ok", detail.Health)
@@ -918,6 +928,55 @@ func TestMergeRuleDetail(t *testing.T) {
 		require.Equal(t, "ok", detail.Health, "the health status should match")
 		require.Equal(t, "recording", detail.Type, "the rule type should be 'recording'")
 		require.Equal(t, "2026-02-28T12:00:00Z", detail.LastEvaluation, "the last evaluation time should match formatted UTC time")
+	})
+
+	t.Run("Data preserves full Graphite query model for round-tripping", func(t *testing.T) {
+		title := "DLB Error Rate"
+		folderUID := "folder-1"
+		ruleGroup := "infra"
+		condition := "A"
+
+		graphiteModel := map[string]any{
+			"datasource": map[string]any{"type": "graphite", "uid": "000000004"},
+			"target":     "alias(asPercent(sumSeries(a), sumSeries(b)), 'error rate')",
+			"textEditor": true,
+			"intervalMs":  float64(1000),
+			"refId":      "C",
+		}
+
+		provisioned := &models.ProvisionedAlertRule{
+			UID:       "rule-graphite",
+			Title:     &title,
+			FolderUID: &folderUID,
+			RuleGroup: &ruleGroup,
+			Condition: &condition,
+			Data: []*models.AlertQuery{
+				{
+					RefID:         "C",
+					DatasourceUID: "000000004",
+					Model:         graphiteModel,
+				},
+			},
+		}
+
+		detail := mergeRuleDetail(provisioned, nil)
+
+		// Queries summary won't have the Graphite target (only expr/expression/query)
+		require.Len(t, detail.Queries, 1)
+		require.Equal(t, "C", detail.Queries[0].RefID)
+		require.Empty(t, detail.Queries[0].Expression, "querySummary does not capture Graphite target")
+
+		// But Data should have the full model for round-tripping
+		require.Len(t, detail.Data, 1, "Data must be populated with full query models")
+		require.Equal(t, "C", detail.Data[0].RefID)
+		require.Equal(t, "000000004", detail.Data[0].DatasourceUID)
+		model, ok := detail.Data[0].Model.(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "alias(asPercent(sumSeries(a), sumSeries(b)), 'error rate')", model["target"], "Graphite target must survive in Data")
+		require.Equal(t, true, model["textEditor"], "textEditor must survive in Data")
+		ds, ok := model["datasource"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "graphite", ds["type"])
 	})
 
 	t.Run("nil runtime leaves state fields empty", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Return the full `Data` field (complete `AlertQuery` models) in alert rule get responses, enabling proper round-trip get→update workflows for all datasource types (Graphite, OpenSearch, etc.)
- Remove the redundant `Queries` summary field — it was a lossy subset of `Data` that couldn't represent non-standard query models. Since this is LLM tool output (not an API contract), there's no need for backwards compatibility.

Supersedes #733 (contributor's branch didn't have maintainer push access enabled).

Original fix by @hanks — thank you! 🙏

## Test plan

- [x] Unit tests updated and passing
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `alertRuleDetail` response shape by removing `queries` and returning full `data`, which can break callers relying on the old summarized field.
> 
> **Overview**
> **Alert rule `get` now returns full query configuration.** `mergeRuleDetail` stops extracting a reduced `queries` summary and instead exposes the full `ProvisionedAlertRule.Data` (`[]*models.AlertQuery`) on `alertRuleDetail` for lossless round-tripping.
> 
> **Cleanup + tests.** Removes `querySummary`/`extractQuerySummaries` and updates/extends unit + integration tests (including a Graphite model case) to assert full `data` preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f5dd0d5805d9893c376522d4d1446f4121bf970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->