### PR TITLE
fix: remove redundant transport middleware in Graphite client

### DIFF
--- a/tools/graphite.go
+++ b/tools/graphite.go
@@ -47,13 +47,10 @@ func newGraphiteClient(ctx context.Context, uid string) (*GraphiteClient, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create custom transport: %w", err)
 	}
-	transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
-	transport = mcpgrafana.NewOrgIDRoundTripper(transport, cfg.OrgID)
 
 	// Wrap with fallback transport: try /proxy first, fall back to /resources
 	// on 403/500 for compatibility with different managed Grafana deployments.
-	var rt http.RoundTripper = mcpgrafana.NewUserAgentTransport(transport)
-	rt = newDatasourceFallbackTransport(rt, proxyBase, resourcesBase)
+	rt := newDatasourceFallbackTransport(transport, proxyBase, resourcesBase)
 
 	client := &http.Client{Transport: rt}
 	return &GraphiteClient{httpClient: client, baseURL: baseURL}, nil


### PR DESCRIPTION
## Summary
- The Graphite tools PR (#741) was merged after the transport refactor (#771), but was based on the older code. This caused a build failure due to `NewAuthRoundTripper` being removed.
- Removed redundant `NewAuthRoundTripper`, `NewOrgIDRoundTripper`, and `NewUserAgentTransport` calls that `BuildTransport()` already handles internally.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound HTTP transport construction for Graphite queries; if `mcpgrafana.BuildTransport` doesn’t apply the same auth/org/user-agent behavior in all deployments, requests could fail or change routing, but the change is small and intended to fix a build break.
> 
> **Overview**
> Removes redundant HTTP transport wrappers in the Graphite client (`NewAuthRoundTripper`, `NewOrgIDRoundTripper`, and `NewUserAgentTransport`) and relies solely on `mcpgrafana.BuildTransport` for those concerns.
> 
> Keeps the existing datasource fallback behavior by wrapping the built transport only with `newDatasourceFallbackTransport`, fixing compilation after the upstream transport refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6714878f6de4ba708b6e8d039366b799719f1087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->