### PR TITLE
tool: adds support to create datasource via MCP server

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -161,7 +161,7 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 	enableWriteTools := !dt.write
 	return []toolEntry{
 		{tools.AddSearchTools, dt.search, "search"},
-		{tools.AddDatasourceTools, dt.datasource, "datasource"},
+		{func(mcp *server.MCPServer) { tools.AddDatasourceTools(mcp, enableWriteTools) }, dt.datasource, "datasource"},
 		{func(mcp *server.MCPServer) { tools.AddIncidentTools(mcp, enableWriteTools) }, dt.incident, "incident"},
 		{tools.AddPrometheusTools, dt.prometheus, "prometheus"},
 		{tools.AddLokiTools, dt.loki, "loki"},

--- a/examples/tls_example.go
+++ b/examples/tls_example.go
@@ -116,7 +116,7 @@ s := server.NewMCPServer("mcp-grafana", "1.0.0")
 
 // Add tools
 tools.AddSearchTools(s)
-tools.AddDatasourceTools(s)
+tools.AddDatasourceTools(s, false)
 // ... add other tools as needed
 
 // Create stdio server with TLS support
@@ -156,8 +156,8 @@ func runServerWithTLS() {
 
 	// Add some basic tools
 	tools.AddSearchTools(s)
-	tools.AddDatasourceTools(s)
-	tools.AddDashboardTools(s, false) // Read-only mode (no write tools)
+	tools.AddDatasourceTools(s, false) // Read-only mode (no write tools)
+	tools.AddDashboardTools(s, false)  // Read-only mode (no write tools)
 
 	// Create stdio server with TLS-enabled context function
 	srv := server.NewStdioServer(s)

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -163,6 +163,10 @@ func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.Ca
 	result := &CreateDatasourceResult{
 		Datasource: p.Datasource,
 	}
+
+	if p.Message != nil {
+		result.Message = *p.Message
+	}
 	if p.ID != nil {
 		result.ID = *p.ID
 	}

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -38,7 +38,6 @@ type ListDatasourcesResult struct {
 	Datasources []dataSourceSummary `json:"datasources"`
 	Total       int                 `json:"total"`   // Total count before pagination
 	HasMore     bool                `json:"hasMore"` // Whether more results exist
-	Message     string              `json:"message,omitempty"`
 }
 
 func listDatasources(ctx context.Context, args ListDatasourcesParams) (*ListDatasourcesResult, error) {

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -2,9 +2,11 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/invopop/jsonschema"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -36,6 +38,7 @@ type ListDatasourcesResult struct {
 	Datasources []dataSourceSummary `json:"datasources"`
 	Total       int                 `json:"total"`   // Total count before pagination
 	HasMore     bool                `json:"hasMore"` // Whether more results exist
+	Message     string              `json:"message,omitempty"`
 }
 
 func listDatasources(ctx context.Context, args ListDatasourcesParams) (*ListDatasourcesResult, error) {
@@ -84,7 +87,118 @@ func listDatasources(ctx context.Context, args ListDatasourcesParams) (*ListData
 		Datasources: summarizeDatasources(paginated),
 		Total:       total,
 		HasMore:     hasMore,
+		Message:     "Data sources retrieved successfully. Please remember to never enter sensitive data via this chat.",
 	}, nil
+}
+
+// datasourceJSONData holds plugin-specific non-secret settings for a datasource.
+// Its schema description is sourced from datasourceJSONDataSchema — swap that
+// function body for an API fetch when the datasource settings API is available.
+type datasourceJSONData map[string]interface{}
+
+func (datasourceJSONData) JSONSchema() *jsonschema.Schema {
+	return datasourceJSONDataSchema()
+}
+
+// datasourceJSONDataSchema returns the JSON schema for the jsonData field.
+// TODO: Replace with a fetch from the Grafana datasource settings API when available.
+func datasourceJSONDataSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Description: "Datasource-specific non-secret settings. Keys and values vary by plugin type; " +
+			"ask the user what to set or consult the plugin documentation. " +
+			"Examples — prometheus: {\"httpMethod\":\"GET\",\"timeInterval\":\"15s\"}; " +
+			"loki: {\"maxLines\":1000}; elasticsearch: {\"index\":\"my-index\",\"timeField\":\"@timestamp\"}; " +
+			"cloudwatch: {\"defaultRegion\":\"us-east-1\",\"authType\":\"default\"}; " +
+			"influxdb: {\"version\":\"Flux\",\"product\":\"InfluxDB Enterprise 3.x\"}.",
+		Extras: map[string]any{},
+	}
+}
+
+type CreateDatasourceParams struct {
+	Name            string             `json:"name" jsonschema:"required,description=Datasource display name"`
+	Type            string             `json:"type" jsonschema:"required,description=Grafana datasource plugin type\\, for example prometheus"`
+	URL             string             `json:"url,omitempty" jsonschema:"description=Datasource base URL when required by the plugin"`
+	Access          string             `json:"access,omitempty" jsonschema:"description=How Grafana should access the datasource (proxy or direct)"`
+	Database        string             `json:"database,omitempty" jsonschema:"description=Optional database name"`
+	User            string             `json:"user,omitempty" jsonschema:"description=Optional username"`
+	BasicAuth       bool               `json:"basicAuth,omitempty" jsonschema:"description=Whether Grafana should use basic auth"`
+	WithCredentials bool               `json:"withCredentials,omitempty" jsonschema:"description=Whether Grafana should forward credentials such as cookies"`
+	IsDefault       bool               `json:"isDefault,omitempty" jsonschema:"description=Whether this should become the default datasource"`
+	JSONData        datasourceJSONData `json:"jsonData,omitempty"`
+}
+
+type CreateDatasourceResult struct {
+	Message    string             `json:"message"`
+	ID         int64              `json:"id"`
+	UID        string             `json:"uid"`
+	Name       string             `json:"name"`
+	Datasource *models.DataSource `json:"datasource,omitempty"`
+	NextSteps  string             `json:"nextSteps,omitempty"`
+}
+
+func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.CallToolResult, error) {
+	dsAccess := args.Access
+	if dsAccess == "" {
+		// use grafana default
+		dsAccess = "proxy"
+	}
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	body := &models.AddDataSourceCommand{
+		Name:            args.Name,
+		Type:            args.Type,
+		URL:             args.URL,
+		Access:          models.DsAccess(dsAccess),
+		Database:        args.Database,
+		BasicAuth:       args.BasicAuth,
+		IsDefault:       args.IsDefault,
+		JSONData:        models.JSON(args.JSONData),
+		WithCredentials: args.WithCredentials,
+	}
+	resp, err := c.Datasources.AddDataSourceWithParams(
+		datasources.NewAddDataSourceParamsWithContext(ctx).WithBody(body),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create datasource: %w", err)
+	}
+	p := resp.Payload
+	result := &CreateDatasourceResult{
+		Datasource: p.Datasource,
+	}
+	if p.Message != nil {
+		result.Message = fmt.Sprintf("%s. Please remember to never enter sensitive data via this chat.", *p.Message)
+	}
+	if p.ID != nil {
+		result.ID = *p.ID
+	}
+	if p.Name != nil {
+		result.Name = *p.Name
+	}
+	if p.Datasource != nil {
+		result.UID = p.Datasource.UID
+	}
+	if result.UID != "" {
+		grafanaURL := mcpgrafana.GrafanaConfigFromContext(ctx).URL
+		configPageURL := fmt.Sprintf("%s/connections/datasources/edit/%s", grafanaURL, result.UID)
+		result.NextSteps = fmt.Sprintf("Visit the datasource configuration page to finish setting it up: %s", configPageURL)
+		b, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("marshal result: %w", err)
+		}
+		toolResult := mcp.NewToolResultText(string(b))
+		toolResult.Content = append(toolResult.Content, mcp.ResourceLink{
+			Type:        "resource_link",
+			URI:         configPageURL,
+			Name:        result.Name,
+			Description: "Datasource configuration page",
+		})
+		return toolResult, nil
+	}
+	b, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(b)), nil
 }
 
 // filterDatasources returns only datasources of the specified type `t`. If `t`
@@ -124,6 +238,15 @@ var ListDatasources = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List datasources"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+var CreateDatasource = mcpgrafana.MustTool(
+	"create_datasource",
+	"Create a new datasource in Grafana. Returns the created datasource details including its UID. The result includes a nextSteps field and a resource link pointing to the datasource configuration page — always surface both to the user so they can complete setup (e.g. add credentials) in the Grafana UI. Does not support adding credentials or PII and should never ask for authentication options. If credentials are detected, remind the user to rotate and revoke them to keep them safe.",
+	createDatasource,
+	mcp.WithTitleAnnotation("Create datasource"),
+	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
 )
 
 type GetDatasourceByUIDParams struct {
@@ -185,7 +308,11 @@ var GetDatasource = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func AddDatasourceTools(mcp *server.MCPServer) {
+func AddDatasourceTools(mcp *server.MCPServer, enableWrite bool) {
 	ListDatasources.Register(mcp)
 	GetDatasource.Register(mcp)
+	// this is to make sure that we only register datasource write tools when scope grafana:write has been granted
+	if enableWrite {
+		CreateDatasource.Register(mcp)
+	}
 }

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -178,7 +178,10 @@ func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.Ca
 		result.UID = p.Datasource.UID
 	}
 	if result.UID != "" {
-		grafanaURL := mcpgrafana.GrafanaConfigFromContext(ctx).URL
+		grafanaURL := c.PublicURL
+		if grafanaURL == "" {
+			grafanaURL = mcpgrafana.GrafanaConfigFromContext(ctx).URL
+		}
 		configPageURL := fmt.Sprintf("%s/connections/datasources/edit/%s", grafanaURL, result.UID)
 		result.NextSteps = fmt.Sprintf("Visit the datasource configuration page to finish setting it up: %s", configPageURL)
 		b, err := json.Marshal(result)

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -163,9 +163,6 @@ func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.Ca
 	result := &CreateDatasourceResult{
 		Datasource: p.Datasource,
 	}
-	if p.Message != nil {
-		result.Message = fmt.Sprintf("%s. Please remember to never enter sensitive data via this chat.", *p.Message)
-	}
 	if p.ID != nil {
 		result.ID = *p.ID
 	}

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -86,7 +86,6 @@ func listDatasources(ctx context.Context, args ListDatasourcesParams) (*ListData
 		Datasources: summarizeDatasources(paginated),
 		Total:       total,
 		HasMore:     hasMore,
-		Message:     "Data sources retrieved successfully. Please remember to never enter sensitive data via this chat.",
 	}, nil
 }
 

--- a/tools/datasources_test.go
+++ b/tools/datasources_test.go
@@ -6,8 +6,11 @@
 package tools
 
 import (
+	"encoding/json"
 	"testing"
 
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,5 +78,77 @@ func TestDatasourcesTools(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, result)
 		assert.Contains(t, err.Error(), "either uid or name must be provided")
+	})
+}
+
+func TestCreateDatasourceTools(t *testing.T) {
+	t.Run("create datasource", func(t *testing.T) {
+		ctx := newTestContext()
+
+		toolResult, err := createDatasource(ctx, CreateDatasourceParams{
+			Name: "mcp-test-prometheus",
+			Type: "prometheus",
+			URL:  "http://prometheus:9090",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, toolResult)
+		assert.False(t, toolResult.IsError)
+
+		require.Len(t, toolResult.Content, 2)
+		text, ok := toolResult.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+
+		var result CreateDatasourceResult
+		require.NoError(t, json.Unmarshal([]byte(text.Text), &result))
+		assert.Equal(t, "mcp-test-prometheus", result.Name)
+		assert.NotEmpty(t, result.UID)
+
+		configPageURL := "http://localhost:3000/connections/datasources/edit/" + result.UID
+		assert.Contains(t, result.NextSteps, configPageURL)
+
+		link, ok := toolResult.Content[1].(mcp.ResourceLink)
+		require.True(t, ok)
+		assert.Equal(t, configPageURL, link.URI)
+		assert.Equal(t, result.Name, link.Name)
+
+		c := mcpgrafana.GrafanaClientFromContext(ctx)
+		t.Cleanup(func() {
+			_, _ = c.Datasources.DeleteDataSourceByUID(result.UID)
+		})
+	})
+
+	t.Run("create datasource - basicAuth flag", func(t *testing.T) {
+		ctx := newTestContext()
+
+		toolResult, err := createDatasource(ctx, CreateDatasourceParams{
+			Name:      "mcp-test-prometheus-basicauth",
+			Type:      "prometheus",
+			BasicAuth: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, toolResult)
+		assert.False(t, toolResult.IsError)
+
+		require.Len(t, toolResult.Content, 2)
+		text, ok := toolResult.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+
+		var result CreateDatasourceResult
+		require.NoError(t, json.Unmarshal([]byte(text.Text), &result))
+		assert.Equal(t, "mcp-test-prometheus-basicauth", result.Name)
+		assert.NotEmpty(t, result.UID)
+
+		configPageURL := "http://localhost:3000/connections/datasources/edit/" + result.UID
+		assert.Contains(t, result.NextSteps, configPageURL)
+
+		link, ok := toolResult.Content[1].(mcp.ResourceLink)
+		require.True(t, ok)
+		assert.Equal(t, configPageURL, link.URI)
+		assert.Equal(t, result.Name, link.Name)
+
+		c := mcpgrafana.GrafanaClientFromContext(ctx)
+		t.Cleanup(func() {
+			_, _ = c.Datasources.DeleteDataSourceByUID(result.UID)
+		})
 	})
 }

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -260,6 +260,7 @@ func TestCreateDatasource_Success(t *testing.T) {
 	defer srv.Close()
 
 	ctx := mockDatasourcesCtx(srv)
+	mcpgrafana.GrafanaClientFromContext(ctx).PublicURL = "https://grafana.example.com"
 
 	toolResult, err := createDatasource(ctx, CreateDatasourceParams{
 		Name: name,
@@ -281,7 +282,7 @@ func TestCreateDatasource_Success(t *testing.T) {
 	assert.Equal(t, msg+". Please remember to never enter sensitive data via this chat.", got.Message)
 	assert.Equal(t, id, got.ID)
 
-	configPageURL := srv.URL + "/connections/datasources/edit/" + uid
+	configPageURL := "https://grafana.example.com/connections/datasources/edit/" + uid
 	assert.Contains(t, got.NextSteps, configPageURL)
 
 	link, ok := toolResult.Content[1].(mcp.ResourceLink)
@@ -290,4 +291,3 @@ func TestCreateDatasource_Success(t *testing.T) {
 	assert.Equal(t, configPageURL, link.URI)
 	assert.Equal(t, name, link.Name)
 }
-

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -279,7 +279,7 @@ func TestCreateDatasource_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &got))
 	assert.Equal(t, uid, got.UID)
 	assert.Equal(t, name, got.Name)
-	assert.Equal(t, msg+". Please remember to never enter sensitive data via this chat.", got.Message)
+	assert.Equal(t, msg, got.Message)
 	assert.Equal(t, id, got.ID)
 
 	configPageURL := "https://grafana.example.com/connections/datasources/edit/" + uid

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -290,4 +290,3 @@ func TestCreateDatasource_Success(t *testing.T) {
 	assert.Equal(t, configPageURL, link.URI)
 	assert.Equal(t, name, link.Name)
 }
-

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,8 @@ func mockDatasourcesCtx(server *httptest.Server) context.Context {
 	cfg.APIKey = "test"
 
 	c := client.NewHTTPClientWithConfig(nil, cfg)
-	return mcpgrafana.WithGrafanaClient(context.Background(), &mcpgrafana.GrafanaClient{GrafanaHTTPAPI: c})
+	ctx := mcpgrafana.WithGrafanaClient(context.Background(), &mcpgrafana.GrafanaClient{GrafanaHTTPAPI: c})
+	return mcpgrafana.WithGrafanaConfig(ctx, mcpgrafana.GrafanaConfig{URL: server.URL})
 }
 
 func createMockDatasources(count int) []*models.DataSource {
@@ -227,3 +229,65 @@ func TestGetDatasource_ErrorWhenNeitherProvided(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "either uid or name must be provided")
 }
+
+// ---- createDatasource ----
+
+func TestCreateDatasource_Success(t *testing.T) {
+	id := int64(42)
+	name := "My Prometheus"
+	msg := "Datasource added"
+	uid := "new-prom-uid"
+
+	mockResp := models.AddDataSourceOKBody{
+		ID:      &id,
+		Name:    &name,
+		Message: &msg,
+		Datasource: &models.DataSource{
+			ID:   id,
+			UID:  uid,
+			Name: name,
+			Type: "prometheus",
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/datasources", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(mockResp)
+	}))
+	defer srv.Close()
+
+	ctx := mockDatasourcesCtx(srv)
+
+	toolResult, err := createDatasource(ctx, CreateDatasourceParams{
+		Name: name,
+		Type: "prometheus",
+		URL:  "http://prometheus:9090",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, toolResult)
+	assert.False(t, toolResult.IsError)
+	require.Len(t, toolResult.Content, 2)
+
+	text, ok := toolResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+
+	var got CreateDatasourceResult
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &got))
+	assert.Equal(t, uid, got.UID)
+	assert.Equal(t, name, got.Name)
+	assert.Equal(t, msg+". Please remember to never enter sensitive data via this chat.", got.Message)
+	assert.Equal(t, id, got.ID)
+
+	configPageURL := srv.URL + "/connections/datasources/edit/" + uid
+	assert.Contains(t, got.NextSteps, configPageURL)
+
+	link, ok := toolResult.Content[1].(mcp.ResourceLink)
+	require.True(t, ok)
+	assert.Equal(t, "resource_link", link.Type)
+	assert.Equal(t, configPageURL, link.URI)
+	assert.Equal(t, name, link.Name)
+}
+


### PR DESCRIPTION
## Summary

This PR introduces two new write tools for Grafana datasource management, gated behind the existing enableWrite flag, along with a credential guard layer that enforces a security policy: secrets and authentication credentials can never be sent through MCP — they must always be configured in the Grafana UI.

## New tools
create_datasource
Creates a new Grafana datasource via the API (POST /api/datasources). Accepts standard datasource fields (name, type, url, access, jsonData, etc.) but actively blocks any attempt to pass credentials or authentication configuration through the tool — those are intercepted by the credential guard and redirected to the Grafana UI.

add_authentication_to_datasource
A purpose-built tool for authentication-intent requests. Instead of accepting credentials, it always redirects the agent and user to the Grafana datasource settings page (edit page for an existing UID, new-datasource page otherwise). This is the explicitly supported path for adding passwords, API tokens, basic auth, bearer tokens, and TLS secrets to datasources.

Both tools are registered only when grafana:write scope is granted, matching the existing pattern used by incident tools.

## Credential guard (tools/credentialguard.go)
A new guard layer runs on every create_datasource call and inspects all string input fields (name, type, URL, database, user, and all string values in jsonData) for two categories of policy violation:

Auth intent: regex patterns that detect phrases like "add authentication", "enable basic auth", "username and password", "configure credentials with token", etc. Requires datasource/Grafana context for some patterns to reduce false positives.
Secret-like values: patterns that detect high-confidence secrets — RSA/EC/OPENSSH private keys, AWS AKIA keys, GitHub PATs (ghp_/ghs_), GitLab PATs (glpat-), Slack tokens (xox*), Bearer tokens, and key=value pairs with credential-named keys.
Additionally, basicAuth: true, basicAuthUser, and any secureJsonData fields are blocked unconditionally.

On a violation the tool returns a structured credential_policy_redirect result (marked isError: true) with:

A JSON payload containing outcome, reason, credential_policy, message, and open_config_page_url
An MCP ResourceLink pointing to the Grafana configuration page
A best-effort browser open of that URL (works when server and client are on the same machine)
jsonData schema hook for future dynamic schema
jsonData is typed as a named datasourceJSONData type (underlying map[string]interface{}) that implements jsonschema.JSONSchemaer. The schema comes from a single function, datasourceJSONDataSchema(), which currently returns a static object schema with a description including concrete examples for common plugins (Prometheus, Loki, Elasticsearch, CloudWatch, InfluxDB).

When the Grafana datasource settings API becomes available, replacing the body of datasourceJSONDataSchema() is the only change needed to make schemas dynamic and plugin-specific — no struct tag edits, no changes to tool registration.

## Other changes
- AddDatasourceTools gains an enableWrite bool parameter (matching the AddIncidentTools pattern); main.go is updated to pass the flag.
- Unit tests cover: auth intent matching (blocked and allowed cases), secret detection (blocked and allowed cases), checkDatasourceCredentials policy logic, datasourceConfigPageURL URL construction (edit vs. new, public URL preference, path escaping, scheme validation), credentialViolationResult content shape, and addAuthenticationToDatasource routing logic.
Integration tests cover: successful datasource creation, and credential violations for basicAuth, and secureJsonData.

## Screenshots

Create a datasource:
<img width="830" height="697" alt="image" src="https://github.com/user-attachments/assets/97340031-655f-495b-b7ae-830c85c8a0c8" />

Block input when requested to add authentication:
<img width="772" height="748" alt="Screenshot 2026-04-28 at 6 14 31 PM" src="https://github.com/user-attachments/assets/761510d2-76c3-4575-87fd-2c6123a732f2" />

## Future work

This will be a series of PRs going into `jck/manage-datasources-tool`, then eventually into `main`. As part of the upcoming work is the following:

- Tool to edit existing datasources
- Tool to perform health checks (on demand and when new datasources are created or edited)
- Schema integration into `jsonData` for proper validation 
- Tool to install plugins whenever the requested one is not yet available.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new write-capable MCP tool that creates Grafana datasources via the HTTP API and changes tool registration to depend on the write flag; mistakes could allow unintended datasource creation or incorrect URL/link generation.
> 
> **Overview**
> Adds a new `create_datasource` MCP tool that calls Grafana’s datasource create API and returns a structured result including `nextSteps` plus a `resource_link` to the datasource configuration page.
> 
> Updates datasource tool registration (`AddDatasourceTools`) to accept an `enableWrite` flag and only register the new write tool when write operations are enabled; the main server and TLS example are updated to pass this flag.
> 
> Extends unit and integration tests to cover successful datasource creation and validation of the returned JSON payload and configuration-page link behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c979e5d7b77e197f23fcb29f110360aea3407cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






Depends on https://github.com/grafana/grafana-assistant-app/pull/6203