### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
-# Default owners is the Machine Learning team.
-* @grafana/machine-learning
+* @grafana/grafana-assistant-loop
 
 .github/workflows/publish-technical-documentation-next.yml @grafana/docs-tooling


### PR DESCRIPTION
The Assistant team is a better default here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes repository ownership routing for reviews and has no runtime or production impact.
> 
> **Overview**
> Updates `CODEOWNERS` to change the **default code owner** from `@grafana/machine-learning` to `@grafana/grafana-assistant-loop`.
> 
> Keeps the existing ownership rule for `.github/workflows/publish-technical-documentation-next.yml` under `@grafana/docs-tooling`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6779da589a42c2d07d0a3594490f7bdd5414fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->