### PR TITLE
fix(dashboard): walk legacy schemaVersion <= 14 rows in panel walkers

### DIFF
--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -448,7 +448,9 @@ func getDashboardSummary(ctx context.Context, args GetDashboardSummaryParams) (*
 	// Extract time range
 	summary.TimeRange = extractTimeRange(db)
 
-	// Extract panel summaries
+	// Extract panel summaries. Modern dashboards put panels at the top
+	// level; legacy schemaVersion <= 14 dashboards put them under
+	// "rows":[{panels:[...]}] with no top-level "panels".
 	if panels := safeArray(db, "panels"); panels != nil {
 		summary.PanelCount = len(panels)
 		for _, p := range panels {
@@ -456,6 +458,19 @@ func getDashboardSummary(ctx context.Context, args GetDashboardSummaryParams) (*
 				summary.Panels = append(summary.Panels, extractPanelSummary(panelObj))
 			}
 		}
+	} else if rows := safeArray(db, "rows"); rows != nil {
+		for _, r := range rows {
+			row, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, p := range safeArray(row, "panels") {
+				if panelObj, ok := p.(map[string]interface{}); ok {
+					summary.Panels = append(summary.Panels, extractPanelSummary(panelObj))
+				}
+			}
+		}
+		summary.PanelCount = len(summary.Panels)
 	}
 
 	// Extract variable summaries

--- a/tools/dashboard_helpers.go
+++ b/tools/dashboard_helpers.go
@@ -93,35 +93,35 @@ func extractDashboardVariables(db map[string]interface{}) map[string]VariableInf
 // Supports both modern dashboards (top-level "panels", with row-typed entries
 // holding nested panels) and legacy schemaVersion <= 14 dashboards
 // (top-level "rows":[{panels:[...]}], no top-level "panels" array).
+// The legacy fallback only triggers when "panels" is absent, mirroring
+// getDashboardSummary so dashboards carrying both keys aren't walked twice.
 func findPanelByID(db map[string]interface{}, panelID int) (map[string]interface{}, error) {
-	panels := safeArray(db, "panels")
-	rows := safeArray(db, "rows")
-	if panels == nil && rows == nil {
-		return nil, fmt.Errorf("dashboard has no panels")
-	}
+	if panels := safeArray(db, "panels"); panels != nil {
+		for _, p := range panels {
+			panel, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
 
-	// Search top-level panels (modern schema)
-	for _, p := range panels {
-		panel, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
+			if safeInt(panel, "id") == panelID {
+				return panel, nil
+			}
 
-		if safeInt(panel, "id") == panelID {
-			return panel, nil
-		}
-
-		// Check for nested panels in row-type entries
-		if safeString(panel, "type") == "row" {
-			for _, np := range safeArray(panel, "panels") {
-				if nested, ok := np.(map[string]interface{}); ok && safeInt(nested, "id") == panelID {
-					return nested, nil
+			if safeString(panel, "type") == "row" {
+				for _, np := range safeArray(panel, "panels") {
+					if nested, ok := np.(map[string]interface{}); ok && safeInt(nested, "id") == panelID {
+						return nested, nil
+					}
 				}
 			}
 		}
+		return nil, fmt.Errorf("panel with ID %d not found", panelID)
 	}
 
-	// Search legacy top-level rows (schemaVersion <= 14)
+	rows := safeArray(db, "rows")
+	if rows == nil {
+		return nil, fmt.Errorf("dashboard has no panels")
+	}
 	for _, r := range rows {
 		row, ok := r.(map[string]interface{})
 		if !ok {
@@ -141,28 +141,31 @@ func findPanelByID(db map[string]interface{}, panelID int) (map[string]interface
 // panels inside rows. Handles modern dashboards (top-level "panels", with
 // row-typed entries that hold nested panels) and legacy schemaVersion <= 14
 // dashboards (top-level "rows":[{panels:[...]}], no top-level "panels").
+// The legacy fallback only triggers when "panels" is absent, mirroring
+// getDashboardSummary so dashboards carrying both keys don't yield duplicates.
 func collectAllPanels(db map[string]interface{}) []map[string]interface{} {
 	var result []map[string]interface{}
 
-	for _, p := range safeArray(db, "panels") {
-		panel, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
+	if panels := safeArray(db, "panels"); panels != nil {
+		for _, p := range panels {
+			panel, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
 
-		result = append(result, panel)
+			result = append(result, panel)
 
-		// Include nested panels from row-type entries (modern schema)
-		if safeString(panel, "type") == "row" {
-			for _, np := range safeArray(panel, "panels") {
-				if nested, ok := np.(map[string]interface{}); ok {
-					result = append(result, nested)
+			if safeString(panel, "type") == "row" {
+				for _, np := range safeArray(panel, "panels") {
+					if nested, ok := np.(map[string]interface{}); ok {
+						result = append(result, nested)
+					}
 				}
 			}
 		}
+		return result
 	}
 
-	// Include panels from legacy top-level rows (schemaVersion <= 14)
 	for _, r := range safeArray(db, "rows") {
 		row, ok := r.(map[string]interface{})
 		if !ok {

--- a/tools/dashboard_helpers.go
+++ b/tools/dashboard_helpers.go
@@ -89,36 +89,47 @@ func extractDashboardVariables(db map[string]interface{}) map[string]VariableInf
 	return variables
 }
 
-// findPanelByID searches for a panel by ID, including nested panels in rows
+// findPanelByID searches for a panel by ID, including nested panels in rows.
+// Supports both modern dashboards (top-level "panels", with row-typed entries
+// holding nested panels) and legacy schemaVersion <= 14 dashboards
+// (top-level "rows":[{panels:[...]}], no top-level "panels" array).
 func findPanelByID(db map[string]interface{}, panelID int) (map[string]interface{}, error) {
 	panels := safeArray(db, "panels")
-	if panels == nil {
+	rows := safeArray(db, "rows")
+	if panels == nil && rows == nil {
 		return nil, fmt.Errorf("dashboard has no panels")
 	}
 
-	// Search top-level panels
+	// Search top-level panels (modern schema)
 	for _, p := range panels {
 		panel, ok := p.(map[string]interface{})
 		if !ok {
 			continue
 		}
 
-		id := safeInt(panel, "id")
-		if id == panelID {
+		if safeInt(panel, "id") == panelID {
 			return panel, nil
 		}
 
-		// Check for nested panels in row type
+		// Check for nested panels in row-type entries
 		if safeString(panel, "type") == "row" {
-			nestedPanels := safeArray(panel, "panels")
-			for _, np := range nestedPanels {
-				nestedPanel, ok := np.(map[string]interface{})
-				if !ok {
-					continue
+			for _, np := range safeArray(panel, "panels") {
+				if nested, ok := np.(map[string]interface{}); ok && safeInt(nested, "id") == panelID {
+					return nested, nil
 				}
-				if safeInt(nestedPanel, "id") == panelID {
-					return nestedPanel, nil
-				}
+			}
+		}
+	}
+
+	// Search legacy top-level rows (schemaVersion <= 14)
+	for _, r := range rows {
+		row, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, np := range safeArray(row, "panels") {
+			if nested, ok := np.(map[string]interface{}); ok && safeInt(nested, "id") == panelID {
+				return nested, nil
 			}
 		}
 	}
@@ -126,16 +137,14 @@ func findPanelByID(db map[string]interface{}, panelID int) (map[string]interface
 	return nil, fmt.Errorf("panel with ID %d not found", panelID)
 }
 
-// collectAllPanels returns all panels from a dashboard, including nested panels inside rows
+// collectAllPanels returns all panels from a dashboard, including nested
+// panels inside rows. Handles modern dashboards (top-level "panels", with
+// row-typed entries that hold nested panels) and legacy schemaVersion <= 14
+// dashboards (top-level "rows":[{panels:[...]}], no top-level "panels").
 func collectAllPanels(db map[string]interface{}) []map[string]interface{} {
 	var result []map[string]interface{}
 
-	panels := safeArray(db, "panels")
-	if panels == nil {
-		return result
-	}
-
-	for _, p := range panels {
+	for _, p := range safeArray(db, "panels") {
 		panel, ok := p.(map[string]interface{})
 		if !ok {
 			continue
@@ -143,13 +152,25 @@ func collectAllPanels(db map[string]interface{}) []map[string]interface{} {
 
 		result = append(result, panel)
 
-		// Also include nested panels from row-type panels
+		// Include nested panels from row-type entries (modern schema)
 		if safeString(panel, "type") == "row" {
-			nestedPanels := safeArray(panel, "panels")
-			for _, np := range nestedPanels {
-				if nestedPanel, ok := np.(map[string]interface{}); ok {
-					result = append(result, nestedPanel)
+			for _, np := range safeArray(panel, "panels") {
+				if nested, ok := np.(map[string]interface{}); ok {
+					result = append(result, nested)
 				}
+			}
+		}
+	}
+
+	// Include panels from legacy top-level rows (schemaVersion <= 14)
+	for _, r := range safeArray(db, "rows") {
+		row, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, np := range safeArray(row, "panels") {
+			if nested, ok := np.(map[string]interface{}); ok {
+				result = append(result, nested)
 			}
 		}
 	}

--- a/tools/dashboard_helpers_test.go
+++ b/tools/dashboard_helpers_test.go
@@ -688,6 +688,36 @@ func TestCollectAllPanels(t *testing.T) {
 
 		assert.Empty(t, panels)
 	})
+
+	t.Run("does not duplicate when both panels and rows are present", func(t *testing.T) {
+		// A dashboard carrying both top-level "panels" and legacy "rows"
+		// (e.g. mid-migration) must not yield duplicates: prefer the
+		// modern walk and skip the legacy rows fallback, mirroring
+		// getDashboardSummary.
+		db := map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"id":    float64(1),
+					"title": "Modern Panel",
+				},
+			},
+			"rows": []interface{}{
+				map[string]interface{}{
+					"panels": []interface{}{
+						map[string]interface{}{
+							"id":    float64(2),
+							"title": "Legacy Panel",
+						},
+					},
+				},
+			},
+		}
+
+		panels := collectAllPanels(db)
+
+		require.Len(t, panels, 1)
+		assert.Equal(t, "Modern Panel", panels[0]["title"])
+	})
 }
 
 func TestReplaceSimpleDollarVar(t *testing.T) {

--- a/tools/dashboard_helpers_test.go
+++ b/tools/dashboard_helpers_test.go
@@ -3,11 +3,62 @@
 package tools
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// loadLegacyRowsDashboard returns the dashboard map from the
+// schemaVersion-14 fixture (top-level "rows":[{panels:[...]}], no
+// top-level "panels" array).
+func loadLegacyRowsDashboard(t *testing.T) map[string]interface{} {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/legacy_rows_dashboard.json")
+	require.NoError(t, err)
+	var doc struct {
+		Dashboard map[string]interface{} `json:"dashboard"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	return doc.Dashboard
+}
+
+// TestLegacyRowsSchemaWalker pins the bug fix: legacy Grafana dashboards
+// (schemaVersion <= 14) keep panels under "rows":[{panels:[...]}], with no
+// top-level "panels" array. The walker must not return zero panels.
+func TestLegacyRowsSchemaWalker(t *testing.T) {
+	db := loadLegacyRowsDashboard(t)
+
+	// Sanity: this fixture has no top-level "panels" — only "rows".
+	require.Nil(t, safeArray(db, "panels"), "fixture must have no top-level panels")
+	require.NotNil(t, safeArray(db, "rows"), "fixture must have top-level rows")
+
+	t.Run("collectAllPanels walks legacy rows", func(t *testing.T) {
+		panels := collectAllPanels(db)
+		require.Len(t, panels, 4, "expected all four legacy-row panels")
+
+		titles := make([]string, 0, len(panels))
+		for _, p := range panels {
+			titles = append(titles, safeString(p, "title"))
+		}
+		assert.ElementsMatch(t,
+			[]string{"CPU", "Memory (go heap inuse)", "Receive bandwidth", "Transmit bandwidth"},
+			titles,
+		)
+	})
+
+	t.Run("findPanelByID resolves legacy-row panels", func(t *testing.T) {
+		panel, err := findPanelByID(db, 5)
+		require.NoError(t, err)
+		assert.Equal(t, "Receive bandwidth", safeString(panel, "title"))
+
+		_, err = findPanelByID(db, 999)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
 
 func TestExtractDashboardVariables(t *testing.T) {
 	t.Run("extracts variables from templating", func(t *testing.T) {

--- a/tools/testdata/legacy_rows_dashboard.json
+++ b/tools/testdata/legacy_rows_dashboard.json
@@ -1,0 +1,82 @@
+{
+  "dashboard": {
+    "uid": "legacy-rows-fixture",
+    "title": "Mimir / Compactor resources",
+    "schemaVersion": 14,
+    "tags": ["mimir", "compactor"],
+    "templating": {
+      "list": [
+        {
+          "name": "datasource",
+          "type": "datasource",
+          "current": {"value": "default"}
+        },
+        {
+          "name": "cluster",
+          "type": "query",
+          "current": {"value": "$__all"}
+        }
+      ]
+    },
+    "rows": [
+      {
+        "title": "CPU and memory",
+        "panels": [
+          {
+            "id": 1,
+            "title": "CPU",
+            "type": "timeseries",
+            "datasource": "$datasource",
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster_id=~\"$cluster\",container=~\"compactor\"}[$__rate_interval]))"
+              }
+            ]
+          },
+          {
+            "id": 2,
+            "title": "Memory (go heap inuse)",
+            "type": "timeseries",
+            "datasource": "$datasource",
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster_id=~\"$cluster\",container=~\"compactor\"})"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Network",
+        "panels": [
+          {
+            "id": 5,
+            "title": "Receive bandwidth",
+            "type": "timeseries",
+            "datasource": "$datasource",
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum by(pod) (rate(container_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))"
+              }
+            ]
+          },
+          {
+            "id": 6,
+            "title": "Transmit bandwidth",
+            "type": "timeseries",
+            "datasource": "$datasource",
+            "targets": [
+              {
+                "refId": "A",
+                "expr": "sum by(pod) (rate(container_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

The dashboard panel walkers (`collectAllPanels`, `findPanelByID`, and `getDashboardSummary`) only inspect `dashboard["panels"]`. 
Grafana dashboards exported with `schemaVersion <= 14` (still common in mixin output for Mimir, Loki, Tempo, etc.) keep their panels under `dashboard["rows"][i]["panels"]` and have **no** top-level `panels` array.

As a consequence, against any such dashboard:

- `get_dashboard_panel_queries` returns `count: 0`
- `get_dashboard_summary` returns `panelCount: 0` with an empty `panels` list
- `get_dashboard_property` (and any caller of `findPanelByID`) cannot resolve panels by ID

Reproducer: any Grafana instance carrying the upstream `mimir-mixin` dashboards (e.g. `Mimir / Compactor resources`) is `schemaVersion: 14` with top-level `rows`.

## Fix

After exhausting the modern top-level `panels` walk, also iterate `safeArray(db, "rows")` and append each row's `panels[*]`:

- `findPanelByID` and `collectAllPanels`: append legacy-row panels in addition to the modern walk (no behaviour change for modern dashboards that have a top-level `panels` array).
- `getDashboardSummary`: the rows fallback only kicks in when `"panels"` is absent, so dashboards that include both for back-compat are not double-counted.

The "no panels at all" error in `findPanelByID` now triggers only when both `"panels"` and `"rows"` are absent.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive traversal changes limited to dashboard JSON walking, with explicit tests covering legacy and mixed-schema cases.
> 
> **Overview**
> Fixes dashboard inspection tools to handle legacy Grafana exports (schemaVersion <= 14) that store panels under `rows[].panels` instead of top-level `panels`.
> 
> `getDashboardSummary`, `collectAllPanels`, and `findPanelByID` now fall back to walking `rows` *only when* `panels` is absent (avoiding double-counting on mixed dashboards), and unit tests + a new `legacy_rows_dashboard.json` fixture pin the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f6d254ea91394bf3cdae96c4054b469be2c538f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->