### PR TITLE
fix(mcpgrafana): reject embedded credentials in X-Grafana-URL

### DIFF
--- a/validate_url.go
+++ b/validate_url.go
@@ -43,6 +43,12 @@ func ValidateGrafanaURL(u string) error {
 	if pu.Host == "" {
 		return fmt.Errorf("%w: URL has no host", ErrInvalidGrafanaURL)
 	}
+	// Reject embedded userinfo (http://user:pass@host). Those values get logged
+	// raw in the extractors' slog.Debug lines, which is a credential-in-log
+	// leak risk. Tracked in issue #776.
+	if pu.User != nil {
+		return fmt.Errorf("%w: embedded credentials not allowed", ErrInvalidGrafanaURL)
+	}
 	return nil
 }
 

--- a/validate_url_test.go
+++ b/validate_url_test.go
@@ -49,6 +49,11 @@ func TestValidateGrafanaURL(t *testing.T) {
 		{"http with triple-slash and no host", "http:///path", true},
 		{"https with empty host", "https://", true},
 		{"control byte in URL", "http://host\x01", true},
+
+		// Embedded credentials rejected (issue #776).
+		{"embedded user:pass", "http://user:pass@host.example", true},
+		{"embedded user only", "http://user@host.example", true},
+		{"embedded user with https", "https://user:pass@host.example/path", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
`ValidateGrafanaURL` (landed in #762) currently accepts URLs with embedded userinfo like `http://user:pass@host`. Those values get logged raw via `slog.Debug("Creating Grafana client", "url", u)` in the header extractors, which is a credential-in-log leak risk.

This PR adds a `pu.User != nil` check after `url.ParseRequestURI` that wraps `ErrInvalidGrafanaURL`. `errors.Is` detection continues to work for existing callers.

## Tests

Three new cases added to `TestValidateGrafanaURL`:

- `http://user:pass@host.example` → error
- `http://user@host.example` → error
- `https://user:pass@host.example/path` → error

## Test plan

- [x] `make test-unit` passes
- [x] `make lint` reports 0 issues

## Closes

- #776

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes input validation for `X-Grafana-URL` to reject URLs containing userinfo, which may break callers that previously embedded credentials but reduces credential-leak risk in logs.
> 
> **Overview**
> `ValidateGrafanaURL` now **rejects URLs with embedded userinfo** (e.g. `http://user:pass@host`) to prevent accidental credential leakage via debug logging when constructing Grafana clients.
> 
> Tests are updated to cover the new rejection behavior for several userinfo variants while preserving the existing `ErrInvalidGrafanaURL` wrapping contract for `errors.Is` callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a929cdc0c3c98a1a838c79c4161990a84e66a88d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->