### PR TITLE
fix: improve Graphite CI seed reliability and diagnostics

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,9 +75,19 @@ jobs:
       - name: Wait for Graphite metrics to be queryable
         run: |
           set -euo pipefail
-          # Graphite port 80 is not exposed on the host; go through Grafana's datasource proxy.
+          # The graphite-seed container sends metrics and verifies they're
+          # queryable before exiting. Wait for it to finish, then do a short
+          # verification via Grafana's datasource proxy.
+          echo "Waiting for graphite-seed container to finish..."
+          exit_code=$(docker wait mcp-grafana-graphite-seed-1 2>/dev/null || echo "1")
+          if [ "$exit_code" != "0" ]; then
+            echo "graphite-seed failed (exit code $exit_code):"
+            docker logs mcp-grafana-graphite-seed-1 2>&1 || true
+            exit 1
+          fi
+          echo "graphite-seed completed successfully, verifying via Grafana proxy..."
           ready=false
-          for i in $(seq 1 60); do
+          for i in $(seq 1 10); do
             count="$(curl -fsS -u admin:admin \
               'http://localhost:3000/api/datasources/proxy/uid/graphite/metrics/find?query=test.*' \
               2>/dev/null | jq 'length' 2>/dev/null || echo 0)"

--- a/testdata/graphite-seed.sh
+++ b/testdata/graphite-seed.sh
@@ -15,20 +15,17 @@ echo "Graphite Carbon is ready."
 
 NOW=$(date +%s)
 
-send_metric() {
-  printf "%s %s %s\n" "$1" "$2" "$3" | nc -w 3 "$GRAPHITE_HOST" "$GRAPHITE_CARBON_PORT"
-}
-
-# Hierarchical metrics for listGraphiteMetrics and queryGraphite tests.
-send_metric "test.servers.web01.cpu.load5"  "1.5" "$NOW"
-send_metric "test.servers.web01.cpu.load15" "1.2" "$NOW"
-send_metric "test.servers.web02.cpu.load5"  "2.3" "$NOW"
-send_metric "test.servers.web02.cpu.load15" "2.1" "$NOW"
-send_metric "test.servers.db01.cpu.load5"   "0.8" "$NOW"
-
-# Tagged metrics for listGraphiteTags tests.
-send_metric "test.tagged.cpu;server=web01;env=prod" "1.5" "$NOW"
-send_metric "test.tagged.cpu;server=web02;env=prod" "2.3" "$NOW"
+# Send all metrics in a single connection. Carbon processes batched writes
+# over one TCP connection much more reliably than many short-lived ones.
+printf "test.servers.web01.cpu.load5 1.5 %s\n\
+test.servers.web01.cpu.load15 1.2 %s\n\
+test.servers.web02.cpu.load5 2.3 %s\n\
+test.servers.web02.cpu.load15 2.1 %s\n\
+test.servers.db01.cpu.load5 0.8 %s\n\
+test.tagged.cpu;server=web01;env=prod 1.5 %s\n\
+test.tagged.cpu;server=web02;env=prod 2.3 %s\n" \
+  "$NOW" "$NOW" "$NOW" "$NOW" "$NOW" "$NOW" "$NOW" \
+  | nc -w 5 "$GRAPHITE_HOST" "$GRAPHITE_CARBON_PORT"
 
 echo "Graphite metrics sent to Carbon."
 


### PR DESCRIPTION
## Summary
- Batch all 7 Graphite test metrics into a single `nc` connection instead of 7 separate TCP connections — more reliable for Carbon ingestion on slow CI runners
- Use `docker wait` in CI to detect `graphite-seed` container failure immediately and show its logs, instead of blindly polling for 120s
- Reduce the verification polling from 60 to 10 attempts since it's now just a safety net after the seed container already confirmed metrics are queryable

## Context
CI was timing out after 120s waiting for Graphite metrics ([example](https://github.com/grafana/mcp-grafana/actions/runs/24831181931/job/72679814951)). The root cause is that the `graphite-seed` container was failing silently — 7 separate short-lived TCP connections to Carbon are unreliable on CI runners. The CI had no way to detect this failure and just polled `count=0` until timeout.

## Test plan
- [x] Verified locally: integration tests pass, seed container completes in ~2s
- [ ] Watch CI to confirm the `docker wait` + batch approach works on GitHub Actions runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow and test seeding scripts, improving reliability and diagnostics without affecting production code paths.
> 
> **Overview**
> Improves Graphite integration-test stability by **batching all seed metrics into a single Carbon `nc` connection** in `testdata/graphite-seed.sh` to avoid flaky short-lived TCP writes.
> 
> Updates the integration workflow to **`docker wait` for the `graphite-seed` container**, fail fast with container logs on error, and reduce the post-seed Grafana proxy verification polling loop from 60 to 10 attempts as a short safety check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09a1ef5f619f8febd143ace73b95914aa832f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->