### PR TITLE
feat(transport): read per-request config from context in RoundTrippers

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -412,11 +412,14 @@ type OrgIDRoundTripper struct {
 }
 
 func (t *OrgIDRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// clone the request to avoid modifying the original
 	clonedReq := req.Clone(req.Context())
 
-	if t.orgID > 0 {
-		clonedReq.Header.Set(client.OrgIDHeader, strconv.FormatInt(t.orgID, 10))
+	orgID := t.orgID
+	if cfg := GrafanaConfigFromContext(req.Context()); cfg.OrgID > 0 {
+		orgID = cfg.OrgID
+	}
+	if orgID > 0 {
+		clonedReq.Header.Set(client.OrgIDHeader, strconv.FormatInt(orgID, 10))
 	}
 
 	return t.underlying.RoundTrip(clonedReq)
@@ -440,7 +443,11 @@ type ExtraHeadersRoundTripper struct {
 
 func (t *ExtraHeadersRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	clonedReq := req.Clone(req.Context())
-	for k, v := range t.headers {
+	headers := t.headers
+	if cfg := GrafanaConfigFromContext(req.Context()); len(cfg.ExtraHeaders) > 0 {
+		headers = mergeHeaders(t.headers, cfg.ExtraHeaders)
+	}
+	for k, v := range headers {
 		clonedReq.Header.Set(k, v)
 	}
 	return t.underlying.RoundTrip(clonedReq)
@@ -470,14 +477,29 @@ type AuthRoundTripper struct {
 func (rt *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	clonedReq := req.Clone(req.Context())
 
-	if rt.accessToken != "" && rt.idToken != "" {
-		clonedReq.Header.Set("X-Access-Token", rt.accessToken)
-		clonedReq.Header.Set("X-Grafana-Id", rt.idToken)
-	} else if rt.apiKey != "" {
-		clonedReq.Header.Set("Authorization", "Bearer "+rt.apiKey)
-	} else if rt.basicAuth != nil {
-		password, _ := rt.basicAuth.Password()
-		clonedReq.SetBasicAuth(rt.basicAuth.Username(), password)
+	accessToken, idToken, apiKey, basicAuth := rt.accessToken, rt.idToken, rt.apiKey, rt.basicAuth
+	cfg := GrafanaConfigFromContext(req.Context())
+	if cfg.AccessToken != "" {
+		accessToken = cfg.AccessToken
+	}
+	if cfg.IDToken != "" {
+		idToken = cfg.IDToken
+	}
+	if cfg.APIKey != "" {
+		apiKey = cfg.APIKey
+	}
+	if cfg.BasicAuth != nil {
+		basicAuth = cfg.BasicAuth
+	}
+
+	if accessToken != "" && idToken != "" {
+		clonedReq.Header.Set("X-Access-Token", accessToken)
+		clonedReq.Header.Set("X-Grafana-Id", idToken)
+	} else if apiKey != "" {
+		clonedReq.Header.Set("Authorization", "Bearer "+apiKey)
+	} else if basicAuth != nil {
+		password, _ := basicAuth.Password()
+		clonedReq.SetBasicAuth(basicAuth.Username(), password)
 	}
 
 	return rt.underlying.RoundTrip(clonedReq)
@@ -566,13 +588,11 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 		transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
 	}
 
-	// Extra headers
-	if len(cfg.ExtraHeaders) > 0 {
-		transport = NewExtraHeadersRoundTripper(transport, cfg.ExtraHeaders)
-	}
+	// Extra headers (always included so per-request context overrides work)
+	transport = NewExtraHeadersRoundTripper(transport, cfg.ExtraHeaders)
 
-	// Org ID
-	if !options.withoutOrgID && cfg.OrgID > 0 {
+	// Org ID (always included so per-request context overrides work)
+	if !options.withoutOrgID {
 		transport = NewOrgIDRoundTripper(transport, cfg.OrgID)
 	}
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -1533,3 +1533,334 @@ func TestNewGrafanaClientFetchesPublicURL(t *testing.T) {
 		assert.Equal(t, "", gc.PublicURL)
 	})
 }
+
+func TestOrgIDRoundTripperContextOverride(t *testing.T) {
+	t.Run("context OrgID overrides captured value", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewOrgIDRoundTripper(mock, 1)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{OrgID: 99})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "99", capturedReq.Header.Get(grafana_client.OrgIDHeader))
+	})
+
+	t.Run("context OrgID used when captured value is zero", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewOrgIDRoundTripper(mock, 0)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{OrgID: 42})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "42", capturedReq.Header.Get(grafana_client.OrgIDHeader))
+	})
+
+	t.Run("falls back to captured value when context has no OrgID", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewOrgIDRoundTripper(mock, 7)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "7", capturedReq.Header.Get(grafana_client.OrgIDHeader))
+	})
+
+	t.Run("no header when both captured and context are zero", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewOrgIDRoundTripper(mock, 0)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Empty(t, capturedReq.Header.Get(grafana_client.OrgIDHeader))
+	})
+}
+
+func TestAuthRoundTripperContextOverride(t *testing.T) {
+	t.Run("context OBO tokens override captured API key", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewAuthRoundTripper(mock, "", "", "captured-key", nil)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			AccessToken: "ctx-access",
+			IDToken:     "ctx-id",
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ctx-access", capturedReq.Header.Get("X-Access-Token"))
+		assert.Equal(t, "ctx-id", capturedReq.Header.Get("X-Grafana-Id"))
+		assert.Empty(t, capturedReq.Header.Get("Authorization"))
+	})
+
+	t.Run("context API key overrides captured API key", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewAuthRoundTripper(mock, "", "", "captured-key", nil)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{APIKey: "ctx-key"})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Bearer ctx-key", capturedReq.Header.Get("Authorization"))
+	})
+
+	t.Run("context basic auth overrides captured basic auth", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewAuthRoundTripper(mock, "", "", "", url.UserPassword("old-user", "old-pass"))
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			BasicAuth: url.UserPassword("new-user", "new-pass"),
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		user, pass, ok := capturedReq.BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "new-user", user)
+		assert.Equal(t, "new-pass", pass)
+	})
+
+	t.Run("falls back to captured values when context has no auth", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewAuthRoundTripper(mock, "", "", "captured-key", nil)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Bearer captured-key", capturedReq.Header.Get("Authorization"))
+	})
+
+	t.Run("context OBO tokens used when no captured auth exists", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewAuthRoundTripper(mock, "", "", "", nil)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			AccessToken: "ctx-access",
+			IDToken:     "ctx-id",
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ctx-access", capturedReq.Header.Get("X-Access-Token"))
+		assert.Equal(t, "ctx-id", capturedReq.Header.Get("X-Grafana-Id"))
+	})
+}
+
+func TestExtraHeadersRoundTripperContextOverride(t *testing.T) {
+	t.Run("context headers override captured headers", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewExtraHeadersRoundTripper(mock, map[string]string{
+			"X-Tenant": "captured-tenant",
+		})
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			ExtraHeaders: map[string]string{"X-Tenant": "ctx-tenant"},
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ctx-tenant", capturedReq.Header.Get("X-Tenant"))
+	})
+
+	t.Run("context headers merged with captured headers", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewExtraHeadersRoundTripper(mock, map[string]string{
+			"X-Static": "from-config",
+		})
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			ExtraHeaders: map[string]string{"X-Dynamic": "from-context"},
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "from-config", capturedReq.Header.Get("X-Static"))
+		assert.Equal(t, "from-context", capturedReq.Header.Get("X-Dynamic"))
+	})
+
+	t.Run("falls back to captured headers when context has none", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewExtraHeadersRoundTripper(mock, map[string]string{
+			"X-Custom": "captured-value",
+		})
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "captured-value", capturedReq.Header.Get("X-Custom"))
+	})
+
+	t.Run("context headers used when no captured headers exist", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		rt := NewExtraHeadersRoundTripper(mock, nil)
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			ExtraHeaders: map[string]string{"X-From-Context": "value"},
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "value", capturedReq.Header.Get("X-From-Context"))
+	})
+}
+
+func TestBuildTransportContextOverrides(t *testing.T) {
+	t.Run("context OrgID works even when construction-time OrgID is zero", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		cfg := &GrafanaConfig{OrgID: 0}
+		transport, err := BuildTransport(cfg, mock, WithoutOtel())
+		require.NoError(t, err)
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{OrgID: 55})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err = transport.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "55", capturedReq.Header.Get(grafana_client.OrgIDHeader))
+	})
+
+	t.Run("context ExtraHeaders work even when construction-time headers are empty", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		cfg := &GrafanaConfig{}
+		transport, err := BuildTransport(cfg, mock, WithoutOtel())
+		require.NoError(t, err)
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			ExtraHeaders: map[string]string{"X-Request-Tenant": "tenant-42"},
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err = transport.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "tenant-42", capturedReq.Header.Get("X-Request-Tenant"))
+	})
+
+	t.Run("context auth overrides work through BuildTransport", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		cfg := &GrafanaConfig{APIKey: "startup-key"}
+		transport, err := BuildTransport(cfg, mock, WithoutOtel())
+		require.NoError(t, err)
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			AccessToken: "per-request-access",
+			IDToken:     "per-request-id",
+		})
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err = transport.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "per-request-access", capturedReq.Header.Get("X-Access-Token"))
+		assert.Equal(t, "per-request-id", capturedReq.Header.Get("X-Grafana-Id"))
+		assert.Empty(t, capturedReq.Header.Get("Authorization"))
+	})
+
+	t.Run("no context overlay preserves existing behavior", func(t *testing.T) {
+		var capturedReq *http.Request
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		cfg := &GrafanaConfig{
+			APIKey:       "my-key",
+			OrgID:        10,
+			ExtraHeaders: map[string]string{"X-Custom": "val"},
+		}
+		transport, err := BuildTransport(cfg, mock, WithoutOtel())
+		require.NoError(t, err)
+
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		_, err = transport.RoundTrip(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Bearer my-key", capturedReq.Header.Get("Authorization"))
+		assert.Equal(t, "10", capturedReq.Header.Get(grafana_client.OrgIDHeader))
+		assert.Equal(t, "val", capturedReq.Header.Get("X-Custom"))
+	})
+}


### PR DESCRIPTION
## Summary

- Makes `OrgIDRoundTripper`, `AuthRoundTripper`, and `ExtraHeadersRoundTripper` check `GrafanaConfigFromContext(req.Context())` at request time, preferring context values when set and falling back to captured construction-time values otherwise.
- Updates `BuildTransport` to always include `OrgID` and `ExtraHeaders` middleware layers (even when construction-time values are zero/empty) so that per-request context overlays can inject headers dynamically.
- Existing single-tenant deployments are unaffected: when the context carries no overlay, behavior is identical to before.

This unblocks multi-tenant deployments where the OrgID and user identity are known per tool call (from MCP request context), not at startup.

Closes #794

## Test plan

- [x] All existing unit tests pass (no regressions)
- [x] New tests for `OrgIDRoundTripper` context override (4 cases: override, zero-to-nonzero, fallback, both-zero)
- [x] New tests for `AuthRoundTripper` context override (5 cases: OBO override, API key override, basic auth override, fallback, no-captured-auth)
- [x] New tests for `ExtraHeadersRoundTripper` context override (4 cases: override, merge, fallback, no-captured-headers)
- [x] New tests for `BuildTransport` end-to-end context overrides (4 cases: zero-orgid, empty-headers, auth-override, no-overlay-preserves-behavior)
- [x] `golangci-lint run` clean
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auth, org ID, and extra headers are applied to outbound HTTP requests by allowing context-based overrides, which could affect request routing/authorization if misconfigured. The behavior is covered by new unit tests but touches security-adjacent header injection logic.
> 
> **Overview**
> Enables **per-request overrides** for Grafana HTTP header injection by having `AuthRoundTripper`, `OrgIDRoundTripper`, and `ExtraHeadersRoundTripper` read `GrafanaConfigFromContext(req.Context())` at `RoundTrip` time, preferring context values over construction-time defaults.
> 
> Updates `BuildTransport` to **always include** the `ExtraHeadersRoundTripper` and (unless `WithoutOrgID`) the `OrgIDRoundTripper` even when startup config is empty/zero, so dynamic context overlays can still inject headers. Adds focused unit tests validating override/merge/fallback behavior end-to-end through `BuildTransport`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62616e14e9d55d5d47a2d081f448d77b3bb7f21d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->