### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-04-29
+
+### Fixed
+
+- Handle common LLM type mismatches (e.g. string vs number) in `alerting_manage_rules` to prevent tool call failures ([#816](https://github.com/grafana/mcp-grafana/pull/816))
+- Convert ISO 8601 timestamps to epoch milliseconds in deeplink time ranges for correct Grafana URL generation ([#808](https://github.com/grafana/mcp-grafana/pull/808))
+- Remove broken `search_logs` tool that was returning errors ([#815](https://github.com/grafana/mcp-grafana/pull/815))
+- Normalize trailing slash in Grafana URL within `WithGrafanaConfig` to prevent malformed API requests ([#809](https://github.com/grafana/mcp-grafana/pull/809))
+- Include on-behalf-of tokens in `fetchPublicURL` config so delegated identity works for public URL resolution ([#810](https://github.com/grafana/mcp-grafana/pull/810))
+- Walk legacy dashboard rows (schemaVersion <= 14) in panel walkers so older dashboards are fully traversed ([#817](https://github.com/grafana/mcp-grafana/pull/817))
+
 ## [0.12.1] - 2026-04-28
 
 ### Added
@@ -180,6 +191,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.13.0]: https://github.com/grafana/mcp-grafana/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/grafana/mcp-grafana/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/grafana/mcp-grafana/compare/v0.11.6...v0.12.0
 [0.11.6]: https://github.com/grafana/mcp-grafana/compare/v0.11.5...v0.11.6


### PR DESCRIPTION
## Summary

- Bump version to v0.13.0
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.13.0` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no code behavior is modified.
> 
> **Overview**
> Adds a new `0.13.0` section to `CHANGELOG.md` (dated 2026-04-29) documenting the release’s fixes, including type-mismatch hardening in `alerting_manage_rules`, timestamp conversion for deeplinks, removal of the broken `search_logs` tool, URL normalization in `WithGrafanaConfig`, on-behalf-of token handling in `fetchPublicURL`, and improved traversal of legacy dashboards.
> 
> Also adds the `[0.13.0]` GitHub compare link at the bottom of the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e4e2449de0c5cc93dbb7bb5c6f3ef142c7209e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->