### PR TITLE
fix(alerting): query datasource rules via proxy with per-type path

### DIFF
--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -219,11 +219,24 @@ type alert struct {
 	Value       string        `json:"value"`
 }
 
-// GetDatasourceRules queries a datasource's Prometheus ruler API
-func (c *alertingClient) GetDatasourceRules(ctx context.Context, datasourceUID string, opts *GetRulesOpts) (*v1.RulesResult, error) {
-	// use the Grafana unified endpoint - maybe we need to use the datasource proxy endpoint in the future as this
-	// is an api for internal use
-	path := fmt.Sprintf("/api/prometheus/%s/api/v1/rules", datasourceUID)
+// GetDatasourceRules queries a datasource's Prometheus ruler API via the
+// generic Grafana datasource proxy. The proxy appends the request path to
+// the configured datasource URL, which already carries any backend-specific
+// prefix (e.g. Mimir gateway URLs that end in /prometheus). The legacy
+// /api/prometheus/{uid}/api/v1/rules unified endpoint applies an internal
+// path template that does not compose correctly with such datasource URLs.
+//
+// dsType is the Grafana datasource type (e.g. "prometheus", "loki"). It
+// determines which ruler path is appended to the datasource URL: Loki
+// exposes the Prometheus-format ruler under /prometheus/api/v1/rules,
+// while Prometheus/Mimir/Cortex datasources expose it at /api/v1/rules
+// (with any /prometheus prefix already baked into the datasource URL).
+func (c *alertingClient) GetDatasourceRules(ctx context.Context, datasourceUID, dsType string, opts *GetRulesOpts) (*v1.RulesResult, error) {
+	apiPath := "/api/v1/rules"
+	if strings.Contains(strings.ToLower(dsType), "loki") {
+		apiPath = "/prometheus/api/v1/rules"
+	}
+	path := fmt.Sprintf("/api/datasources/proxy/uid/%s%s", datasourceUID, apiPath)
 	var params url.Values
 	if opts != nil {
 		params = opts.queryValues()

--- a/tools/alerting_client_test.go
+++ b/tools/alerting_client_test.go
@@ -312,22 +312,36 @@ func TestAlertingClient_GetDatasourceRules(t *testing.T) {
 	tests := []struct {
 		name          string
 		dsUID         string
+		dsType        string
 		opts          *GetRulesOpts
 		assertRequest func(t *testing.T, r *http.Request)
 	}{
 		{
-			name:  "nil opts produces no query params",
-			dsUID: "my-datasource",
-			opts:  nil,
+			name:   "prometheus datasource hits /api/v1/rules via proxy",
+			dsUID:  "my-datasource",
+			dsType: "prometheus",
+			opts:   nil,
 			assertRequest: func(t *testing.T, r *http.Request) {
 				t.Helper()
-				require.Equal(t, "/api/prometheus/my-datasource/api/v1/rules", r.URL.Path)
+				require.Equal(t, "/api/datasources/proxy/uid/my-datasource/api/v1/rules", r.URL.Path)
 				require.Empty(t, r.URL.RawQuery)
 			},
 		},
 		{
-			name:  "opts are forwarded as query params",
-			dsUID: "prom-ds",
+			name:   "loki datasource hits /prometheus/api/v1/rules via proxy",
+			dsUID:  "loki-ds",
+			dsType: "loki",
+			opts:   nil,
+			assertRequest: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				require.Equal(t, "/api/datasources/proxy/uid/loki-ds/prometheus/api/v1/rules", r.URL.Path)
+				require.Empty(t, r.URL.RawQuery)
+			},
+		},
+		{
+			name:   "opts are forwarded as query params",
+			dsUID:  "prom-ds",
+			dsType: "prometheus",
 			opts: &GetRulesOpts{
 				FolderUID: "test-folder",
 				RuleGroup: "test-group",
@@ -338,7 +352,7 @@ func TestAlertingClient_GetDatasourceRules(t *testing.T) {
 			},
 			assertRequest: func(t *testing.T, r *http.Request) {
 				t.Helper()
-				require.Equal(t, "/api/prometheus/prom-ds/api/v1/rules", r.URL.Path)
+				require.Equal(t, "/api/datasources/proxy/uid/prom-ds/api/v1/rules", r.URL.Path)
 				q := r.URL.Query()
 				require.Equal(t, "test-folder", q.Get("folder_uid"))
 				require.Equal(t, "test-group", q.Get("rule_group"))
@@ -360,7 +374,7 @@ func TestAlertingClient_GetDatasourceRules(t *testing.T) {
 			})
 			defer server.Close()
 
-			result, err := client.GetDatasourceRules(context.Background(), tc.dsUID, tc.opts)
+			result, err := client.GetDatasourceRules(context.Background(), tc.dsUID, tc.dsType, tc.opts)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 		})

--- a/tools/alerting_manage_rules_datasource.go
+++ b/tools/alerting_manage_rules_datasource.go
@@ -24,7 +24,7 @@ func listDatasourceAlertRules(ctx context.Context, dsUID string, opts *GetRulesO
 		return nil, fmt.Errorf("creating alerting client: %w", err)
 	}
 
-	rulesResp, err := client.GetDatasourceRules(ctx, dsUID, opts)
+	rulesResp, err := client.GetDatasourceRules(ctx, dsUID, ds.Type, opts)
 	if err != nil {
 		return nil, fmt.Errorf("querying datasource %s rules: %w", dsUID, err)
 	}


### PR DESCRIPTION
## Summary

`GetDatasourceRules` currently hits Grafana's legacy unified endpoint `/api/prometheus/{uid}/api/v1/rules`. That endpoint applies an internal path template that does not compose with datasource URLs already carrying a backend prefix — e.g. a Mimir gateway DS configured with `http://mimir-gateway/prometheus` produces 404s, even though hitting the same datasource through the generic DS proxy at `/api/datasources/proxy/uid/{uid}/api/v1/rules` returns rules correctly.

The inline comment in `alerting_client.go` already flagged this: *"use the Grafana unified endpoint - maybe we need to use the datasource proxy endpoint in the future as this is an api for internal use"*. This PR makes that switch, mirroring how `GetAlertmanagerConfig` already operates.

The path appended through the proxy depends on the datasource type, because the two Grafana DS plugins handle prefixes differently:

| DS type | Path appended | Reason |
|---|---|---|
| prometheus / mimir / cortex | `/api/v1/rules` | Prom plugin doesn't add a prefix; any `/prometheus` is in the DS URL itself |
| loki | `/prometheus/api/v1/rules` | Loki plugin hardcodes `/loki/...` so the DS URL is the gateway root; `/prometheus/api/v1/rules` is Loki's Prom-compat ruler endpoint that returns the `{status, data: {groups: [...]}}` shape the decoder expects (the native `/loki/api/v1/rules` returns YAML — incompatible) |

The caller `listDatasourceAlertRules` already fetches the datasource record (for `isRulerDatasource`) and now threads `ds.Type` through.

Independent of #819 (recording-rules emission); the two PRs touch different files.