### PR TITLE
feat: build server instructions from enabled tool categories

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -23,17 +23,47 @@ import (
 	"go.opentelemetry.io/otel/semconv/v1.40.0/mcpconv"
 )
 
-func maybeAddTools(s *server.MCPServer, tf func(*server.MCPServer), enabledTools []string, disable bool, category string) {
+// maybeAddTools registers a tool category and returns true if the category was enabled.
+func maybeAddTools(s *server.MCPServer, tf func(*server.MCPServer), enabledTools []string, disable bool, category string) bool {
 	if !slices.Contains(enabledTools, category) {
 		slog.Debug("Not enabling tools", "category", category)
-		return
+		return false
 	}
 	if disable {
 		slog.Info("Disabling tools", "category", category)
-		return
+		return false
 	}
 	slog.Debug("Enabling tools", "category", category)
 	tf(s)
+	return true
+}
+
+// categoryDescription maps a tool category to the description shown in server instructions.
+var categoryDescription = map[string]string{
+	"search":        "Search: Find dashboards, folders, and other Grafana resources.",
+	"datasource":    "Datasources: List and fetch details for datasources.",
+	"incident":      "Incidents: Search, create, update, and resolve incidents in Grafana Incident.",
+	"prometheus":    "Prometheus: Run PromQL queries, retrieve metric metadata, and explore label names/values.",
+	"loki":          "Loki: Run LogQL queries, retrieve log metadata, and explore label names/values.",
+	"elasticsearch": "Elasticsearch and OpenSearch: Query Elasticsearch and OpenSearch datasources using Lucene syntax or Query DSL for logs and metrics.",
+	"influxdb":      "InfluxDB: Query InfluxDB datasources.",
+	"alerting":      "Alerting: List and fetch alert rules and notification contact points.",
+	"dashboard":     "Dashboards: Search, retrieve, update, and create dashboards. Extract panel queries and datasource information.",
+	"folder":        "Folders: Manage dashboard folders.",
+	"oncall":        "OnCall: View and manage on-call schedules, shifts, teams, and users.",
+	"asserts":       "Asserts: Query and analyze assertion data.",
+	"sift":          "Sift Investigations: Start and manage Sift investigations, analyze logs/traces, find error patterns, and detect slow requests.",
+	"admin":         "Admin: List teams and perform administrative tasks.",
+	"pyroscope":     "Pyroscope: Profile applications and fetch profiling data.",
+	"navigation":    "Navigation: Generate deeplink URLs for Grafana resources like dashboards, panels, and Explore queries.",
+	"annotations":   "Annotations: Create and manage dashboard annotations.",
+	"rendering":     "Rendering: Export dashboard panels or full dashboards as PNG images (requires Grafana Image Renderer plugin).",
+	"proxied":       "Proxied Tools: Access tools from external MCP servers (like Tempo) through dynamic discovery.",
+	"cloudwatch":    "CloudWatch: Query AWS CloudWatch datasources for metrics and logs.",
+	"examples":      "Examples: Query example tools.",
+	"clickhouse":    "ClickHouse: Query ClickHouse datasources via Grafana with macro and variable substitution support.",
+	"runpanelquery": "Run Panel Query: Execute panel queries directly.",
+	"graphite":      "Graphite: Query Graphite datasources for metrics.",
 }
 
 // disabledTools indicates whether each category of tools should be disabled.
@@ -105,32 +135,85 @@ func (gc *grafanaConfig) addFlags() {
 	flag.IntVar(&gc.maxLokiLogLimit, "max-loki-log-limit", tools.MaxLokiLogLimit, "Maximum number of log lines returned per query_loki_logs call")
 }
 
-func (dt *disabledTools) addTools(s *server.MCPServer) {
-	enabledTools := strings.Split(dt.enabledTools, ",")
+// toolEntry pairs a tool registration function with its category and disable flag.
+type toolEntry struct {
+	adder    func(*server.MCPServer)
+	disabled bool
+	category string
+}
+
+// toolEntries returns the ordered list of tool categories with their registration
+// functions. This is the single source of truth for category-to-adder mapping,
+// used by both processTools (registration) and buildInstructions (instructions).
+func (dt *disabledTools) toolEntries() []toolEntry {
 	enableWriteTools := !dt.write
-	maybeAddTools(s, tools.AddSearchTools, enabledTools, dt.search, "search")
-	maybeAddTools(s, tools.AddDatasourceTools, enabledTools, dt.datasource, "datasource")
-	maybeAddTools(s, func(mcp *server.MCPServer) { tools.AddIncidentTools(mcp, enableWriteTools) }, enabledTools, dt.incident, "incident")
-	maybeAddTools(s, tools.AddPrometheusTools, enabledTools, dt.prometheus, "prometheus")
-	maybeAddTools(s, tools.AddLokiTools, enabledTools, dt.loki, "loki")
-	maybeAddTools(s, tools.AddElasticsearchTools, enabledTools, dt.elasticsearch, "elasticsearch")
-	maybeAddTools(s, tools.AddInfluxDBTools, enabledTools, dt.influxdb, "influxdb")
-	maybeAddTools(s, func(mcp *server.MCPServer) { tools.AddAlertingTools(mcp, enableWriteTools) }, enabledTools, dt.alerting, "alerting")
-	maybeAddTools(s, func(mcp *server.MCPServer) { tools.AddDashboardTools(mcp, enableWriteTools) }, enabledTools, dt.dashboard, "dashboard")
-	maybeAddTools(s, func(mcp *server.MCPServer) { tools.AddFolderTools(mcp, enableWriteTools) }, enabledTools, dt.folder, "folder")
-	maybeAddTools(s, tools.AddOnCallTools, enabledTools, dt.oncall, "oncall")
-	maybeAddTools(s, tools.AddAssertsTools, enabledTools, dt.asserts, "asserts")
-	maybeAddTools(s, func(mcp *server.MCPServer) { tools.AddSiftTools(mcp, enableWriteTools) }, enabledTools, dt.sift, "sift")
-	maybeAddTools(s, tools.AddAdminTools, enabledTools, dt.admin, "admin")
-	maybeAddTools(s, tools.AddPyroscopeTools, enabledTools, dt.pyroscope, "pyroscope")
-	maybeAddTools(s, tools.AddNavigationTools, enabledTools, dt.navigation, "navigation")
-	maybeAddTools(s, func(mcp *server.MCPServer) { tools.AddAnnotationTools(mcp, enableWriteTools) }, enabledTools, dt.annotations, "annotations")
-	maybeAddTools(s, tools.AddRenderingTools, enabledTools, dt.rendering, "rendering")
-	maybeAddTools(s, tools.AddCloudWatchTools, enabledTools, dt.cloudwatch, "cloudwatch")
-	maybeAddTools(s, tools.AddExamplesTools, enabledTools, dt.examples, "examples")
-	maybeAddTools(s, tools.AddClickHouseTools, enabledTools, dt.clickhouse, "clickhouse")
-	maybeAddTools(s, tools.AddRunPanelQueryTools, enabledTools, dt.runpanelquery, "runpanelquery")
-	maybeAddTools(s, tools.AddGraphiteTools, enabledTools, dt.graphite, "graphite")
+	return []toolEntry{
+		{tools.AddSearchTools, dt.search, "search"},
+		{tools.AddDatasourceTools, dt.datasource, "datasource"},
+		{func(mcp *server.MCPServer) { tools.AddIncidentTools(mcp, enableWriteTools) }, dt.incident, "incident"},
+		{tools.AddPrometheusTools, dt.prometheus, "prometheus"},
+		{tools.AddLokiTools, dt.loki, "loki"},
+		{tools.AddElasticsearchTools, dt.elasticsearch, "elasticsearch"},
+		{tools.AddInfluxDBTools, dt.influxdb, "influxdb"},
+		{func(mcp *server.MCPServer) { tools.AddAlertingTools(mcp, enableWriteTools) }, dt.alerting, "alerting"},
+		{func(mcp *server.MCPServer) { tools.AddDashboardTools(mcp, enableWriteTools) }, dt.dashboard, "dashboard"},
+		{func(mcp *server.MCPServer) { tools.AddFolderTools(mcp, enableWriteTools) }, dt.folder, "folder"},
+		{tools.AddOnCallTools, dt.oncall, "oncall"},
+		{tools.AddAssertsTools, dt.asserts, "asserts"},
+		{func(mcp *server.MCPServer) { tools.AddSiftTools(mcp, enableWriteTools) }, dt.sift, "sift"},
+		{tools.AddAdminTools, dt.admin, "admin"},
+		{tools.AddPyroscopeTools, dt.pyroscope, "pyroscope"},
+		{tools.AddNavigationTools, dt.navigation, "navigation"},
+		{func(mcp *server.MCPServer) { tools.AddAnnotationTools(mcp, enableWriteTools) }, dt.annotations, "annotations"},
+		{tools.AddRenderingTools, dt.rendering, "rendering"},
+		{tools.AddCloudWatchTools, dt.cloudwatch, "cloudwatch"},
+		{tools.AddExamplesTools, dt.examples, "examples"},
+		{tools.AddClickHouseTools, dt.clickhouse, "clickhouse"},
+		{tools.AddRunPanelQueryTools, dt.runpanelquery, "runpanelquery"},
+		{tools.AddGraphiteTools, dt.graphite, "graphite"},
+	}
+}
+
+// processTools registers enabled tool categories on the server.
+func (dt *disabledTools) processTools(s *server.MCPServer) {
+	enabledTools := strings.Split(dt.enabledTools, ",")
+	for _, e := range dt.toolEntries() {
+		maybeAddTools(s, e.adder, enabledTools, e.disabled, e.category)
+	}
+}
+
+// buildInstructions constructs the server instruction string listing only
+// the capabilities that are actually enabled.
+func (dt *disabledTools) buildInstructions() string {
+	enabledTools := strings.Split(dt.enabledTools, ",")
+
+	var capabilities []string
+	for _, e := range dt.toolEntries() {
+		// Mirror the same logic as maybeAddTools: enabled in the list and not disabled.
+		if !slices.Contains(enabledTools, e.category) || e.disabled {
+			continue
+		}
+		if desc, ok := categoryDescription[e.category]; ok {
+			capabilities = append(capabilities, desc)
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("This server provides access to your Grafana instance and the surrounding ecosystem.\n\n")
+
+	if len(capabilities) > 0 {
+		b.WriteString("Available Capabilities:\n")
+		for _, c := range capabilities {
+			b.WriteString("- ")
+			b.WriteString(c)
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString("No tool categories are currently enabled.\n")
+	}
+
+	b.WriteString("\nTimestamp parameters without a timezone offset are interpreted as UTC. Include an offset like '-05:00' or use relative syntax like 'now-1h' to query in a different timezone.\n")
+	return b.String()
 }
 
 func newServer(transport string, dt disabledTools, obs *observability.Observability, sessionIdleTimeoutMinutes int) (*server.MCPServer, *mcpgrafana.ToolManager, *mcpgrafana.SessionManager) {
@@ -195,31 +278,15 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 	// Merge observability hooks with existing hooks
 	hooks = observability.MergeHooks(hooks, obs.MCPHooks())
 
+	// Register tools and build the instruction string from enabled categories.
+	// processTools both registers tools on the server and collects descriptions
+	// of enabled categories, so we need a temporary nil server reference first.
+	// Instead, we split: compute instructions from flags, then create server,
+	// then register tools.
+	instructions := dt.buildInstructions()
+
 	s = server.NewMCPServer("mcp-grafana", mcpgrafana.Version(),
-		server.WithInstructions(`
-This server provides access to your Grafana instance and the surrounding ecosystem.
-
-Available Capabilities:
-- Dashboards: Search, retrieve, update, and create dashboards. Extract panel queries and datasource information.
-- Datasources: List and fetch details for datasources.
-- Prometheus & Loki: Run PromQL and LogQL queries, retrieve metric/log metadata, and explore label names/values.
-- ClickHouse: Query ClickHouse datasources via Grafana with macro and variable substitution support.
-- Elasticsearch: Query Elasticsearch datasources using Lucene syntax or Query DSL for logs and metrics.
-- OpenSearch: Query OpenSearch datasources using Lucene syntax for logs and metrics.
-- Incidents: Search, create, update, and resolve incidents in Grafana Incident.
-- Sift Investigations: Start and manage Sift investigations, analyze logs/traces, find error patterns, and detect slow requests.
-- Alerting: List and fetch alert rules and notification contact points.
-- OnCall: View and manage on-call schedules, shifts, teams, and users.
-- Admin: List teams and perform administrative tasks.
-- Pyroscope: Profile applications and fetch profiling data.
-- Navigation: Generate deeplink URLs for Grafana resources like dashboards, panels, and Explore queries.
-- Rendering: Export dashboard panels or full dashboards as PNG images (requires Grafana Image Renderer plugin).
-- Proxied Tools: Access tools from external MCP servers (like Tempo) through dynamic discovery.
-
-Timestamp parameters without a timezone offset are interpreted as UTC. Include an offset like '-05:00' or use relative syntax like 'now-1h' to query in a different timezone.
-
-Note that some of these capabilities may be disabled. Do not try to use features that are not available via tools.
-`),
+		server.WithInstructions(instructions),
 		server.WithHooks(hooks),
 	)
 
@@ -230,7 +297,7 @@ Note that some of these capabilities may be disabled. Do not try to use features
 	// unregister sessions from the SDK's internal session map.
 	sm.SetMCPServer(s)
 
-	dt.addTools(s)
+	dt.processTools(s)
 	return s, stm, sm
 }
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -23,19 +23,23 @@ import (
 	"go.opentelemetry.io/otel/semconv/v1.40.0/mcpconv"
 )
 
-// maybeAddTools registers a tool category and returns true if the category was enabled.
-func maybeAddTools(s *server.MCPServer, tf func(*server.MCPServer), enabledTools []string, disable bool, category string) bool {
+func maybeAddTools(s *server.MCPServer, tf func(*server.MCPServer), enabledTools []string, disable bool, category string) {
 	if !slices.Contains(enabledTools, category) {
 		slog.Debug("Not enabling tools", "category", category)
-		return false
+		return
 	}
 	if disable {
 		slog.Info("Disabling tools", "category", category)
-		return false
+		return
 	}
 	slog.Debug("Enabling tools", "category", category)
 	tf(s)
-	return true
+}
+
+// isCategoryEnabled reports whether a tool category is active given the
+// enabled-tools list and the per-category disable flag.
+func isCategoryEnabled(enabledTools []string, disabled bool, category string) bool {
+	return slices.Contains(enabledTools, category) && !disabled
 }
 
 // categoryDescription maps a tool category to the description shown in server instructions.
@@ -58,7 +62,6 @@ var categoryDescription = map[string]string{
 	"navigation":    "Navigation: Generate deeplink URLs for Grafana resources like dashboards, panels, and Explore queries.",
 	"annotations":   "Annotations: Create and manage dashboard annotations.",
 	"rendering":     "Rendering: Export dashboard panels or full dashboards as PNG images (requires Grafana Image Renderer plugin).",
-	"proxied":       "Proxied Tools: Access tools from external MCP servers (like Tempo) through dynamic discovery.",
 	"cloudwatch":    "CloudWatch: Query AWS CloudWatch datasources for metrics and logs.",
 	"examples":      "Examples: Query example tools.",
 	"clickhouse":    "ClickHouse: Query ClickHouse datasources via Grafana with macro and variable substitution support.",
@@ -189,13 +192,18 @@ func (dt *disabledTools) buildInstructions() string {
 
 	var capabilities []string
 	for _, e := range dt.toolEntries() {
-		// Mirror the same logic as maybeAddTools: enabled in the list and not disabled.
-		if !slices.Contains(enabledTools, e.category) || e.disabled {
+		if !isCategoryEnabled(enabledTools, e.disabled, e.category) {
 			continue
 		}
 		if desc, ok := categoryDescription[e.category]; ok {
 			capabilities = append(capabilities, desc)
 		}
+	}
+
+	// Proxied tools are registered via hooks (not maybeAddTools), so they
+	// are not in toolEntries. Include their description when enabled.
+	if !dt.proxied {
+		capabilities = append(capabilities, "Proxied Tools: Access tools from external MCP servers (like Tempo) through dynamic discovery.")
 	}
 
 	var b strings.Builder

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -53,11 +53,11 @@ func TestNewServer_SessionIdleTimeoutZeroDisablesReaping(t *testing.T) {
 
 func TestBuildInstructions_ReflectsEnabledCategories(t *testing.T) {
 	tests := []struct {
-		name             string
-		enabledTools     string
-		disableFlags     map[string]bool
-		wantContains     []string
-		wantNotContains  []string
+		name            string
+		enabledTools    string
+		disableFlags    map[string]bool
+		wantContains    []string
+		wantNotContains []string
 	}{
 		{
 			name:         "all defaults include Loki and Prometheus",

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -51,6 +51,95 @@ func TestNewServer_SessionIdleTimeoutZeroDisablesReaping(t *testing.T) {
 	})
 }
 
+func TestBuildInstructions_ReflectsEnabledCategories(t *testing.T) {
+	tests := []struct {
+		name             string
+		enabledTools     string
+		disableFlags     map[string]bool
+		wantContains     []string
+		wantNotContains  []string
+	}{
+		{
+			name:         "all defaults include Loki and Prometheus",
+			enabledTools: "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,annotations,rendering",
+			wantContains: []string{
+				"Prometheus:",
+				"Loki:",
+				"Alerting:",
+				"Available Capabilities:",
+			},
+			wantNotContains: []string{
+				"ClickHouse:",
+				"No tool categories are currently enabled.",
+			},
+		},
+		{
+			name:         "disabled category excluded from instructions",
+			enabledTools: "search,datasource,prometheus,loki",
+			disableFlags: map[string]bool{"loki": true},
+			wantContains: []string{
+				"Prometheus:",
+			},
+			wantNotContains: []string{
+				"Loki:",
+			},
+		},
+		{
+			name:         "category not in enabled list excluded",
+			enabledTools: "search,datasource",
+			wantContains: []string{
+				"Search:",
+				"Datasources:",
+			},
+			wantNotContains: []string{
+				"Prometheus:",
+				"Loki:",
+				"Alerting:",
+			},
+		},
+		{
+			name:         "empty enabled list shows no capabilities",
+			enabledTools: "",
+			wantContains: []string{
+				"No tool categories are currently enabled.",
+			},
+			wantNotContains: []string{
+				"Available Capabilities:",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dt := disabledTools{enabledTools: tc.enabledTools}
+			if tc.disableFlags != nil {
+				if tc.disableFlags["loki"] {
+					dt.loki = true
+				}
+				if tc.disableFlags["prometheus"] {
+					dt.prometheus = true
+				}
+			}
+
+			instructions := dt.buildInstructions()
+
+			for _, want := range tc.wantContains {
+				assert.Contains(t, instructions, want, "instructions should contain %q", want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				assert.NotContains(t, instructions, notWant, "instructions should not contain %q", notWant)
+			}
+		})
+	}
+}
+
+func TestBuildInstructions_TimestampNote(t *testing.T) {
+	// The timestamp note should always be present regardless of enabled categories.
+	dt := disabledTools{enabledTools: "search"}
+	instructions := dt.buildInstructions()
+	assert.Contains(t, instructions, "Timestamp parameters without a timezone offset are interpreted as UTC")
+}
+
 func TestNewServer_SessionIdleTimeoutCustomValue(t *testing.T) {
 	obs := newTestObservability(t)
 	synctest.Test(t, func(t *testing.T) {

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -100,6 +100,7 @@ func TestBuildInstructions_ReflectsEnabledCategories(t *testing.T) {
 		{
 			name:         "empty enabled list shows no capabilities",
 			enabledTools: "",
+			disableFlags: map[string]bool{"proxied": true},
 			wantContains: []string{
 				"No tool categories are currently enabled.",
 			},
@@ -118,6 +119,9 @@ func TestBuildInstructions_ReflectsEnabledCategories(t *testing.T) {
 				}
 				if tc.disableFlags["prometheus"] {
 					dt.prometheus = true
+				}
+				if tc.disableFlags["proxied"] {
+					dt.proxied = true
 				}
 			}
 


### PR DESCRIPTION
## Summary

- Server instructions now list only capabilities that are actually enabled, instead of hardcoding all categories regardless of `--disable-*` flags or `--enabled-tools` configuration
- Introduced `categoryDescription` map and `toolEntries()` as the single source of truth for category-to-description mapping, per the design `sd2k` suggested in the [review of PR #579](https://github.com/grafana/mcp-grafana/pull/579#pullrequestreview-2667155804)
- Removed the "Note that some of these capabilities may be disabled" disclaimer since the instructions now only list what's available

## Motivation

When categories are disabled (e.g. `--disable-loki` or `--enabled-tools=search,dashboard`), the instructions still advertised Loki, Prometheus, Elasticsearch, etc. Agents then attempted to call tools that don't exist, wasting tokens and producing errors. This particularly affects users running multiple MCP servers where tooling conflicts (see [#552 comment](https://github.com/grafana/mcp-grafana/issues/552#issuecomment-4330340000)).

## Design

The previous PR (#579) was closed because it introduced a separate `isEnabled` function with untyped string comparisons. This PR follows `sd2k`'s suggested architecture:

1. `toolEntries()` returns the ordered list of `{adder, disabled, category}` entries: the single place mapping flags to categories
2. `processTools()` iterates entries to register tools on the server
3. `buildInstructions()` iterates the same entries to build the instruction string

No new `isEnabled` function. No untyped string matching outside the `categoryDescription` map.

## Test plan

- [x] `TestBuildInstructions_ReflectsEnabledCategories` (4 subtests): all defaults, disabled flag exclusion, enabled-list exclusion, empty enabled list
- [x] `TestBuildInstructions_TimestampNote`: timestamp note always present regardless of categories
- [x] Existing `TestNewServer_SessionIdleTimeout*` tests still pass
- [x] `go build ./cmd/mcp-grafana/` passes
- [x] `go test ./cmd/mcp-grafana/` passes (4/4)

Fixes #552

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to how server instructions are generated and how tool registration is iterated, with no changes to underlying tool implementations or auth/data paths.
> 
> **Overview**
> Server startup now **builds the MCP instruction text dynamically** from the actually enabled tool categories (respecting `--enabled-tools` and per-category `--disable-*` flags), instead of using a hardcoded capabilities list.
> 
> Tool registration is refactored to use a single ordered `toolEntries()` list shared by both `processTools()` (registration) and `buildInstructions()` (instructions), and new unit tests validate instruction content for enabled/disabled/empty configurations and that the timestamp note is always present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d96e7e04c7eb7dd44477eed8f779d769dfa4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->