### PR TITLE
fix(alerting): handle common LLM type mismatches in alerting_manage_rules

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -71,13 +71,13 @@ func MustTool[T any, R any](
 // T is the request parameter type (must be a struct with jsonschema tags), and R is the response type which can be a string, struct, or *mcp.CallToolResult.
 type ToolHandlerFunc[T any, R any] = func(ctx context.Context, request T) (R, error)
 
-// unmarshalWithIntConversion unmarshals JSON data into a target struct,
-// automatically converting string values to integer types for integer-typed fields.
-// This allows MCP tool parameters to accept both string and integer values for integer fields.
+// unmarshalWithTypeCoercion unmarshals JSON data into a target struct,
+// automatically coercing common LLM type mismatches:
+//   - string → integer (e.g., "42" → 42)
+//   - string → []string (e.g., "value" → ["value"])
 //
 // Fast path: tries standard json.Unmarshal first (the common case — types already match).
-// Only on failure does it strip quotes from string-wrapped integers (e.g., "42" → 42)
-// and retry, delegating all validation (overflow, non-numeric strings, etc.) to json.Unmarshal.
+// Only on failure does it apply coercions and retry.
 func unmarshalWithIntConversion(data []byte, target any) error {
 	// Fast path: standard unmarshal covers the common case with no reflection overhead.
 	if err := json.Unmarshal(data, target); err == nil {
@@ -89,8 +89,10 @@ func unmarshalWithIntConversion(data []byte, target any) error {
 		return json.Unmarshal(data, target)
 	}
 
-	intFields := collectIntFieldNames(targetType.Elem())
-	if len(intFields) == 0 {
+	structType := targetType.Elem()
+	intFields := collectIntFieldNames(structType)
+	stringSliceFields := collectStringSliceFieldNames(structType)
+	if len(intFields) == 0 && len(stringSliceFields) == 0 {
 		return json.Unmarshal(data, target)
 	}
 
@@ -104,6 +106,13 @@ func unmarshalWithIntConversion(data []byte, target any) error {
 		v, ok := raw[name]
 		if ok && len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
 			raw[name] = v[1 : len(v)-1] // strip quotes: "42" → 42
+			changed = true
+		}
+	}
+	for name := range stringSliceFields {
+		v, ok := raw[name]
+		if ok && len(v) >= 2 && v[0] == '"' {
+			raw[name] = json.RawMessage("[" + string(v) + "]")
 			changed = true
 		}
 	}
@@ -155,6 +164,30 @@ func isIntegerKind(kind reflect.Kind) bool {
 		return true
 	}
 	return false
+}
+
+// collectStringSliceFieldNames returns the set of JSON field names that map to
+// []string types. This enables coercing a bare string into a single-element
+// array, which LLMs frequently send for array-typed parameters.
+func collectStringSliceFieldNames(structType reflect.Type) map[string]bool {
+	fields := make(map[string]bool)
+	for _, f := range reflect.VisibleFields(structType) {
+		if !f.IsExported() {
+			continue
+		}
+		ft := f.Type
+		if ft.Kind() == reflect.Slice && ft.Elem().Kind() == reflect.String {
+			name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+			if name == "-" {
+				continue
+			}
+			if name == "" {
+				name = f.Name
+			}
+			fields[name] = true
+		}
+	}
+	return fields
 }
 
 // ConvertTool converts a toolHandler function to an MCP Tool and ToolHandlerFunc.

--- a/tools/alerting_manage_rules_types.go
+++ b/tools/alerting_manage_rules_types.go
@@ -16,7 +16,6 @@ var promqlParser = parser.NewParser(parser.Options{})
 var validAlertStates = map[string]bool{
 	"firing": true, "pending": true, "normal": true,
 	"recovering": true, "nodata": true, "error": true,
-	"inactive": true,
 }
 
 // unquotedLabelValueRe matches a label matcher operator followed by an unquoted

--- a/tools/alerting_manage_rules_types.go
+++ b/tools/alerting_manage_rules_types.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -11,6 +12,35 @@ import (
 )
 
 var promqlParser = parser.NewParser(parser.Options{})
+
+var validAlertStates = map[string]bool{
+	"firing": true, "pending": true, "normal": true,
+	"recovering": true, "nodata": true, "error": true,
+	"inactive": true,
+}
+
+// unquotedLabelValueRe matches a label matcher operator followed by an unquoted
+// value. Values already starting with " are excluded by [^"}.
+var unquotedLabelValueRe = regexp.MustCompile(`(!=|!~|=~|=)\s*([^"}\s,][^},]*)`)
+
+// quoteUnquotedLabelValues adds double quotes around unquoted label values in
+// Prometheus-style selectors. LLMs frequently omit the required quotes, e.g.
+// {severity=critical} instead of {severity="critical"}.
+func quoteUnquotedLabelValues(s string) string {
+	return unquotedLabelValueRe.ReplaceAllStringFunc(s, func(match string) string {
+		groups := unquotedLabelValueRe.FindStringSubmatch(match)
+		if len(groups) < 3 {
+			return match
+		}
+		// When "=" matched but the value starts with "~", the actual operator
+		// is "=~" with an already-quoted value — the regex fell back from =~ to
+		// = because " didn't match the value-start character class.
+		if groups[1] == "=" && strings.HasPrefix(groups[2], "~") {
+			return match
+		}
+		return groups[1] + `"` + strings.TrimSpace(groups[2]) + `"`
+	})
+}
 
 type alertRuleSummary struct {
 	UID            string            `json:"uid"`
@@ -466,6 +496,7 @@ func parseMatcherStrings(strs []string) ([]*labels.Matcher, error) {
 		if !strings.HasPrefix(s, "{") {
 			s = "{" + s + "}"
 		}
+		s = quoteUnquotedLabelValues(s)
 		parsed, err := promqlParser.ParseMetricSelector(s)
 		if err != nil {
 			return nil, fmt.Errorf("invalid matcher %q: %w", s, err)
@@ -487,6 +518,7 @@ func parseSelectorStrings(strs []string) ([]Selector, error) {
 		if !strings.HasPrefix(s, "{") {
 			s = "{" + s + "}"
 		}
+		s = quoteUnquotedLabelValues(s)
 		parsed, err := promqlParser.ParseMetricSelector(s)
 		if err != nil {
 			return nil, fmt.Errorf("invalid label selector %q: %w", s, err)
@@ -511,6 +543,11 @@ func buildGetRulesOpts(f listFilterParams, folderUID, ruleGroup string) (*GetRul
 	}
 	if folderUID != "" && f.SearchFolder != "" {
 		return nil, fmt.Errorf("folder_uid and search_folder are mutually exclusive")
+	}
+	for _, s := range f.States {
+		if !validAlertStates[s] {
+			return nil, fmt.Errorf("invalid state %q, must be one of: firing, pending, normal, recovering, nodata, error", s)
+		}
 	}
 	matchers, err := parseMatcherStrings(f.Matchers)
 	if err != nil {

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -1589,7 +1589,7 @@ func TestQuoteUnquotedLabelValues(t *testing.T) {
 
 func TestBuildGetRulesOpts_StateValidation(t *testing.T) {
 	t.Run("valid states accepted", func(t *testing.T) {
-		for _, state := range []string{"firing", "pending", "normal", "recovering", "nodata", "error", "inactive"} {
+		for _, state := range []string{"firing", "pending", "normal", "recovering", "nodata", "error"} {
 			_, err := buildGetRulesOpts(listFilterParams{States: []string{state}}, "", "")
 			require.NoError(t, err, "state %q should be valid", state)
 		}

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -1525,3 +1525,120 @@ func TestAlertQueryModel_JSONRoundTrip(t *testing.T) {
 		require.Equal(t, "C", params[0])
 	})
 }
+
+func TestQuoteUnquotedLabelValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "already quoted",
+			input:    `{severity="critical"}`,
+			expected: `{severity="critical"}`,
+		},
+		{
+			name:     "unquoted value",
+			input:    `{severity=critical}`,
+			expected: `{severity="critical"}`,
+		},
+		{
+			name:     "unquoted regex",
+			input:    `{team=~backend.*}`,
+			expected: `{team=~"backend.*"}`,
+		},
+		{
+			name:     "quoted regex unchanged",
+			input:    `{team=~"backend.*"}`,
+			expected: `{team=~"backend.*"}`,
+		},
+		{
+			name:     "multiple unquoted",
+			input:    `{severity=critical, team=backend}`,
+			expected: `{severity="critical", team="backend"}`,
+		},
+		{
+			name:     "mixed quoted and unquoted",
+			input:    `{severity="critical", team=backend}`,
+			expected: `{severity="critical", team="backend"}`,
+		},
+		{
+			name:     "negation unquoted",
+			input:    `{env!=dev}`,
+			expected: `{env!="dev"}`,
+		},
+		{
+			name:     "negative regex unquoted",
+			input:    `{env!~staging.*}`,
+			expected: `{env!~"staging.*"}`,
+		},
+		{
+			name:     "empty selector",
+			input:    `{}`,
+			expected: `{}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := quoteUnquotedLabelValues(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBuildGetRulesOpts_StateValidation(t *testing.T) {
+	t.Run("valid states accepted", func(t *testing.T) {
+		for _, state := range []string{"firing", "pending", "normal", "recovering", "nodata", "error", "inactive"} {
+			_, err := buildGetRulesOpts(listFilterParams{States: []string{state}}, "", "")
+			require.NoError(t, err, "state %q should be valid", state)
+		}
+	})
+
+	t.Run("invalid state rejected", func(t *testing.T) {
+		_, err := buildGetRulesOpts(listFilterParams{States: []string{"unknown"}}, "", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid state")
+	})
+
+	t.Run("mixed valid and invalid states rejected", func(t *testing.T) {
+		_, err := buildGetRulesOpts(listFilterParams{States: []string{"firing", "bogus"}}, "", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid state")
+	})
+}
+
+func TestParseSelectorStrings_UnquotedValues(t *testing.T) {
+	t.Run("accepts unquoted values", func(t *testing.T) {
+		selectors, err := parseSelectorStrings([]string{`{severity=critical}`})
+		require.NoError(t, err)
+		require.Len(t, selectors, 1)
+		require.Len(t, selectors[0].Filters, 1)
+		require.Equal(t, "severity", selectors[0].Filters[0].Name)
+		require.Equal(t, "critical", selectors[0].Filters[0].Value)
+	})
+
+	t.Run("accepts already-quoted values", func(t *testing.T) {
+		selectors, err := parseSelectorStrings([]string{`{severity="critical"}`})
+		require.NoError(t, err)
+		require.Len(t, selectors, 1)
+		require.Equal(t, "critical", selectors[0].Filters[0].Value)
+	})
+}
+
+func TestParseMatcherStrings_UnquotedValues(t *testing.T) {
+	t.Run("accepts unquoted values", func(t *testing.T) {
+		matchers, err := parseMatcherStrings([]string{`severity=critical`})
+		require.NoError(t, err)
+		require.Len(t, matchers, 1)
+		require.Equal(t, "severity", matchers[0].Name)
+		require.Equal(t, "critical", matchers[0].Value)
+	})
+
+	t.Run("accepts already-quoted values", func(t *testing.T) {
+		matchers, err := parseMatcherStrings([]string{`severity="critical"`})
+		require.NoError(t, err)
+		require.Len(t, matchers, 1)
+		require.Equal(t, "critical", matchers[0].Value)
+	})
+}

--- a/tools_string_to_int_test.go
+++ b/tools_string_to_int_test.go
@@ -463,3 +463,79 @@ func TestUnmarshalWithAllIntegerTypes(t *testing.T) {
 		}
 	})
 }
+
+func TestUnmarshalWithStringToSliceCoercion(t *testing.T) {
+	type params struct {
+		Tags   []string `json:"tags,omitempty"`
+		States []string `json:"states,omitempty"`
+		Name   string   `json:"name"`
+		Count  int      `json:"count"`
+	}
+
+	t.Run("accepts array as-is", func(t *testing.T) {
+		data := `{"tags":["a","b"],"name":"test","count":1}`
+		var got params
+		require.NoError(t, unmarshalWithIntConversion([]byte(data), &got))
+		assert.Equal(t, []string{"a", "b"}, got.Tags)
+		assert.Equal(t, "test", got.Name)
+	})
+
+	t.Run("coerces string to single-element array", func(t *testing.T) {
+		data := `{"tags":"{severity=\"critical\"}","name":"test","count":1}`
+		var got params
+		require.NoError(t, unmarshalWithIntConversion([]byte(data), &got))
+		assert.Equal(t, []string{`{severity="critical"}`}, got.Tags)
+	})
+
+	t.Run("coerces string and int simultaneously", func(t *testing.T) {
+		data := `{"tags":"single","name":"test","count":"42"}`
+		var got params
+		require.NoError(t, unmarshalWithIntConversion([]byte(data), &got))
+		assert.Equal(t, []string{"single"}, got.Tags)
+		assert.Equal(t, 42, got.Count)
+	})
+
+	t.Run("omitted array field stays nil", func(t *testing.T) {
+		data := `{"name":"test","count":1}`
+		var got params
+		require.NoError(t, unmarshalWithIntConversion([]byte(data), &got))
+		assert.Nil(t, got.Tags)
+	})
+
+	t.Run("handles embedded struct with string slice", func(t *testing.T) {
+		type inner struct {
+			Filters []string `json:"filters,omitempty"`
+		}
+		type outer struct {
+			inner
+			Name string `json:"name"`
+		}
+		data := `{"filters":"one-filter","name":"test"}`
+		var got outer
+		require.NoError(t, unmarshalWithIntConversion([]byte(data), &got))
+		assert.Equal(t, []string{"one-filter"}, got.Filters)
+	})
+
+	t.Run("end-to-end through ConvertTool", func(t *testing.T) {
+		type toolParams struct {
+			Labels []string `json:"labels,omitempty" jsonschema:"description=Label selectors"`
+		}
+		handler := func(ctx context.Context, p toolParams) (string, error) {
+			if len(p.Labels) == 1 && p.Labels[0] == "test" {
+				return "ok", nil
+			}
+			return "", nil
+		}
+		_, h, err := ConvertTool("test", "test", handler)
+		require.NoError(t, err)
+
+		result, err := h(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "test",
+				Arguments: map[string]any{"labels": "test"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", result.Content[0].(mcp.TextContent).Text)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes three classes of production errors in `alerting_manage_rules` observed via cloud MCP telemetry:

- **String→[]string coercion**: LLMs send a bare string for array parameters (`label_selectors`, `states`, `matchers`). Extended the unmarshal layer in `tools.go` to auto-wrap bare strings in a single-element array for `[]string` fields. This benefits all tools, not just alerting.
- **State validation**: LLMs send invalid state values like `"unknown"` which Grafana's API rejects with a 400. Added client-side validation against the allowed set (`firing`, `pending`, `normal`, `recovering`, `nodata`, `error`, `inactive`).
- **Unquoted label values**: LLMs send `{severity=critical}` instead of `{severity="critical"}`. Added a `quoteUnquotedLabelValues` preprocessing step that auto-quotes unquoted values before PromQL parsing.

## Changes

- `tools.go` — `collectStringSliceFieldNames` + extended `unmarshalWithIntConversion` for string→[]string coercion
- `tools/alerting_manage_rules_types.go` — `validAlertStates` allowlist, `quoteUnquotedLabelValues` regex preprocessor, validation in `buildGetRulesOpts`, preprocessing in `parseSelectorStrings`/`parseMatcherStrings`
- `tools_string_to_int_test.go` — tests for string→[]string coercion (unit + end-to-end through `ConvertTool`)
- `tools/alerting_manage_rules_unit_test.go` — tests for quoting, state validation, and parse functions

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New unit tests for `quoteUnquotedLabelValues` (9 cases including edge cases)
- [x] New unit tests for state validation (valid, invalid, mixed)
- [x] New unit tests for `parseSelectorStrings`/`parseMatcherStrings` with unquoted values
- [x] New unit tests for string→[]string coercion (array passthrough, single string, combined with int coercion, embedded structs, end-to-end)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the shared tool argument decoding path and could alter how some existing tools interpret string vs `[]string` inputs. Alerting filter validation/normalization is low risk but may reject previously accepted invalid state values earlier.
> 
> **Overview**
> Improves tool argument robustness by extending `unmarshalWithIntConversion` to also coerce a bare string into a single-element `[]string` for any tool parameter struct field typed as `[]string`.
> 
> Hardens `alerting_manage_rules` filtering by (1) auto-quoting unquoted PromQL label selector values before parsing, and (2) validating `states` against an allowlist before building `GetRulesOpts`, returning clearer client-side errors.
> 
> Adds focused unit tests for the new coercions, selector/matcher quoting behavior, and state validation (including an end-to-end `ConvertTool` decode case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14eb4a9f0712e56f4171aa267acdd0ee1b5240df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->