### PR TITLE
fix(asserts): validate timestamps as strings instead of time.Time

### DIFF
--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -35,13 +34,13 @@ func newAssertsClient(ctx context.Context) (*Client, error) {
 }
 
 type GetAssertionsParams struct {
-	StartTime  time.Time `json:"startTime" jsonschema:"required,description=The start time in RFC3339 format"`
-	EndTime    time.Time `json:"endTime" jsonschema:"required,description=The end time in RFC3339 format"`
-	EntityType string    `json:"entityType" jsonschema:"description=The type of the entity to list (e.g. Service\\, Node\\, Pod\\, etc.)"`
-	EntityName string    `json:"entityName" jsonschema:"description=The name of the entity to list"`
-	Env        string    `json:"env,omitempty" jsonschema:"description=The env of the entity to list"`
-	Site       string    `json:"site,omitempty" jsonschema:"description=The site of the entity to list"`
-	Namespace  string    `json:"namespace,omitempty" jsonschema:"description=The namespace of the entity to list"`
+	StartTime  string `json:"startTime" jsonschema:"required,description=The start time in RFC3339 format (e.g. 2024-01-01T00:00:00Z) or relative format (e.g. now-1h)"`
+	EndTime    string `json:"endTime" jsonschema:"required,description=The end time in RFC3339 format (e.g. 2024-01-01T00:00:00Z) or relative format (e.g. now)"`
+	EntityType string `json:"entityType" jsonschema:"description=The type of the entity to list (e.g. Service\\, Node\\, Pod\\, etc.)"`
+	EntityName string `json:"entityName" jsonschema:"description=The name of the entity to list"`
+	Env        string `json:"env,omitempty" jsonschema:"description=The env of the entity to list"`
+	Site       string `json:"site,omitempty" jsonschema:"description=The site of the entity to list"`
+	Namespace  string `json:"namespace,omitempty" jsonschema:"description=The namespace of the entity to list"`
 }
 
 type scope struct {
@@ -97,6 +96,15 @@ func (c *Client) fetchAssertsData(ctx context.Context, urlPath string, method st
 }
 
 func getAssertions(ctx context.Context, args GetAssertionsParams) (string, error) {
+	startTime, err := parseStartTime(args.StartTime)
+	if err != nil {
+		return "", fmt.Errorf("parsing start time: %w", err)
+	}
+	endTime, err := parseEndTime(args.EndTime)
+	if err != nil {
+		return "", fmt.Errorf("parsing end time: %w", err)
+	}
+
 	client, err := newAssertsClient(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Asserts client: %w", err)
@@ -104,8 +112,8 @@ func getAssertions(ctx context.Context, args GetAssertionsParams) (string, error
 
 	// Create request body
 	reqBody := requestBody{
-		StartTime: args.StartTime.UnixMilli(),
-		EndTime:   args.EndTime.UnixMilli(),
+		StartTime: startTime.UnixMilli(),
+		EndTime:   endTime.UnixMilli(),
 		EntityKeys: []entity{
 			{
 				Name:  args.EntityName,

--- a/tools/asserts_test.go
+++ b/tools/asserts_test.go
@@ -65,8 +65,8 @@ func TestAssertTools(t *testing.T) {
 		defer server.Close()
 
 		result, err := getAssertions(ctx, GetAssertionsParams{
-			StartTime:  startTime,
-			EndTime:    endTime,
+			StartTime:  startTime.Format(time.RFC3339),
+			EndTime:    endTime.Format(time.RFC3339),
 			EntityType: "Service",
 			EntityName: "mongodb",
 			Env:        "asserts-demo",
@@ -114,8 +114,8 @@ func TestAssertTools(t *testing.T) {
 		defer server.Close()
 
 		result, err := getAssertions(ctx, GetAssertionsParams{
-			StartTime:  startTime,
-			EndTime:    endTime,
+			StartTime:  startTime.Format(time.RFC3339),
+			EndTime:    endTime.Format(time.RFC3339),
 			EntityType: "Service",
 			EntityName: "mongodb",
 			Env:        "asserts-demo",
@@ -123,5 +123,35 @@ func TestAssertTools(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 		assert.Equal(t, `{"summary": "test summary"}`, result)
+	})
+
+	t.Run("get assertions with invalid start time", func(t *testing.T) {
+		_, ctx := setupMockAssertsServer(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("server should not be called with invalid timestamps")
+		})
+
+		_, err := getAssertions(ctx, GetAssertionsParams{
+			StartTime:  "not-a-date",
+			EndTime:    "2025-04-23T11:00:00Z",
+			EntityType: "Service",
+			EntityName: "mongodb",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing start time")
+	})
+
+	t.Run("get assertions with invalid end time", func(t *testing.T) {
+		_, ctx := setupMockAssertsServer(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("server should not be called with invalid timestamps")
+		})
+
+		_, err := getAssertions(ctx, GetAssertionsParams{
+			StartTime:  "2025-04-23T10:00:00Z",
+			EndTime:    "also-not-a-date",
+			EntityType: "Service",
+			EntityName: "mongodb",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing end time")
 	})
 }


### PR DESCRIPTION
## Summary

- `get_assertions` used `time.Time` fields for `startTime`/`endTime`, causing the mcp-go SDK to return `internal error` (-32603) on invalid timestamps
- Changed to `string` fields with explicit parsing via `parseStartTime`/`parseEndTime` (the same helpers used by clickhouse, elasticsearch, and other tools in this repo)
- Invalid timestamps now return `isError: true` with a descriptive message instead of an opaque internal error
- Also enables relative time formats (e.g., `now-1h`) through Grafana's gtime package, matching other query tools

## Test plan

- [x] Existing unit tests updated to pass RFC3339 strings instead of `time.Time` values
- [x] Two new test cases for invalid start/end timestamps
- [x] `go build ./...` passes
- [x] `go test -tags unit ./tools/ -run TestAssertTools` passes (4/4)

Fixes #792

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `get_assertions` tool contract from `time.Time` to string timestamps and adds explicit parsing/validation, which could affect existing callers and error handling. Scope is limited to asserts querying and covered by updated/new unit tests.
> 
> **Overview**
> `get_assertions` now takes `startTime`/`endTime` as **strings** (RFC3339 or relative like `now-1h`) instead of `time.Time`, and explicitly parses them via `parseStartTime`/`parseEndTime` before building the request payload.
> 
> Unit tests were updated to pass RFC3339 strings and new cases assert that invalid timestamps fail fast with descriptive `parsing start/end time` errors (and do not call the server).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ea8c1a4fb0e9757ca18f55fc50f94fd0301ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->