### PR TITLE
refactor(mcpgrafana): use BuildTransport in fetchPublicURL

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -774,7 +774,7 @@ func doFetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
 		return ""
 	}
 
-	transport, err := BuildTransport(cfg, nil, WithoutOtel())
+	transport, err := BuildTransport(cfg, nil)
 	if err != nil {
 		slog.Warn("Failed to build transport for frontend settings request", "error", err)
 		return ""

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -734,16 +734,16 @@ var publicURLFlight singleflight.Group
 // It returns the appUrl if available, or an empty string if the request fails.
 // Successful results are cached permanently; failures are retried on subsequent calls.
 // Concurrent calls for the same grafanaURL are coalesced via singleflight.
-func fetchPublicURL(ctx context.Context, grafanaURL, apiKey string, auth *url.Userinfo, tlsConfig *TLSConfig, extraHeaders map[string]string) string {
+func fetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
 	// Check cache first (only successful results are cached)
-	if cached, ok := publicURLCache.Load(grafanaURL); ok {
+	if cached, ok := publicURLCache.Load(cfg.URL); ok {
 		return cached.(string)
 	}
 
 	// Use singleflight to coalesce concurrent requests for the same URL
-	result, _, _ := publicURLFlight.Do(grafanaURL, func() (any, error) {
+	result, _, _ := publicURLFlight.Do(cfg.URL, func() (any, error) {
 		// Double-check cache inside singleflight (another goroutine may have populated it)
-		if cached, ok := publicURLCache.Load(grafanaURL); ok {
+		if cached, ok := publicURLCache.Load(cfg.URL); ok {
 			return cached.(string), nil
 		}
 
@@ -752,11 +752,11 @@ func fetchPublicURL(ctx context.Context, grafanaURL, apiKey string, auth *url.Us
 		fetchCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		publicURL := doFetchPublicURL(fetchCtx, grafanaURL, apiKey, auth, tlsConfig, extraHeaders)
+		publicURL := doFetchPublicURL(fetchCtx, cfg)
 
 		// Only cache successful (non-empty) results so transient failures are retried
 		if publicURL != "" {
-			publicURLCache.Store(grafanaURL, publicURL)
+			publicURLCache.Store(cfg.URL, publicURL)
 		}
 
 		return publicURL, nil
@@ -766,38 +766,23 @@ func fetchPublicURL(ctx context.Context, grafanaURL, apiKey string, auth *url.Us
 }
 
 // doFetchPublicURL performs the actual HTTP request to fetch the public URL.
-func doFetchPublicURL(ctx context.Context, grafanaURL, apiKey string, auth *url.Userinfo, tlsConfig *TLSConfig, extraHeaders map[string]string) string {
-	settingsURL := strings.TrimRight(grafanaURL, "/") + "/api/frontend/settings"
+func doFetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
+	settingsURL := strings.TrimRight(cfg.URL, "/") + "/api/frontend/settings"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, settingsURL, nil)
 	if err != nil {
 		slog.Warn("Failed to create request for frontend settings", "error", err)
 		return ""
 	}
 
-	if apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	} else if auth != nil {
-		password, _ := auth.Password()
-		req.SetBasicAuth(auth.Username(), password)
-	}
-	req.Header.Set("User-Agent", UserAgent())
-
-	// Apply extra headers (e.g., for proxies requiring custom headers)
-	for k, v := range extraHeaders {
-		req.Header.Set(k, v)
+	transport, err := BuildTransport(cfg, nil, WithoutOtel())
+	if err != nil {
+		slog.Warn("Failed to build transport for frontend settings request", "error", err)
+		return ""
 	}
 
-	httpClient := &http.Client{Timeout: 5 * time.Second}
-	if tlsConfig != nil {
-		tlsCfg, err := tlsConfig.CreateTLSConfig()
-		if err != nil {
-			slog.Warn("Failed to create TLS config for frontend settings request", "error", err)
-			return ""
-		}
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig: tlsCfg,
-			Proxy:           http.ProxyFromEnvironment,
-		}
+	httpClient := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
 	}
 
 	resp, err := httpClient.Do(req)
@@ -965,7 +950,14 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 	}
 
 	// Fetch the public URL from Grafana's frontend settings.
-	publicURL := fetchPublicURL(ctx, grafanaURL, apiKey, auth, config.TLSConfig, config.ExtraHeaders)
+	fetchCfg := &GrafanaConfig{
+		URL:          grafanaURL,
+		APIKey:       apiKey,
+		BasicAuth:    auth,
+		TLSConfig:    config.TLSConfig,
+		ExtraHeaders: config.ExtraHeaders,
+	}
+	publicURL := fetchPublicURL(ctx, fetchCfg)
 
 	return &GrafanaClient{
 		GrafanaHTTPAPI: grafanaClient,

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -1362,7 +1362,7 @@ func TestFetchPublicURL(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		})
 
-		publicURL := fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL := fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL, APIKey: "test-key"})
 		assert.Equal(t, "https://grafana.example.com", publicURL)
 	})
 
@@ -1371,7 +1371,7 @@ func TestFetchPublicURL(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 		})
 
-		publicURL := fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL := fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL, APIKey: "test-key"})
 		assert.Equal(t, "", publicURL)
 	})
 
@@ -1381,7 +1381,7 @@ func TestFetchPublicURL(t *testing.T) {
 			_, _ = w.Write([]byte(`{"appUrl": ""}`))
 		})
 
-		publicURL := fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL := fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL, APIKey: "test-key"})
 		assert.Equal(t, "", publicURL)
 	})
 
@@ -1390,7 +1390,7 @@ func TestFetchPublicURL(t *testing.T) {
 			_, _ = w.Write([]byte(`not json`))
 		})
 
-		publicURL := fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL := fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL, APIKey: "test-key"})
 		assert.Equal(t, "", publicURL)
 	})
 
@@ -1402,7 +1402,7 @@ func TestFetchPublicURL(t *testing.T) {
 			_, _ = w.Write([]byte(`{"appUrl": "https://grafana.example.com"}`))
 		})
 
-		fetchPublicURL(context.Background(), ts.URL, "my-token", nil, nil, nil)
+		fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL, APIKey: "my-token"})
 		assert.Equal(t, "Bearer my-token", capturedAuth)
 	})
 
@@ -1415,7 +1415,7 @@ func TestFetchPublicURL(t *testing.T) {
 		})
 
 		auth := url.UserPassword("admin", "secret")
-		fetchPublicURL(context.Background(), ts.URL, "", auth, nil, nil)
+		fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL, BasicAuth: auth})
 		assert.Equal(t, "admin", capturedUser)
 		assert.Equal(t, "secret", capturedPass)
 	})
@@ -1426,7 +1426,7 @@ func TestFetchPublicURL(t *testing.T) {
 			_, _ = w.Write([]byte(`{"appUrl": "https://grafana.example.com/"}`))
 		})
 
-		publicURL := fetchPublicURL(context.Background(), ts.URL, "", nil, nil, nil)
+		publicURL := fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL})
 		assert.Equal(t, "https://grafana.example.com", publicURL)
 	})
 
@@ -1442,7 +1442,7 @@ func TestFetchPublicURL(t *testing.T) {
 			"X-Custom-Auth":   "proxy-token-123",
 			"X-Forwarded-For": "10.0.0.1",
 		}
-		fetchPublicURL(context.Background(), ts.URL, "", nil, nil, extraHeaders)
+		fetchPublicURL(context.Background(), &GrafanaConfig{URL: ts.URL, ExtraHeaders: extraHeaders})
 		assert.Equal(t, "proxy-token-123", capturedHeaders.Get("X-Custom-Auth"))
 		assert.Equal(t, "10.0.0.1", capturedHeaders.Get("X-Forwarded-For"))
 	})
@@ -1455,13 +1455,15 @@ func TestFetchPublicURL(t *testing.T) {
 			_, _ = w.Write([]byte(`{"appUrl": "https://grafana.example.com"}`))
 		})
 
+		cfg := &GrafanaConfig{URL: ts.URL, APIKey: "test-key"}
+
 		// First call should hit the server
-		publicURL := fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL := fetchPublicURL(context.Background(), cfg)
 		assert.Equal(t, "https://grafana.example.com", publicURL)
 		assert.Equal(t, 1, callCount)
 
 		// Second call should use cache
-		publicURL = fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL = fetchPublicURL(context.Background(), cfg)
 		assert.Equal(t, "https://grafana.example.com", publicURL)
 		assert.Equal(t, 1, callCount) // no additional HTTP call
 	})
@@ -1478,18 +1480,20 @@ func TestFetchPublicURL(t *testing.T) {
 			_, _ = w.Write([]byte(`{"appUrl": "https://grafana.example.com"}`))
 		})
 
+		cfg := &GrafanaConfig{URL: ts.URL, APIKey: "test-key"}
+
 		// First call fails
-		publicURL := fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL := fetchPublicURL(context.Background(), cfg)
 		assert.Equal(t, "", publicURL)
 		assert.Equal(t, 1, callCount)
 
 		// Second call retries and succeeds (failures are not cached)
-		publicURL = fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL = fetchPublicURL(context.Background(), cfg)
 		assert.Equal(t, "https://grafana.example.com", publicURL)
 		assert.Equal(t, 2, callCount)
 
 		// Third call uses cached success
-		publicURL = fetchPublicURL(context.Background(), ts.URL, "test-key", nil, nil, nil)
+		publicURL = fetchPublicURL(context.Background(), cfg)
 		assert.Equal(t, "https://grafana.example.com", publicURL)
 		assert.Equal(t, 2, callCount) // no additional HTTP call
 	})


### PR DESCRIPTION
## Summary
- Refactors `doFetchPublicURL` to use `BuildTransport` instead of manually constructing auth headers, user-agent, TLS config, and extra headers
- Changes `fetchPublicURL` and `doFetchPublicURL` signatures to accept `*GrafanaConfig` instead of individual parameters, matching the pattern used elsewhere

## Test plan
- [x] All existing `TestFetchPublicURL` subtests pass (auth, basic auth, extra headers, caching, retry)
- [x] `TestNewGrafanaClientFetchesPublicURL` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTTP transport/auth/TLS setup used to fetch Grafana `appUrl`; misconfiguration could cause the public URL lookup to fail or send different headers, but it’s limited to this startup metadata call.
> 
> **Overview**
> Refactors the Grafana public URL lookup (`/api/frontend/settings`) to build its HTTP client via the shared `BuildTransport` middleware chain instead of manually setting auth headers, user-agent, TLS, and extra headers.
> 
> Updates `fetchPublicURL`/`doFetchPublicURL` to accept a `*GrafanaConfig` and adjusts `NewGrafanaClient` and the `TestFetchPublicURL` suite to pass a config object (preserving caching/retry behavior and header expectations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bfa6ccbc986ddb8faf2fbbc2c019b35ee8f833d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->