### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2026-04-28
+
+### Added
+
+- Support per-request Grafana configuration via context in HTTP RoundTrippers ([#805](https://github.com/grafana/mcp-grafana/pull/805))
+- Optional `Logger` field on `GrafanaConfig` for structured logging ([#787](https://github.com/grafana/mcp-grafana/pull/787))
+
+### Fixed
+
+- Validate assertion timestamps as strings instead of `time.Time` to prevent type errors ([#793](https://github.com/grafana/mcp-grafana/pull/793))
+- Trim trailing slash from Grafana URL during proxied tool discovery to avoid malformed requests ([#788](https://github.com/grafana/mcp-grafana/pull/788))
+
+### Changed
+
+- Use shared `BuildTransport` constructor in `fetchPublicURL` for consistent HTTP middleware ([#789](https://github.com/grafana/mcp-grafana/pull/789))
+
 ## [0.12.0] - 2026-04-23
 
 ### Added
@@ -164,6 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.12.1]: https://github.com/grafana/mcp-grafana/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/grafana/mcp-grafana/compare/v0.11.6...v0.12.0
 [0.11.6]: https://github.com/grafana/mcp-grafana/compare/v0.11.5...v0.11.6
 [0.11.5]: https://github.com/grafana/mcp-grafana/compare/v0.11.4...v0.11.5


### PR DESCRIPTION
## Summary

- Bump version to v0.12.1
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.12.1` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating the changelog with release notes and links; no runtime code paths are modified.
> 
> **Overview**
> Documents the `v0.12.1` release in `CHANGELOG.md`, adding **Added/Fixed/Changed** entries and the new `[0.12.1]` compare link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb4bb8dbb7b35915d38c6887796cedc9bd3203b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->