### PR TITLE
fix(tools): propagate context to jq and error on non-JSON jq input

### DIFF
--- a/tools/api.go
+++ b/tools/api.go
@@ -139,9 +139,6 @@ func doAPIRequest(ctx context.Context, endpoint, method, body string, headers ma
 
 	var parsed any
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
-		if jqCode != nil {
-			return nil, fmt.Errorf("cannot apply jq expression: response is not valid JSON")
-		}
 		result.Data = string(respBody)
 		return result, nil
 	}

--- a/tools/api.go
+++ b/tools/api.go
@@ -139,12 +139,15 @@ func doAPIRequest(ctx context.Context, endpoint, method, body string, headers ma
 
 	var parsed any
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		if jqCode != nil {
+			return nil, fmt.Errorf("cannot apply jq expression: response is not valid JSON")
+		}
 		result.Data = string(respBody)
 		return result, nil
 	}
 
 	if jqCode != nil {
-		filtered, err := applyJQ(jqCode, parsed)
+		filtered, err := applyJQ(ctx, jqCode, parsed)
 		if err != nil {
 			return nil, fmt.Errorf("apply jq expression: %w", err)
 		}
@@ -156,8 +159,8 @@ func doAPIRequest(ctx context.Context, endpoint, method, body string, headers ma
 	return result, nil
 }
 
-func applyJQ(code *gojq.Code, input any) (any, error) {
-	iter := code.Run(input)
+func applyJQ(ctx context.Context, code *gojq.Code, input any) (any, error) {
+	iter := code.RunWithContext(ctx, input)
 	var results []any
 	for {
 		v, ok := iter.Next()

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -305,7 +305,7 @@ func TestAPIRequest_ResponseTooLarge(t *testing.T) {
 	assert.Contains(t, err.Error(), "exceeds maximum size")
 }
 
-func TestAPIRequest_JQWithNonJSONResponseReturnsError(t *testing.T) {
+func TestAPIRequest_JQWithNonJSONResponseReturnsText(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		_, _ = w.Write([]byte("plain text response"))
@@ -313,13 +313,13 @@ func TestAPIRequest_JQWithNonJSONResponseReturnsError(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := apiTestContext(t, ts.URL)
-	_, err := apiRequest(ctx, APIRequestParams{
+	result, err := apiRequest(ctx, APIRequestParams{
 		Endpoint: "/api/health",
 		JQ:       ".status",
 	})
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "response is not valid JSON")
+	require.NoError(t, err)
+	assert.Equal(t, "plain text response", result.Data)
 }
 
 func TestAPIRequest_JQRespectsContextCancellation(t *testing.T) {

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/itchyny/gojq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -323,23 +324,17 @@ func TestAPIRequest_JQWithNonJSONResponseReturnsText(t *testing.T) {
 }
 
 func TestAPIRequest_JQRespectsContextCancellation(t *testing.T) {
-	payload := map[string]any{"value": float64(1)}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(payload)
-	}))
-	t.Cleanup(ts.Close)
+	// Test applyJQ directly to verify RunWithContext propagates cancellation,
+	// avoiding the HTTP layer which would fail on a cancelled context first.
+	query, err := gojq.Parse("while(true; . + 1)")
+	require.NoError(t, err)
+	code, err := gojq.Compile(query)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cfg := mcpgrafana.GrafanaConfig{URL: ts.URL}
-	ctx = mcpgrafana.WithGrafanaConfig(ctx, cfg)
-	cancel() // cancel immediately
+	cancel()
 
-	_, err := apiRequest(ctx, APIRequestParams{
-		Endpoint: "/api/test",
-		JQ:       "while(true; . + 1)",
-	})
-
+	_, err = applyJQ(ctx, code, float64(1))
 	require.Error(t, err)
 }
 

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -305,6 +305,44 @@ func TestAPIRequest_ResponseTooLarge(t *testing.T) {
 	assert.Contains(t, err.Error(), "exceeds maximum size")
 }
 
+func TestAPIRequest_JQWithNonJSONResponseReturnsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("plain text response"))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	_, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/health",
+		JQ:       ".status",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response is not valid JSON")
+}
+
+func TestAPIRequest_JQRespectsContextCancellation(t *testing.T) {
+	payload := map[string]any{"value": float64(1)}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := mcpgrafana.GrafanaConfig{URL: ts.URL}
+	ctx = mcpgrafana.WithGrafanaConfig(ctx, cfg)
+	cancel() // cancel immediately
+
+	_, err := apiRequest(ctx, APIRequestParams{
+		Endpoint: "/api/test",
+		JQ:       "while(true; . + 1)",
+	})
+
+	require.Error(t, err)
+}
+
 func TestAPIRequest_HTTPErrorStatus(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

- Use `RunWithContext` instead of `Run` for jq execution so that context cancellation and timeouts are respected. Previously, an expensive expression like `while(true; . + 1)` would run forever, ignoring client disconnects.

Addresses a Cursor Bugbot finding from #841.

## Test plan

- [x] New test: `TestAPIRequest_JQRespectsContextCancellation` — cancelled context terminates jq
- [x] New test: `TestAPIRequest_JQWithNonJSONResponseReturnsText` — jq + non-JSON gracefully returns raw text
- [x] All existing tests pass
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes jq execution to honor request context cancellation/timeouts, which could alter behavior for long-running filters and surface new errors on cancelled requests. Scope is limited to the `grafana_api_request` tool and covered by new unit tests.
> 
> **Overview**
> Updates `grafana_api_request` jq processing to propagate the request `context.Context` into gojq execution by switching to `RunWithContext` (and threading `ctx` through `applyJQ`).
> 
> Adds unit tests to ensure jq is not applied to non-JSON responses (raw text is returned) and that cancelled contexts terminate potentially unbounded jq expressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c25b2b78ed4f294e1279eb93854aa8367250a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->