### PR TITLE
fix: normalize Grafana URL trailing slash in WithGrafanaConfig

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -51,7 +51,7 @@ const (
 )
 
 func urlAndAPIKeyFromEnv(logger *slog.Logger) (string, string) {
-	u := os.Getenv(grafanaURLEnvVar)
+	u := strings.TrimRight(os.Getenv(grafanaURLEnvVar), "/")
 
 	// Check for the new service account token environment variable first
 	apiKey := os.Getenv(grafanaServiceAccountTokenEnvVar)
@@ -181,7 +181,7 @@ func orgIdFromHeaders(req *http.Request, logger *slog.Logger) int64 {
 }
 
 func urlAndAPIKeyFromHeaders(req *http.Request) (string, string) {
-	u := req.Header.Get(grafanaURLHeader)
+	u := strings.TrimRight(req.Header.Get(grafanaURLHeader), "/")
 
 	// Check for the new service account token header first
 	apiKey := req.Header.Get(grafanaServiceAccountTokenHeader)

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -51,7 +51,7 @@ const (
 )
 
 func urlAndAPIKeyFromEnv(logger *slog.Logger) (string, string) {
-	u := strings.TrimRight(os.Getenv(grafanaURLEnvVar), "/")
+	u := os.Getenv(grafanaURLEnvVar)
 
 	// Check for the new service account token environment variable first
 	apiKey := os.Getenv(grafanaServiceAccountTokenEnvVar)
@@ -181,7 +181,7 @@ func orgIdFromHeaders(req *http.Request, logger *slog.Logger) int64 {
 }
 
 func urlAndAPIKeyFromHeaders(req *http.Request) (string, string) {
-	u := strings.TrimRight(req.Header.Get(grafanaURLHeader), "/")
+	u := req.Header.Get(grafanaURLHeader)
 
 	// Check for the new service account token header first
 	apiKey := req.Header.Get(grafanaServiceAccountTokenHeader)
@@ -305,6 +305,7 @@ const (
 // WithGrafanaConfig adds Grafana configuration to the context.
 // This configuration includes API credentials, debug settings, and TLS options that will be used by all Grafana clients created from this context.
 func WithGrafanaConfig(ctx context.Context, config GrafanaConfig) context.Context {
+	config.URL = strings.TrimRight(config.URL, "/")
 	return context.WithValue(ctx, grafanaConfigKey{}, config)
 }
 
@@ -813,7 +814,7 @@ func fetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
 // doFetchPublicURL performs the actual HTTP request to fetch the public URL.
 func doFetchPublicURL(ctx context.Context, cfg *GrafanaConfig) string {
 	logger := cfg.LoggerOrDefault()
-	settingsURL := strings.TrimRight(cfg.URL, "/") + "/api/frontend/settings"
+	settingsURL := cfg.URL + "/api/frontend/settings"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, settingsURL, nil)
 	if err != nil {
 		logger.Warn("Failed to create request for frontend settings", "error", err)

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -675,6 +675,26 @@ func TestTextMimeConsumerOverride(t *testing.T) {
 	}
 }
 
+func TestWithGrafanaConfigNormalizesURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputURL string
+		wantURL  string
+	}{
+		{"trailing slash stripped", "https://example.grafana.net/", "https://example.grafana.net"},
+		{"multiple trailing slashes stripped", "https://example.grafana.net///", "https://example.grafana.net"},
+		{"no trailing slash unchanged", "https://example.grafana.net", "https://example.grafana.net"},
+		{"empty string unchanged", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: tt.inputURL})
+			got := GrafanaConfigFromContext(ctx)
+			assert.Equal(t, tt.wantURL, got.URL)
+		})
+	}
+}
+
 func TestHTTPTracingConfiguration(t *testing.T) {
 	t.Run("HTTP tracing always enabled for context propagation", func(t *testing.T) {
 		// Create context (HTTP tracing always enabled)

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -60,7 +60,7 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 	if config.URL == "" {
 		return nil, fmt.Errorf("grafana url not found in context")
 	}
-	grafanaBaseURL := strings.TrimRight(config.URL, "/")
+	grafanaBaseURL := config.URL
 
 	// Filter for datasources that support MCP and collect candidates
 	type candidate struct {

--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -33,7 +33,7 @@ type alertingClient struct {
 
 func newAlertingClientFromContext(ctx context.Context) (*alertingClient, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := strings.TrimRight(cfg.URL, "/")
+	baseURL := cfg.URL
 	parsedBaseURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Grafana base URL %q: %w", baseURL, err)

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -16,7 +15,7 @@ import (
 
 func newAssertsClient(ctx context.Context) (*Client, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	url := fmt.Sprintf("%s/api/plugins/grafana-asserts-app/resources/asserts/api-server", strings.TrimRight(cfg.URL, "/"))
+	url := fmt.Sprintf("%s/api/plugins/grafana-asserts-app/resources/asserts/api-server", cfg.URL)
 
 	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
 	if err != nil {

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -105,7 +105,7 @@ func newClickHouseClient(ctx context.Context, uid string) (*clickHouseClient, er
 	}
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := strings.TrimRight(cfg.URL, "/")
+	baseURL := cfg.URL
 
 	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
 	if err != nil {

--- a/tools/cloudwatch.go
+++ b/tools/cloudwatch.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
@@ -93,7 +92,7 @@ func newCloudWatchClient(ctx context.Context, uid string) (*cloudWatchClient, er
 	}
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := strings.TrimRight(cfg.URL, "/")
+	baseURL := cfg.URL
 
 	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
 	if err != nil {

--- a/tools/elasticsearch.go
+++ b/tools/elasticsearch.go
@@ -73,7 +73,7 @@ func newElasticsearchClient(ctx context.Context, uid string) (*ElasticsearchClie
 	}
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	url := fmt.Sprintf("%s/api/datasources/proxy/uid/%s", strings.TrimRight(cfg.URL, "/"), uid)
+	url := fmt.Sprintf("%s/api/datasources/proxy/uid/%s", cfg.URL, uid)
 
 	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
 	if err != nil {

--- a/tools/graphite.go
+++ b/tools/graphite.go
@@ -39,7 +39,7 @@ func newGraphiteClient(ctx context.Context, uid string) (*GraphiteClient, error)
 	}
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	grafanaURL := strings.TrimRight(cfg.URL, "/")
+	grafanaURL := cfg.URL
 	resourcesBase, proxyBase := datasourceProxyPaths(uid)
 	baseURL := grafanaURL + proxyBase
 
@@ -58,7 +58,7 @@ func newGraphiteClient(ctx context.Context, uid string) (*GraphiteClient, error)
 
 // doGet performs a GET request to the Graphite API via the Grafana proxy
 func (c *GraphiteClient) doGet(ctx context.Context, path string, params url.Values) ([]byte, error) {
-	fullURL := strings.TrimRight(c.baseURL, "/") + path
+	fullURL := c.baseURL + path
 	if len(params) > 0 {
 		fullURL += "?" + params.Encode()
 	}

--- a/tools/influxdb.go
+++ b/tools/influxdb.go
@@ -102,7 +102,7 @@ func newInfluxDBClient(ctx context.Context, uid string) (*influxDBClient, *model
 	}
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := strings.TrimRight(cfg.URL, "/")
+	baseURL := cfg.URL
 
 	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
 	if err != nil {

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -67,7 +67,7 @@ func newLokiClient(ctx context.Context, uid string) (*Client, error) {
 	}
 
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	grafanaURL := strings.TrimRight(cfg.URL, "/")
+	grafanaURL := cfg.URL
 	resourcesBase, proxyBase := datasourceProxyPaths(uid)
 	url := grafanaURL + proxyBase
 

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -36,7 +36,7 @@ func generateDeeplink(ctx context.Context, args GenerateDeeplinkParams) (string,
 		baseURL = gc.PublicURL
 	} else {
 		config := mcpgrafana.GrafanaConfigFromContext(ctx)
-		baseURL = strings.TrimRight(config.URL, "/")
+		baseURL = config.URL
 	}
 
 	if baseURL == "" {

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -19,7 +19,7 @@ import (
 // the OnCall URL from the jsonData.onCallApiUrl field in the response.
 // Returns the OnCall URL if found, or an error if the URL cannot be retrieved.
 func getOnCallURLFromSettings(ctx context.Context, cfg mcpgrafana.GrafanaConfig) (string, error) {
-	settingsURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/settings", strings.TrimRight(cfg.URL, "/"))
+	settingsURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/settings", cfg.URL)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", settingsURL, nil)
 	if err != nil {

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -83,7 +83,7 @@ type RenderTimeRange struct {
 
 func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallToolResult, error) {
 	config := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := strings.TrimRight(config.URL, "/")
+	baseURL := config.URL
 
 	if baseURL == "" {
 		return nil, fmt.Errorf("grafana URL not configured. Please set GRAFANA_URL environment variable or X-Grafana-URL header")

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -549,7 +549,7 @@ func executeInfluxDBQuery(ctx context.Context, datasourceUID string, panelData *
 // executeGrafanaDSQuery executes a query through Grafana's /api/ds/query endpoint
 func executeGrafanaDSQuery(ctx context.Context, payload map[string]interface{}) (interface{}, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := strings.TrimRight(cfg.URL, "/")
+	baseURL := cfg.URL
 
 	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Centralizes trailing-slash stripping in `WithGrafanaConfig` so that `config.URL` is guaranteed clean for all downstream consumers
- Fixes `find_slow_requests` and `find_error_pattern_logs` Sift tools which were completely broken in production
- Removes 17 redundant `strings.TrimRight` calls scattered across individual tool clients

## Root cause

The Sift client (`tools/sift.go`) stored `cfg.URL` without stripping the trailing slash, unlike every other client. When the URL was `https://host.grafana.net/`, Sift API calls went to `https://host.grafana.net//api/plugins/...` (double slash). The server returned a **301 redirect**, Go's `http.Client` followed it converting **POST→GET**, and the GET hit the list endpoint instead of create — returning an array where a single object was expected:

```
creating investigation: unmarshaling response: json: cannot unmarshal array into Go struct field .data of type tools.Investigation
```

This was confirmed via traces (e.g. `1bab414c2bc7ee248c03e343774c60a1`) showing the POST→301→GET chain, and Loki logs showing failures across 5+ tenants and all regions over the past 7 days.

## Approach

Rather than adding yet another per-tool `TrimRight` (which is what caused this bug — the Sift client simply forgot to do it), the fix normalizes the URL once in `WithGrafanaConfig`, making it impossible for any tool to receive a URL with a trailing slash. All 17 existing per-tool trims are now redundant and removed.

## Test plan

- [x] Added `TestWithGrafanaConfigNormalizesURL` covering trailing slash, multiple slashes, no slash, and empty string
- [x] `go vet ./...` passes
- [x] Verified no remaining `TrimRight(cfg.URL, "/")` calls except the one canonical location
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches URL construction across many tool clients; if any caller relied on preserving a trailing slash/path semantics, requests could change, but behavior is largely a safe normalization with test coverage.
> 
> **Overview**
> Centralizes Grafana URL normalization by stripping trailing slashes once in `WithGrafanaConfig`, ensuring downstream clients consistently build request URLs without accidental `//`.
> 
> Removes redundant per-client `strings.TrimRight` usage and updates multiple tool clients (and `fetchPublicURL`) to use the normalized `cfg.URL` directly when constructing API endpoints. Adds `TestWithGrafanaConfigNormalizesURL` to lock in the new normalization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7f13a31ea7b535ca0ac7542983b0f7dfe9cd69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->