### PR TITLE
fix(sift): use comma-ok assertion for patterns to prevent panic

### DIFF
--- a/tools/sift.go
+++ b/tools/sift.go
@@ -321,7 +321,12 @@ func findErrorPatternLogs(ctx context.Context, args FindErrorPatternLogsParams) 
 		// No patterns found, return the analysis without examples
 		return errorPatternLogsAnalysis, nil
 	}
-	for _, pattern := range errorPatternLogsAnalysis.Result.Details["patterns"].([]any) {
+	patterns, ok := errorPatternLogsAnalysis.Result.Details["patterns"].([]any)
+	if !ok {
+		// Patterns key missing or unexpected type; return analysis without examples
+		return errorPatternLogsAnalysis, nil
+	}
+	for _, pattern := range patterns {
 		patternMap, ok := pattern.(map[string]any)
 		if !ok {
 			continue


### PR DESCRIPTION
## Summary

Use comma-ok type assertion for `Details["patterns"]` in the Sift error pattern handler to prevent a runtime panic when the API returns unexpected data.

## Motivation and Context

The unchecked `.([]any)` assertion at line 324 panics if:
- The `"patterns"` key is missing from `Details`
- The value is `null` (unmarshaled as nil)
- The API returns an unexpected type

The very next line already uses the defensive comma-ok pattern for the inner assertion. This change applies the same approach for consistency.

## How Has This Been Tested?

- `go build ./...` passes
- The change is defensive (adds an early return on unexpected data) and does not alter the happy path

Fixes #833

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change that only affects how `ErrorPatternLogs` results are post-processed, returning early when the API response shape is unexpected instead of panicking.
> 
> **Overview**
> Prevents a runtime panic in `findErrorPatternLogs` (`tools/sift.go`) by replacing the unchecked type assertion on `Result.Details["patterns"]` with a comma-ok check.
> 
> If the `patterns` field is missing or not a `[]any`, the tool now returns the analysis as-is (without fetching/attaching log examples), while preserving the existing happy path behavior when the data is well-formed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7c64000d2452ea626cdb83d616d6039f0a02a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->