### PR TITLE
feat: add optional Logger to GrafanaConfig for structured logging

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ run:
 linters:
   enable:
     - depguard
+    - sloglint
   settings:
     depguard:
       rules:
@@ -23,3 +24,10 @@ linters:
           deny:
             - pkg: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
               desc: "Use mcpgrafana.BuildTransport() instead of wrapping with otelhttp directly."
+    sloglint:
+      no-global: "all"
+  exclusions:
+    rules:
+      - linters:
+          - sloglint
+        path: "cmd/"

--- a/client_cache.go
+++ b/client_cache.go
@@ -268,15 +268,16 @@ func hashAPIKey(key string) string {
 func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		config := GrafanaConfigFromContext(ctx)
+		logger := config.LoggerOrDefault()
 		if config.OrgID == 0 {
-			slog.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
+			logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 		}
 
 		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		grafanaClient := cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {
-			slog.Debug("Creating new Grafana client (cache miss)", "url", u, "api_key_hash", hashAPIKey(apiKey))
+			logger.Debug("Creating new Grafana client (cache miss)", "url", u, "api_key_hash", hashAPIKey(apiKey))
 			return NewGrafanaClient(ctx, u, apiKey, basicAuth)
 		})
 
@@ -290,16 +291,18 @@ func extractIncidentClientCached(cache *ClientCache) httpContextFunc {
 		grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req)
 		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID, req)
 
+		config := GrafanaConfigFromContext(ctx)
+		logger := config.LoggerOrDefault()
+
 		incidentClient := cache.GetOrCreateIncidentClient(key, func() *incident.Client {
 			incidentURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/v1/", grafanaURL)
-			slog.Debug("Creating new incident client (cache miss)", "url", incidentURL)
+			logger.Debug("Creating new incident client (cache miss)", "url", incidentURL)
 			client := incident.NewClient(incidentURL, apiKey)
 
-			config := GrafanaConfigFromContext(ctx)
 			config.OrgID = orgID
 			transport, err := BuildTransport(&config, nil, WithoutAuth())
 			if err != nil {
-				slog.Error("Failed to create custom transport for incident client, using default", "error", err)
+				logger.Error("Failed to create custom transport for incident client, using default", "error", err)
 			} else {
 				client.HTTPClient.Transport = transport
 			}

--- a/client_cache.go
+++ b/client_cache.go
@@ -120,14 +120,19 @@ type ClientCache struct {
 	metrics         clientCacheMetrics
 	sfGrafana       singleflight.Group
 	sfIncident      singleflight.Group
+	logger          *slog.Logger
 }
 
 // NewClientCache creates a new client cache.
-func NewClientCache() *ClientCache {
+func NewClientCache(logger *slog.Logger) *ClientCache {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &ClientCache{
 		grafanaClients:  make(map[clientCacheKey]*GrafanaClient),
 		incidentClients: make(map[clientCacheKey]*incident.Client),
 		metrics:         newClientCacheMetrics(),
+		logger:          logger,
 	}
 }
 
@@ -171,7 +176,7 @@ func (c *ClientCache) GetOrCreateGrafanaClient(key clientCacheKey, createFn func
 		c.grafanaClients[key] = client
 		c.metrics.misses.Add(ctx, 1, typeAttr)
 		c.metrics.size.Record(ctx, int64(len(c.grafanaClients)), typeAttr)
-		slog.Debug("Cached new Grafana client", "key", key, "cache_size", len(c.grafanaClients))
+		c.logger.Debug("Cached new Grafana client", "key", key, "cache_size", len(c.grafanaClients))
 		c.mu.Unlock()
 
 		return client, nil
@@ -214,7 +219,7 @@ func (c *ClientCache) GetOrCreateIncidentClient(key clientCacheKey, createFn fun
 		c.incidentClients[key] = client
 		c.metrics.misses.Add(ctx, 1, typeAttr)
 		c.metrics.size.Record(ctx, int64(len(c.incidentClients)), typeAttr)
-		slog.Debug("Cached new incident client", "key", key, "cache_size", len(c.incidentClients))
+		c.logger.Debug("Cached new incident client", "key", key, "cache_size", len(c.incidentClients))
 		c.mu.Unlock()
 
 		return client, nil
@@ -244,7 +249,7 @@ func (c *ClientCache) Close() {
 	ctx := context.Background()
 	c.metrics.size.Record(ctx, 0, metric.WithAttributes(attrClientTypeGrafana))
 	c.metrics.size.Record(ctx, 0, metric.WithAttributes(attrClientTypeIncident))
-	slog.Debug("Client cache closed")
+	c.logger.Debug("Client cache closed")
 }
 
 // Size returns the number of cached clients (for testing/metrics).
@@ -273,7 +278,7 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 			logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 		}
 
-		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req)
+		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		grafanaClient := cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {
@@ -288,11 +293,11 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 // extractIncidentClientCached creates an httpContextFunc that uses the cache.
 func extractIncidentClientCached(cache *ClientCache) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
-		grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req)
-		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID, req)
-
 		config := GrafanaConfigFromContext(ctx)
 		logger := config.LoggerOrDefault()
+
+		grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req, logger)
+		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID, req)
 
 		incidentClient := cache.GetOrCreateIncidentClient(key, func() *incident.Client {
 			incidentURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/v1/", grafanaURL)

--- a/client_cache_test.go
+++ b/client_cache_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClientCache_GrafanaClient(t *testing.T) {
-	cache := NewClientCache()
+	cache := NewClientCache(nil)
 	defer cache.Close()
 
 	key := clientCacheKey{url: "http://localhost:3000", apiKey: "test-key", orgID: 1}
@@ -44,7 +44,7 @@ func TestClientCache_GrafanaClient(t *testing.T) {
 }
 
 func TestClientCache_IncidentClient(t *testing.T) {
-	cache := NewClientCache()
+	cache := NewClientCache(nil)
 	defer cache.Close()
 
 	key := clientCacheKey{url: "http://localhost:3000", apiKey: "test-key", orgID: 1}
@@ -68,7 +68,7 @@ func TestClientCache_IncidentClient(t *testing.T) {
 }
 
 func TestClientCache_ConcurrentAccess(t *testing.T) {
-	cache := NewClientCache()
+	cache := NewClientCache(nil)
 	defer cache.Close()
 
 	key := clientCacheKey{url: "http://localhost:3000", apiKey: "test-key", orgID: 1}
@@ -106,7 +106,7 @@ func TestClientCache_ConcurrentAccess(t *testing.T) {
 }
 
 func TestClientCache_DifferentCredentials(t *testing.T) {
-	cache := NewClientCache()
+	cache := NewClientCache(nil)
 	defer cache.Close()
 
 	keys := []clientCacheKey{
@@ -152,7 +152,7 @@ func TestCacheKeyFromRequest(t *testing.T) {
 }
 
 func TestClientCache_Close(t *testing.T) {
-	cache := NewClientCache()
+	cache := NewClientCache(nil)
 
 	key := clientCacheKey{url: "http://localhost:3000", apiKey: "key", orgID: 1}
 	cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -327,7 +327,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 	// transport allocation (see https://github.com/grafana/mcp-grafana/issues/682).
 	var clientCache *mcpgrafana.ClientCache
 	if transport != "stdio" {
-		clientCache = mcpgrafana.NewClientCache()
+		clientCache = mcpgrafana.NewClientCache(nil)
 		defer clientCache.Close()
 	}
 

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -265,6 +265,13 @@ type GrafanaConfig struct {
 	// Note: NewGrafanaClient still wraps this transport with ExtraHeaders,
 	// OrgID, UserAgent, and otelhttp layers.
 	BaseTransport http.RoundTripper
+
+	// Logger is an optional structured logger. When set, functions that have
+	// access to the GrafanaConfig will use this logger instead of the global
+	// slog.Default(). This allows callers (e.g. the hosted Cloud MCP server)
+	// to inject their own slog.Logger for consistent structured logging with
+	// per-request context such as tenant_id.
+	Logger *slog.Logger
 }
 
 // HTTPTransport returns the base HTTP transport for this config.
@@ -274,6 +281,14 @@ func (c GrafanaConfig) HTTPTransport() http.RoundTripper {
 		return c.BaseTransport
 	}
 	return http.DefaultTransport
+}
+
+// LoggerOrDefault returns the configured logger, or slog.Default() if none is set.
+func (c GrafanaConfig) LoggerOrDefault() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	return slog.Default()
 }
 
 const (
@@ -642,11 +657,11 @@ var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context
 	}
 
 	extraHeaders := extraHeadersFromEnv()
-	slog.Info("Using Grafana configuration", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil, "org_id", orgID, "extra_headers_count", len(extraHeaders))
 
 	// Get existing config or create a new one.
 	// This will respect the existing debug flag, if set.
 	config := GrafanaConfigFromContext(ctx)
+	config.LoggerOrDefault().Info("Using Grafana configuration", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil, "org_id", orgID, "extra_headers_count", len(extraHeaders))
 	config.URL = u
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
@@ -767,16 +782,17 @@ func fetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
 
 // doFetchPublicURL performs the actual HTTP request to fetch the public URL.
 func doFetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
+	logger := cfg.LoggerOrDefault()
 	settingsURL := strings.TrimRight(cfg.URL, "/") + "/api/frontend/settings"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, settingsURL, nil)
 	if err != nil {
-		slog.Warn("Failed to create request for frontend settings", "error", err)
+		logger.Warn("Failed to create request for frontend settings", "error", err)
 		return ""
 	}
 
 	transport, err := BuildTransport(cfg, nil)
 	if err != nil {
-		slog.Warn("Failed to build transport for frontend settings request", "error", err)
+		logger.Warn("Failed to build transport for frontend settings request", "error", err)
 		return ""
 	}
 
@@ -787,19 +803,19 @@ func doFetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		slog.Warn("Failed to fetch frontend settings", "error", err)
+		logger.Warn("Failed to fetch frontend settings", "error", err)
 		return ""
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Warn("Frontend settings request returned non-OK status", "status", resp.StatusCode)
+		logger.Warn("Frontend settings request returned non-OK status", "status", resp.StatusCode)
 		return ""
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		slog.Warn("Failed to read frontend settings response", "error", err)
+		logger.Warn("Failed to read frontend settings response", "error", err)
 		return ""
 	}
 
@@ -807,13 +823,13 @@ func doFetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
 		AppURL string `json:"appUrl"`
 	}
 	if err := json.Unmarshal(body, &settings); err != nil {
-		slog.Warn("Failed to parse frontend settings response", "error", err)
+		logger.Warn("Failed to parse frontend settings response", "error", err)
 		return ""
 	}
 
 	publicURL := strings.TrimRight(settings.AppURL, "/")
 	if publicURL != "" {
-		slog.Info("Fetched public URL from Grafana frontend settings", "public_url", publicURL)
+		logger.Info("Fetched public URL from Grafana frontend settings", "public_url", publicURL)
 	}
 	return publicURL
 }
@@ -854,6 +870,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 	}
 
 	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
 	cfg.Debug = config.Debug
 
 	if config.OrgID > 0 {
@@ -867,7 +884,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 			panic(fmt.Errorf("failed to create TLS config: %w", err))
 		}
 		cfg.TLSConfig = tlsCfg
-		slog.Debug("Using custom TLS configuration",
+		logger.Debug("Using custom TLS configuration",
 			"cert_file", tlsConfig.CertFile,
 			"ca_file", tlsConfig.CAFile,
 			"skip_verify", tlsConfig.SkipVerify)
@@ -879,7 +896,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 		timeout = DefaultGrafanaClientTimeout
 	}
 
-	slog.Debug("Creating Grafana client", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", config.BasicAuth != nil, "org_id", cfg.OrgID, "timeout", timeout, "extra_headers_count", len(config.ExtraHeaders))
+	logger.Debug("Creating Grafana client", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", config.BasicAuth != nil, "org_id", cfg.OrgID, "timeout", timeout, "extra_headers_count", len(config.ExtraHeaders))
 	grafanaClient := client.NewHTTPClientWithConfig(strfmt.Default, cfg)
 
 	// Some Grafana versions (v12+) and reverse proxies return JSON responses
@@ -943,7 +960,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 						panic(fmt.Errorf("failed to build transport: %w", err))
 					}
 					transportField.Set(reflect.ValueOf(wrapped))
-					slog.Debug("HTTP tracing, user agent tracking, and timeout enabled for Grafana client", "timeout", timeout)
+					logger.Debug("HTTP tracing, user agent tracking, and timeout enabled for Grafana client", "timeout", timeout)
 				}
 			}
 		}
@@ -956,6 +973,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 		BasicAuth:    auth,
 		TLSConfig:    config.TLSConfig,
 		ExtraHeaders: config.ExtraHeaders,
+		Logger:       config.Logger,
 	}
 	publicURL := fetchPublicURL(ctx, fetchCfg)
 
@@ -983,13 +1001,14 @@ var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Conte
 // It prioritizes configuration from HTTP headers (X-Grafana-URL, X-Grafana-API-Key) over environment variables for multi-tenant scenarios.
 var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
 	if config.OrgID == 0 {
-		slog.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
+		logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 	}
 
 	// Extract transport config from request headers, and set it on the context.
 	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req)
-	slog.Debug("Creating Grafana client", "url", u, "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil)
+	logger.Debug("Creating Grafana client", "url", u, "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil)
 
 	grafanaClient := NewGrafanaClient(ctx, u, apiKey, basicAuth)
 	return WithGrafanaClient(ctx, grafanaClient)
@@ -1025,13 +1044,14 @@ var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Cont
 	if err != nil {
 		panic(fmt.Errorf("invalid incident URL %s: %w", incidentURL, err))
 	}
-	slog.Debug("Creating Incident client", "url", parsedURL.Redacted(), "api_key_set", apiKey != "")
+	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
+	logger.Debug("Creating Incident client", "url", parsedURL.Redacted(), "api_key_set", apiKey != "")
 	client := incident.NewClient(incidentURL, apiKey)
 
-	config := GrafanaConfigFromContext(ctx)
 	transport, err := BuildTransport(&config, nil, WithoutAuth())
 	if err != nil {
-		slog.Error("Failed to create custom transport for incident client, using default", "error", err)
+		logger.Error("Failed to create custom transport for incident client, using default", "error", err)
 	} else {
 		client.HTTPClient.Transport = transport
 	}
@@ -1047,12 +1067,13 @@ var ExtractIncidentClientFromHeaders httpContextFunc = func(ctx context.Context,
 	client := incident.NewClient(incidentURL, apiKey)
 
 	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
 	// Use orgID from the request headers rather than config, since
 	// the incident client may be created with a different org context.
 	config.OrgID = orgID
 	transport, err := BuildTransport(&config, nil, WithoutAuth())
 	if err != nil {
-		slog.Error("Failed to create custom transport for incident client, using default", "error", err)
+		logger.Error("Failed to create custom transport for incident client, using default", "error", err)
 	} else {
 		client.HTTPClient.Transport = transport
 	}

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -291,6 +291,12 @@ func (c GrafanaConfig) LoggerOrDefault() *slog.Logger {
 	return slog.Default()
 }
 
+// LoggerFromContext extracts the logger from the GrafanaConfig in the context.
+// Returns slog.Default() if no config or logger is set.
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	return GrafanaConfigFromContext(ctx).LoggerOrDefault()
+}
+
 const (
 	// DefaultGrafanaClientTimeout is the default timeout for Grafana HTTP client requests.
 	DefaultGrafanaClientTimeout = 10 * time.Second
@@ -992,8 +998,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 // the client with proper authentication.
 var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
 	// Extract transport config from env vars
-	config := GrafanaConfigFromContext(ctx)
-	logger := config.LoggerOrDefault()
+	logger := LoggerFromContext(ctx)
 	grafanaURL, apiKey := urlAndAPIKeyFromEnv(logger)
 	if grafanaURL == "" {
 		grafanaURL = defaultGrafanaURL

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -50,7 +50,7 @@ const (
 	grafanaAPIKeyHeader              = "X-Grafana-API-Key" // Deprecated: use X-Grafana-Service-Account-Token instead
 )
 
-func urlAndAPIKeyFromEnv() (string, string) {
+func urlAndAPIKeyFromEnv(logger *slog.Logger) (string, string) {
 	u := strings.TrimRight(os.Getenv(grafanaURLEnvVar), "/")
 
 	// Check for the new service account token environment variable first
@@ -62,7 +62,7 @@ func urlAndAPIKeyFromEnv() (string, string) {
 	// Fall back to the deprecated API key environment variable
 	apiKey = os.Getenv(grafanaAPIEnvVar)
 	if apiKey != "" {
-		slog.Warn("GRAFANA_API_KEY is deprecated, please use GRAFANA_SERVICE_ACCOUNT_TOKEN instead. See https://grafana.com/docs/grafana/latest/administration/service-accounts/#add-a-token-to-a-service-account-in-grafana for details on creating service account tokens.")
+		logger.Warn("GRAFANA_API_KEY is deprecated, please use GRAFANA_SERVICE_ACCOUNT_TOKEN instead. See https://grafana.com/docs/grafana/latest/administration/service-accounts/#add-a-token-to-a-service-account-in-grafana for details on creating service account tokens.")
 	}
 
 	return u, apiKey
@@ -80,27 +80,27 @@ func userAndPassFromEnv() *url.Userinfo {
 	return url.UserPassword(username, password)
 }
 
-func orgIdFromEnv() int64 {
+func orgIdFromEnv(logger *slog.Logger) int64 {
 	orgIDStr := os.Getenv(grafanaOrgIDEnvVar)
 	if orgIDStr == "" {
 		return 0
 	}
 	orgID, err := strconv.ParseInt(orgIDStr, 10, 64)
 	if err != nil {
-		slog.Warn("Invalid GRAFANA_ORG_ID value, ignoring", "value", orgIDStr, "error", err)
+		logger.Warn("Invalid GRAFANA_ORG_ID value, ignoring", "value", orgIDStr, "error", err)
 		return 0
 	}
 	return orgID
 }
 
-func extraHeadersFromEnv() map[string]string {
+func extraHeadersFromEnv(logger *slog.Logger) map[string]string {
 	headersJSON := os.Getenv(grafanaExtraHeadersEnvVar)
 	if headersJSON == "" {
 		return nil
 	}
 	var headers map[string]string
 	if err := json.Unmarshal([]byte(headersJSON), &headers); err != nil {
-		slog.Warn("invalid GRAFANA_EXTRA_HEADERS value, ignoring", "value", headersJSON, "error", err)
+		logger.Warn("invalid GRAFANA_EXTRA_HEADERS value, ignoring", "value", headersJSON, "error", err)
 		return nil
 	}
 	return headers
@@ -167,14 +167,14 @@ func mergeHeaders(base, override map[string]string) map[string]string {
 	return merged
 }
 
-func orgIdFromHeaders(req *http.Request) int64 {
+func orgIdFromHeaders(req *http.Request, logger *slog.Logger) int64 {
 	orgIDStr := req.Header.Get(client.OrgIDHeader)
 	if orgIDStr == "" {
 		return 0
 	}
 	orgID, err := strconv.ParseInt(orgIDStr, 10, 64)
 	if err != nil {
-		slog.Warn("Invalid X-Grafana-Org-Id header value, ignoring", "value", orgIDStr, "error", err)
+		logger.Warn("Invalid X-Grafana-Org-Id header value, ignoring", "value", orgIDStr, "error", err)
 		return 0
 	}
 	return orgID
@@ -605,20 +605,20 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 }
 
 // Gets info from environment
-func extractKeyGrafanaInfoFromEnv() (url, apiKey string, auth *url.Userinfo, orgId int64) {
-	url, apiKey = urlAndAPIKeyFromEnv()
+func extractKeyGrafanaInfoFromEnv(logger *slog.Logger) (url, apiKey string, auth *url.Userinfo, orgId int64) {
+	url, apiKey = urlAndAPIKeyFromEnv(logger)
 	if url == "" {
 		url = defaultGrafanaURL
 	}
 	auth = userAndPassFromEnv()
-	orgId = orgIdFromEnv()
+	orgId = orgIdFromEnv(logger)
 	return
 }
 
 // Tries to get grafana info from a request.
 // Gets info from environment if it can't get it from request
-func extractKeyGrafanaInfoFromReq(req *http.Request) (grafanaUrl, apiKey string, auth *url.Userinfo, orgId int64) {
-	eUrl, eApiKey, eAuth, eOrgId := extractKeyGrafanaInfoFromEnv()
+func extractKeyGrafanaInfoFromReq(req *http.Request, logger *slog.Logger) (grafanaUrl, apiKey string, auth *url.Userinfo, orgId int64) {
+	eUrl, eApiKey, eAuth, eOrgId := extractKeyGrafanaInfoFromEnv(logger)
 	username, password, _ := req.BasicAuth()
 
 	grafanaUrl, apiKey = urlAndAPIKeyFromHeaders(req)
@@ -639,7 +639,7 @@ func extractKeyGrafanaInfoFromReq(req *http.Request) (grafanaUrl, apiKey string,
 	}
 
 	// extract org ID from header, fall back to environment
-	orgId = orgIdFromHeaders(req)
+	orgId = orgIdFromHeaders(req, logger)
 	if orgId == 0 {
 		orgId = eOrgId
 	}
@@ -650,18 +650,20 @@ func extractKeyGrafanaInfoFromReq(req *http.Request) (grafanaUrl, apiKey string,
 // ExtractGrafanaInfoFromEnv is a StdioContextFunc that extracts Grafana configuration from environment variables.
 // It reads GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN (or deprecated GRAFANA_API_KEY) environment variables and adds the configuration to the context for use by Grafana clients.
 var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
-	u, apiKey, basicAuth, orgID := extractKeyGrafanaInfoFromEnv()
+	// Get existing config or create a new one.
+	// This will respect the existing debug flag, if set.
+	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
+
+	u, apiKey, basicAuth, orgID := extractKeyGrafanaInfoFromEnv(logger)
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		panic(fmt.Errorf("invalid Grafana URL %s: %w", u, err))
 	}
 
-	extraHeaders := extraHeadersFromEnv()
+	extraHeaders := extraHeadersFromEnv(logger)
 
-	// Get existing config or create a new one.
-	// This will respect the existing debug flag, if set.
-	config := GrafanaConfigFromContext(ctx)
-	config.LoggerOrDefault().Info("Using Grafana configuration", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil, "org_id", orgID, "extra_headers_count", len(extraHeaders))
+	logger.Info("Using Grafana configuration", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil, "org_id", orgID, "extra_headers_count", len(extraHeaders))
 	config.URL = u
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
@@ -679,16 +681,18 @@ type httpContextFunc func(ctx context.Context, req *http.Request) context.Contex
 // It reads X-Grafana-URL and X-Grafana-API-Key headers, falling back to environment variables if headers are not present.
 // Headers listed in GRAFANA_FORWARD_HEADERS are copied from the incoming request and merged with GRAFANA_EXTRA_HEADERS.
 var ExtractGrafanaInfoFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
-	u, apiKey, basicAuth, orgID := extractKeyGrafanaInfoFromReq(req)
-
 	// Get existing config or create a new one.
 	// This will respect the existing debug flag, if set.
 	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
+
+	u, apiKey, basicAuth, orgID := extractKeyGrafanaInfoFromReq(req, logger)
+
 	config.URL = u
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
 	config.OrgID = orgID
-	config.ExtraHeaders = mergeHeaders(extraHeadersFromEnv(), forwardedHeadersFromRequest(req))
+	config.ExtraHeaders = mergeHeaders(extraHeadersFromEnv(logger), forwardedHeadersFromRequest(req))
 	return WithGrafanaConfig(ctx, config)
 }
 
@@ -988,7 +992,9 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 // the client with proper authentication.
 var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
 	// Extract transport config from env vars
-	grafanaURL, apiKey := urlAndAPIKeyFromEnv()
+	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
+	grafanaURL, apiKey := urlAndAPIKeyFromEnv(logger)
 	if grafanaURL == "" {
 		grafanaURL = defaultGrafanaURL
 	}
@@ -1007,7 +1013,7 @@ var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, 
 	}
 
 	// Extract transport config from request headers, and set it on the context.
-	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req)
+	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
 	logger.Debug("Creating Grafana client", "url", u, "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil)
 
 	grafanaClient := NewGrafanaClient(ctx, u, apiKey, basicAuth)
@@ -1035,7 +1041,9 @@ type incidentClientKey struct{}
 // ExtractIncidentClientFromEnv is a StdioContextFunc that creates and injects a Grafana Incident client into the context.
 // It configures the client using environment variables and applies any custom TLS settings from the context.
 var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
-	grafanaURL, apiKey := urlAndAPIKeyFromEnv()
+	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
+	grafanaURL, apiKey := urlAndAPIKeyFromEnv(logger)
 	if grafanaURL == "" {
 		grafanaURL = defaultGrafanaURL
 	}
@@ -1044,8 +1052,6 @@ var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Cont
 	if err != nil {
 		panic(fmt.Errorf("invalid incident URL %s: %w", incidentURL, err))
 	}
-	config := GrafanaConfigFromContext(ctx)
-	logger := config.LoggerOrDefault()
 	logger.Debug("Creating Incident client", "url", parsedURL.Redacted(), "api_key_set", apiKey != "")
 	client := incident.NewClient(incidentURL, apiKey)
 
@@ -1062,12 +1068,12 @@ var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Cont
 // ExtractIncidentClientFromHeaders is a HTTPContextFunc that creates and injects a Grafana Incident client into the context.
 // It uses HTTP headers for configuration with environment variable fallbacks, enabling per-request incident management configuration.
 var ExtractIncidentClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
-	grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req)
+	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
+	grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req, logger)
 	incidentURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/v1/", grafanaURL)
 	client := incident.NewClient(incidentURL, apiKey)
 
-	config := GrafanaConfigFromContext(ctx)
-	logger := config.LoggerOrDefault()
 	// Use orgID from the request headers rather than config, since
 	// the incident client may be created with a different org context.
 	config.OrgID = orgID

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -2,6 +2,7 @@ package mcpgrafana
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -764,13 +764,13 @@ func assertHasAttribute(t *testing.T, attributes []attribute.KeyValue, key strin
 func TestExtraHeadersFromEnv(t *testing.T) {
 	t.Run("empty env returns nil", func(t *testing.T) {
 		t.Setenv("GRAFANA_EXTRA_HEADERS", "")
-		headers := extraHeadersFromEnv()
+		headers := extraHeadersFromEnv(slog.Default())
 		assert.Nil(t, headers)
 	})
 
 	t.Run("valid JSON", func(t *testing.T) {
 		t.Setenv("GRAFANA_EXTRA_HEADERS", `{"X-Custom-Header": "custom-value", "X-Another": "another-value"}`)
-		headers := extraHeadersFromEnv()
+		headers := extraHeadersFromEnv(slog.Default())
 		assert.Equal(t, map[string]string{
 			"X-Custom-Header": "custom-value",
 			"X-Another":       "another-value",
@@ -779,13 +779,13 @@ func TestExtraHeadersFromEnv(t *testing.T) {
 
 	t.Run("invalid JSON returns nil", func(t *testing.T) {
 		t.Setenv("GRAFANA_EXTRA_HEADERS", "not-json")
-		headers := extraHeadersFromEnv()
+		headers := extraHeadersFromEnv(slog.Default())
 		assert.Nil(t, headers)
 	})
 
 	t.Run("empty object", func(t *testing.T) {
 		t.Setenv("GRAFANA_EXTRA_HEADERS", "{}")
-		headers := extraHeadersFromEnv()
+		headers := extraHeadersFromEnv(slog.Default())
 		assert.Equal(t, map[string]string{}, headers)
 	})
 }

--- a/proxied_client.go
+++ b/proxied_client.go
@@ -3,7 +3,6 @@ package mcpgrafana
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"sync"
 
@@ -25,13 +24,14 @@ type ProxiedClient struct {
 // NewProxiedClient creates a new connection to a remote MCP server
 func NewProxiedClient(ctx context.Context, datasourceUID, datasourceName, datasourceType, mcpEndpoint string) (*ProxiedClient, error) {
 	config := GrafanaConfigFromContext(ctx)
+	logger := config.LoggerOrDefault()
 
 	rt, err := BuildTransport(&config, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transport: %w", err)
 	}
 
-	slog.DebugContext(ctx, "connecting to MCP server", "datasource", datasourceUID, "url", mcpEndpoint)
+	logger.DebugContext(ctx, "connecting to MCP server", "datasource", datasourceUID, "url", mcpEndpoint)
 	httpTransport, err := transport.NewStreamableHTTP(
 		mcpEndpoint,
 		transport.WithHTTPBasicClient(&http.Client{Transport: rt}),
@@ -65,7 +65,7 @@ func NewProxiedClient(ctx context.Context, datasourceUID, datasourceName, dataso
 		return nil, fmt.Errorf("failed to list tools from remote MCP server: %w", err)
 	}
 
-	slog.DebugContext(ctx, "connected to proxied MCP server",
+	logger.DebugContext(ctx, "connected to proxied MCP server",
 		"datasource", datasourceUID,
 		"type", datasourceType,
 		"tools", len(toolsResult.Tools))

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -151,7 +151,7 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 					enabled: true,
 				}
 			} else {
-				slog.DebugContext(ctx, "MCP probe returned non-OK status", "datasource", c.uid, "status", resp.StatusCode, "url", probeURL)
+				logger.DebugContext(ctx, "MCP probe returned non-OK status", "datasource", c.uid, "status", resp.StatusCode, "url", probeURL)
 			}
 		}(c)
 	}

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -41,7 +41,7 @@ type DiscoveredDatasource struct {
 
 // discoverMCPDatasources discovers datasources that support MCP
 // Returns a list of datasources with MCP endpoints
-func discoverMCPDatasources(ctx context.Context) ([]DiscoveredDatasource, error) {
+func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]DiscoveredDatasource, error) {
 	gc := GrafanaClientFromContext(ctx)
 	if gc == nil {
 		return nil, fmt.Errorf("grafana client not found in context")
@@ -85,7 +85,7 @@ func discoverMCPDatasources(ctx context.Context) ([]DiscoveredDatasource, error)
 	}
 
 	if len(candidates) == 0 {
-		slog.DebugContext(ctx, "no candidate MCP datasources found")
+		logger.DebugContext(ctx, "no candidate MCP datasources found")
 		return nil, nil
 	}
 
@@ -127,13 +127,13 @@ func discoverMCPDatasources(ctx context.Context) ([]DiscoveredDatasource, error)
 			probeURL := fmt.Sprintf("%s/api/datasources/proxy/uid/%s%s", grafanaBaseURL, c.uid, c.dsConfig.EndpointPath)
 			req, err := http.NewRequestWithContext(probeCtx, http.MethodDelete, probeURL, nil)
 			if err != nil {
-				slog.DebugContext(ctx, "failed to create probe request", "datasource", c.uid, "error", err)
+				logger.DebugContext(ctx, "failed to create probe request", "datasource", c.uid, "error", err)
 				return
 			}
 
 			resp, err := httpClient.Do(req)
 			if err != nil {
-				slog.DebugContext(ctx, "MCP probe failed", "datasource", c.uid, "error", err)
+				logger.DebugContext(ctx, "MCP probe failed", "datasource", c.uid, "error", err)
 				return
 			}
 			defer func() { _ = resp.Body.Close() }()
@@ -169,7 +169,7 @@ func discoverMCPDatasources(ctx context.Context) ([]DiscoveredDatasource, error)
 		}
 	}
 
-	slog.DebugContext(ctx, "discovered MCP datasources", "count", len(discovered), "candidates", len(candidates))
+	logger.DebugContext(ctx, "discovered MCP datasources", "count", len(discovered), "candidates", len(candidates))
 	return discovered, nil
 }
 
@@ -210,6 +210,7 @@ func parseProxiedToolName(toolName string) (string, string, error) {
 type ToolManager struct {
 	sm     *SessionManager
 	server *server.MCPServer
+	logger *slog.Logger
 
 	// Whether to enable proxied tools.
 	enableProxiedTools bool
@@ -231,6 +232,9 @@ func NewToolManager(sm *SessionManager, mcpServer *server.MCPServer, opts ...too
 	for _, opt := range opts {
 		opt(tm)
 	}
+	if tm.logger == nil {
+		tm.logger = slog.Default()
+	}
 	return tm
 }
 
@@ -240,6 +244,13 @@ type toolManagerOption func(*ToolManager)
 func WithProxiedTools(enabled bool) toolManagerOption {
 	return func(tm *ToolManager) {
 		tm.enableProxiedTools = enabled
+	}
+}
+
+// WithToolManagerLogger sets the logger for the ToolManager.
+func WithToolManagerLogger(logger *slog.Logger) toolManagerOption {
+	return func(tm *ToolManager) {
+		tm.logger = logger
 	}
 }
 
@@ -254,13 +265,13 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 	tm.serverMode = true
 
 	// Discover datasources with MCP support
-	discovered, err := discoverMCPDatasources(ctx)
+	discovered, err := discoverMCPDatasources(ctx, tm.logger)
 	if err != nil {
 		return fmt.Errorf("failed to discover MCP datasources: %w", err)
 	}
 
 	if len(discovered) == 0 {
-		slog.Info("no MCP datasources discovered")
+		tm.logger.Info("no MCP datasources discovered")
 		return nil
 	}
 
@@ -269,7 +280,7 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 	for _, ds := range discovered {
 		client, err := NewProxiedClient(ctx, ds.UID, ds.Name, ds.Type, ds.MCPURL)
 		if err != nil {
-			slog.Error("failed to create proxied client", "datasource", ds.UID, "error", err)
+			tm.logger.Error("failed to create proxied client", "datasource", ds.UID, "error", err)
 			continue
 		}
 		key := ds.Type + "_" + ds.UID
@@ -279,11 +290,11 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 	tm.clientsMutex.Unlock()
 
 	if clientCount == 0 {
-		slog.Warn("no proxied clients created")
+		tm.logger.Warn("no proxied clients created")
 		return nil
 	}
 
-	slog.Info("connected to proxied MCP servers", "datasources", clientCount)
+	tm.logger.Info("connected to proxied MCP servers", "datasources", clientCount)
 
 	// Collect and register all unique tools
 	tm.clientsMutex.RLock()
@@ -305,7 +316,7 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 		tm.server.AddTool(tool, handler.Handle)
 	}
 
-	slog.Info("registered proxied tools on server", "tools", len(toolMap))
+	tm.logger.Info("registered proxied tools on server", "tools", len(toolMap))
 	return nil
 }
 
@@ -323,7 +334,7 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 		tm.sm.CreateSession(ctx, session)
 		state, exists = tm.sm.GetSession(sessionID)
 		if !exists {
-			slog.Error("failed to create session in SessionManager", "sessionID", sessionID)
+			tm.logger.Error("failed to create session in SessionManager", "sessionID", sessionID)
 			return
 		}
 	}
@@ -331,9 +342,9 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 	// Step 1: Discover and connect (guaranteed to run exactly once per session)
 	state.initOnce.Do(func() {
 		// Discover datasources with MCP support
-		discovered, err := discoverMCPDatasources(ctx)
+		discovered, err := discoverMCPDatasources(ctx, tm.logger)
 		if err != nil {
-			slog.Error("failed to discover MCP datasources", "error", err)
+			tm.logger.Error("failed to discover MCP datasources", "error", err)
 			state.mutex.Lock()
 			state.proxiedToolsInitialized = true
 			state.mutex.Unlock()
@@ -345,7 +356,7 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 		for _, ds := range discovered {
 			client, err := NewProxiedClient(ctx, ds.UID, ds.Name, ds.Type, ds.MCPURL)
 			if err != nil {
-				slog.Error("failed to create proxied client", "datasource", ds.UID, "error", err)
+				tm.logger.Error("failed to create proxied client", "datasource", ds.UID, "error", err)
 				continue
 			}
 
@@ -356,7 +367,7 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 		state.proxiedToolsInitialized = true
 		state.mutex.Unlock()
 
-		slog.Info("connected to proxied MCP servers", "session", sessionID, "datasources", len(state.proxiedClients))
+		tm.logger.Info("connected to proxied MCP servers", "session", sessionID, "datasources", len(state.proxiedClients))
 	})
 
 	// Step 2: Register tools with the MCP server
@@ -407,9 +418,9 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 	}
 
 	if err := tm.server.AddSessionTools(sessionID, serverTools...); err != nil {
-		slog.Warn("failed to add session tools", "session", sessionID, "error", err)
+		tm.logger.Warn("failed to add session tools", "session", sessionID, "error", err)
 	} else {
-		slog.Info("registered proxied tools", "session", sessionID, "tools", len(state.proxiedTools))
+		tm.logger.Info("registered proxied tools", "session", sessionID, "tools", len(state.proxiedTools))
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -80,6 +80,14 @@ func WithSessionTTL(ttl time.Duration) SessionManagerOption {
 	}
 }
 
+// WithSessionLogger sets the logger for the SessionManager. If not set,
+// slog.Default() is used.
+func WithSessionLogger(logger *slog.Logger) SessionManagerOption {
+	return func(sm *SessionManager) {
+		sm.logger = logger
+	}
+}
+
 // SessionManager manages client sessions and their state
 type SessionManager struct {
 	sessions   map[string]*SessionState
@@ -89,6 +97,7 @@ type SessionManager struct {
 	reaperDone chan struct{}
 	closeOnce  sync.Once
 	metrics    sessionMetrics
+	logger     *slog.Logger
 
 	// mcpServer is an optional reference to the MCP server, used to unregister
 	// sessions from the SDK's internal session map when they are reaped. This
@@ -117,6 +126,9 @@ func NewSessionManager(opts ...SessionManagerOption) *SessionManager {
 	}
 	for _, opt := range opts {
 		opt(sm)
+	}
+	if sm.logger == nil {
+		sm.logger = slog.Default()
 	}
 	if sm.sessionTTL > 0 {
 		go sm.runReaper()
@@ -164,17 +176,17 @@ func (sm *SessionManager) RemoveSession(ctx context.Context, session server.Clie
 		return
 	}
 
-	cleanupSessionState(state)
+	sm.cleanupSessionState(state)
 }
 
 // cleanupSessionState closes all proxied clients in a session state.
-func cleanupSessionState(state *SessionState) {
+func (sm *SessionManager) cleanupSessionState(state *SessionState) {
 	state.mutex.Lock()
 	defer state.mutex.Unlock()
 
 	for key, client := range state.proxiedClients {
 		if err := client.Close(); err != nil {
-			slog.Error("failed to close proxied client", "key", key, "error", err)
+			sm.logger.Error("failed to close proxied client", "key", key, "error", err)
 		}
 	}
 }
@@ -197,9 +209,9 @@ func (sm *SessionManager) Close() {
 		sm.mutex.Unlock()
 
 		for _, state := range sessions {
-			cleanupSessionState(state)
+			sm.cleanupSessionState(state)
 		}
-		slog.Debug("SessionManager closed", "cleaned_sessions", len(sessions))
+		sm.logger.Debug("SessionManager closed", "cleaned_sessions", len(sessions))
 	})
 }
 
@@ -246,12 +258,12 @@ func (sm *SessionManager) reapStaleSessions() {
 	sm.mutex.Unlock()
 
 	if len(stale) > 0 {
-		slog.Info("Reaping stale sessions", "count", len(stale), "session_ids", staleIDs)
+		sm.logger.Info("Reaping stale sessions", "count", len(stale), "session_ids", staleIDs)
 	}
 
 	ctx := context.Background()
 	for i, state := range stale {
-		cleanupSessionState(state)
+		sm.cleanupSessionState(state)
 		// Also unregister from MCPServer.sessions to prevent a memory leak.
 		// Sessions may have been registered there via RegisterSession in the
 		// OnBeforeListTools/OnBeforeCallTool hooks for horizontal scaling support.

--- a/session_test.go
+++ b/session_test.go
@@ -94,7 +94,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 
 	t.Run("returns error when grafana client not in context", func(t *testing.T) {
 		emptyCtx := context.Background()
-		discovered, err := discoverMCPDatasources(emptyCtx)
+		discovered, err := discoverMCPDatasources(emptyCtx, slog.Default())
 		assert.Error(t, err)
 		assert.Nil(t, discovered)
 		assert.Contains(t, err.Error(), "grafana client not found in context")

--- a/session_test.go
+++ b/session_test.go
@@ -9,6 +9,7 @@ package mcpgrafana
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"strings"
@@ -67,7 +68,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 	ctx := newProxiedToolsTestContext(t)
 
 	t.Run("discovers tempo datasources", func(t *testing.T) {
-		discovered, err := discoverMCPDatasources(ctx)
+		discovered, err := discoverMCPDatasources(ctx, slog.Default())
 		require.NoError(t, err)
 
 		// Should find two Tempo datasources from docker-compose
@@ -113,7 +114,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), grafanaCfg)
 		ctx = WithGrafanaClient(ctx, &GrafanaClient{GrafanaHTTPAPI: grafanaClient})
 
-		discovered, err := discoverMCPDatasources(ctx)
+		discovered, err := discoverMCPDatasources(ctx, slog.Default())
 		assert.Error(t, err)
 		assert.Nil(t, discovered)
 		assert.Contains(t, err.Error(), "Unauthorized")
@@ -358,7 +359,7 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 
 	t.Run("full flow from discovery to tool call", func(t *testing.T) {
 		// Step 1: Discover MCP datasources
-		discovered, err := discoverMCPDatasources(ctx)
+		discovered, err := discoverMCPDatasources(ctx, slog.Default())
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(discovered), 1, "Should discover at least one Tempo datasource")
 
@@ -421,7 +422,7 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 	})
 
 	t.Run("multiple datasources in single session", func(t *testing.T) {
-		discovered, err := discoverMCPDatasources(ctx)
+		discovered, err := discoverMCPDatasources(ctx, slog.Default())
 		require.NoError(t, err)
 
 		if len(discovered) < 2 {

--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -107,7 +107,7 @@ func getAlertRuleDetail(ctx context.Context, uid string, limitAlerts int) (*aler
 
 	rulesResp, err := ac.GetRules(ctx, opts)
 	if err != nil {
-		mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault().WarnContext(ctx, "failed to fetch runtime state for alert rule",
+		mcpgrafana.LoggerFromContext(ctx).WarnContext(ctx, "failed to fetch runtime state for alert rule",
 			"uid", uid, "error", err)
 		detail := mergeRuleDetail(alertRule.Payload, nil)
 		return &detail, nil

--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -108,7 +107,7 @@ func getAlertRuleDetail(ctx context.Context, uid string, limitAlerts int) (*aler
 
 	rulesResp, err := ac.GetRules(ctx, opts)
 	if err != nil {
-		slog.WarnContext(ctx, "failed to fetch runtime state for alert rule",
+		mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault().WarnContext(ctx, "failed to fetch runtime state for alert rule",
 			"uid", uid, "error", err)
 		detail := mergeRuleDetail(alertRule.Payload, nil)
 		return &detail, nil

--- a/tools/asserts_cloud_test.go
+++ b/tools/asserts_cloud_test.go
@@ -20,14 +20,14 @@ func TestAssertsCloudIntegration(t *testing.T) {
 	ctx := createCloudTestContext(t, "Asserts", "ASSERTS_GRAFANA_URL", "ASSERTS_GRAFANA_API_KEY")
 
 	t.Run("get assertions", func(t *testing.T) {
-		// Set up time range for the last hour
+		// Set up time range for the last 24 hours
 		endTime := time.Now()
 		startTime := endTime.Add(-24 * time.Hour)
 
 		// Test parameters for a known service in the environment
 		params := GetAssertionsParams{
-			StartTime:  startTime,
-			EndTime:    endTime,
+			StartTime:  startTime.Format(time.RFC3339),
+			EndTime:    endTime.Format(time.RFC3339),
 			EntityType: "Service", // Adjust these values based on your actual environment
 			EntityName: "model-builder",
 			Env:        "dev-us-central-0",

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -98,7 +97,7 @@ func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
 				if httpClient, ok := httpClientField.Interface().(*http.Client); ok {
 					transport, err := mcpgrafana.BuildTransport(&cfg, nil, mcpgrafana.WithoutAuth())
 					if err != nil {
-						slog.Error("Failed to build transport for OnCall client", "error", err)
+						mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault().Error("Failed to build transport for OnCall client", "error", err)
 					} else {
 						httpClient.Transport = transport
 					}

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -97,7 +97,7 @@ func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
 				if httpClient, ok := httpClientField.Interface().(*http.Client); ok {
 					transport, err := mcpgrafana.BuildTransport(&cfg, nil, mcpgrafana.WithoutAuth())
 					if err != nil {
-						mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault().Error("Failed to build transport for OnCall client", "error", err)
+						mcpgrafana.LoggerFromContext(ctx).Error("Failed to build transport for OnCall client", "error", err)
 					} else {
 						httpClient.Transport = transport
 					}

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -268,6 +268,7 @@ type FindErrorPatternLogsParams struct {
 
 // findErrorPatternLogs creates an investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis
 func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) (*analysis, error) {
+	logger := mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault()
 	client, err := siftClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating Sift client: %w", err)
@@ -288,13 +289,13 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 	}
 
 	// Create the investigation and wait for it to complete
-	completedInvestigation, err := client.createSiftInvestigation(ctx, investigation, requestData)
+	completedInvestigation, err := client.createSiftInvestigation(ctx, investigation, requestData, logger)
 	if err != nil {
 		return nil, fmt.Errorf("creating investigation: %w", err)
 	}
 
 	// Get all analyses from the completed investigation
-	slog.Debug("Getting analyses", "investigation_id", completedInvestigation.ID)
+	logger.Debug("Getting analyses", "investigation_id", completedInvestigation.ID)
 	analyses, err := client.getSiftAnalyses(ctx, completedInvestigation.ID)
 	if err != nil {
 		return nil, fmt.Errorf("getting analyses: %w", err)
@@ -312,7 +313,7 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 	if errorPatternLogsAnalysis == nil {
 		return nil, fmt.Errorf("ErrorPatternLogs analysis not found in investigation %s", completedInvestigation.ID)
 	}
-	slog.Debug("Found ErrorPatternLogs analysis", "analysis_id", errorPatternLogsAnalysis.ID)
+	logger.Debug("Found ErrorPatternLogs analysis", "analysis_id", errorPatternLogsAnalysis.ID)
 
 	datasourceUID := completedInvestigation.Datasources.LokiDatasource.UID
 
@@ -354,6 +355,7 @@ type FindSlowRequestsParams struct {
 
 // findSlowRequests creates an investigation with SlowRequests check, waits for it to complete, and returns the analysis
 func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*analysis, error) {
+	logger := mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault()
 	client, err := siftClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating Sift client: %w", err)
@@ -374,7 +376,7 @@ func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*analys
 	}
 
 	// Create the investigation and wait for it to complete
-	completedInvestigation, err := client.createSiftInvestigation(ctx, investigation, requestData)
+	completedInvestigation, err := client.createSiftInvestigation(ctx, investigation, requestData, logger)
 	if err != nil {
 		return nil, fmt.Errorf("creating investigation: %w", err)
 	}
@@ -488,7 +490,7 @@ func (c *siftClient) getSiftInvestigation(ctx context.Context, id uuid.UUID) (*I
 	return &investigationResponse.Data, nil
 }
 
-func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation *Investigation, requestData investigationRequest) (*Investigation, error) {
+func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation *Investigation, requestData investigationRequest, logger *slog.Logger) (*Investigation, error) {
 	// Set default time range to last 30 minutes if not provided
 	if requestData.Start.IsZero() {
 		requestData.Start = time.Now().Add(-30 * time.Minute)
@@ -511,12 +513,12 @@ func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation 
 		return nil, fmt.Errorf("marshaling investigation: %w", err)
 	}
 
-	slog.Debug("Creating investigation", "payload", string(jsonData))
+	logger.Debug("Creating investigation", "payload", string(jsonData))
 	buf, err := c.makeRequest(ctx, "POST", "/api/plugins/grafana-ml-app/resources/sift/api/v1/investigations", jsonData)
 	if err != nil {
 		return nil, err
 	}
-	slog.Debug("Investigation created", "response", string(buf))
+	logger.Debug("Investigation created", "response", string(buf))
 
 	investigationResponse := struct {
 		Status string        `json:"status"`
@@ -540,7 +542,7 @@ func (c *siftClient) createSiftInvestigation(ctx context.Context, investigation 
 		case <-timeout:
 			return nil, fmt.Errorf("timeout waiting for investigation completion after 5 minutes")
 		case <-ticker.C:
-			slog.Debug("Polling investigation status", "investigation_id", investigationResponse.Data.ID)
+			logger.Debug("Polling investigation status", "investigation_id", investigationResponse.Data.ID)
 			investigation, err := c.getSiftInvestigation(ctx, investigationResponse.Data.ID)
 			if err != nil {
 				return nil, err

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -268,7 +268,7 @@ type FindErrorPatternLogsParams struct {
 
 // findErrorPatternLogs creates an investigation with ErrorPatternLogs check, waits for it to complete, and returns the analysis
 func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) (*analysis, error) {
-	logger := mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault()
+	logger := mcpgrafana.LoggerFromContext(ctx)
 	client, err := siftClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating Sift client: %w", err)
@@ -355,7 +355,7 @@ type FindSlowRequestsParams struct {
 
 // findSlowRequests creates an investigation with SlowRequests check, waits for it to complete, and returns the analysis
 func findSlowRequests(ctx context.Context, args FindSlowRequestsParams) (*analysis, error) {
-	logger := mcpgrafana.GrafanaConfigFromContext(ctx).LoggerOrDefault()
+	logger := mcpgrafana.LoggerFromContext(ctx)
 	client, err := siftClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating Sift client: %w", err)


### PR DESCRIPTION
## Summary
- Add `Logger *slog.Logger` field to `GrafanaConfig` with `LoggerOrDefault()` fallback to `slog.Default()`
- Update ~20 log call sites across `mcpgrafana.go` and `client_cache.go` to use the config logger
- Update `fetchPublicURL`/`doFetchPublicURL` to accept and use the logger parameter

Callers like the hosted Cloud MCP server can now inject their own `*slog.Logger` for consistent structured logging. Functions without access to `GrafanaConfig` still use `slog.Default()` and can be migrated in a follow-up.

## Test plan
- [ ] `go test ./...` passes (updated 13 test call sites)
- [ ] Backwards compatible — nil Logger falls back to `slog.Default()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a logging/observability refactor with signature changes and no expected impact on request handling beyond which logger receives messages.
> 
> **Overview**
> Adds an optional `Logger *slog.Logger` to `GrafanaConfig` (with `LoggerOrDefault()` / `LoggerFromContext`) and threads it through client creation/config extraction so logs no longer rely on global `slog`.
> 
> Plumbs logger injection into supporting components (`ClientCache`, `ToolManager`, `SessionManager`) and updates proxied tools/Sift/OnCall/alerting handlers to log via the context/config logger; also enables `sloglint` (excluding `cmd/`) to enforce non-global logging usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26ec1a0c1e4547a29d3d3e3b4d65873a24778d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->