### PR TITLE
fix(loki): unquote timestamp in query_loki_logs result (#803)

### DIFF
--- a/tools/loki.go
+++ b/tools/loki.go
@@ -592,6 +592,15 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 		for _, stream := range streams {
 			for _, value := range stream.Values {
 				if len(value) >= 2 {
+					// Parse timestamp. value[0] is a json.RawMessage containing
+					// a JSON-encoded string like `"1234567890"`; using string()
+					// directly would keep the surrounding quotes and double-encode
+					// when the LogEntry is marshalled (see issue #803).
+					var ts string
+					if err := json.Unmarshal(value[0], &ts); err != nil {
+						continue // Skip invalid timestamps
+					}
+
 					// Parse log line
 					var logLine string
 					if err := json.Unmarshal(value[1], &logLine); err != nil {
@@ -599,7 +608,7 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 					}
 
 					entry := LogEntry{
-						Timestamp: string(value[0]), // Nanoseconds as string
+						Timestamp: ts, // Nanoseconds as string (unquoted)
 						Line:      logLine,
 						Labels:    stream.Stream,
 					}

--- a/tools/loki_unit_test.go
+++ b/tools/loki_unit_test.go
@@ -158,6 +158,69 @@ func TestCategorizedLabelsParsing(t *testing.T) {
 	assert.Equal(t, map[string]string{"level": "error"}, cats2.Parsed)
 }
 
+// Regression test for #803: timestamps in `value[0]` arrive as JSON-encoded
+// strings (e.g. `"1234567890"`) and must be unquoted before being placed in
+// LogEntry.Timestamp; otherwise the surrounding quotes are double-encoded
+// when the entry is marshalled, producing `"timestamp":"\"1234567890\""` and
+// breaking any downstream `json.Unmarshal` of the tool result.
+func TestLogEntryTimestampNotDoubleEncoded(t *testing.T) {
+	rawResponse := `{
+		"status": "success",
+		"data": {
+			"resultType": "streams",
+			"result": [
+				{
+					"stream": {"app": "frontend"},
+					"values": [
+						["1693996529000222496", "some log line"]
+					]
+				}
+			]
+		}
+	}`
+
+	var response lokiQueryResponse
+	require.NoError(t, json.Unmarshal([]byte(rawResponse), &response))
+
+	var streams []LokiLogStream
+	require.NoError(t, json.Unmarshal(response.Data.Result, &streams))
+	require.Len(t, streams, 1)
+	require.Len(t, streams[0].Values, 1)
+
+	// Mirror the parsing the production code does in queryLokiLogs.
+	var ts string
+	require.NoError(t, json.Unmarshal(streams[0].Values[0][0], &ts))
+
+	var line string
+	require.NoError(t, json.Unmarshal(streams[0].Values[0][1], &line))
+
+	entry := LogEntry{
+		Timestamp: ts,
+		Line:      line,
+		Labels:    streams[0].Stream,
+	}
+
+	// Timestamp must be the plain numeric string, with no surrounding quotes.
+	assert.Equal(t, "1693996529000222496", entry.Timestamp)
+	assert.NotContains(t, entry.Timestamp, `"`,
+		"timestamp must not contain literal quotes — see #803")
+
+	// Marshalling the entry must produce a JSON object that can be
+	// re-parsed with json.Unmarshal without further unescaping.
+	out, err := json.Marshal([]LogEntry{entry})
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"timestamp":"1693996529000222496"`,
+		"timestamp must serialise as a plain string, not as a JSON-encoded JSON string")
+	assert.NotContains(t, string(out), `"timestamp":"\"`,
+		"timestamp must not be double-encoded (#803)")
+
+	var roundtrip []LogEntry
+	require.NoError(t, json.Unmarshal(out, &roundtrip),
+		"the serialised tool output must round-trip through json.Unmarshal")
+	require.Len(t, roundtrip, 1)
+	assert.Equal(t, "1693996529000222496", roundtrip[0].Timestamp)
+}
+
 func TestCategorizedLabelsBackwardCompat(t *testing.T) {
 	// Without the encoding flag, values only have 2 elements (old Loki).
 	rawResponse := `{


### PR DESCRIPTION
## Summary

Fixes #803.

`value[0]` from a Loki streams response is a `json.RawMessage` containing a JSON-encoded string (`"1234567890"` — quotes included). The current code does `string(value[0])` which preserves those literal quotes, so `LogEntry.Timestamp` ends up holding `"1234567890"` instead of `1234567890`. When the entry array is marshalled into the tool result's `content[0].text`, `encoding/json` faithfully escapes the embedded quotes, producing:

```text
"timestamp":"\"1234567890\""
```

After the outer JSON-RPC envelope is unescaped once, the resulting string is no longer parseable JSON, and clients that follow the documented `JSON.parse(content[0].text)` pattern silently get a parse error. Real matches end up looking like 0 results.

The same code path already does the right thing for `value[1]` (the log line) with `json.Unmarshal(value[1], &logLine)`. This change applies the same unmarshalling to `value[0]`, stripping the surrounding quotes before storing the timestamp.

## Diff at the call site

```go
// before
entry := LogEntry{
    Timestamp: string(value[0]), // keeps the literal quotes
    Line:      logLine,
    Labels:    stream.Stream,
}

// after
var ts string
if err := json.Unmarshal(value[0], &ts); err != nil {
    continue
}
entry := LogEntry{
    Timestamp: ts,           // unquoted nanoseconds-as-string
    Line:      logLine,
    Labels:    stream.Stream,
}
```

## Test plan

- [x] `TestLogEntryTimestampNotDoubleEncoded` (new) — asserts (a) the timestamp is plain digits, no embedded `"`, (b) the serialised array contains `"timestamp":"<digits>"` and never `"timestamp":"\"`, and (c) `json.Unmarshal` round-trips the marshalled output back into `[]LogEntry` without any further unescaping.
- [x] `TestEnforceLogLimit`, `TestHasCategorizeLabelsFlag`, `TestCategorizedLabelsParsing`, `TestCategorizedLabelsBackwardCompat` all still pass — change is fully behaviour-preserving for the rest of the parsing pipeline.
- Manually verified against a live Loki tenant (chart 6.55.0, schema v13) with structured-metadata-bearing log lines.

## Notes

The fix is intentionally minimal: only the timestamp parse changes, the rest of the function is untouched. No public API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small parsing change isolated to Loki stream results plus a regression test; main risk is skipping entries if a timestamp is malformed.
> 
> **Overview**
> Fixes `query_loki_logs` stream parsing so the timestamp (`values[0]`) is `json.Unmarshal`’d into a plain string instead of using `string(raw)`, preventing *double-encoded quotes* in `LogEntry.Timestamp` that break downstream JSON parsing.
> 
> Adds a regression unit test (`TestLogEntryTimestampNotDoubleEncoded`) that asserts the marshalled `[]LogEntry` output contains a normal `"timestamp":"<digits>"` value and round-trips through `json.Unmarshal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8698a83c321344e32cd09d10489cd9e1293bad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->