### PR TITLE
fix(oncall): route OnCall tools through IRM plugin proxy for OBO auth

### DIFF
--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -225,7 +225,7 @@ func amixrGetShift(ctx context.Context, shiftID string) (*OnCallShift, error) {
 		Type:          shift.Type,
 		PriorityLevel: shift.Level,
 		ShiftStart:    shift.Start,
-		RotationStart: shift.Start,
+		RotationStart: shift.Start, // amixr only has one "start" field
 		Frequency:     shift.Frequency,
 		Interval:      derefIntOr(shift.Interval, 0),
 		ByDay:         derefStrSlice(shift.ByDay),

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -15,9 +15,7 @@ import (
 )
 
 // getOnCallURLFromSettings retrieves the OnCall API URL from the Grafana settings endpoint.
-// It makes a GET request to <grafana-url>/api/plugins/grafana-irm-app/settings and extracts
-// the OnCall URL from the jsonData.onCallApiUrl field in the response.
-// Returns the OnCall URL if found, or an error if the URL cannot be retrieved.
+// Only used for the public API fallback path (when no OBO tokens are available).
 func getOnCallURLFromSettings(ctx context.Context, cfg mcpgrafana.GrafanaConfig) (string, error) {
 	settingsURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/settings", cfg.URL)
 
@@ -37,7 +35,7 @@ func getOnCallURLFromSettings(ctx context.Context, cfg mcpgrafana.GrafanaConfig)
 		return "", fmt.Errorf("fetching settings: %w", err)
 	}
 	defer func() {
-		_ = resp.Body.Close() //nolint:errcheck
+		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode != http.StatusOK {
@@ -61,11 +59,11 @@ func getOnCallURLFromSettings(ctx context.Context, cfg mcpgrafana.GrafanaConfig)
 	return settings.JSONData.OnCallAPIURL, nil
 }
 
+// oncallClientFromContext creates an amixr client for the public OnCall API.
+// Used as fallback when OBO auth is not available (OSS / self-hosted with API key).
 func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
-	// Get the standard Grafana URL and API key
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
 
-	// Try to get OnCall URL from settings endpoint
 	grafanaOnCallURL, err := getOnCallURLFromSettings(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("getting OnCall URL from settings: %w", err)
@@ -73,7 +71,6 @@ func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
 
 	grafanaOnCallURL = strings.TrimRight(grafanaOnCallURL, "/")
 
-	// TODO: Allow access to OnCall using an access token instead of an API key.
 	client, err := aapi.NewWithGrafanaURL(grafanaOnCallURL, cfg.APIKey, cfg.URL)
 	if err != nil {
 		return nil, fmt.Errorf("creating OnCall client: %w", err)
@@ -109,45 +106,7 @@ func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
 	return client, nil
 }
 
-// getUserServiceFromContext creates a new UserService using the OnCall client from the context
-func getUserServiceFromContext(ctx context.Context) (*aapi.UserService, error) {
-	client, err := oncallClientFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall client: %w", err)
-	}
-
-	return aapi.NewUserService(client), nil
-}
-
-// getScheduleServiceFromContext creates a new ScheduleService using the OnCall client from the context
-func getScheduleServiceFromContext(ctx context.Context) (*aapi.ScheduleService, error) {
-	client, err := oncallClientFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall client: %w", err)
-	}
-
-	return aapi.NewScheduleService(client), nil
-}
-
-// getTeamServiceFromContext creates a new TeamService using the OnCall client from the context
-func getTeamServiceFromContext(ctx context.Context) (*aapi.TeamService, error) {
-	client, err := oncallClientFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall client: %w", err)
-	}
-
-	return aapi.NewTeamService(client), nil
-}
-
-// getOnCallShiftServiceFromContext creates a new OnCallShiftService using the OnCall client from the context
-func getOnCallShiftServiceFromContext(ctx context.Context) (*aapi.OnCallShiftService, error) {
-	client, err := oncallClientFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall client: %w", err)
-	}
-
-	return aapi.NewOnCallShiftService(client), nil
-}
+// --- Schedules ---
 
 type ListOnCallSchedulesParams struct {
 	TeamID     string `json:"teamId,omitempty" jsonschema:"description=The ID of the team to list schedules for"`
@@ -155,7 +114,7 @@ type ListOnCallSchedulesParams struct {
 	Page       int    `json:"page,omitempty" jsonschema:"description=The page number to return (1-based)"`
 }
 
-// ScheduleSummary represents a simplified view of an OnCall schedule
+// ScheduleSummary represents a simplified view of an OnCall schedule.
 type ScheduleSummary struct {
 	ID       string   `json:"id" jsonschema:"description=The unique identifier of the schedule"`
 	Name     string   `json:"name" jsonschema:"description=The name of the schedule"`
@@ -165,10 +124,19 @@ type ScheduleSummary struct {
 }
 
 func listOnCallSchedules(ctx context.Context, args ListOnCallSchedulesParams) ([]*ScheduleSummary, error) {
-	scheduleService, err := getScheduleServiceFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall schedule service: %w", err)
+	if useOncallProxy(ctx) {
+		return proxyListSchedules(ctx, args)
 	}
+	return amixrListSchedules(ctx, args)
+}
+
+func amixrListSchedules(ctx context.Context, args ListOnCallSchedulesParams) ([]*ScheduleSummary, error) {
+	client, err := oncallClientFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting OnCall client: %w", err)
+	}
+
+	scheduleService := aapi.NewScheduleService(client)
 
 	if args.ScheduleID != "" {
 		schedule, _, err := scheduleService.GetSchedule(args.ScheduleID, &aapi.GetScheduleOptions{})
@@ -200,7 +168,6 @@ func listOnCallSchedules(ctx context.Context, args ListOnCallSchedulesParams) ([
 		return nil, fmt.Errorf("listing OnCall schedules: %w", err)
 	}
 
-	// Convert schedules to summaries
 	summaries := make([]*ScheduleSummary, 0, len(response.Schedules))
 	for _, schedule := range response.Schedules {
 		summary := &ScheduleSummary{
@@ -227,22 +194,45 @@ var ListOnCallSchedules = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
+// --- Shifts ---
+
 type GetOnCallShiftParams struct {
 	ShiftID string `json:"shiftId" jsonschema:"required,description=The ID of the shift to get details for"`
 }
 
-func getOnCallShift(ctx context.Context, args GetOnCallShiftParams) (*aapi.OnCallShift, error) {
-	shiftService, err := getOnCallShiftServiceFromContext(ctx)
+func getOnCallShift(ctx context.Context, args GetOnCallShiftParams) (*OnCallShift, error) {
+	if useOncallProxy(ctx) {
+		return proxyGetShift(ctx, args.ShiftID)
+	}
+	return amixrGetShift(ctx, args.ShiftID)
+}
+
+func amixrGetShift(ctx context.Context, shiftID string) (*OnCallShift, error) {
+	client, err := oncallClientFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting OnCall shift service: %w", err)
+		return nil, fmt.Errorf("getting OnCall client: %w", err)
 	}
 
-	shift, _, err := shiftService.GetOnCallShift(args.ShiftID, &aapi.GetOnCallShiftOptions{})
+	shiftService := aapi.NewOnCallShiftService(client)
+	shift, _, err := shiftService.GetOnCallShift(shiftID, &aapi.GetOnCallShiftOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("getting OnCall shift %s: %w", args.ShiftID, err)
+		return nil, fmt.Errorf("getting OnCall shift %s: %w", shiftID, err)
 	}
 
-	return shift, nil
+	return &OnCallShift{
+		ID:            shift.ID,
+		Name:          shift.Name,
+		Type:          shift.Type,
+		PriorityLevel: shift.Level,
+		ShiftStart:    shift.Start,
+		RotationStart: shift.Start,
+		Frequency:     shift.Frequency,
+		Interval:      derefIntOr(shift.Interval, 0),
+		ByDay:         derefStrSlice(shift.ByDay),
+		WeekStart:     derefStrOr(shift.WeekStart, ""),
+		RollingUsers:  shift.RollingUsers,
+		Until:         derefStrOr(shift.Until, ""),
+	}, nil
 }
 
 var GetOnCallShift = mcpgrafana.MustTool(
@@ -254,11 +244,13 @@ var GetOnCallShift = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-// CurrentOnCallUsers represents the currently on-call users for a schedule
+// --- Current On-Call Users ---
+
+// CurrentOnCallUsers represents the currently on-call users for a schedule.
 type CurrentOnCallUsers struct {
-	ScheduleID   string       `json:"scheduleId" jsonschema:"description=The ID of the schedule"`
-	ScheduleName string       `json:"scheduleName" jsonschema:"description=The name of the schedule"`
-	Users        []*aapi.User `json:"users" jsonschema:"description=List of users currently on call"`
+	ScheduleID   string        `json:"scheduleId" jsonschema:"description=The ID of the schedule"`
+	ScheduleName string        `json:"scheduleName" jsonschema:"description=The name of the schedule"`
+	Users        []*OnCallUser `json:"users" jsonschema:"description=List of users currently on call"`
 }
 
 type GetCurrentOnCallUsersParams struct {
@@ -266,43 +258,46 @@ type GetCurrentOnCallUsersParams struct {
 }
 
 func getCurrentOnCallUsers(ctx context.Context, args GetCurrentOnCallUsersParams) (*CurrentOnCallUsers, error) {
-	scheduleService, err := getScheduleServiceFromContext(ctx)
+	if useOncallProxy(ctx) {
+		return proxyGetCurrentOnCallUsers(ctx, args.ScheduleID)
+	}
+	return amixrGetCurrentOnCallUsers(ctx, args.ScheduleID)
+}
+
+func amixrGetCurrentOnCallUsers(ctx context.Context, scheduleID string) (*CurrentOnCallUsers, error) {
+	client, err := oncallClientFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting OnCall schedule service: %w", err)
+		return nil, fmt.Errorf("getting OnCall client: %w", err)
 	}
 
-	schedule, _, err := scheduleService.GetSchedule(args.ScheduleID, &aapi.GetScheduleOptions{})
+	scheduleService := aapi.NewScheduleService(client)
+	schedule, _, err := scheduleService.GetSchedule(scheduleID, &aapi.GetScheduleOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("getting schedule %s: %w", args.ScheduleID, err)
+		return nil, fmt.Errorf("getting schedule %s: %w", scheduleID, err)
 	}
 
-	// Create the result with the schedule info
 	result := &CurrentOnCallUsers{
 		ScheduleID:   schedule.ID,
 		ScheduleName: schedule.Name,
-		Users:        make([]*aapi.User, 0, len(schedule.OnCallNow)),
+		Users:        make([]*OnCallUser, 0, len(schedule.OnCallNow)),
 	}
 
-	// If there are no users on call, return early
 	if len(schedule.OnCallNow) == 0 {
 		return result, nil
 	}
 
-	// Get the user service to fetch user details
-	userService, err := getUserServiceFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall user service: %w", err)
-	}
-
-	// Fetch details for each user currently on call
+	userService := aapi.NewUserService(client)
 	for _, userID := range schedule.OnCallNow {
 		user, _, err := userService.GetUser(userID, &aapi.GetUserOptions{})
 		if err != nil {
-			// Log the error but continue with other users
-			fmt.Printf("Error fetching user %s: %v\n", userID, err)
 			continue
 		}
-		result.Users = append(result.Users, user)
+		result.Users = append(result.Users, &OnCallUser{
+			ID:       user.ID,
+			Username: user.Username,
+			Email:    user.Email,
+			Role:     user.Role,
+		})
 	}
 
 	return result, nil
@@ -317,16 +312,26 @@ var GetCurrentOnCallUsers = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
+// --- Teams ---
+
 type ListOnCallTeamsParams struct {
 	Page int `json:"page,omitempty" jsonschema:"description=The page number to return"`
 }
 
-func listOnCallTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*aapi.Team, error) {
-	teamService, err := getTeamServiceFromContext(ctx)
+func listOnCallTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*OnCallTeam, error) {
+	if useOncallProxy(ctx) {
+		return proxyListTeams(ctx, args)
+	}
+	return amixrListTeams(ctx, args)
+}
+
+func amixrListTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*OnCallTeam, error) {
+	client, err := oncallClientFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting OnCall team service: %w", err)
+		return nil, fmt.Errorf("getting OnCall client: %w", err)
 	}
 
+	teamService := aapi.NewTeamService(client)
 	listOptions := &aapi.ListTeamOptions{}
 	if args.Page > 0 {
 		listOptions.Page = args.Page
@@ -337,7 +342,16 @@ func listOnCallTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*aapi.T
 		return nil, fmt.Errorf("listing OnCall teams: %w", err)
 	}
 
-	return response.Teams, nil
+	result := make([]*OnCallTeam, 0, len(response.Teams))
+	for _, team := range response.Teams {
+		result = append(result, &OnCallTeam{
+			ID:        team.ID,
+			Name:      team.Name,
+			Email:     team.Email,
+			AvatarURL: team.AvatarUrl,
+		})
+	}
+	return result, nil
 }
 
 var ListOnCallTeams = mcpgrafana.MustTool(
@@ -349,27 +363,42 @@ var ListOnCallTeams = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
+// --- Users ---
+
 type ListOnCallUsersParams struct {
 	UserID   string `json:"userId,omitempty" jsonschema:"description=The ID of the user to get details for. If provided\\, returns only that user's details"`
 	Username string `json:"username,omitempty" jsonschema:"description=The username to filter users by. If provided\\, returns only the user matching this username"`
 	Page     int    `json:"page,omitempty" jsonschema:"description=The page number to return"`
 }
 
-func listOnCallUsers(ctx context.Context, args ListOnCallUsersParams) ([]*aapi.User, error) {
-	userService, err := getUserServiceFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall user service: %w", err)
+func listOnCallUsers(ctx context.Context, args ListOnCallUsersParams) ([]*OnCallUser, error) {
+	if useOncallProxy(ctx) {
+		return proxyListUsers(ctx, args)
 	}
+	return amixrListUsers(ctx, args)
+}
+
+func amixrListUsers(ctx context.Context, args ListOnCallUsersParams) ([]*OnCallUser, error) {
+	client, err := oncallClientFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting OnCall client: %w", err)
+	}
+
+	userService := aapi.NewUserService(client)
 
 	if args.UserID != "" {
 		user, _, err := userService.GetUser(args.UserID, &aapi.GetUserOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("getting OnCall user %s: %w", args.UserID, err)
 		}
-		return []*aapi.User{user}, nil
+		return []*OnCallUser{{
+			ID:       user.ID,
+			Username: user.Username,
+			Email:    user.Email,
+			Role:     user.Role,
+		}}, nil
 	}
 
-	// Otherwise, list all users
 	listOptions := &aapi.ListUserOptions{}
 	if args.Page > 0 {
 		listOptions.Page = args.Page
@@ -383,7 +412,16 @@ func listOnCallUsers(ctx context.Context, args ListOnCallUsersParams) ([]*aapi.U
 		return nil, fmt.Errorf("listing OnCall users: %w", err)
 	}
 
-	return response.Users, nil
+	result := make([]*OnCallUser, 0, len(response.Users))
+	for _, user := range response.Users {
+		result = append(result, &OnCallUser{
+			ID:       user.ID,
+			Username: user.Username,
+			Email:    user.Email,
+			Role:     user.Role,
+		})
+	}
+	return result, nil
 }
 
 var ListOnCallUsers = mcpgrafana.MustTool(
@@ -395,14 +433,7 @@ var ListOnCallUsers = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
-func getAlertGroupServiceFromContext(ctx context.Context) (*aapi.AlertGroupService, error) {
-	client, err := oncallClientFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall client: %w", err)
-	}
-
-	return aapi.NewAlertGroupService(client), nil
-}
+// --- Alert Groups ---
 
 type ListAlertGroupsParams struct {
 	Page          int      `json:"page,omitempty" jsonschema:"description=The page number to return"`
@@ -416,11 +447,20 @@ type ListAlertGroupsParams struct {
 	Name          string   `json:"name,omitempty" jsonschema:"description=Filter by alert group name"`
 }
 
-func listAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*aapi.AlertGroup, error) {
-	alertGroupService, err := getAlertGroupServiceFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting OnCall alert group service: %w", err)
+func listAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*OnCallAlertGroup, error) {
+	if useOncallProxy(ctx) {
+		return proxyListAlertGroups(ctx, args)
 	}
+	return amixrListAlertGroups(ctx, args)
+}
+
+func amixrListAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*OnCallAlertGroup, error) {
+	client, err := oncallClientFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting OnCall client: %w", err)
+	}
+
+	alertGroupService := aapi.NewAlertGroupService(client)
 
 	listOptions := &aapi.ListAlertGroupOptions{}
 	if args.Page > 0 {
@@ -456,7 +496,21 @@ func listAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*aapi.A
 		return nil, fmt.Errorf("listing OnCall alert groups: %w", err)
 	}
 
-	return response.AlertGroups, nil
+	result := make([]*OnCallAlertGroup, 0, len(response.AlertGroups))
+	for _, ag := range response.AlertGroups {
+		result = append(result, &OnCallAlertGroup{
+			ID:             ag.ID,
+			IntegrationID:  ag.IntegrationID,
+			AlertsCount:    ag.AlertsCount,
+			State:          ag.State,
+			CreatedAt:      ag.CreatedAt,
+			ResolvedAt:     ag.ResolvedAt,
+			AcknowledgedAt: ag.AcknowledgedAt,
+			Title:          ag.Title,
+			Permalinks:     ag.Permalinks,
+		})
+	}
+	return result, nil
 }
 
 var ListAlertGroups = mcpgrafana.MustTool(
@@ -472,18 +526,36 @@ type GetAlertGroupParams struct {
 	AlertGroupID string `json:"alertGroupId" jsonschema:"required,description=The ID of the alert group to retrieve"`
 }
 
-func getAlertGroup(ctx context.Context, args GetAlertGroupParams) (*aapi.AlertGroup, error) {
-	alertGroupService, err := getAlertGroupServiceFromContext(ctx)
+func getAlertGroup(ctx context.Context, args GetAlertGroupParams) (*OnCallAlertGroup, error) {
+	if useOncallProxy(ctx) {
+		return proxyGetAlertGroup(ctx, args.AlertGroupID)
+	}
+	return amixrGetAlertGroup(ctx, args.AlertGroupID)
+}
+
+func amixrGetAlertGroup(ctx context.Context, alertGroupID string) (*OnCallAlertGroup, error) {
+	client, err := oncallClientFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting OnCall alert group service: %w", err)
+		return nil, fmt.Errorf("getting OnCall client: %w", err)
 	}
 
-	alertGroup, _, err := alertGroupService.GetAlertGroup(args.AlertGroupID)
+	alertGroupService := aapi.NewAlertGroupService(client)
+	ag, _, err := alertGroupService.GetAlertGroup(alertGroupID)
 	if err != nil {
-		return nil, fmt.Errorf("getting OnCall alert group %s: %w", args.AlertGroupID, err)
+		return nil, fmt.Errorf("getting OnCall alert group %s: %w", alertGroupID, err)
 	}
 
-	return alertGroup, nil
+	return &OnCallAlertGroup{
+		ID:             ag.ID,
+		IntegrationID:  ag.IntegrationID,
+		AlertsCount:    ag.AlertsCount,
+		State:          ag.State,
+		CreatedAt:      ag.CreatedAt,
+		ResolvedAt:     ag.ResolvedAt,
+		AcknowledgedAt: ag.AcknowledgedAt,
+		Title:          ag.Title,
+		Permalinks:     ag.Permalinks,
+	}, nil
 }
 
 var GetAlertGroup = mcpgrafana.MustTool(
@@ -503,4 +575,27 @@ func AddOnCallTools(mcp *server.MCPServer) {
 	ListOnCallUsers.Register(mcp)
 	ListAlertGroups.Register(mcp)
 	GetAlertGroup.Register(mcp)
+}
+
+// helpers for converting amixr pointer types
+
+func derefStrOr(p *string, fallback string) string {
+	if p != nil {
+		return *p
+	}
+	return fallback
+}
+
+func derefIntOr(p *int, fallback int) int {
+	if p != nil {
+		return *p
+	}
+	return fallback
+}
+
+func derefStrSlice(p *[]string) []string {
+	if p != nil {
+		return *p
+	}
+	return nil
 }

--- a/tools/oncall_cloud_test.go
+++ b/tools/oncall_cloud_test.go
@@ -134,7 +134,6 @@ func TestCloudGetCurrentOnCallUsers(t *testing.T) {
 		assert.NotEmpty(t, result.ScheduleName, "Schedule should have a name")
 		assert.NotNil(t, result.Users, "Users field should be present")
 
-		// Assert that Users is of type []*aapi.User
 		if len(result.Users) > 0 {
 			user := result.Users[0]
 			assert.NotEmpty(t, user.ID, "User should have an ID")

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -97,6 +97,40 @@ func handleProxyErrorResponse(resp *http.Response) error {
 	return fmt.Errorf("request failed with status %d", resp.StatusCode)
 }
 
+// fetchSinglePage fetches a single page from a paginated endpoint (no auto-follow).
+func fetchSinglePage[T any](ctx context.Context, c *oncallProxyClient, path string) ([]T, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if len(body) > 0 {
+			return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+		}
+		return nil, fmt.Errorf("request failed with status %d", resp.StatusCode)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var items []T
+		if err := json.Unmarshal(body, &items); err != nil {
+			return nil, fmt.Errorf("decoding response: %w", err)
+		}
+		return items, nil
+	}
+
+	var page paginatedResult[T]
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return page.Results, nil
+}
+
 // fetchPaginated fetches all pages from a paginated endpoint.
 func fetchPaginated[T any](ctx context.Context, c *oncallProxyClient, path string) ([]T, error) {
 	var all []T
@@ -208,9 +242,15 @@ func proxyListAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*O
 		path += "?" + params.Encode()
 	}
 
-	internal, err := fetchPaginated[onCallAlertGroupInternal](ctx, client, path)
-	if err != nil {
-		return nil, fmt.Errorf("listing alert groups: %w", err)
+	var internal []onCallAlertGroupInternal
+	var err2 error
+	if args.Page > 0 {
+		internal, err2 = fetchSinglePage[onCallAlertGroupInternal](ctx, client, path)
+	} else {
+		internal, err2 = fetchPaginated[onCallAlertGroupInternal](ctx, client, path)
+	}
+	if err2 != nil {
+		return nil, fmt.Errorf("listing alert groups: %w", err2)
 	}
 
 	result := make([]*OnCallAlertGroup, 0, len(internal))
@@ -259,7 +299,12 @@ func proxyListSchedules(ctx context.Context, args ListOnCallSchedulesParams) ([]
 		path += "?" + params.Encode()
 	}
 
-	schedules, err := fetchPaginated[onCallScheduleInternal](ctx, client, path)
+	var schedules []onCallScheduleInternal
+	if args.Page > 0 {
+		schedules, err = fetchSinglePage[onCallScheduleInternal](ctx, client, path)
+	} else {
+		schedules, err = fetchPaginated[onCallScheduleInternal](ctx, client, path)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("listing schedules: %w", err)
 	}
@@ -321,7 +366,12 @@ func proxyListUsers(ctx context.Context, args ListOnCallUsersParams) ([]*OnCallU
 		path += "?" + params.Encode()
 	}
 
-	internal, err := fetchPaginated[onCallUserInternal](ctx, client, path)
+	var internal []onCallUserInternal
+	if args.Page > 0 {
+		internal, err = fetchSinglePage[onCallUserInternal](ctx, client, path)
+	} else {
+		internal, err = fetchPaginated[onCallUserInternal](ctx, client, path)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("listing users: %w", err)
 	}
@@ -348,7 +398,12 @@ func proxyListTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*OnCallT
 		path += "?" + params.Encode()
 	}
 
-	teams, err := fetchPaginated[OnCallTeam](ctx, client, path)
+	var teams []OnCallTeam
+	if args.Page > 0 {
+		teams, err = fetchSinglePage[OnCallTeam](ctx, client, path)
+	} else {
+		teams, err = fetchPaginated[OnCallTeam](ctx, client, path)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("listing teams: %w", err)
 	}

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -231,9 +231,11 @@ func proxyListAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*O
 		params.Set("integration_id", args.IntegrationID)
 	}
 	if args.State != "" {
-		if v, ok := stateToStatus[args.State]; ok {
-			params.Set("status", v)
+		v, ok := stateToStatus[args.State]
+		if !ok {
+			return nil, fmt.Errorf("invalid alert group state %q: must be one of new, acknowledged, resolved, silenced", args.State)
 		}
+		params.Set("status", v)
 	}
 	if args.TeamID != "" {
 		params.Set("team", args.TeamID)

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -181,6 +181,9 @@ func proxyListAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*O
 	if args.AlertGroupID != "" {
 		params.Set("id", args.AlertGroupID)
 	}
+	if args.RouteID != "" {
+		params.Set("route_id", args.RouteID)
+	}
 	if args.IntegrationID != "" {
 		params.Set("integration_id", args.IntegrationID)
 	}

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -33,7 +33,7 @@ type oncallProxyClient struct {
 func newOncallProxyClient(ctx context.Context) (*oncallProxyClient, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
 	if cfg.URL == "" {
-		return nil, fmt.Errorf("Grafana URL is not configured")
+		return nil, fmt.Errorf("grafana URL is not configured")
 	}
 
 	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
@@ -107,7 +107,7 @@ func fetchPaginated[T any](ctx context.Context, c *oncallProxyClient, path strin
 			return nil, err
 		}
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			if len(body) > 0 {
 				return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
@@ -153,7 +153,7 @@ func fetchOne[T any](ctx context.Context, c *oncallProxyClient, basePath, id str
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, handleProxyErrorResponse(resp)

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -1,0 +1,413 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+// IRM plugin proxy paths. The proxy prepends "api/internal/v1/" before forwarding.
+const (
+	irmProxyBasePath = "/api/plugins/grafana-irm-app/resources"
+
+	proxyAlertGroupsPath = "alertgroups/"
+	proxySchedulesPath   = "schedules/"
+	proxyShiftsPath      = "oncall_shifts/"
+	proxyUsersPath       = "users/"
+	proxyTeamsPath       = "teams/"
+)
+
+// oncallProxyClient makes requests to the OnCall internal API via the IRM plugin proxy.
+type oncallProxyClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func newOncallProxyClient(ctx context.Context) (*oncallProxyClient, error) {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	if cfg.URL == "" {
+		return nil, fmt.Errorf("Grafana URL is not configured")
+	}
+
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building transport: %w", err)
+	}
+
+	return &oncallProxyClient{
+		httpClient: &http.Client{Transport: transport},
+		baseURL:    cfg.URL + irmProxyBasePath,
+	}, nil
+}
+
+func (c *oncallProxyClient) doRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	reqURL := c.baseURL + "/" + path
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(req)
+}
+
+// paginatedResult is the standard paginated response from the internal OnCall API.
+type paginatedResult[T any] struct {
+	Results []T     `json:"results"`
+	Next    *string `json:"next"`
+}
+
+// extractNextPath extracts the relative path from pagination URLs.
+// The backend returns absolute URLs pointing to the real OnCall host;
+// we strip the prefix and re-request through the proxy.
+func extractNextPath(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid pagination URL %q: %w", rawURL, err)
+	}
+	const marker = "/api/internal/v1/"
+	if idx := strings.Index(parsed.Path, marker); idx >= 0 {
+		path := parsed.Path[idx+len(marker):]
+		if parsed.RawQuery != "" {
+			path += "?" + parsed.RawQuery
+		}
+		return path, nil
+	}
+	path := strings.TrimPrefix(parsed.Path, "/")
+	if parsed.RawQuery != "" {
+		path += "?" + parsed.RawQuery
+	}
+	return path, nil
+}
+
+func handleProxyErrorResponse(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("request failed with status %d (could not read body: %w)", resp.StatusCode, err)
+	}
+	if len(body) > 0 {
+		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return fmt.Errorf("request failed with status %d", resp.StatusCode)
+}
+
+// fetchPaginated fetches all pages from a paginated endpoint.
+func fetchPaginated[T any](ctx context.Context, c *oncallProxyClient, path string) ([]T, error) {
+	var all []T
+	next := path
+	for next != "" {
+		resp, err := c.doRequest(ctx, http.MethodGet, next, nil)
+		if err != nil {
+			return nil, err
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			if len(body) > 0 {
+				return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+			}
+			return nil, fmt.Errorf("request failed with status %d", resp.StatusCode)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading response: %w", err)
+		}
+
+		// The internal API returns either paginated {"results": [...], "next": "..."} or a raw array.
+		trimmed := bytes.TrimSpace(body)
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			var items []T
+			if err := json.Unmarshal(body, &items); err != nil {
+				return nil, fmt.Errorf("decoding response: %w", err)
+			}
+			all = append(all, items...)
+			break
+		}
+
+		var page paginatedResult[T]
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("decoding response: %w", err)
+		}
+		all = append(all, page.Results...)
+
+		if page.Next == nil || *page.Next == "" {
+			break
+		}
+		next, err = extractNextPath(*page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("pagination: %w", err)
+		}
+	}
+	return all, nil
+}
+
+// fetchOne fetches a single resource by ID.
+func fetchOne[T any](ctx context.Context, c *oncallProxyClient, basePath, id string) (*T, error) {
+	path := fmt.Sprintf("%s%s/", basePath, url.PathEscape(id))
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleProxyErrorResponse(resp)
+	}
+
+	var result T
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &result, nil
+}
+
+// --- Proxy implementations for each tool ---
+
+func proxyListAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*OnCallAlertGroup, error) {
+	client, err := newOncallProxyClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy client: %w", err)
+	}
+
+	params := url.Values{}
+	if args.Page > 0 {
+		params.Set("page", fmt.Sprintf("%d", args.Page))
+	}
+	if args.AlertGroupID != "" {
+		params.Set("id", args.AlertGroupID)
+	}
+	if args.IntegrationID != "" {
+		params.Set("integration_id", args.IntegrationID)
+	}
+	if args.State != "" {
+		params.Set("state", args.State)
+	}
+	if args.TeamID != "" {
+		params.Set("team", args.TeamID)
+	}
+	if args.StartedAt != "" {
+		params.Set("started_at", args.StartedAt)
+	}
+	if args.Name != "" {
+		params.Set("search", args.Name)
+	}
+	for _, label := range args.Labels {
+		params.Add("label", label)
+	}
+
+	path := proxyAlertGroupsPath
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	internal, err := fetchPaginated[onCallAlertGroupInternal](ctx, client, path)
+	if err != nil {
+		return nil, fmt.Errorf("listing alert groups: %w", err)
+	}
+
+	result := make([]*OnCallAlertGroup, 0, len(internal))
+	for i := range internal {
+		result = append(result, internal[i].toOnCallAlertGroup())
+	}
+	return result, nil
+}
+
+func proxyGetAlertGroup(ctx context.Context, id string) (*OnCallAlertGroup, error) {
+	client, err := newOncallProxyClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy client: %w", err)
+	}
+
+	internal, err := fetchOne[onCallAlertGroupInternal](ctx, client, proxyAlertGroupsPath, id)
+	if err != nil {
+		return nil, fmt.Errorf("getting alert group %s: %w", id, err)
+	}
+	return internal.toOnCallAlertGroup(), nil
+}
+
+func proxyListSchedules(ctx context.Context, args ListOnCallSchedulesParams) ([]*ScheduleSummary, error) {
+	client, err := newOncallProxyClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy client: %w", err)
+	}
+
+	if args.ScheduleID != "" {
+		schedule, err := fetchOne[onCallScheduleInternal](ctx, client, proxySchedulesPath, args.ScheduleID)
+		if err != nil {
+			return nil, fmt.Errorf("getting schedule %s: %w", args.ScheduleID, err)
+		}
+		return []*ScheduleSummary{internalScheduleToSummary(schedule)}, nil
+	}
+
+	params := url.Values{}
+	if args.Page > 0 {
+		params.Set("page", fmt.Sprintf("%d", args.Page))
+	}
+	if args.TeamID != "" {
+		params.Set("team", args.TeamID)
+	}
+	path := proxySchedulesPath
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	schedules, err := fetchPaginated[onCallScheduleInternal](ctx, client, path)
+	if err != nil {
+		return nil, fmt.Errorf("listing schedules: %w", err)
+	}
+
+	result := make([]*ScheduleSummary, 0, len(schedules))
+	for i := range schedules {
+		result = append(result, internalScheduleToSummary(&schedules[i]))
+	}
+	return result, nil
+}
+
+func internalScheduleToSummary(s *onCallScheduleInternal) *ScheduleSummary {
+	summary := &ScheduleSummary{
+		ID:       s.ID,
+		Name:     s.Name,
+		Timezone: s.TimeZone,
+		Shifts:   s.Shifts,
+	}
+	if t, ok := s.Team.(string); ok {
+		summary.TeamID = t
+	}
+	if summary.Shifts == nil {
+		summary.Shifts = []string{}
+	}
+	return summary
+}
+
+func proxyGetShift(ctx context.Context, id string) (*OnCallShift, error) {
+	client, err := newOncallProxyClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy client: %w", err)
+	}
+	return fetchOne[OnCallShift](ctx, client, proxyShiftsPath, id)
+}
+
+func proxyListUsers(ctx context.Context, args ListOnCallUsersParams) ([]*OnCallUser, error) {
+	client, err := newOncallProxyClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy client: %w", err)
+	}
+
+	if args.UserID != "" {
+		internal, err := fetchOne[onCallUserInternal](ctx, client, proxyUsersPath, args.UserID)
+		if err != nil {
+			return nil, fmt.Errorf("getting user %s: %w", args.UserID, err)
+		}
+		return []*OnCallUser{internal.toOnCallUser()}, nil
+	}
+
+	params := url.Values{}
+	if args.Page > 0 {
+		params.Set("page", fmt.Sprintf("%d", args.Page))
+	}
+	if args.Username != "" {
+		params.Set("search", args.Username)
+	}
+	path := proxyUsersPath
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	internal, err := fetchPaginated[onCallUserInternal](ctx, client, path)
+	if err != nil {
+		return nil, fmt.Errorf("listing users: %w", err)
+	}
+
+	result := make([]*OnCallUser, 0, len(internal))
+	for i := range internal {
+		result = append(result, internal[i].toOnCallUser())
+	}
+	return result, nil
+}
+
+func proxyListTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*OnCallTeam, error) {
+	client, err := newOncallProxyClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy client: %w", err)
+	}
+
+	params := url.Values{}
+	if args.Page > 0 {
+		params.Set("page", fmt.Sprintf("%d", args.Page))
+	}
+	path := proxyTeamsPath
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	teams, err := fetchPaginated[OnCallTeam](ctx, client, path)
+	if err != nil {
+		return nil, fmt.Errorf("listing teams: %w", err)
+	}
+
+	result := make([]*OnCallTeam, 0, len(teams))
+	for i := range teams {
+		result = append(result, &teams[i])
+	}
+	return result, nil
+}
+
+func proxyGetCurrentOnCallUsers(ctx context.Context, scheduleID string) (*CurrentOnCallUsers, error) {
+	client, err := newOncallProxyClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy client: %w", err)
+	}
+
+	schedule, err := fetchOne[onCallScheduleInternal](ctx, client, proxySchedulesPath, scheduleID)
+	if err != nil {
+		return nil, fmt.Errorf("getting schedule %s: %w", scheduleID, err)
+	}
+
+	result := &CurrentOnCallUsers{
+		ScheduleID:   schedule.ID,
+		ScheduleName: schedule.Name,
+		Users:        make([]*OnCallUser, 0),
+	}
+
+	userIDs := extractUserIDs(schedule.OnCallNow)
+	for _, userID := range userIDs {
+		internal, err := fetchOne[onCallUserInternal](ctx, client, proxyUsersPath, userID)
+		if err != nil {
+			mcpgrafana.LoggerFromContext(ctx).Warn("Failed to fetch on-call user", "user_id", userID, "error", err)
+			continue
+		}
+		result.Users = append(result.Users, internal.toOnCallUser())
+	}
+
+	return result, nil
+}
+
+// extractUserIDs extracts user ID strings from the on_call_now field,
+// which can be []string or []any depending on the API.
+func extractUserIDs(onCallNow any) []string {
+	switch v := onCallNow.(type) {
+	case []string:
+		return v
+	case []any:
+		ids := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				ids = append(ids, s)
+			}
+		}
+		return ids
+	}
+	return nil
+}
+
+// useOncallProxy returns true when OBO auth tokens are available,
+// meaning we should route through the IRM plugin proxy.
+func useOncallProxy(ctx context.Context) bool {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	return cfg.AccessToken != "" && cfg.IDToken != ""
+}

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -419,19 +419,19 @@ func proxyListTeams(ctx context.Context, args ListOnCallTeamsParams) ([]*OnCallT
 		path += "?" + params.Encode()
 	}
 
-	var teams []OnCallTeam
+	var internal []onCallTeamInternal
 	if args.Page > 0 {
-		teams, err = fetchSinglePage[OnCallTeam](ctx, client, path)
+		internal, err = fetchSinglePage[onCallTeamInternal](ctx, client, path)
 	} else {
-		teams, err = fetchPaginated[OnCallTeam](ctx, client, path)
+		internal, err = fetchPaginated[onCallTeamInternal](ctx, client, path)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("listing teams: %w", err)
 	}
 
-	result := make([]*OnCallTeam, 0, len(teams))
-	for i := range teams {
-		result = append(result, &teams[i])
+	result := make([]*OnCallTeam, 0, len(internal))
+	for i := range internal {
+		result = append(result, internal[i].toOnCallTeam())
 	}
 	return result, nil
 }

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -350,7 +350,11 @@ func proxyGetShift(ctx context.Context, id string) (*OnCallShift, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating proxy client: %w", err)
 	}
-	return fetchOne[OnCallShift](ctx, client, proxyShiftsPath, id)
+	internal, err := fetchOne[onCallShiftInternal](ctx, client, proxyShiftsPath, id)
+	if err != nil {
+		return nil, fmt.Errorf("getting shift %s: %w", id, err)
+	}
+	return internal.toOnCallShift(), nil
 }
 
 func proxyListUsers(ctx context.Context, args ListOnCallUsersParams) ([]*OnCallUser, error) {
@@ -391,7 +395,11 @@ func proxyListUsers(ctx context.Context, args ListOnCallUsersParams) ([]*OnCallU
 
 	result := make([]*OnCallUser, 0, len(internal))
 	for i := range internal {
-		result = append(result, internal[i].toOnCallUser())
+		u := internal[i].toOnCallUser()
+		if args.Username != "" && u.Username != args.Username {
+			continue
+		}
+		result = append(result, u)
 	}
 	return result, nil
 }

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -24,6 +24,15 @@ const (
 	proxyTeamsPath       = "teams/"
 )
 
+// stateToStatus maps public API state strings to internal API numeric status values.
+// The internal API's status filter expects integers: 0=new, 1=acknowledged, 2=resolved, 3=silenced.
+var stateToStatus = map[string]string{
+	"new":          "0",
+	"acknowledged": "1",
+	"resolved":     "2",
+	"silenced":     "3",
+}
+
 // oncallProxyClient makes requests to the OnCall internal API via the IRM plugin proxy.
 type oncallProxyClient struct {
 	httpClient *http.Client
@@ -222,7 +231,9 @@ func proxyListAlertGroups(ctx context.Context, args ListAlertGroupsParams) ([]*O
 		params.Set("integration_id", args.IntegrationID)
 	}
 	if args.State != "" {
-		params.Set("state", args.State)
+		if v, ok := stateToStatus[args.State]; ok {
+			params.Set("status", v)
+		}
 	}
 	if args.TeamID != "" {
 		params.Set("team", args.TeamID)

--- a/tools/oncall_proxy_test.go
+++ b/tools/oncall_proxy_test.go
@@ -1,0 +1,324 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractNextPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "standard pagination URL",
+			rawURL: "https://oncall-prod-us-east-0.grafana.net/oncall/api/internal/v1/alertgroups/?cursor=abc123",
+			want:   "alertgroups/?cursor=abc123",
+		},
+		{
+			name:   "pagination with page number",
+			rawURL: "https://oncall-prod.grafana.net/oncall/api/internal/v1/schedules/?page=2",
+			want:   "schedules/?page=2",
+		},
+		{
+			name:   "no query params",
+			rawURL: "https://oncall.grafana.net/oncall/api/internal/v1/users/",
+			want:   "users/",
+		},
+		{
+			name:   "fallback for non-standard URL",
+			rawURL: "https://example.com/some/other/path?page=2",
+			want:   "some/other/path?page=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractNextPath(tt.rawURL)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAlertGroupStatusToState(t *testing.T) {
+	tests := []struct {
+		status any
+		want   string
+	}{
+		{float64(0), "new"},
+		{float64(1), "acknowledged"},
+		{float64(2), "resolved"},
+		{float64(3), "silenced"},
+		{float64(99), "unknown"},
+		{"resolved", "resolved"},
+		{nil, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("status_%v", tt.status), func(t *testing.T) {
+			got := alertGroupStatusToState(tt.status)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInternalAlertGroupConversion(t *testing.T) {
+	ag := &onCallAlertGroupInternal{
+		PK:          "ABC123",
+		AlertsCount: 5,
+		Status:      float64(2),
+		StartedAt:   "2025-01-15T10:00:00Z",
+		ResolvedAt:  "2025-01-15T11:00:00Z",
+		SilencedAt:  "",
+		AlertReceiveChannel: map[string]any{
+			"id":   "INT456",
+			"name": "My Integration",
+		},
+		Team: "TEAM789",
+		RenderForWeb: &renderForWeb{
+			Title:   "High CPU Alert",
+			Message: "CPU usage exceeded 90%",
+		},
+		Permalinks: map[string]string{
+			"slack": "https://slack.com/archives/C123",
+			"web":   "https://grafana.com/a/grafana-irm-app/alert-groups/ABC123",
+		},
+	}
+
+	result := ag.toOnCallAlertGroup()
+
+	assert.Equal(t, "ABC123", result.ID)
+	assert.Equal(t, 5, result.AlertsCount)
+	assert.Equal(t, "resolved", result.State)
+	assert.Equal(t, "2025-01-15T10:00:00Z", result.CreatedAt)
+	assert.Equal(t, "2025-01-15T11:00:00Z", result.ResolvedAt)
+	assert.Equal(t, "INT456", result.IntegrationID)
+	assert.Equal(t, "TEAM789", result.Team)
+	assert.Equal(t, "High CPU Alert", result.Title)
+	assert.Equal(t, "https://slack.com/archives/C123", result.Permalinks["slack"])
+}
+
+func TestInternalUserConversion(t *testing.T) {
+	u := &onCallUserInternal{
+		PK:       "USER123",
+		Username: "testuser",
+		Email:    "test@example.com",
+		Name:     "Test User",
+		Role:     "admin",
+	}
+
+	result := u.toOnCallUser()
+
+	assert.Equal(t, "USER123", result.ID)
+	assert.Equal(t, "testuser", result.Username)
+	assert.Equal(t, "test@example.com", result.Email)
+	assert.Equal(t, "Test User", result.Name)
+	assert.Equal(t, "admin", result.Role)
+}
+
+func TestExtractUserIDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  []string
+	}{
+		{
+			name:  "string slice",
+			input: []string{"user1", "user2"},
+			want:  []string{"user1", "user2"},
+		},
+		{
+			name:  "any slice",
+			input: []any{"user1", "user2"},
+			want:  []string{"user1", "user2"},
+		},
+		{
+			name:  "nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty any slice",
+			input: []any{},
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractUserIDs(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUseOncallProxy(t *testing.T) {
+	t.Run("with OBO tokens", func(t *testing.T) {
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+			URL:         "https://example.grafana.net",
+			AccessToken: "access-token",
+			IDToken:     "id-token",
+		})
+		assert.True(t, useOncallProxy(ctx))
+	})
+
+	t.Run("with API key only", func(t *testing.T) {
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+			URL:    "https://example.grafana.net",
+			APIKey: "my-api-key",
+		})
+		assert.False(t, useOncallProxy(ctx))
+	})
+
+	t.Run("with no auth", func(t *testing.T) {
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+			URL: "https://example.grafana.net",
+		})
+		assert.False(t, useOncallProxy(ctx))
+	})
+}
+
+func TestProxyListAlertGroups(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/api/plugins/grafana-irm-app/resources/alertgroups/")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(paginatedResult[onCallAlertGroupInternal]{
+			Results: []onCallAlertGroupInternal{
+				{
+					PK:          "AG1",
+					AlertsCount: 3,
+					Status:      float64(0),
+					StartedAt:   "2025-01-15T10:00:00Z",
+					RenderForWeb: &renderForWeb{
+						Title: "Test Alert",
+					},
+					Permalinks: map[string]string{"web": "https://example.com/ag1"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+		URL:         server.URL,
+		AccessToken: "test-access",
+		IDToken:     "test-id",
+	})
+
+	result, err := proxyListAlertGroups(ctx, ListAlertGroupsParams{})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "AG1", result[0].ID)
+	assert.Equal(t, "new", result[0].State)
+	assert.Equal(t, "Test Alert", result[0].Title)
+	assert.Equal(t, 3, result[0].AlertsCount)
+}
+
+func TestProxyGetAlertGroup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/api/plugins/grafana-irm-app/resources/alertgroups/AG123/")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(onCallAlertGroupInternal{
+			PK:          "AG123",
+			AlertsCount: 1,
+			Status:      float64(1),
+			StartedAt:   "2025-02-01T08:00:00Z",
+			RenderForWeb: &renderForWeb{
+				Title: "Acknowledged Alert",
+			},
+		})
+	}))
+	defer server.Close()
+
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+		URL:         server.URL,
+		AccessToken: "test-access",
+		IDToken:     "test-id",
+	})
+
+	result, err := proxyGetAlertGroup(ctx, "AG123")
+	require.NoError(t, err)
+	assert.Equal(t, "AG123", result.ID)
+	assert.Equal(t, "acknowledged", result.State)
+	assert.Equal(t, "Acknowledged Alert", result.Title)
+}
+
+func TestProxyListSchedules(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(paginatedResult[onCallScheduleInternal]{
+			Results: []onCallScheduleInternal{
+				{
+					ID:       "SCHED1",
+					Name:     "Primary Schedule",
+					TimeZone: "UTC",
+					Team:     "TEAM1",
+					Shifts:   []string{"SHIFT1", "SHIFT2"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+		URL:         server.URL,
+		AccessToken: "test-access",
+		IDToken:     "test-id",
+	})
+
+	result, err := proxyListSchedules(ctx, ListOnCallSchedulesParams{})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "SCHED1", result[0].ID)
+	assert.Equal(t, "Primary Schedule", result[0].Name)
+	assert.Equal(t, "UTC", result[0].Timezone)
+	assert.Equal(t, "TEAM1", result[0].TeamID)
+	assert.Equal(t, []string{"SHIFT1", "SHIFT2"}, result[0].Shifts)
+}
+
+func TestProxyPagination(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		w.Header().Set("Content-Type", "application/json")
+		if page == 1 {
+			nextURL := fmt.Sprintf("https://oncall-prod.grafana.net/oncall/api/internal/v1/users/?page=2")
+			json.NewEncoder(w).Encode(paginatedResult[onCallUserInternal]{
+				Results: []onCallUserInternal{{PK: "U1", Username: "user1"}},
+				Next:    &nextURL,
+			})
+		} else {
+			json.NewEncoder(w).Encode(paginatedResult[onCallUserInternal]{
+				Results: []onCallUserInternal{{PK: "U2", Username: "user2"}},
+			})
+		}
+	}))
+	defer server.Close()
+
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+		URL:         server.URL,
+		AccessToken: "test-access",
+		IDToken:     "test-id",
+	})
+
+	result, err := proxyListUsers(ctx, ListOnCallUsersParams{})
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, "U1", result[0].ID)
+	assert.Equal(t, "U2", result[1].ID)
+}

--- a/tools/oncall_proxy_test.go
+++ b/tools/oncall_proxy_test.go
@@ -197,7 +197,7 @@ func TestProxyListAlertGroups(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "/api/plugins/grafana-irm-app/resources/alertgroups/")
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(paginatedResult[onCallAlertGroupInternal]{
+		_ = json.NewEncoder(w).Encode(paginatedResult[onCallAlertGroupInternal]{
 			Results: []onCallAlertGroupInternal{
 				{
 					PK:          "AG1",
@@ -233,7 +233,7 @@ func TestProxyGetAlertGroup(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "/api/plugins/grafana-irm-app/resources/alertgroups/AG123/")
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(onCallAlertGroupInternal{
+		_ = json.NewEncoder(w).Encode(onCallAlertGroupInternal{
 			PK:          "AG123",
 			AlertsCount: 1,
 			Status:      float64(1),
@@ -261,7 +261,7 @@ func TestProxyGetAlertGroup(t *testing.T) {
 func TestProxyListSchedules(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(paginatedResult[onCallScheduleInternal]{
+		_ = json.NewEncoder(w).Encode(paginatedResult[onCallScheduleInternal]{
 			Results: []onCallScheduleInternal{
 				{
 					ID:       "SCHED1",
@@ -297,13 +297,13 @@ func TestProxyPagination(t *testing.T) {
 		page++
 		w.Header().Set("Content-Type", "application/json")
 		if page == 1 {
-			nextURL := fmt.Sprintf("https://oncall-prod.grafana.net/oncall/api/internal/v1/users/?page=2")
-			json.NewEncoder(w).Encode(paginatedResult[onCallUserInternal]{
+			nextURL := "https://oncall-prod.grafana.net/oncall/api/internal/v1/users/?page=2"
+			_ = json.NewEncoder(w).Encode(paginatedResult[onCallUserInternal]{
 				Results: []onCallUserInternal{{PK: "U1", Username: "user1"}},
 				Next:    &nextURL,
 			})
 		} else {
-			json.NewEncoder(w).Encode(paginatedResult[onCallUserInternal]{
+			_ = json.NewEncoder(w).Encode(paginatedResult[onCallUserInternal]{
 				Results: []onCallUserInternal{{PK: "U2", Username: "user2"}},
 			})
 		}

--- a/tools/oncall_proxy_test.go
+++ b/tools/oncall_proxy_test.go
@@ -131,6 +131,67 @@ func TestInternalUserConversion(t *testing.T) {
 	assert.Equal(t, "admin", result.Role)
 }
 
+func TestInternalShiftConversion(t *testing.T) {
+	s := &onCallShiftInternal{
+		ID:            "SHIFT1",
+		Name:          "Morning Shift",
+		Type:          float64(2),
+		Schedule:      "SCHED1",
+		PriorityLevel: 1,
+		ShiftStart:    "2025-01-15T08:00:00Z",
+		ShiftEnd:      "2025-01-15T16:00:00Z",
+		RotationStart: "2025-01-01T08:00:00Z",
+		Until:         "2025-06-01T00:00:00Z",
+		Frequency:     "weekly",
+		Interval:      1,
+		ByDay:         []string{"MO", "TU", "WE", "TH", "FR"},
+		WeekStart:     "MO",
+		RollingUsers:  []any{[]any{"USER1", "USER2"}},
+	}
+
+	result := s.toOnCallShift()
+
+	assert.Equal(t, "SHIFT1", result.ID)
+	assert.Equal(t, "Morning Shift", result.Name)
+	assert.Equal(t, float64(2), result.Type)
+	assert.Equal(t, "SCHED1", result.Schedule)
+	assert.Equal(t, 1, result.PriorityLevel)
+	assert.Equal(t, "2025-01-15T08:00:00Z", result.ShiftStart)
+	assert.Equal(t, "2025-01-15T16:00:00Z", result.ShiftEnd)
+	assert.Equal(t, "2025-01-01T08:00:00Z", result.RotationStart)
+	assert.Equal(t, "2025-06-01T00:00:00Z", result.Until)
+	assert.Equal(t, "weekly", result.Frequency)
+	assert.Equal(t, 1, result.Interval)
+	assert.Equal(t, []string{"MO", "TU", "WE", "TH", "FR"}, result.ByDay)
+	assert.Equal(t, "MO", result.WeekStart)
+}
+
+func TestProxyUsernameExactMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(paginatedResult[onCallUserInternal]{
+			Results: []onCallUserInternal{
+				{PK: "U1", Username: "ben"},
+				{PK: "U2", Username: "benjamin"},
+				{PK: "U3", Username: "benny"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+		URL:         server.URL,
+		AccessToken: "test-access",
+		IDToken:     "test-id",
+	})
+
+	result, err := proxyListUsers(ctx, ListOnCallUsersParams{Username: "ben"})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "U1", result[0].ID)
+	assert.Equal(t, "ben", result[0].Username)
+}
+
 func TestExtractUserIDs(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/tools/oncall_types.go
+++ b/tools/oncall_types.go
@@ -88,6 +88,43 @@ type renderForWeb struct {
 	Message string `json:"message"`
 }
 
+// onCallShiftInternal is the internal API response for a shift.
+type onCallShiftInternal struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Type          any      `json:"type"`
+	Schedule      string   `json:"schedule"`
+	PriorityLevel int      `json:"priority_level"`
+	ShiftStart    string   `json:"shift_start"`
+	ShiftEnd      any      `json:"shift_end"`
+	RotationStart string   `json:"rotation_start"`
+	Until         string   `json:"until"`
+	Frequency     any      `json:"frequency"`
+	Interval      int      `json:"interval"`
+	ByDay         []string `json:"by_day"`
+	WeekStart     string   `json:"week_start"`
+	RollingUsers  any      `json:"rolling_users"`
+}
+
+func (s *onCallShiftInternal) toOnCallShift() *OnCallShift {
+	return &OnCallShift{
+		ID:            s.ID,
+		Name:          s.Name,
+		Type:          s.Type,
+		Schedule:      s.Schedule,
+		PriorityLevel: s.PriorityLevel,
+		ShiftStart:    s.ShiftStart,
+		ShiftEnd:      s.ShiftEnd,
+		RotationStart: s.RotationStart,
+		Until:         s.Until,
+		Frequency:     s.Frequency,
+		Interval:      s.Interval,
+		ByDay:         s.ByDay,
+		WeekStart:     s.WeekStart,
+		RollingUsers:  s.RollingUsers,
+	}
+}
+
 // onCallUserInternal is the internal API response for a user.
 type onCallUserInternal struct {
 	PK       string `json:"pk"`

--- a/tools/oncall_types.go
+++ b/tools/oncall_types.go
@@ -88,6 +88,23 @@ type renderForWeb struct {
 	Message string `json:"message"`
 }
 
+// onCallTeamInternal is the internal API response for a team.
+type onCallTeamInternal struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+func (t *onCallTeamInternal) toOnCallTeam() *OnCallTeam {
+	return &OnCallTeam{
+		ID:        t.ID,
+		Name:      t.Name,
+		Email:     t.Email,
+		AvatarURL: t.AvatarURL,
+	}
+}
+
 // onCallShiftInternal is the internal API response for a shift.
 type onCallShiftInternal struct {
 	ID            string   `json:"id"`

--- a/tools/oncall_types.go
+++ b/tools/oncall_types.go
@@ -1,0 +1,157 @@
+package tools
+
+// OnCall response types used by MCP tools.
+// These types provide a unified interface regardless of whether the data
+// comes from the IRM plugin proxy (internal API) or the public OnCall API.
+
+// OnCallAlertGroup represents an alert group returned by MCP tools.
+type OnCallAlertGroup struct {
+	ID             string            `json:"id"`
+	IntegrationID  string            `json:"integration_id,omitempty"`
+	AlertsCount    int               `json:"alerts_count"`
+	State          string            `json:"state"`
+	CreatedAt      string            `json:"created_at"`
+	ResolvedAt     string            `json:"resolved_at,omitempty"`
+	AcknowledgedAt string            `json:"acknowledged_at,omitempty"`
+	SilencedAt     string            `json:"silenced_at,omitempty"`
+	Title          string            `json:"title,omitempty"`
+	Permalinks     map[string]string `json:"permalinks,omitempty"`
+	Labels         any               `json:"labels,omitempty"`
+	Team           string            `json:"team,omitempty"`
+}
+
+// OnCallUser represents an OnCall user returned by MCP tools.
+type OnCallUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	Email    string `json:"email,omitempty"`
+	Role     string `json:"role,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+// OnCallTeam represents an OnCall team returned by MCP tools.
+type OnCallTeam struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Email     string `json:"email,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+}
+
+// OnCallShift represents an on-call shift returned by MCP tools.
+type OnCallShift struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Type          any      `json:"type"`
+	Schedule      string   `json:"schedule,omitempty"`
+	PriorityLevel int      `json:"priority_level,omitempty"`
+	ShiftStart    string   `json:"shift_start,omitempty"`
+	ShiftEnd      any      `json:"shift_end,omitempty"`
+	RotationStart string   `json:"rotation_start,omitempty"`
+	Until         string   `json:"until,omitempty"`
+	Frequency     any      `json:"frequency,omitempty"`
+	Interval      int      `json:"interval,omitempty"`
+	ByDay         []string `json:"by_day,omitempty"`
+	WeekStart     string   `json:"week_start,omitempty"`
+	RollingUsers  any      `json:"rolling_users,omitempty"`
+}
+
+// onCallScheduleInternal is the internal API response for a schedule.
+// Used to parse the IRM proxy response before mapping to ScheduleSummary.
+type onCallScheduleInternal struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Type       any      `json:"type"`
+	Team       any      `json:"team"`
+	TimeZone   string   `json:"time_zone"`
+	OnCallNow  any      `json:"on_call_now"`
+	Shifts     []string `json:"shifts"`
+}
+
+// onCallAlertGroupInternal is the internal API response for an alert group.
+type onCallAlertGroupInternal struct {
+	PK                  string            `json:"pk"`
+	AlertsCount         int               `json:"alerts_count"`
+	Status              any               `json:"status"`
+	StartedAt           string            `json:"started_at"`
+	ResolvedAt          string            `json:"resolved_at"`
+	AcknowledgedAt      string            `json:"acknowledged_at"`
+	SilencedAt          string            `json:"silenced_at"`
+	AlertReceiveChannel any               `json:"alert_receive_channel"`
+	Team                any               `json:"team"`
+	Labels              any               `json:"labels"`
+	RenderForWeb        *renderForWeb     `json:"render_for_web"`
+	Permalinks          map[string]string `json:"permalinks"`
+}
+
+type renderForWeb struct {
+	Title   string `json:"title"`
+	Message string `json:"message"`
+}
+
+// onCallUserInternal is the internal API response for a user.
+type onCallUserInternal struct {
+	PK       string `json:"pk"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Role     any    `json:"role"`
+}
+
+// alertGroupStatusToState converts the internal API numeric status to a string state.
+func alertGroupStatusToState(status any) string {
+	switch v := status.(type) {
+	case float64:
+		switch int(v) {
+		case 0:
+			return "new"
+		case 1:
+			return "acknowledged"
+		case 2:
+			return "resolved"
+		case 3:
+			return "silenced"
+		}
+	case string:
+		return v
+	}
+	return "unknown"
+}
+
+func (ag *onCallAlertGroupInternal) toOnCallAlertGroup() *OnCallAlertGroup {
+	result := &OnCallAlertGroup{
+		ID:             ag.PK,
+		AlertsCount:    ag.AlertsCount,
+		State:          alertGroupStatusToState(ag.Status),
+		CreatedAt:      ag.StartedAt,
+		ResolvedAt:     ag.ResolvedAt,
+		AcknowledgedAt: ag.AcknowledgedAt,
+		SilencedAt:     ag.SilencedAt,
+		Labels:         ag.Labels,
+		Permalinks:     ag.Permalinks,
+	}
+	if ag.RenderForWeb != nil {
+		result.Title = ag.RenderForWeb.Title
+	}
+	if m, ok := ag.AlertReceiveChannel.(map[string]any); ok {
+		if id, ok := m["id"].(string); ok {
+			result.IntegrationID = id
+		}
+	}
+	if t, ok := ag.Team.(string); ok {
+		result.Team = t
+	}
+	return result
+}
+
+func (u *onCallUserInternal) toOnCallUser() *OnCallUser {
+	result := &OnCallUser{
+		ID:       u.PK,
+		Username: u.Username,
+		Email:    u.Email,
+		Name:     u.Name,
+	}
+	if r, ok := u.Role.(string); ok {
+		result.Role = r
+	}
+	return result
+}

--- a/tools/oncall_types.go
+++ b/tools/oncall_types.go
@@ -58,13 +58,13 @@ type OnCallShift struct {
 // onCallScheduleInternal is the internal API response for a schedule.
 // Used to parse the IRM proxy response before mapping to ScheduleSummary.
 type onCallScheduleInternal struct {
-	ID         string   `json:"id"`
-	Name       string   `json:"name"`
-	Type       any      `json:"type"`
-	Team       any      `json:"team"`
-	TimeZone   string   `json:"time_zone"`
-	OnCallNow  any      `json:"on_call_now"`
-	Shifts     []string `json:"shifts"`
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Type      any      `json:"type"`
+	Team      any      `json:"team"`
+	TimeZone  string   `json:"time_zone"`
+	OnCallNow any      `json:"on_call_now"`
+	Shifts    []string `json:"shifts"`
 }
 
 // onCallAlertGroupInternal is the internal API response for an alert group.


### PR DESCRIPTION
## Summary

- OnCall MCP tools (`get_alert_group`, `list_alert_groups`, `list_oncall_schedules`, etc.) had a **100% failure rate** in Cloud MCP production because they used the amixr-api-go-client which requires an API key, but OBO auth contexts leave the API key empty → 403 "Invalid token" from the OnCall public API.
- Adds a dual-path client: when OBO tokens are present (Cloud), requests route through the **IRM plugin proxy** (`/api/plugins/grafana-irm-app/resources/`), which authenticates to OnCall using its own provisioned token. When an API key is present (OSS/self-hosted), the existing amixr client is preserved as fallback.
- Follows the same pattern used by [gcx](https://github.com/grafana/gcx/blob/main/internal/providers/irm/oncall_client.go).

## Changes

- **`tools/oncall_types.go`** — New unified response types (`OnCallAlertGroup`, `OnCallUser`, `OnCallTeam`, `OnCallShift`) and internal API response structs with conversion methods.
- **`tools/oncall_proxy.go`** — IRM plugin proxy client with paginated fetching, path handling for internal API differences (`alertgroups` vs `alert_groups`, `oncall_shifts` vs `on_call_shifts`).
- **`tools/oncall.go`** — Each tool function now checks `useOncallProxy(ctx)` and routes to the proxy or amixr path. Tool interfaces (names, params, descriptions) are unchanged.
- **`tools/oncall_proxy_test.go`** — Unit tests for type conversion, pagination URL extraction, proxy routing logic, and httptest-based integration tests.
- **`tools/oncall_cloud_test.go`** — Updated to use new unified return types.

## Testing

- All existing tests pass (`go test ./... -short`)
- New unit tests cover: status-to-state mapping, internal→unified type conversion, pagination URL extraction, proxy routing detection, and httptest-based proxy endpoint tests.
- Cloud integration tests updated for new types (behind `//go:build cloud` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing and response shaping for all OnCall MCP tools, adding a new proxy client and pagination logic; failures would impact Cloud OnCall tool functionality. Risk is mitigated by keeping the existing public-API (API key) path and adding targeted unit/integration tests.
> 
> **Overview**
> Fixes Cloud OnCall MCP tool failures by **routing OnCall reads through the IRM plugin proxy when OBO tokens are present**, falling back to the existing amixr public OnCall API client when only an API key is available.
> 
> This introduces a dedicated proxy client with pagination handling and query mapping (including state→status conversion), plus new unified response structs (`OnCallAlertGroup`, `OnCallUser`, `OnCallTeam`, `OnCallShift`) so tool outputs are consistent across proxy vs public API paths. Existing tool interfaces remain the same, and tests are updated/added to cover proxy routing, conversions, and pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bcbafd0abf8369fc273f8bb16bbecc87778ad57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->