### PR TITLE
fix: convert ISO 8601 timestamps to epoch ms in deeplink time range

### DIFF
--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -87,10 +89,10 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 		if args.TimeRange != nil {
 			rangeObj := map[string]string{}
 			if args.TimeRange.From != "" {
-				rangeObj["from"] = args.TimeRange.From
+				rangeObj["from"] = toGrafanaTimeParam(args.TimeRange.From)
 			}
 			if args.TimeRange.To != "" {
-				rangeObj["to"] = args.TimeRange.To
+				rangeObj["to"] = toGrafanaTimeParam(args.TimeRange.To)
 			}
 			if len(rangeObj) > 0 {
 				exploreState["range"] = rangeObj
@@ -121,10 +123,10 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 		}
 		timeParams := url.Values{}
 		if args.TimeRange.From != "" {
-			timeParams.Set("from", args.TimeRange.From)
+			timeParams.Set("from", toGrafanaTimeParam(args.TimeRange.From))
 		}
 		if args.TimeRange.To != "" {
-			timeParams.Set("to", args.TimeRange.To)
+			timeParams.Set("to", toGrafanaTimeParam(args.TimeRange.To))
 		}
 		if len(timeParams) > 0 {
 			deeplink = fmt.Sprintf("%s%s%s", deeplink, separator, timeParams.Encode())
@@ -157,4 +159,27 @@ var GenerateDeeplink = mcpgrafana.MustTool(
 
 func AddNavigationTools(mcp *server.MCPServer) {
 	GenerateDeeplink.Register(mcp)
+}
+
+// toGrafanaTimeParam converts a time value to a format Grafana understands
+// in URL query parameters. Grafana's Scenes parseUrlParam uses hardcoded
+// string length checks and only recognizes ISO 8601 at exactly 24 chars
+// (with milliseconds, e.g. "2026-04-28T12:45:00.000Z"). Shorter ISO 8601
+// strings like "2026-04-28T12:45:00Z" (20 chars) are silently ignored.
+// This function converts RFC 3339 timestamps to epoch milliseconds, which
+// is universally supported. Relative strings and epoch values pass through.
+func toGrafanaTimeParam(value string) string {
+	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return value
+	}
+	if strings.HasPrefix(value, "now") {
+		return value
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return strconv.FormatInt(t.UnixMilli(), 10)
+	}
+	if t, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return strconv.FormatInt(t.UnixMilli(), 10)
+	}
+	return value
 }

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -307,3 +307,70 @@ func TestGenerateDeeplink_RejectsMalformedBaseURL_NoClient(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid",
 		"error message must include 'invalid' for operator/LLM readability; got %q", err.Error())
 }
+
+func TestToGrafanaTimeParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"relative now-1h", "now-1h", "now-1h"},
+		{"relative now", "now", "now"},
+		{"epoch milliseconds", "1777380300000", "1777380300000"},
+		{"ISO 8601 UTC", "2026-04-28T12:45:00Z", "1777380300000"},
+		{"ISO 8601 with offset", "2026-04-28T13:45:00+01:00", "1777380300000"},
+		{"ISO 8601 with ms", "2026-04-28T12:45:00.000Z", "1777380300000"},
+		{"unrecognized format passthrough", "yesterday", "yesterday"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, toGrafanaTimeParam(tt.input))
+		})
+	}
+}
+
+func TestGenerateDeeplink_ISO8601TimeRange(t *testing.T) {
+	grafanaCfg := mcpgrafana.GrafanaConfig{
+		URL: "http://localhost:3000",
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	panelID := 8
+	params := GenerateDeeplinkParams{
+		ResourceType: "panel",
+		DashboardUID: stringPtr("dash-123"),
+		PanelID:      &panelID,
+		TimeRange: &TimeRange{
+			From: "2026-04-28T12:45:00Z",
+			To:   "2026-04-28T13:15:00Z",
+		},
+	}
+
+	result, err := generateDeeplink(ctx, params)
+	require.NoError(t, err)
+	assert.Contains(t, result, "from=1777380300000")
+	assert.Contains(t, result, "to=1777382100000")
+	assert.NotContains(t, result, "2026-04-28")
+}
+
+func TestGenerateDeeplink_ExploreISO8601TimeRange(t *testing.T) {
+	grafanaCfg := mcpgrafana.GrafanaConfig{
+		URL: "http://localhost:3000",
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	params := GenerateDeeplinkParams{
+		ResourceType:  "explore",
+		DatasourceUID: stringPtr("prometheus-uid"),
+		TimeRange: &TimeRange{
+			From: "2026-04-28T12:45:00Z",
+			To:   "2026-04-28T13:15:00Z",
+		},
+	}
+
+	result, err := generateDeeplink(ctx, params)
+	require.NoError(t, err)
+	assert.Contains(t, result, "1777380300000")
+	assert.Contains(t, result, "1777382100000")
+	assert.NotContains(t, result, "2026-04-28")
+}


### PR DESCRIPTION
## Summary

Fixes #807.

Grafana's Scenes [`parseUrlParam`](https://github.com/grafana/scenes/blob/main/packages/scenes/src/utils/parseUrlParam.ts) uses hardcoded string length checks and only recognizes ISO 8601 at exactly 24 chars (with milliseconds, e.g. `2026-04-28T12:45:00.000Z`). Shorter ISO 8601 strings like `2026-04-28T12:45:00Z` (20 chars) silently return `null`, causing Grafana to fall back to the dashboard's default time range.

The fix converts ISO 8601 timestamps to epoch milliseconds — universally supported across all Grafana versions and code paths. Relative strings (`now-1h`) and epoch values pass through unchanged.

## Changes

- Added `toGrafanaTimeParam()` in `tools/navigation.go` that detects RFC 3339 / ISO 8601 timestamps and converts them to epoch milliseconds.
- Applied the conversion to both the **dashboard/panel** `from`/`to` query params and the **explore** `rangeObj` JSON (addresses Cursor Bugbot feedback).

## Testing

- `TestToGrafanaTimeParam`: unit tests covering relative strings, epoch ms, ISO 8601 UTC, ISO 8601 with offset, ISO 8601 with ms, and unrecognized format passthrough.
- `TestGenerateDeeplink_ISO8601TimeRange`: panel deeplink with ISO 8601 timestamps produces epoch ms in the URL.
- `TestGenerateDeeplink_ExploreISO8601TimeRange`: explore deeplink with ISO 8601 timestamps produces epoch ms in the left JSON.
- All existing `TestGenerateDeeplink` tests continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to URL time-range formatting plus new tests; main impact is on how `from`/`to` are serialized for Grafana deeplink URLs.
> 
> **Overview**
> Fixes deeplink time ranges by converting RFC3339/ISO8601 timestamps in `timeRange.from`/`to` to epoch milliseconds before embedding them in dashboard/panel query params and Explore `left` state.
> 
> Adds `toGrafanaTimeParam()` to preserve relative (`now...`) and already-epoch values, and introduces unit/integration tests to ensure ISO8601 inputs no longer appear in generated URLs and are replaced with ms epoch values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b82d70b4a53bc4d33eff58d0e2063f85310b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->