### PR TITLE
chore: add Grafana Cloud remote MCP to server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -8,6 +8,21 @@
   },
   "version": "$VERSION",
   "icon": "assets/icon.png",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.grafana.com/mcp",
+      "headers": [
+        {
+          "name": "X-Grafana-URL",
+          "description": "URL of your Grafana Cloud instance",
+          "placeholder": "https://<instance>.grafana.net",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ],
   "packages": [
     {
       "registryType": "oci",


### PR DESCRIPTION
So it can be used when installing the server from the registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata/config change only; it adds an optional remote endpoint definition without modifying runtime server logic.
> 
> **Overview**
> Enables registry installs to target a hosted Grafana Cloud MCP endpoint by adding a `remotes` entry to `server.json` for `streamable-http` at `https://mcp.grafana.com/mcp`.
> 
> The remote configuration includes an optional `X-Grafana-URL` header to specify the user’s Grafana Cloud instance URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5e2d2f0c2a55ce999760dd6846e4a124147ab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->