### PR TITLE
fix: include OBO tokens in fetchPublicURL config

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -1001,6 +1001,8 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 		URL:          grafanaURL,
 		APIKey:       apiKey,
 		BasicAuth:    auth,
+		AccessToken:  config.AccessToken,
+		IDToken:      config.IDToken,
 		TLSConfig:    config.TLSConfig,
 		ExtraHeaders: config.ExtraHeaders,
 		Logger:       config.Logger,

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -1421,6 +1421,24 @@ func TestFetchPublicURL(t *testing.T) {
 		assert.Equal(t, "secret", capturedPass)
 	})
 
+	t.Run("sends OBO access and ID tokens", func(t *testing.T) {
+		var capturedAccessToken, capturedIDToken string
+		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedAccessToken = r.Header.Get("X-Access-Token")
+			capturedIDToken = r.Header.Get("X-Grafana-Id")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"appUrl": "https://grafana.example.com"}`))
+		})
+
+		fetchPublicURL(context.Background(), &GrafanaConfig{
+			URL:         ts.URL,
+			AccessToken: "obo-access-token",
+			IDToken:     "obo-id-token",
+		})
+		assert.Equal(t, "obo-access-token", capturedAccessToken)
+		assert.Equal(t, "obo-id-token", capturedIDToken)
+	})
+
 	t.Run("trims trailing slash from appUrl", func(t *testing.T) {
 		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
The fetchCfg for frontend settings requests was missing AccessToken and
IDToken, causing 401s for all cloud MCP sessions using OBO auth.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication used for the `/api/frontend/settings` call by adding OBO token headers; small in scope but touches request auth paths that can cause 401s if incorrect.
> 
> **Overview**
> Fixes `NewGrafanaClient` so the config used by `fetchPublicURL` now includes `AccessToken` and `IDToken`, ensuring the `/api/frontend/settings` request authenticates correctly for on-behalf-of (OBO) Grafana Cloud sessions.
> 
> Adds a regression test asserting `fetchPublicURL` sends `X-Access-Token` and `X-Grafana-Id` headers when OBO tokens are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ab7f20e53bcb309913e9f9d6911e9527dc556e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->