### PR TITLE
tools: add generic API request tool

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -69,6 +69,7 @@ var categoryDescription = map[string]string{
 	"clickhouse":    "ClickHouse: Query ClickHouse datasources via Grafana with macro and variable substitution support.",
 	"runpanelquery": "Run Panel Query: Execute panel queries directly.",
 	"graphite":      "Graphite: Query Graphite datasources for metrics.",
+	"api":           "API: Make authenticated HTTP requests to any Grafana API endpoint with optional jq-style response filtering.",
 }
 
 // disabledTools indicates whether each category of tools should be disabled.
@@ -80,7 +81,7 @@ type disabledTools struct {
 	dashboard, folder, oncall, asserts, sift, admin,
 	pyroscope, navigation, proxied, annotations, rendering, cloudwatch, write,
 	examples, clickhouse, graphite,
-	runpanelquery, plugin bool
+	runpanelquery, plugin, api bool
 }
 
 // Configuration for the Grafana client.
@@ -99,7 +100,7 @@ type grafanaConfig struct {
 }
 
 func (dt *disabledTools) addFlags() {
-	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,plugin", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
+	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,plugin,api", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
 	flag.BoolVar(&dt.search, "disable-search", false, "Disable search tools")
 	flag.BoolVar(&dt.datasource, "disable-datasource", false, "Disable datasource tools")
 	flag.BoolVar(&dt.incident, "disable-incident", false, "Disable incident tools")
@@ -126,6 +127,7 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.runpanelquery, "disable-runpanelquery", false, "Disable run panel query tools")
 	flag.BoolVar(&dt.graphite, "disable-graphite", false, "Disable Graphite tools")
 	flag.BoolVar(&dt.plugin, "disable-plugin", false, "Disable plugin tools")
+	flag.BoolVar(&dt.api, "disable-api", false, "Disable API tools")
 }
 
 func (gc *grafanaConfig) addFlags() {
@@ -178,6 +180,7 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{tools.AddRunPanelQueryTools, dt.runpanelquery, "runpanelquery"},
 		{tools.AddGraphiteTools, dt.graphite, "graphite"},
 		{tools.AddPluginTools, dt.plugin, "plugin"},
+		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools) }, dt.api, "api"},
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,8 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
+	github.com/itchyny/gojq v0.12.19 // indirect
+	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/jaegertracing/jaeger-idl v0.6.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,10 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
+github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
+github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
+github.com/itchyny/timefmt-go v0.1.8/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/jaegertracing/jaeger-idl v0.6.0 h1:LOVQfVby9ywdMPI9n3hMwKbyLVV3BL1XH2QqsP5KTMk=
 github.com/jaegertracing/jaeger-idl v0.6.0/go.mod h1:mpW0lZfG907/+o5w5OlnNnig7nHJGT3SfKmRqC42HGQ=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=

--- a/tools/api.go
+++ b/tools/api.go
@@ -122,9 +122,12 @@ func doAPIRequest(ctx context.Context, endpoint, method, body string, headers ma
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if len(respBody) > maxAPIResponseBytes {
+		return nil, fmt.Errorf("response body exceeds maximum size of %d bytes", maxAPIResponseBytes)
 	}
 
 	result := &APIRequestResult{

--- a/tools/api.go
+++ b/tools/api.go
@@ -1,0 +1,196 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/itchyny/gojq"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+const maxAPIResponseBytes = 10 * 1024 * 1024 // 10MB
+
+var allowedMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodPatch:  true,
+	http.MethodDelete: true,
+}
+
+var readOnlyMethods = map[string]bool{
+	http.MethodGet: true,
+}
+
+type APIRequestParams struct {
+	Endpoint string            `json:"endpoint" jsonschema:"required,description=The API path relative to the Grafana base URL (e.g. '/api/org'\\, '/api/dashboards/uid/abc123'). Must start with '/'."`
+	Method   string            `json:"method,omitempty" jsonschema:"enum=GET,enum=POST,enum=PUT,enum=PATCH,enum=DELETE,description=HTTP method. Defaults to GET"`
+	Body     string            `json:"body,omitempty" jsonschema:"description=Request body (JSON string). Used with POST\\, PUT\\, and PATCH requests."`
+	Headers  map[string]string `json:"headers,omitempty" jsonschema:"description=Additional HTTP headers to include in the request."`
+	JQ       string            `json:"jq,omitempty" jsonschema:"description=A jq expression to filter or transform the JSON response (e.g. '.dashboards[] | .title')."`
+}
+
+type APIRequestResult struct {
+	Status  int               `json:"status"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Data    any               `json:"data"`
+}
+
+func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, error) {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	if cfg.URL == "" {
+		return nil, fmt.Errorf("grafana URL is not configured")
+	}
+
+	method := strings.ToUpper(args.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+	if !allowedMethods[method] {
+		return nil, fmt.Errorf("unsupported HTTP method: %s", method)
+	}
+
+	endpoint := args.Endpoint
+	if !strings.HasPrefix(endpoint, "/") {
+		return nil, fmt.Errorf("endpoint must be a relative path starting with '/' (got %q)", endpoint)
+	}
+
+	var jqCode *gojq.Code
+	if args.JQ != "" {
+		query, err := gojq.Parse(args.JQ)
+		if err != nil {
+			return nil, fmt.Errorf("invalid jq expression: %w", err)
+		}
+		code, err := gojq.Compile(query)
+		if err != nil {
+			return nil, fmt.Errorf("compile jq expression: %w", err)
+		}
+		jqCode = code
+	}
+
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build transport: %w", err)
+	}
+
+	url := strings.TrimRight(cfg.URL, "/") + endpoint
+
+	var bodyReader io.Reader
+	if args.Body != "" {
+		bodyReader = strings.NewReader(args.Body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	if args.Body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range args.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := (&http.Client{Transport: transport}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	result := &APIRequestResult{
+		Status: resp.StatusCode,
+		Headers: map[string]string{
+			"Content-Type": resp.Header.Get("Content-Type"),
+		},
+	}
+
+	var parsed any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		result.Data = string(body)
+		return result, nil
+	}
+
+	if jqCode != nil {
+		filtered, err := applyJQ(jqCode, parsed)
+		if err != nil {
+			return nil, fmt.Errorf("apply jq expression: %w", err)
+		}
+		result.Data = filtered
+	} else {
+		result.Data = parsed
+	}
+
+	return result, nil
+}
+
+func applyJQ(code *gojq.Code, input any) (any, error) {
+	iter := code.Run(input)
+	var results []any
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, isErr := v.(error); isErr {
+			return nil, err
+		}
+		results = append(results, v)
+	}
+	if len(results) == 1 {
+		return results[0], nil
+	}
+	return results, nil
+}
+
+var APIRequest = mcpgrafana.MustTool(
+	"grafana_api_request",
+	"Make an authenticated HTTP request to the Grafana API. Similar to 'gh api' for GitHub. "+
+		"Supports any Grafana API endpoint with optional jq-style response filtering. "+
+		"Use this for API endpoints that don't have a dedicated tool.",
+	apiRequest,
+	mcp.WithTitleAnnotation("Grafana API request"),
+)
+
+var APIRequestReadOnly = mcpgrafana.MustTool(
+	"grafana_api_request",
+	"Make an authenticated HTTP request to the Grafana API. Similar to 'gh api' for GitHub. "+
+		"Supports any Grafana API endpoint with optional jq-style response filtering. "+
+		"Use this for API endpoints that don't have a dedicated tool. "+
+		"Only GET requests are allowed.",
+	apiRequestReadOnly,
+	mcp.WithTitleAnnotation("Grafana API request"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+func apiRequestReadOnly(ctx context.Context, args APIRequestParams) (*APIRequestResult, error) {
+	method := strings.ToUpper(args.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+	if !readOnlyMethods[method] {
+		return nil, fmt.Errorf("method %s is not allowed in read-only mode; only GET requests are permitted", method)
+	}
+	return apiRequest(ctx, args)
+}
+
+func AddAPITools(mcp *server.MCPServer, enableWriteTools bool) {
+	if enableWriteTools {
+		APIRequest.Register(mcp)
+	} else {
+		APIRequestReadOnly.Register(mcp)
+	}
+}

--- a/tools/api.go
+++ b/tools/api.go
@@ -25,14 +25,17 @@ var allowedMethods = map[string]bool{
 	http.MethodDelete: true,
 }
 
-var readOnlyMethods = map[string]bool{
-	http.MethodGet: true,
-}
-
 type APIRequestParams struct {
 	Endpoint string            `json:"endpoint" jsonschema:"required,description=The API path relative to the Grafana base URL (e.g. '/api/org'\\, '/api/dashboards/uid/abc123'). Must start with '/'."`
 	Method   string            `json:"method,omitempty" jsonschema:"enum=GET,enum=POST,enum=PUT,enum=PATCH,enum=DELETE,description=HTTP method. Defaults to GET"`
 	Body     string            `json:"body,omitempty" jsonschema:"description=Request body (JSON string). Used with POST\\, PUT\\, and PATCH requests."`
+	Headers  map[string]string `json:"headers,omitempty" jsonschema:"description=Additional HTTP headers to include in the request."`
+	JQ       string            `json:"jq,omitempty" jsonschema:"description=A jq expression to filter or transform the JSON response (e.g. '.dashboards[] | .title')."`
+}
+
+type APIRequestReadOnlyParams struct {
+	Endpoint string            `json:"endpoint" jsonschema:"required,description=The API path relative to the Grafana base URL (e.g. '/api/org'\\, '/api/dashboards/uid/abc123'). Must start with '/'."`
+	Method   string            `json:"method,omitempty" jsonschema:"enum=GET,description=HTTP method. Only GET is allowed in read-only mode"`
 	Headers  map[string]string `json:"headers,omitempty" jsonschema:"description=Additional HTTP headers to include in the request."`
 	JQ       string            `json:"jq,omitempty" jsonschema:"description=A jq expression to filter or transform the JSON response (e.g. '.dashboards[] | .title')."`
 }
@@ -44,12 +47,27 @@ type APIRequestResult struct {
 }
 
 func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, error) {
+	return doAPIRequest(ctx, args.Endpoint, args.Method, args.Body, args.Headers, args.JQ)
+}
+
+func apiRequestReadOnly(ctx context.Context, args APIRequestReadOnlyParams) (*APIRequestResult, error) {
+	method := strings.ToUpper(args.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+	if method != http.MethodGet {
+		return nil, fmt.Errorf("method %s is not allowed in read-only mode; only GET requests are permitted", method)
+	}
+	return doAPIRequest(ctx, args.Endpoint, method, "", args.Headers, args.JQ)
+}
+
+func doAPIRequest(ctx context.Context, endpoint, method, body string, headers map[string]string, jqExpr string) (*APIRequestResult, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
 	if cfg.URL == "" {
 		return nil, fmt.Errorf("grafana URL is not configured")
 	}
 
-	method := strings.ToUpper(args.Method)
+	method = strings.ToUpper(method)
 	if method == "" {
 		method = http.MethodGet
 	}
@@ -57,14 +75,13 @@ func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, 
 		return nil, fmt.Errorf("unsupported HTTP method: %s", method)
 	}
 
-	endpoint := args.Endpoint
 	if !strings.HasPrefix(endpoint, "/") {
 		return nil, fmt.Errorf("endpoint must be a relative path starting with '/' (got %q)", endpoint)
 	}
 
 	var jqCode *gojq.Code
-	if args.JQ != "" {
-		query, err := gojq.Parse(args.JQ)
+	if jqExpr != "" {
+		query, err := gojq.Parse(jqExpr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid jq expression: %w", err)
 		}
@@ -83,8 +100,8 @@ func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, 
 	url := strings.TrimRight(cfg.URL, "/") + endpoint
 
 	var bodyReader io.Reader
-	if args.Body != "" {
-		bodyReader = strings.NewReader(args.Body)
+	if body != "" {
+		bodyReader = strings.NewReader(body)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
@@ -92,10 +109,10 @@ func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, 
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	if args.Body != "" {
+	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	for k, v := range args.Headers {
+	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
 
@@ -105,7 +122,7 @@ func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, 
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
@@ -118,8 +135,8 @@ func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, 
 	}
 
 	var parsed any
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		result.Data = string(body)
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		result.Data = string(respBody)
 		return result, nil
 	}
 
@@ -175,17 +192,6 @@ var APIRequestReadOnly = mcpgrafana.MustTool(
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 )
-
-func apiRequestReadOnly(ctx context.Context, args APIRequestParams) (*APIRequestResult, error) {
-	method := strings.ToUpper(args.Method)
-	if method == "" {
-		method = http.MethodGet
-	}
-	if !readOnlyMethods[method] {
-		return nil, fmt.Errorf("method %s is not allowed in read-only mode; only GET requests are permitted", method)
-	}
-	return apiRequest(ctx, args)
-}
 
 func AddAPITools(mcp *server.MCPServer, enableWriteTools bool) {
 	if enableWriteTools {

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -1,0 +1,295 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func apiTestContext(t *testing.T, serverURL string) context.Context {
+	t.Helper()
+	cfg := mcpgrafana.GrafanaConfig{URL: serverURL}
+	return mcpgrafana.WithGrafanaConfig(context.Background(), cfg)
+}
+
+func TestAPIRequest_GET(t *testing.T) {
+	payload := map[string]any{"name": "Main Org.", "id": float64(1)}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/org", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequest(ctx, APIRequestParams{Endpoint: "/api/org"})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, result.Status)
+	assert.Equal(t, "application/json", result.Headers["Content-Type"])
+	data, ok := result.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Main Org.", data["name"])
+}
+
+func TestAPIRequest_DefaultMethodIsGET(t *testing.T) {
+	var capturedMethod string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	_, err := apiRequest(ctx, APIRequestParams{Endpoint: "/api/org"})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodGet, capturedMethod)
+}
+
+func TestAPIRequest_POST(t *testing.T) {
+	var capturedMethod string
+	var capturedBody string
+	var capturedContentType string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"created"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/annotations",
+		Method:   "POST",
+		Body:     `{"text":"test annotation"}`,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Equal(t, "application/json", capturedContentType)
+	assert.Equal(t, `{"text":"test annotation"}`, capturedBody)
+	assert.Equal(t, http.StatusOK, result.Status)
+}
+
+func TestAPIRequest_CustomHeaders(t *testing.T) {
+	var capturedHeaders http.Header
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	_, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/org",
+		Headers:  map[string]string{"X-Custom-Header": "custom-value"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "custom-value", capturedHeaders.Get("X-Custom-Header"))
+}
+
+func TestAPIRequest_JQFilter(t *testing.T) {
+	payload := map[string]any{
+		"dashboards": []any{
+			map[string]any{"title": "Dashboard 1", "uid": "abc"},
+			map[string]any{"title": "Dashboard 2", "uid": "def"},
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/search",
+		JQ:       ".dashboards | length",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Data)
+}
+
+func TestAPIRequest_JQFilterMultipleResults(t *testing.T) {
+	payload := map[string]any{
+		"items": []any{"a", "b", "c"},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/test",
+		JQ:       ".items[]",
+	})
+
+	require.NoError(t, err)
+	data, ok := result.Data.([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"a", "b", "c"}, data)
+}
+
+func TestAPIRequest_InvalidJQExpression(t *testing.T) {
+	ctx := apiTestContext(t, "http://localhost")
+	_, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/org",
+		JQ:       "invalid[[[",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid jq expression")
+}
+
+func TestAPIRequest_NonJSONResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("plain text response"))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequest(ctx, APIRequestParams{Endpoint: "/api/health"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "plain text response", result.Data)
+}
+
+func TestAPIRequest_RelativeURLRequired(t *testing.T) {
+	ctx := apiTestContext(t, "http://localhost")
+	_, err := apiRequest(ctx, APIRequestParams{Endpoint: "api/org"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a relative path starting with '/'")
+}
+
+func TestAPIRequest_InvalidMethod(t *testing.T) {
+	ctx := apiTestContext(t, "http://localhost")
+	_, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/org",
+		Method:   "INVALID",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported HTTP method")
+}
+
+func TestAPIRequest_NoURLConfigured(t *testing.T) {
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{})
+	_, err := apiRequest(ctx, APIRequestParams{Endpoint: "/api/org"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "grafana URL is not configured")
+}
+
+func TestAPIRequest_AuthHeadersIncluded(t *testing.T) {
+	var capturedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	cfg := mcpgrafana.GrafanaConfig{URL: ts.URL, APIKey: "glsa_test_token"}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), cfg)
+	_, err := apiRequest(ctx, APIRequestParams{Endpoint: "/api/org"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer glsa_test_token", capturedAuth)
+}
+
+func TestAPIRequest_ReadOnlyRejectsNonGET(t *testing.T) {
+	ctx := apiTestContext(t, "http://localhost")
+
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		_, err := apiRequestReadOnly(ctx, APIRequestParams{
+			Endpoint: "/api/org",
+			Method:   method,
+		})
+		require.Error(t, err, "method %s should be rejected", method)
+		assert.Contains(t, err.Error(), "not allowed in read-only mode")
+	}
+}
+
+func TestAPIRequest_ReadOnlyAllowsGET(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequestReadOnly(ctx, APIRequestParams{Endpoint: "/api/org"})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, result.Status)
+}
+
+func TestAPIRequest_ReadOnlyDefaultMethodIsGET(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	_, err := apiRequestReadOnly(ctx, APIRequestParams{Endpoint: "/api/org"})
+	require.NoError(t, err)
+}
+
+func TestAPIRequest_MethodCaseInsensitive(t *testing.T) {
+	var capturedMethod string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	_, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/org",
+		Method:   "post",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, capturedMethod)
+}
+
+func TestAPIRequest_HTTPErrorStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not found"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequest(ctx, APIRequestParams{Endpoint: "/api/dashboards/uid/nonexistent"})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, result.Status)
+	data, ok := result.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Not found", data["message"])
+}

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -290,6 +290,21 @@ func TestAPIRequest_MethodCaseInsensitive(t *testing.T) {
 	assert.Equal(t, http.MethodPost, capturedMethod)
 }
 
+func TestAPIRequest_ResponseTooLarge(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Write more than maxAPIResponseBytes
+		_, _ = w.Write(make([]byte, maxAPIResponseBytes+1))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	_, err := apiRequest(ctx, APIRequestParams{Endpoint: "/api/large"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
 func TestAPIRequest_HTTPErrorStatus(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -221,7 +221,7 @@ func TestAPIRequest_ReadOnlyRejectsNonGET(t *testing.T) {
 	ctx := apiTestContext(t, "http://localhost")
 
 	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
-		_, err := apiRequestReadOnly(ctx, APIRequestParams{
+		_, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{
 			Endpoint: "/api/org",
 			Method:   method,
 		})
@@ -238,7 +238,7 @@ func TestAPIRequest_ReadOnlyAllowsGET(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := apiTestContext(t, ts.URL)
-	result, err := apiRequestReadOnly(ctx, APIRequestParams{Endpoint: "/api/org"})
+	result, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{Endpoint: "/api/org"})
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, result.Status)
@@ -253,7 +253,21 @@ func TestAPIRequest_ReadOnlyDefaultMethodIsGET(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := apiTestContext(t, ts.URL)
-	_, err := apiRequestReadOnly(ctx, APIRequestParams{Endpoint: "/api/org"})
+	_, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{Endpoint: "/api/org"})
+	require.NoError(t, err)
+}
+
+func TestAPIRequest_ReadOnlyParamsHasNoBodyField(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		assert.Empty(t, body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	_, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{Endpoint: "/api/org"})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary

- Adds a `grafana_api_request` tool that lets agents make authenticated HTTP requests to any Grafana API endpoint, similar to `gh api` for GitHub
- Supports configurable HTTP method, request body, custom headers, and jq-style response filtering (via `gojq`)
- Mutating methods (POST/PUT/PATCH/DELETE) gated behind `--disable-write` for consistency with other write-capable tools
- New `api` tool category with `--disable-api` flag, enabled by default

## Test plan

- [x] Unit tests for all parameter combinations (GET, POST, headers, jq, validation, error cases)
- [x] `make test-unit` passes
- [x] `make lint` passes (jsonschema + golangci-lint)
- [x] `make build` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a powerful new tool that can call arbitrary Grafana API endpoints (including mutating requests when write tools are enabled), which could increase blast radius if misused despite method gating and response size limits.
> 
> **Overview**
> Adds a new **generic Grafana API tool** (`grafana_api_request`) that can make authenticated requests to any Grafana API endpoint, optionally applying `jq`-style JSON filtering via `gojq`.
> 
> Introduces an `api` tool category (enabled by default) with `--disable-api`, and reuses the existing `--disable-write` flag to switch between full method support vs *read-only GET-only* mode. Includes unit tests covering method/body/header handling, jq filtering, validation, auth header injection, and response size limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d2d1a66a3c9ce7ff0403dd7c301ad140f74784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->