### PR TITLE
feat: add linter to enforce context propagation in openapi client calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,15 @@ build-image: ## Build the Docker image.
 build: ## Build the binary.
 	go build -o dist/mcp-grafana ./cmd/mcp-grafana
 
-.PHONY: lint lint-jsonschema lint-jsonschema-fix
-lint: lint-jsonschema ## Lint the Go code.
+.PHONY: lint lint-jsonschema lint-jsonschema-fix lint-openapi
+lint: lint-jsonschema lint-openapi ## Lint the Go code.
 	golangci-lint run
 
 lint-jsonschema: ## Lint for unescaped commas in jsonschema tags.
 	go run ./cmd/linters/jsonschema --path .
+
+lint-openapi: ## Lint for openapi client calls missing context propagation.
+	go run ./cmd/linters/openapi ./tools/... ./
 
 lint-jsonschema-fix: ## Automatically fix unescaped commas in jsonschema tags.
 	go run ./cmd/linters/jsonschema --path . --fix

--- a/cmd/linters/openapi/main.go
+++ b/cmd/linters/openapi/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	openapi "github.com/grafana/mcp-grafana/internal/linter/openapi"
+)
+
+func main() {
+	singlechecker.Main(openapi.Analyzer)
+}

--- a/internal/linter/openapi/analyzer.go
+++ b/internal/linter/openapi/analyzer.go
@@ -1,0 +1,87 @@
+package openapi
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const clientPkgPrefix = "github.com/grafana/grafana-openapi-client-go/client/"
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "openapicontext",
+	Doc:      "checks that openapi client calls use the WithParams variant to propagate request context",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{(*ast.CallExpr)(nil)}
+
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+
+		methodName := sel.Sel.Name
+		if strings.HasSuffix(methodName, "WithParams") {
+			return
+		}
+
+		// Skip test files
+		pos := pass.Fset.Position(call.Pos())
+		if strings.HasSuffix(pos.Filename, "_test.go") {
+			return
+		}
+
+		selection, ok := pass.TypesInfo.Selections[sel]
+		if !ok {
+			return
+		}
+		if selection.Kind() != types.MethodVal {
+			return
+		}
+
+		recvType := selection.Recv()
+		if !isOpenAPIClientType(recvType) {
+			return
+		}
+
+		withParamsName := methodName + "WithParams"
+		mset := types.NewMethodSet(recvType)
+		for i := range mset.Len() {
+			if mset.At(i).Obj().Name() == withParamsName {
+				pass.Reportf(call.Pos(),
+					"use %s with a context-aware params object instead of %s which drops request context",
+					withParamsName, methodName)
+				return
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+func isOpenAPIClientType(t types.Type) bool {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	pkg := named.Obj().Pkg()
+	if pkg == nil {
+		return false
+	}
+	return strings.HasPrefix(pkg.Path(), clientPkgPrefix)
+}

--- a/internal/linter/openapi/analyzer_test.go
+++ b/internal/linter/openapi/analyzer_test.go
@@ -1,0 +1,12 @@
+package openapi
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "testpkg")
+}

--- a/internal/linter/openapi/testdata/src/github.com/grafana/grafana-openapi-client-go/client/datasources/fake.go
+++ b/internal/linter/openapi/testdata/src/github.com/grafana/grafana-openapi-client-go/client/datasources/fake.go
@@ -1,0 +1,16 @@
+package datasources
+
+type GetDataSourcesParams struct{}
+type GetDataSourcesOK struct{}
+type GetDataSourceByUIDParams struct{}
+type GetDataSourceByUIDOK struct{}
+type ClientOption func()
+
+type ClientService interface {
+	GetDataSources(opts ...ClientOption) (*GetDataSourcesOK, error)
+	GetDataSourcesWithParams(params *GetDataSourcesParams, opts ...ClientOption) (*GetDataSourcesOK, error)
+	GetDataSourceByUID(uid string, opts ...ClientOption) (*GetDataSourceByUIDOK, error)
+	GetDataSourceByUIDWithParams(params *GetDataSourceByUIDParams, opts ...ClientOption) (*GetDataSourceByUIDOK, error)
+	// A method with no WithParams variant should not be flagged.
+	SomeHelperMethod() error
+}

--- a/internal/linter/openapi/testdata/src/testpkg/usage.go
+++ b/internal/linter/openapi/testdata/src/testpkg/usage.go
@@ -1,0 +1,14 @@
+package testpkg
+
+import "github.com/grafana/grafana-openapi-client-go/client/datasources"
+
+func badCalls(c datasources.ClientService) {
+	c.GetDataSources()            // want "use GetDataSourcesWithParams with a context-aware params object instead of GetDataSources which drops request context"
+	c.GetDataSourceByUID("myuid") // want "use GetDataSourceByUIDWithParams with a context-aware params object instead of GetDataSourceByUID which drops request context"
+}
+
+func goodCalls(c datasources.ClientService) {
+	c.GetDataSourcesWithParams(nil)
+	c.GetDataSourceByUIDWithParams(nil)
+	c.SomeHelperMethod() // no WithParams variant, should not be flagged
+}

--- a/internal/linter/openapi/testdata/src/testpkg/usage_test.go
+++ b/internal/linter/openapi/testdata/src/testpkg/usage_test.go
@@ -1,0 +1,9 @@
+package testpkg
+
+import "github.com/grafana/grafana-openapi-client-go/client/datasources"
+
+func testHelper(c datasources.ClientService) {
+	// These convenience calls in test files should NOT be flagged.
+	c.GetDataSources()
+	c.GetDataSourceByUID("myuid")
+}

--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -87,7 +87,9 @@ func manageRulesReadWrite(ctx context.Context, args ManageRulesReadWriteParams) 
 
 func getAlertRuleDetail(ctx context.Context, uid string, limitAlerts int) (*alertRuleDetail, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	alertRule, err := c.Provisioning.GetAlertRule(uid)
+	alertRule, err := c.Provisioning.GetAlertRuleWithParams(
+		provisioning.NewGetAlertRuleParamsWithContext(ctx).WithUID(uid),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get alert rule %s: %w", uid, err)
 	}

--- a/tools/alerting_routing.go
+++ b/tools/alerting_routing.go
@@ -91,7 +91,9 @@ func manageRouting(ctx context.Context, args ManageRoutingParams) (any, error) {
 // getNotificationPolicies retrieves the full notification policy tree.
 func getNotificationPolicies(ctx context.Context) (*models.Route, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	resp, err := c.Provisioning.GetPolicyTree()
+	resp, err := c.Provisioning.GetPolicyTreeWithParams(
+		provisioning.NewGetPolicyTreeParamsWithContext(ctx),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get notification policies: %w", err)
 	}
@@ -123,7 +125,9 @@ type muteTimingSummary struct {
 // getTimeIntervals retrieves all mute timings / time intervals.
 func getTimeIntervals(ctx context.Context) ([]muteTimingSummary, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	resp, err := c.Provisioning.GetMuteTimings()
+	resp, err := c.Provisioning.GetMuteTimingsWithParams(
+		provisioning.NewGetMuteTimingsParamsWithContext(ctx),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get time intervals: %w", err)
 	}
@@ -140,7 +144,9 @@ func getTimeIntervals(ctx context.Context) ([]muteTimingSummary, error) {
 // getTimeInterval retrieves a specific mute timing by name.
 func getTimeInterval(ctx context.Context, name string) (*models.MuteTimeInterval, error) {
 	c := mcpgrafana.GrafanaClientFromContext(ctx)
-	resp, err := c.Provisioning.GetMuteTiming(name)
+	resp, err := c.Provisioning.GetMuteTimingWithParams(
+		provisioning.NewGetMuteTimingParamsWithContext(ctx).WithName(name),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get time interval %q: %w", name, err)
 	}

--- a/tools/folder.go
+++ b/tools/folder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
@@ -31,7 +32,9 @@ func createFolder(ctx context.Context, args CreateFolderParams) (*models.Folder,
 		cmd.ParentUID = args.ParentUID
 	}
 
-	resp, err := c.Folders.CreateFolder(cmd)
+	resp, err := c.Folders.CreateFolderWithParams(
+		folders.NewCreateFolderParamsWithContext(ctx).WithBody(cmd),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create folder '%s': %w", args.Title, err)
 	}


### PR DESCRIPTION
## Summary

- Adds a `go/analysis`-based linter (`openapicontext`) that detects calls to go-swagger convenience methods when a `*WithParams` variant exists on the same type. The convenience methods silently use `context.Background()`, which prevents our middleware (OrgIDRoundTripper, OBO auth, extra headers) from reading per-call config.
- Fixes the 5 remaining call sites not covered by #822: `GetAlertRule`, `GetPolicyTree`, `GetMuteTimings`, `GetMuteTiming` (alerting), and `CreateFolder`.
- Integrated into `make lint` so CI catches any future regressions automatically.

The linter uses type information to check whether the receiver type (from `github.com/grafana/grafana-openapi-client-go/client/*`) has a `<Method>WithParams` method — if it does, calling the bare `<Method>` is flagged. Test files are excluded.

## Test plan

- [x] `go test ./internal/linter/openapi/` passes — covers both flagged and clean calls, plus test file exclusion
- [x] `make lint-openapi` passes clean against the full codebase
- [x] `go vet ./...` and `go build ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `go/analysis` linter to fail builds when OpenAPI convenience methods are used without context propagation, and updates several alerting/folder API calls to new `*WithParams` variants; incorrect params wiring could impact these tool operations at runtime.
> 
> **Overview**
> Introduces a new `openapicontext` static analyzer (wired into `make lint`) that flags Grafana OpenAPI client method calls that drop request context when a corresponding `*WithParams` method exists, excluding `_test.go` files.
> 
> Updates remaining production call sites to use the context-aware `*WithParams` APIs for alerting provisioning reads (`GetAlertRule`, `GetPolicyTree`, `GetMuteTimings`, `GetMuteTiming`) and folder creation (`CreateFolder`), ensuring per-request middleware/config can flow through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985ec58a975a1b02919f730f61c8040d50de7d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->