### PR TITLE
fix: wait for Graphite metrics to be queryable in seed script

### DIFF
--- a/testdata/graphite-seed.sh
+++ b/testdata/graphite-seed.sh
@@ -30,9 +30,20 @@ send_metric "test.servers.db01.cpu.load5"   "0.8" "$NOW"
 send_metric "test.tagged.cpu;server=web01;env=prod" "1.5" "$NOW"
 send_metric "test.tagged.cpu;server=web02;env=prod" "2.3" "$NOW"
 
-echo "Graphite metrics seeded successfully."
+echo "Graphite metrics sent to Carbon."
 
-# Give Carbon a moment to process the received metrics into its cache
-# so they are available via the render API before the tests run.
-sleep 5
-echo "Done."
+# Wait until metrics are actually queryable via the Graphite web API.
+# Carbon writes to Whisper files asynchronously, and /metrics/find requires
+# the files to exist on disk, so a fixed sleep is unreliable on slow CI runners.
+MAX_ATTEMPTS=60
+attempt=0
+echo "Waiting for metrics to be queryable via Graphite API..."
+until wget -q -O - "http://${GRAPHITE_HOST}/metrics/find?query=test.*" 2>/dev/null | grep -q "test"; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "Timed out waiting for metrics to become queryable after ${MAX_ATTEMPTS} attempts."
+    exit 1
+  fi
+  sleep 2
+done
+echo "Metrics are queryable. Done."


### PR DESCRIPTION
## Summary
- The Graphite seed script used a fixed 5-second sleep after sending metrics to Carbon, but `/metrics/find` requires Whisper files on disk and Carbon writes asynchronously
- On slow CI runners the sleep wasn't enough, causing the "Wait for Graphite metrics to be queryable" step to time out (seen on #777 and other PRs)
- Replaced the fixed sleep with a poll loop that verifies metrics are actually queryable via the Graphite web API before the seed container exits

## Test plan
- [ ] Integration tests pass in CI (the previously-flaky "Wait for Graphite metrics to be queryable" step should now succeed reliably)
- [ ] Graphite integration tests themselves still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test harness change that only affects Graphite integration test seeding; main risk is longer waits or failures if the Graphite web API is unreachable/misconfigured in CI.
> 
> **Overview**
> Replaces the Graphite seed script’s fixed post-send `sleep` with a bounded poll loop that waits until seeded metrics are actually queryable via Graphite’s `/metrics/find` API.
> 
> Adds retry/timeout logic (up to 60 attempts with 2s sleeps) and fails fast with a clear error if metrics never become visible, reducing CI flakiness from asynchronous Whisper writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5a269fd3887c2a26f9479ff048eb7d033fcf13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->