### PR TITLE
tools: adds new tool to get plugin information

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -62,6 +62,7 @@ var categoryDescription = map[string]string{
 	"navigation":    "Navigation: Generate deeplink URLs for Grafana resources like dashboards, panels, and Explore queries.",
 	"annotations":   "Annotations: Create and manage dashboard annotations.",
 	"rendering":     "Rendering: Export dashboard panels or full dashboards as PNG images (requires Grafana Image Renderer plugin).",
+	"plugin":        "Plugins: Check whether Grafana plugins are installed and fetch plugin details.",
 	"cloudwatch":    "CloudWatch: Query AWS CloudWatch datasources for metrics and logs.",
 	"examples":      "Examples: Query example tools.",
 	"clickhouse":    "ClickHouse: Query ClickHouse datasources via Grafana with macro and variable substitution support.",

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -45,7 +45,7 @@ type disabledTools struct {
 	dashboard, folder, oncall, asserts, sift, admin,
 	pyroscope, navigation, proxied, annotations, rendering, cloudwatch, write,
 	examples, clickhouse, graphite,
-	runpanelquery bool
+	runpanelquery, plugin bool
 }
 
 // Configuration for the Grafana client.
@@ -64,7 +64,7 @@ type grafanaConfig struct {
 }
 
 func (dt *disabledTools) addFlags() {
-	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
+	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,plugin", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
 	flag.BoolVar(&dt.search, "disable-search", false, "Disable search tools")
 	flag.BoolVar(&dt.datasource, "disable-datasource", false, "Disable datasource tools")
 	flag.BoolVar(&dt.incident, "disable-incident", false, "Disable incident tools")
@@ -90,6 +90,7 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.clickhouse, "disable-clickhouse", false, "Disable ClickHouse tools")
 	flag.BoolVar(&dt.runpanelquery, "disable-runpanelquery", false, "Disable run panel query tools")
 	flag.BoolVar(&dt.graphite, "disable-graphite", false, "Disable Graphite tools")
+	flag.BoolVar(&dt.plugin, "disable-plugin", false, "Disable plugin tools")
 }
 
 func (gc *grafanaConfig) addFlags() {
@@ -131,6 +132,7 @@ func (dt *disabledTools) addTools(s *server.MCPServer) {
 	maybeAddTools(s, tools.AddClickHouseTools, enabledTools, dt.clickhouse, "clickhouse")
 	maybeAddTools(s, tools.AddRunPanelQueryTools, enabledTools, dt.runpanelquery, "runpanelquery")
 	maybeAddTools(s, tools.AddGraphiteTools, enabledTools, dt.graphite, "graphite")
+	maybeAddTools(s, tools.AddPluginTools, enabledTools, dt.plugin, "plugin")
 }
 
 func newServer(transport string, dt disabledTools, obs *observability.Observability, sessionIdleTimeoutMinutes int) (*server.MCPServer, *mcpgrafana.ToolManager, *mcpgrafana.SessionManager) {
@@ -214,6 +216,7 @@ Available Capabilities:
 - Navigation: Generate deeplink URLs for Grafana resources like dashboards, panels, and Explore queries.
 - Rendering: Export dashboard panels or full dashboards as PNG images (requires Grafana Image Renderer plugin).
 - Proxied Tools: Access tools from external MCP servers (like Tempo) through dynamic discovery.
+- Plugins: Check whether a given plugin is installed in the Grafana instance.
 
 Timestamp parameters without a timezone offset are interpreted as UTC. Include an offset like '-05:00' or use relative syntax like 'now-1h' to query in a different timezone.
 

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -24,7 +24,7 @@ type GetPluginResult struct {
 	Name      string `json:"name,omitempty"`
 	Version   string `json:"version,omitempty"`
 	Type      string `json:"type,omitempty"`
-	Enabled   bool   `json:"enabled"`
+	Enabled   *bool  `json:"enabled,omitempty"`
 }
 
 // pluginSettingsResponse mirrors the relevant fields from GET /api/plugins/{id}/settings.
@@ -90,13 +90,14 @@ func getPlugin(ctx context.Context, args GetPluginParams) (*GetPluginResult, err
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 
+	enabled := settings.Enabled
 	return &GetPluginResult{
 		Installed: true,
 		PluginID:  settings.ID,
 		Name:      settings.Name,
 		Version:   settings.Info.Version,
 		Type:      settings.Type,
-		Enabled:   settings.Enabled,
+		Enabled:   &enabled,
 	}, nil
 }
 

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -24,7 +24,7 @@ type GetPluginResult struct {
 	Name      string `json:"name,omitempty"`
 	Version   string `json:"version,omitempty"`
 	Type      string `json:"type,omitempty"`
-	Enabled   bool   `json:"enabled,omitempty"`
+	Enabled   bool   `json:"enabled"`
 }
 
 // pluginSettingsResponse mirrors the relevant fields from GET /api/plugins/{id}/settings.
@@ -51,9 +51,6 @@ func grafanaPluginGet(ctx context.Context, cfg mcpgrafana.GrafanaConfig, apiPath
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("create request: %w", err)
-	}
-	if cfg.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
 	}
 
 	resp, err := (&http.Client{Transport: transport}).Do(req)

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -73,7 +74,7 @@ func getPlugin(ctx context.Context, args GetPluginParams) (*GetPluginResult, err
 	}
 
 	pluginID := strings.TrimSpace(args.PluginID)
-	body, status, err := grafanaPluginGet(ctx, cfg, "/api/plugins/"+pluginID+"/settings")
+	body, status, err := grafanaPluginGet(ctx, cfg, "/api/plugins/"+url.PathEscape(pluginID)+"/settings")
 	if err != nil {
 		return nil, fmt.Errorf("get plugin settings: %w", err)
 	}

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -16,7 +16,7 @@ import (
 )
 
 type GetPluginParams struct {
-	PluginID string `json:"pluginId" jsonschema:"required,description=The plugin ID to check (e.g. 'grafana-image-renderer'\\, 'grafana-piechart-panel'\\, 'grafana-oncall-app')"`
+	PluginID string `json:"pluginId" jsonschema:"required,description=The plugin ID to check (e.g. 'prometheus'\\, 'grafana-piechart-panel'\\, 'grafana-oncall-app')"`
 }
 
 type GetPluginResult struct {

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+type GetPluginParams struct {
+	PluginID string `json:"pluginId" jsonschema:"required,description=The plugin ID to check (e.g. 'grafana-image-renderer'\\, 'grafana-piechart-panel'\\, 'grafana-oncall-app')"`
+}
+
+type GetPluginResult struct {
+	Installed bool   `json:"installed"`
+	PluginID  string `json:"pluginId"`
+	Name      string `json:"name,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Type      string `json:"type,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+}
+
+// pluginSettingsResponse mirrors the relevant fields from GET /api/plugins/{id}/settings.
+type pluginSettingsResponse struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Enabled bool   `json:"enabled"`
+	Info    struct {
+		Version string `json:"version"`
+	} `json:"info"`
+}
+
+// grafanaPluginGet issues an authenticated GET request to the given Grafana API
+// path (e.g. "/api/plugins/foo/settings") and returns the raw response body and
+// HTTP status code. Only transport-level errors are returned as Go errors.
+func grafanaPluginGet(ctx context.Context, cfg mcpgrafana.GrafanaConfig, apiPath string) ([]byte, int, error) {
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build transport: %w", err)
+	}
+
+	endpoint := strings.TrimRight(cfg.URL, "/") + apiPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create request: %w", err)
+	}
+	if cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+
+	resp, err := (&http.Client{Transport: transport}).Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response: %w", err)
+	}
+	return body, resp.StatusCode, nil
+}
+
+func getPlugin(ctx context.Context, args GetPluginParams) (*GetPluginResult, error) {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	if cfg.URL == "" {
+		return nil, fmt.Errorf("Grafana URL is not configured")
+	}
+
+	pluginID := strings.TrimSpace(args.PluginID)
+	body, status, err := grafanaPluginGet(ctx, cfg, "/api/plugins/"+pluginID+"/settings")
+	if err != nil {
+		return nil, fmt.Errorf("get plugin settings: %w", err)
+	}
+
+	if status == http.StatusNotFound {
+		return &GetPluginResult{Installed: false, PluginID: pluginID}, nil
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("get plugin settings: unexpected status %d", status)
+	}
+
+	var settings pluginSettingsResponse
+	if err := json.Unmarshal(body, &settings); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &GetPluginResult{
+		Installed: true,
+		PluginID:  settings.ID,
+		Name:      settings.Name,
+		Version:   settings.Info.Version,
+		Type:      settings.Type,
+		Enabled:   settings.Enabled,
+	}, nil
+}
+
+var GetPlugin = mcpgrafana.MustTool(
+	"get_plugin",
+	"Check whether a Grafana plugin is installed and retrieve its details (name, version, type, enabled status). Returns installed=false when the plugin is not found.",
+	getPlugin,
+	mcp.WithTitleAnnotation("Get plugin"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+func AddPluginTools(s *server.MCPServer) {
+	GetPlugin.Register(s)
+}

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -72,7 +72,7 @@ func grafanaPluginGet(ctx context.Context, cfg mcpgrafana.GrafanaConfig, apiPath
 func getPlugin(ctx context.Context, args GetPluginParams) (*GetPluginResult, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
 	if cfg.URL == "" {
-		return nil, fmt.Errorf("Grafana URL is not configured")
+		return nil, fmt.Errorf("grafana URL is not configured")
 	}
 
 	pluginID := strings.TrimSpace(args.PluginID)

--- a/tools/plugins_integration_test.go
+++ b/tools/plugins_integration_test.go
@@ -1,0 +1,50 @@
+// Requires a Grafana instance running on localhost:3000.
+// Run with `go test -tags integration`.
+//go:build integration
+
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginTools(t *testing.T) {
+	t.Run("installed plugin is detected", func(t *testing.T) {
+		// grafana-clickhouse-datasource is provisioned via GF_INSTALL_PLUGINS in docker-compose.yaml.
+		ctx := newTestContext()
+		result, err := getPlugin(ctx, GetPluginParams{PluginID: "grafana-clickhouse-datasource"})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.Installed, "grafana-clickhouse-datasource should be installed")
+		assert.Equal(t, "grafana-clickhouse-datasource", result.PluginID)
+		assert.NotEmpty(t, result.Name)
+		assert.NotEmpty(t, result.Version)
+		assert.Equal(t, "datasource", result.Type)
+	})
+
+	t.Run("missing plugin returns installed=false", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := getPlugin(ctx, GetPluginParams{PluginID: "grafana-nonexistent-plugin-xyz"})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.Installed)
+		assert.Equal(t, "grafana-nonexistent-plugin-xyz", result.PluginID)
+		assert.Empty(t, result.Name)
+		assert.Empty(t, result.Version)
+	})
+
+	t.Run("whitespace in plugin id is trimmed", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := getPlugin(ctx, GetPluginParams{PluginID: "  grafana-clickhouse-datasource  "})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.Installed)
+		assert.Equal(t, "grafana-clickhouse-datasource", result.PluginID)
+	})
+}

--- a/tools/plugins_unit_test.go
+++ b/tools/plugins_unit_test.go
@@ -45,7 +45,8 @@ func TestGetPlugin_Found(t *testing.T) {
 	assert.Equal(t, "Pie Chart", result.Name)
 	assert.Equal(t, "2.0.1", result.Version)
 	assert.Equal(t, "panel", result.Type)
-	assert.True(t, result.Enabled)
+	require.NotNil(t, result.Enabled)
+	assert.True(t, *result.Enabled)
 }
 
 func TestGetPlugin_NotFound(t *testing.T) {
@@ -63,6 +64,11 @@ func TestGetPlugin_NotFound(t *testing.T) {
 	assert.Equal(t, "grafana-nonexistent-panel", result.PluginID)
 	assert.Empty(t, result.Name)
 	assert.Empty(t, result.Version)
+	assert.Nil(t, result.Enabled)
+
+	serialized, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.NotContains(t, string(serialized), "enabled")
 }
 
 func TestGetPlugin_UnexpectedStatus(t *testing.T) {
@@ -162,7 +168,8 @@ func TestGetPlugin_DisabledPlugin(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.Installed)
-	assert.False(t, result.Enabled)
+	require.NotNil(t, result.Enabled)
+	assert.False(t, *result.Enabled)
 	assert.Equal(t, "2.1.3", result.Version)
 }
 

--- a/tools/plugins_unit_test.go
+++ b/tools/plugins_unit_test.go
@@ -129,6 +129,27 @@ func TestGetPlugin_TrimsWhitespaceFromPluginID(t *testing.T) {
 	assert.Equal(t, "my-plugin", result.PluginID)
 }
 
+func TestGetPlugin_EscapesPluginIDPathSegment(t *testing.T) {
+	var capturedEscapedPath string
+	var capturedRawQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedEscapedPath = r.URL.EscapedPath()
+		capturedRawQuery = r.URL.RawQuery
+		payload := pluginSettingsResponse{ID: "test?x=1/../../admin", Name: "Test Plugin", Type: "panel", Enabled: true}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "test?x=1/../../admin"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/api/plugins/test%3Fx=1%2F..%2F..%2Fadmin/settings", capturedEscapedPath)
+	assert.Empty(t, capturedRawQuery)
+	assert.True(t, result.Installed)
+}
+
 func TestGetPlugin_SendsAPIKeyHeader(t *testing.T) {
 	var capturedAuth string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/plugins_unit_test.go
+++ b/tools/plugins_unit_test.go
@@ -1,0 +1,191 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func pluginTestContext(t *testing.T, serverURL string) context.Context {
+	t.Helper()
+	cfg := mcpgrafana.GrafanaConfig{URL: serverURL}
+	return mcpgrafana.WithGrafanaConfig(context.Background(), cfg)
+}
+
+func TestGetPlugin_Found(t *testing.T) {
+	payload := pluginSettingsResponse{
+		ID:      "grafana-piechart-panel",
+		Name:    "Pie Chart",
+		Type:    "panel",
+		Enabled: true,
+	}
+	payload.Info.Version = "2.0.1"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/plugins/grafana-piechart-panel/settings", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "grafana-piechart-panel"})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Installed)
+	assert.Equal(t, "grafana-piechart-panel", result.PluginID)
+	assert.Equal(t, "Pie Chart", result.Name)
+	assert.Equal(t, "2.0.1", result.Version)
+	assert.Equal(t, "panel", result.Type)
+	assert.True(t, result.Enabled)
+}
+
+func TestGetPlugin_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Plugin not found"}`, http.StatusNotFound)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "grafana-nonexistent-panel"})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.Installed)
+	assert.Equal(t, "grafana-nonexistent-panel", result.PluginID)
+	assert.Empty(t, result.Name)
+	assert.Empty(t, result.Version)
+}
+
+func TestGetPlugin_UnexpectedStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "some-plugin"})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestGetPlugin_MalformedJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "some-plugin"})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "parse response")
+}
+
+func TestGetPlugin_NoURLConfigured(t *testing.T) {
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{})
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "some-plugin"})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "Grafana URL is not configured")
+}
+
+func TestGetPlugin_TrimsWhitespaceFromPluginID(t *testing.T) {
+	var capturedPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		payload := pluginSettingsResponse{ID: "my-plugin", Name: "My Plugin", Type: "datasource", Enabled: true}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "  my-plugin  "})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/api/plugins/my-plugin/settings", capturedPath)
+	assert.True(t, result.Installed)
+	assert.Equal(t, "my-plugin", result.PluginID)
+}
+
+func TestGetPlugin_SendsAPIKeyHeader(t *testing.T) {
+	var capturedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		payload := pluginSettingsResponse{ID: "some-plugin", Name: "Some Plugin", Type: "panel", Enabled: true}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	cfg := mcpgrafana.GrafanaConfig{URL: ts.URL, APIKey: "glsa_test_token"}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), cfg)
+	_, err := getPlugin(ctx, GetPluginParams{PluginID: "some-plugin"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer glsa_test_token", capturedAuth)
+}
+
+func TestGetPlugin_DisabledPlugin(t *testing.T) {
+	payload := pluginSettingsResponse{
+		ID:      "grafana-clock-panel",
+		Name:    "Clock",
+		Type:    "panel",
+		Enabled: false,
+	}
+	payload.Info.Version = "2.1.3"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "grafana-clock-panel"})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Installed)
+	assert.False(t, result.Enabled)
+	assert.Equal(t, "2.1.3", result.Version)
+}
+
+func TestGetPlugin_AppType(t *testing.T) {
+	payload := pluginSettingsResponse{
+		ID:      "grafana-oncall-app",
+		Name:    "Grafana OnCall",
+		Type:    "app",
+		Enabled: true,
+	}
+	payload.Info.Version = "1.9.0"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := pluginTestContext(t, ts.URL)
+	result, err := getPlugin(ctx, GetPluginParams{PluginID: "grafana-oncall-app"})
+
+	require.NoError(t, err)
+	assert.True(t, result.Installed)
+	assert.Equal(t, "app", result.Type)
+	assert.Equal(t, "grafana-oncall-app", result.PluginID)
+}

--- a/tools/plugins_unit_test.go
+++ b/tools/plugins_unit_test.go
@@ -101,7 +101,7 @@ func TestGetPlugin_NoURLConfigured(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "Grafana URL is not configured")
+	assert.Contains(t, err.Error(), "grafana URL is not configured")
 }
 
 func TestGetPlugin_TrimsWhitespaceFromPluginID(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a new get_plugin MCP tool that checks whether a Grafana plugin is installed and returns its details (name, version, type, enabled status). Returns installed: false when the plugin is not found rather than an error, so LLMs can reason about presence/absence cleanly.
Registers the tool under the plugin capability group with a --disable-plugin flag and includes it in the default --enabled-tools list.

## Future work
Eventually, end goal will be for datasource management tool to be able to use these flows so that in cases where, for example, a user prompts to create a datasource for which the plugin has not yet been installed, the user is given the option to install it.

Next step will be to expand this tool and add functionality to install a plugin via mcp server.

## Screenshots

Installed plugin:

<img width="675" height="719" alt="Screenshot 2026-04-30 at 4 52 49 PM" src="https://github.com/user-attachments/assets/a18e483d-7540-48cd-b98f-99b2051ab3bd" />

Plugin that has not yet been installed:

<img width="661" height="476" alt="Screenshot 2026-04-30 at 4 53 15 PM" src="https://github.com/user-attachments/assets/69285b08-36d4-421f-850e-b34f089c4c86" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change: introduces a new read-only MCP tool and wires it into tool registration/flags without modifying existing tool behavior or data writes.
> 
> **Overview**
> Adds a new **Plugins** capability with a `get_plugin` tool that calls Grafana `GET /api/plugins/{id}/settings` and returns `installed=false` on 404 plus basic plugin metadata when present.
> 
> Wires the new category into server startup by adding `plugin` to the default `--enabled-tools` list, supporting `--disable-plugin`, and registering `tools.AddPluginTools`; includes both unit and integration tests covering status handling, path escaping, and auth header behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054f675b3e822e0941cb70fc4ab72daaf3ba344d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->