### PR TITLE
fix: propagate request context through openapi convenience calls

### DIFF
--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 )
 
 const (
@@ -50,7 +52,9 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 	var discovered []DiscoveredDatasource
 
 	// List all datasources
-	resp, err := gc.Datasources.GetDataSources()
+	resp, err := gc.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(ctx),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list datasources: %w", err)
 	}

--- a/tools/annotations.go
+++ b/tools/annotations.go
@@ -95,7 +95,9 @@ func createAnnotation(ctx context.Context, args CreateAnnotationInput) (any, err
 			Tags: args.Tags,
 			Data: args.GraphiteData,
 		}
-		resp, err := c.Annotations.PostGraphiteAnnotation(req)
+		resp, err := c.Annotations.PostGraphiteAnnotationWithParams(
+			annotations.NewPostGraphiteAnnotationParamsWithContext(ctx).WithBody(req),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("create graphite annotation: %w", err)
 		}
@@ -116,7 +118,9 @@ func createAnnotation(ctx context.Context, args CreateAnnotationInput) (any, err
 		Data:         args.Data,
 	}
 
-	resp, err := c.Annotations.PostAnnotation(&req)
+	resp, err := c.Annotations.PostAnnotationWithParams(
+		annotations.NewPostAnnotationParamsWithContext(ctx).WithBody(&req),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create annotation: %w", err)
 	}
@@ -165,7 +169,9 @@ func updateAnnotation(ctx context.Context, args UpdateAnnotationInput) (*annotat
 		body.Data = args.Data
 	}
 
-	resp, err := c.Annotations.PatchAnnotation(id, body)
+	resp, err := c.Annotations.PatchAnnotationWithParams(
+		annotations.NewPatchAnnotationParamsWithContext(ctx).WithAnnotationID(id).WithBody(body),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("update annotation: %w", err)
 	}

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
@@ -25,7 +26,9 @@ type GetDashboardByUIDParams struct {
 
 func getDashboardByUID(ctx context.Context, args GetDashboardByUIDParams) (*models.DashboardFullWithMeta, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	dashboard, err := c.Dashboards.GetDashboardByUID(args.UID)
+	dashboard, err := c.Dashboards.GetDashboardByUIDWithParams(
+		dashboards.NewGetDashboardByUIDParamsWithContext(ctx).WithUID(args.UID),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get dashboard by uid %s: %w", args.UID, err)
 	}
@@ -150,7 +153,9 @@ func updateDashboardWithFullJSON(ctx context.Context, args UpdateDashboardParams
 		Overwrite: args.Overwrite,
 		UserID:    args.UserID,
 	}
-	dashboard, err := c.Dashboards.PostDashboard(cmd)
+	dashboard, err := c.Dashboards.PostDashboardWithParams(
+		dashboards.NewPostDashboardParamsWithContext(ctx).WithBody(cmd),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to save dashboard: %w", err)
 	}

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
@@ -39,7 +40,9 @@ type ListDatasourcesResult struct {
 
 func listDatasources(ctx context.Context, args ListDatasourcesParams) (*ListDatasourcesResult, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	resp, err := c.Datasources.GetDataSources()
+	resp, err := c.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(ctx),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("list datasources: %w", err)
 	}
@@ -129,7 +132,9 @@ type GetDatasourceByUIDParams struct {
 
 func getDatasourceByUID(ctx context.Context, args GetDatasourceByUIDParams) (*models.DataSource, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	datasource, err := c.Datasources.GetDataSourceByUID(args.UID)
+	datasource, err := c.Datasources.GetDataSourceByUIDWithParams(
+		datasources.NewGetDataSourceByUIDParamsWithContext(ctx).WithUID(args.UID),
+	)
 	if err != nil {
 		// Check if it's a 404 Not Found Error
 		if strings.Contains(err.Error(), "404") {
@@ -146,7 +151,9 @@ type GetDatasourceByNameParams struct {
 
 func getDatasourceByName(ctx context.Context, args GetDatasourceByNameParams) (*models.DataSource, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	datasource, err := c.Datasources.GetDataSourceByName(args.Name)
+	datasource, err := c.Datasources.GetDataSourceByNameWithParams(
+		datasources.NewGetDataSourceByNameParamsWithContext(ctx).WithName(args.Name),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get datasource by name %s: %w", args.Name, err)
 	}


### PR DESCRIPTION
## Summary

Convenience methods like `c.Datasources.GetDataSources()` build their params with a nil context, so the openapi runtime sends requests with `context.Background()` and our middleware (`OrgIDRoundTripper`, OBO auth, extra headers) can't read the per-call config. The wire ends up using whatever was baked in at client construction — usually the SA's home org — and there's no way to override per call.

This swaps the nine remaining sites in `tools/datasources.go`, `tools/dashboard.go`, `tools/annotations.go`, and `proxied_tools.go` to the `*WithParams(...).WithContext(ctx)` form already used in `tools/search.go`, `tools/admin.go`, and the get-side of `tools/annotations.go`. Same convention, just applied consistently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in how Grafana API requests are scoped (context/org/auth propagation), which could surface previously-masked configuration issues. The changes are mechanical but touch multiple read/write endpoints.
> 
> **Overview**
> Ensures per-request `context.Context` is propagated into Grafana OpenAPI client calls by replacing convenience methods (e.g., `GetDataSources`, `GetDashboardByUID`, `PostAnnotation`, `PostDashboard`) with the corresponding `*WithParams(...WithContext(ctx))` variants.
> 
> This updates datasource discovery (`proxied_tools.go`) and several MCP tools (`tools/datasources.go`, `tools/dashboard.go`, `tools/annotations.go`) so middleware-dependent behaviors (org/OBO auth/headers, timeouts, cancellation) can be applied on each call rather than being fixed at client construction time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6304cd820fbf5a13ea554e0a5711b406f57184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->