### PR TITLE
fix: trim trailing slash from Grafana URL in proxied discovery

### DIFF
--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -60,7 +60,7 @@ func discoverMCPDatasources(ctx context.Context) ([]DiscoveredDatasource, error)
 	if config.URL == "" {
 		return nil, fmt.Errorf("grafana url not found in context")
 	}
-	grafanaBaseURL := config.URL
+	grafanaBaseURL := strings.TrimRight(config.URL, "/")
 
 	// Filter for datasources that support MCP and collect candidates
 	type candidate struct {
@@ -150,6 +150,8 @@ func discoverMCPDatasources(ctx context.Context) ([]DiscoveredDatasource, error)
 					},
 					enabled: true,
 				}
+			} else {
+				slog.DebugContext(ctx, "MCP probe returned non-OK status", "datasource", c.uid, "status", resp.StatusCode, "url", probeURL)
 			}
 		}(c)
 	}


### PR DESCRIPTION
The GrafanaURL from the grant/config often has a trailing slash (e.g. "http://grafana:3000/"). When constructing the datasource proxy URL, fmt.Sprintf("%s/api/datasources/proxy/...", grafanaBaseURL) produces a double slash ("//api/...") which Grafana's router rejects with 404.

Also add a debug log for non-200 probe responses to aid future debugging — previously these were completely silent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to URL string handling plus additional debug logging, affecting only datasource MCP probe/discovery behavior.
> 
> **Overview**
> Prevents malformed datasource proxy URLs during MCP datasource discovery by trimming any trailing `/` from the Grafana base URL before building `.../api/datasources/proxy/...` endpoints.
> 
> Adds a `slog.DebugContext` message when an MCP probe returns a non-`200` status, so disabled/misrouted endpoints are no longer silent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c9667697d6ba018f4aaa83140c7e0798f59a5c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->