### PR TITLE
feat(loki): support VictoriaLogs through existing Loki tools

### DIFF
--- a/tools/loki.go
+++ b/tools/loki.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -59,13 +60,13 @@ type Pattern struct {
 	TotalCount int64  `json:"totalCount"`
 }
 
-func newLokiClient(ctx context.Context, uid string) (*Client, error) {
-	// First check if the datasource exists
-	_, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
-	if err != nil {
-		return nil, err
-	}
-
+// newLokiClient builds the HTTP client used by the native Loki backend.
+// Callers are expected to have already resolved the datasource (so the
+// existence check happens in lokiBackendForDatasource and isn't repeated
+// here); the ds argument is currently unused but kept to mirror the
+// prom_backend constructor signature and to leave room for per-datasource
+// configuration (e.g. JSONData) without churning the call sites again.
+func newLokiClient(ctx context.Context, uid string, _ *models.DataSource) (*Client, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
 	grafanaURL := cfg.URL
 	resourcesBase, proxyBase := datasourceProxyPaths(uid)

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -245,7 +245,7 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 // ListLokiLabelNames is a tool for listing Loki label names
 var ListLokiLabelNames = mcpgrafana.MustTool(
 	"list_loki_label_names",
-	"Lists all available label names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). On VictoriaLogs (`victoriametrics-logs-datasource`) this maps to the LogsQL field-names endpoint. If the time range is not provided, it defaults to the last hour.",
+	"Lists all available label/field names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
 	listLokiLabelNames,
 	mcp.WithTitleAnnotation("List Loki label names"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -292,7 +292,7 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 // ListLokiLabelValues is a tool for listing Loki label values
 var ListLokiLabelValues = mcpgrafana.MustTool(
 	"list_loki_label_values",
-	"Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. On VictoriaLogs (`victoriametrics-logs-datasource`) this maps to the LogsQL field-values endpoint. Defaults to the last hour if the time range is omitted.",
+	"Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
 	listLokiLabelValues,
 	mcp.WithTitleAnnotation("List Loki label values"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -756,7 +756,7 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 // QueryLokiLogs is a tool for querying logs from Loki
 var QueryLokiLogs = mcpgrafana.MustTool(
 	"query_loki_logs",
-	"Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki datasources (e.g., `{app=\"foo\"} |= \"error\"`, `rate({app=\"bar\"}[1m])`) and LogsQL on VictoriaLogs (`victoriametrics-logs-datasource`) datasources (e.g., `{app=\"foo\"} \"error\"`). Metric / aggregation result types (`vector`, `matrix`) are only produced by Loki; on VictoriaLogs the response always contains log records. Prefer using `query_loki_stats` first to check stream size and `list_loki_label_names` / `list_loki_label_values` to verify labels exist.",
+	"Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki and LogsQL on VictoriaLogs (e.g., Loki: `{app=\"foo\"} |= \"error\"`; VictoriaLogs: `{app=\"foo\"} \"error\"`). Prefer using `query_loki_stats` first to check stream size and `list_loki_label_names` / `list_loki_label_values` to verify labels exist.",
 	queryLokiLogs,
 	mcp.WithTitleAnnotation("Query Loki logs"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -868,7 +868,7 @@ func queryLokiStats(ctx context.Context, args QueryLokiStatsParams) (*Stats, err
 // QueryLokiStats is a tool for querying stats from Loki
 var QueryLokiStats = mcpgrafana.MustTool(
 	"query_loki_stats",
-	"Retrieves statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). On VictoriaLogs (`victoriametrics-logs-datasource`) only `entries` is populated — chunks/streams/bytes are not exposed by the LogsQL stats_query endpoint and remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
+	"Retrieves statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). On VictoriaLogs only `entries` is populated; the other fields remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
 	queryLokiStats,
 	mcp.WithTitleAnnotation("Get Loki log statistics"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -909,7 +909,7 @@ func queryLokiPatterns(ctx context.Context, args QueryLokiPatternsParams) ([]Pat
 // QueryLokiPatterns is a tool for querying detected log patterns from Loki
 var QueryLokiPatterns = mcpgrafana.MustTool(
 	"query_loki_patterns",
-	"Retrieves detected log patterns from a Loki datasource for a given stream selector and time range. Returns a list of patterns, each containing a pattern string and a total count of occurrences. Patterns help identify common log structures and anomalies. The `logql` parameter must be a stream selector (e.g., `{job=\"nginx\"}`) and does not support line filters or aggregations. Defaults to the last hour if the time range is omitted. **Not supported on VictoriaLogs** datasources — the LogsQL HTTP API has no equivalent of `/loki/api/v1/patterns`; the call returns an error explaining how to approximate it via `list_loki_label_values` or a `| stats` pipeline.",
+	"Retrieves detected log patterns from a Loki datasource for a given stream selector and time range. Returns a list of patterns, each containing a pattern string and a total count of occurrences. Patterns help identify common log structures and anomalies. The `logql` parameter must be a stream selector (e.g., `{job=\"nginx\"}`) and does not support line filters or aggregations. Defaults to the last hour if the time range is omitted. **Not supported on VictoriaLogs** datasources - use a `| stats` pipeline instead.",
 	queryLokiPatterns,
 	mcp.WithTitleAnnotation("Query Loki patterns"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -199,14 +199,37 @@ type ListLokiLabelNamesParams struct {
 	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
 }
 
-// listLokiLabelNames lists all label names in a Loki datasource
-func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]string, error) {
-	client, err := newLokiClient(ctx, args.DatasourceUID)
+// parseRFC3339OrZero converts an RFC3339 string to a time.Time, returning a
+// zero time when the input is empty. Unparseable strings are surfaced as
+// errors so callers don't silently send garbage to the backend.
+func parseRFC3339OrZero(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
-		return nil, fmt.Errorf("creating Loki client: %w", err)
+		return time.Time{}, fmt.Errorf("parsing time %q: %w", s, err)
+	}
+	return t, nil
+}
+
+// listLokiLabelNames lists all label names in a Loki (or VictoriaLogs) datasource
+func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]string, error) {
+	backend, err := lokiBackendForDatasource(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating Loki backend: %w", err)
 	}
 
-	result, err := client.fetchData(ctx, "/loki/api/v1/labels", args.StartRFC3339, args.EndRFC3339)
+	start, err := parseRFC3339OrZero(args.StartRFC3339)
+	if err != nil {
+		return nil, err
+	}
+	end, err := parseRFC3339OrZero(args.EndRFC3339)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := backend.ListLabelNames(ctx, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +244,7 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 // ListLokiLabelNames is a tool for listing Loki label names
 var ListLokiLabelNames = mcpgrafana.MustTool(
 	"list_loki_label_names",
-	"Lists all available label names (keys) found in logs within a specified Loki datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
+	"Lists all available label names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). On VictoriaLogs (`victoriametrics-logs-datasource`) this maps to the LogsQL field-names endpoint. If the time range is not provided, it defaults to the last hour.",
 	listLokiLabelNames,
 	mcp.WithTitleAnnotation("List Loki label names"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -236,17 +259,23 @@ type ListLokiLabelValuesParams struct {
 	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
 }
 
-// listLokiLabelValues lists all values for a specific label in a Loki datasource
+// listLokiLabelValues lists all values for a specific label in a Loki (or VictoriaLogs) datasource
 func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([]string, error) {
-	client, err := newLokiClient(ctx, args.DatasourceUID)
+	backend, err := lokiBackendForDatasource(ctx, args.DatasourceUID)
 	if err != nil {
-		return nil, fmt.Errorf("creating Loki client: %w", err)
+		return nil, fmt.Errorf("creating Loki backend: %w", err)
 	}
 
-	// Use the client's fetchData method
-	urlPath := fmt.Sprintf("/loki/api/v1/label/%s/values", args.LabelName)
+	start, err := parseRFC3339OrZero(args.StartRFC3339)
+	if err != nil {
+		return nil, err
+	}
+	end, err := parseRFC3339OrZero(args.EndRFC3339)
+	if err != nil {
+		return nil, err
+	}
 
-	result, err := client.fetchData(ctx, urlPath, args.StartRFC3339, args.EndRFC3339)
+	result, err := backend.ListLabelValues(ctx, args.LabelName, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +291,7 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 // ListLokiLabelValues is a tool for listing Loki label values
 var ListLokiLabelValues = mcpgrafana.MustTool(
 	"list_loki_label_values",
-	"Retrieves all unique values associated with a specific `labelName` within a Loki datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
+	"Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. On VictoriaLogs (`victoriametrics-logs-datasource`) this maps to the LogsQL field-values endpoint. Defaults to the last hour if the time range is omitted.",
 	listLokiLabelValues,
 	mcp.WithTitleAnnotation("List Loki label values"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -529,82 +558,38 @@ func parseMetricTimestamp(raw json.RawMessage) (string, error) {
 	return fmt.Sprintf("%.3f", ts), nil
 }
 
-// queryLokiLogs queries logs from a Loki datasource using LogQL
-func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLogsResult, error) {
-	client, err := newLokiClient(ctx, args.DatasourceUID)
-	if err != nil {
-		return nil, fmt.Errorf("creating Loki client: %w", err)
-	}
-
-	// Get default time range if not provided (for range queries)
-	var startTime, endTime string
-	if args.QueryType == "instant" {
-		// For instant queries, use the provided times as-is
-		startTime = args.StartRFC3339
-		endTime = args.EndRFC3339
-	} else {
-		// For range queries, apply defaults
-		startTime, endTime = getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
-	}
-
-	// Apply limit constraints (only relevant for log queries)
-	limit := enforceLogLimit(ctx, args.Limit)
-
-	// Request one extra to detect truncation
-	queryLimit := limit + 1
-
-	// Set default direction if not provided
-	direction := args.Direction
-	if direction == "" {
-		direction = "backward" // Most recent logs first
-	}
-
-	// Execute the query
-	response, err := client.fetchQuery(ctx, fetchQueryParams{
-		Query:       args.LogQL,
-		QueryType:   args.QueryType,
-		Start:       startTime,
-		End:         endTime,
-		Limit:       queryLimit,
-		Direction:   direction,
-		StepSeconds: args.StepSeconds,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse results based on resultType
+// parseLokiQueryResponse converts a raw Loki /query(_range) response body
+// into a slice of LogEntry. Extracted from queryLokiLogs so that the native
+// Loki backend can reuse it without depending on the tool wrapper.
+func parseLokiQueryResponse(response *lokiQueryResponse) ([]LogEntry, error) {
 	var entries []LogEntry
 
 	switch response.Data.ResultType {
 	case "streams":
-		// Log query results
 		var streams []LokiLogStream
 		if err := json.Unmarshal(response.Data.Result, &streams); err != nil {
 			return nil, fmt.Errorf("parsing streams result: %w", err)
 		}
 
-		// Check if Loki returned categorized labels (Loki >= 3.0).
-		// When present, values[2] is a JSON object with "structuredMetadata"
-		// and "parsed" maps; stream.Stream contains only index labels.
+		// Loki >= 3.0 surfaces structured metadata and parser-extracted
+		// labels in values[2] when the categorize-labels encoding flag is
+		// echoed back in the response.
 		categorized := hasCategorizeLabelsFlag(response.Data.EncodingFlags)
 
 		for _, stream := range streams {
 			for _, value := range stream.Values {
 				if len(value) >= 2 {
-					// Parse log line
 					var logLine string
 					if err := json.Unmarshal(value[1], &logLine); err != nil {
-						continue // Skip invalid log lines
+						continue
 					}
 
 					entry := LogEntry{
-						Timestamp: string(value[0]), // Nanoseconds as string
+						Timestamp: string(value[0]),
 						Line:      logLine,
 						Labels:    stream.Stream,
 					}
 
-					// Parse categorized labels from the optional third element.
 					if categorized && len(value) >= 3 {
 						var cats categorizedLabels
 						if err := json.Unmarshal(value[2], &cats); err == nil {
@@ -619,24 +604,20 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 		}
 
 	case "vector":
-		// Instant metric query results
 		var samples []LokiMetricSample
 		if err := json.Unmarshal(response.Data.Result, &samples); err != nil {
 			return nil, fmt.Errorf("parsing vector result: %w", err)
 		}
-
 		for _, sample := range samples {
 			if len(sample.Value) >= 2 {
 				ts, err := parseMetricTimestamp(sample.Value[0])
 				if err != nil {
 					continue
 				}
-
 				val, err := parseMetricValue(sample.Value[1])
 				if err != nil {
 					continue
 				}
-
 				entries = append(entries, LogEntry{
 					Timestamp: ts,
 					Value:     &val,
@@ -646,12 +627,10 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 		}
 
 	case "matrix":
-		// Range metric query results
 		var samples []LokiMetricSample
 		if err := json.Unmarshal(response.Data.Result, &samples); err != nil {
 			return nil, fmt.Errorf("parsing matrix result: %w", err)
 		}
-
 		for _, sample := range samples {
 			var metricValues []MetricValue
 			for _, value := range sample.Values {
@@ -660,19 +639,13 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 					if err != nil {
 						continue
 					}
-
 					val, err := parseMetricValue(value[1])
 					if err != nil {
 						continue
 					}
-
-					metricValues = append(metricValues, MetricValue{
-						Timestamp: ts,
-						Value:     val,
-					})
+					metricValues = append(metricValues, MetricValue{Timestamp: ts, Value: val})
 				}
 			}
-
 			if len(metricValues) > 0 {
 				entries = append(entries, LogEntry{
 					Values: metricValues,
@@ -685,66 +658,104 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 		return nil, fmt.Errorf("unsupported result type: %s", response.Data.ResultType)
 	}
 
-	// Ensure entries is not nil
+	if entries == nil {
+		entries = []LogEntry{}
+	}
+	return entries, nil
+}
+
+// queryLokiLogs queries logs from a Loki-compatible datasource. The actual
+// transport (native Loki vs VictoriaLogs) is selected by the backend
+// dispatch; this function owns parameter normalization, truncation
+// detection, metadata, and empty-result hints.
+func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLogsResult, error) {
+	backend, err := lokiBackendForDatasource(ctx, args.DatasourceUID)
+	if err != nil {
+		return nil, fmt.Errorf("creating Loki backend: %w", err)
+	}
+
+	// Time defaults: range queries default to "last hour"; instant queries
+	// pass through verbatim because the backend chooses the anchor itself.
+	var startTimeStr, endTimeStr string
+	if args.QueryType == "instant" {
+		startTimeStr = args.StartRFC3339
+		endTimeStr = args.EndRFC3339
+	} else {
+		startTimeStr, endTimeStr = getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	}
+
+	startTime, err := parseRFC3339OrZero(startTimeStr)
+	if err != nil {
+		return nil, err
+	}
+	endTime, err := parseRFC3339OrZero(endTimeStr)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := enforceLogLimit(ctx, args.Limit)
+	queryLimit := limit + 1 // ask for one extra so we can detect truncation
+
+	direction := args.Direction
+	if direction == "" {
+		direction = "backward"
+	}
+
+	result, err := backend.QueryLogs(ctx, lokiQueryParams{
+		Query:       args.LogQL,
+		QueryType:   args.QueryType,
+		Start:       startTime,
+		End:         endTime,
+		Limit:       queryLimit,
+		Direction:   direction,
+		StepSeconds: args.StepSeconds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	entries := result.Entries
 	if entries == nil {
 		entries = []LogEntry{}
 	}
 
-	// Detect truncation and trim to actual limit (only for log queries, not metrics).
-	// For metric queries (vector/matrix), Loki doesn't receive a limit parameter,
-	// so we preserve the old behavior of returning all results.
+	// Truncation only applies to log (streams) queries — metric responses
+	// don't carry a row limit on Loki and VictoriaLogs returns metric
+	// shapes only for stats queries we don't route here.
 	truncated := false
-	if response.Data.ResultType == "streams" { // streams = log queries
+	if result.ResultType == "streams" {
 		truncated = len(entries) > limit
 		if truncated {
 			entries = entries[:limit]
 		}
 	}
 
-	// Get lines scanned from stats (nil if stats unavailable, 0 if actually zero)
-	var linesScanned *int
-	if response.Data.Stats != nil {
-		val := response.Data.Stats.Summary.TotalLinesProcessed
-		linesScanned = &val
-	}
-
-	// Build the response
-	result := &QueryLokiLogsResult{
+	out := &QueryLokiLogsResult{
 		Data: entries,
 		Metadata: &QueryMetadata{
 			LinesReturned:     len(entries),
 			MaxLinesAllowed:   limit,
 			ResultsTruncated:  truncated,
-			TotalLinesScanned: linesScanned,
+			TotalLinesScanned: result.TotalLinesScanned,
 		},
 	}
 
-	// Add hints if the result is empty
 	if len(entries) == 0 {
-		// Parse time strings for hints
-		var parsedStartTime, parsedEndTime time.Time
-		if startTime != "" {
-			parsedStartTime, _ = time.Parse(time.RFC3339, startTime)
-		}
-		if endTime != "" {
-			parsedEndTime, _ = time.Parse(time.RFC3339, endTime)
-		}
-
-		result.Hints = GenerateEmptyResultHints(HintContext{
+		out.Hints = GenerateEmptyResultHints(HintContext{
 			DatasourceType: "loki",
 			Query:          args.LogQL,
-			StartTime:      parsedStartTime,
-			EndTime:        parsedEndTime,
+			StartTime:      startTime,
+			EndTime:        endTime,
 		})
 	}
 
-	return result, nil
+	return out, nil
 }
 
 // QueryLokiLogs is a tool for querying logs from Loki
 var QueryLokiLogs = mcpgrafana.MustTool(
 	"query_loki_logs",
-	"Executes a LogQL query against a Loki datasource to retrieve log entries or metric values. Returns a list of results, each containing a timestamp, labels, and either a log line (`line`) or a numeric metric value (`value`). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). Supports full LogQL syntax for log and metric queries (e.g., `{app=\"foo\"} |= \"error\"`, `rate({app=\"bar\"}[1m])`). Prefer using `query_loki_stats` first to check stream size and `list_loki_label_names` and `list_loki_label_values` to verify labels exist.",
+	"Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki datasources (e.g., `{app=\"foo\"} |= \"error\"`, `rate({app=\"bar\"}[1m])`) and LogsQL on VictoriaLogs (`victoriametrics-logs-datasource`) datasources (e.g., `{app=\"foo\"} \"error\"`). Metric / aggregation result types (`vector`, `matrix`) are only produced by Loki; on VictoriaLogs the response always contains log records. Prefer using `query_loki_stats` first to check stream size and `list_loki_label_names` / `list_loki_label_values` to verify labels exist.",
 	queryLokiLogs,
 	mcp.WithTitleAnnotation("Query Loki logs"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -832,28 +843,31 @@ type QueryLokiStatsParams struct {
 	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format"`
 }
 
-// queryLokiStats queries stats from a Loki datasource using LogQL
+// queryLokiStats queries stats from a Loki-compatible datasource. On
+// VictoriaLogs only the entries count is populated (no chunks/streams/bytes).
 func queryLokiStats(ctx context.Context, args QueryLokiStatsParams) (*Stats, error) {
-	client, err := newLokiClient(ctx, args.DatasourceUID)
+	backend, err := lokiBackendForDatasource(ctx, args.DatasourceUID)
 	if err != nil {
-		return nil, fmt.Errorf("creating Loki client: %w", err)
+		return nil, fmt.Errorf("creating Loki backend: %w", err)
 	}
 
-	// Get default time range if not provided
-	startTime, endTime := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
-
-	stats, err := client.fetchStats(ctx, args.LogQL, startTime, endTime)
+	startTimeStr, endTimeStr := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	startTime, err := parseRFC3339OrZero(startTimeStr)
+	if err != nil {
+		return nil, err
+	}
+	endTime, err := parseRFC3339OrZero(endTimeStr)
 	if err != nil {
 		return nil, err
 	}
 
-	return stats, nil
+	return backend.QueryStats(ctx, args.LogQL, startTime, endTime)
 }
 
 // QueryLokiStats is a tool for querying stats from Loki
 var QueryLokiStats = mcpgrafana.MustTool(
 	"query_loki_stats",
-	"Retrieves statistics about log streams matching a given LogQL *selector* within a Loki datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
+	"Retrieves statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). On VictoriaLogs (`victoriametrics-logs-datasource`) only `entries` is populated — chunks/streams/bytes are not exposed by the LogsQL stats_query endpoint and remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
 	queryLokiStats,
 	mcp.WithTitleAnnotation("Get Loki log statistics"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -869,28 +883,32 @@ type QueryLokiPatternsParams struct {
 	Step          string `json:"step,omitempty" jsonschema:"description=Optionally\\, the query resolution step (e.g. '5m')"`
 }
 
-// queryLokiPatterns queries detected log patterns from a Loki datasource
+// queryLokiPatterns queries detected log patterns from a Loki-compatible
+// datasource. VictoriaLogs has no equivalent endpoint and surfaces a clear
+// error from the backend.
 func queryLokiPatterns(ctx context.Context, args QueryLokiPatternsParams) ([]Pattern, error) {
-	client, err := newLokiClient(ctx, args.DatasourceUID)
+	backend, err := lokiBackendForDatasource(ctx, args.DatasourceUID)
 	if err != nil {
-		return nil, fmt.Errorf("creating Loki client: %w", err)
+		return nil, fmt.Errorf("creating Loki backend: %w", err)
 	}
 
-	// Get default time range if not provided
-	startTime, endTime := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
-
-	patterns, err := client.fetchPatterns(ctx, args.LogQL, startTime, endTime, args.Step)
+	startTimeStr, endTimeStr := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
+	startTime, err := parseRFC3339OrZero(startTimeStr)
+	if err != nil {
+		return nil, err
+	}
+	endTime, err := parseRFC3339OrZero(endTimeStr)
 	if err != nil {
 		return nil, err
 	}
 
-	return patterns, nil
+	return backend.QueryPatterns(ctx, args.LogQL, args.Step, startTime, endTime)
 }
 
 // QueryLokiPatterns is a tool for querying detected log patterns from Loki
 var QueryLokiPatterns = mcpgrafana.MustTool(
 	"query_loki_patterns",
-	"Retrieves detected log patterns from a Loki datasource for a given stream selector and time range. Returns a list of patterns, each containing a pattern string and a total count of occurrences. Patterns help identify common log structures and anomalies. The `logql` parameter must be a stream selector (e.g., `{job=\"nginx\"}`) and does not support line filters or aggregations. Defaults to the last hour if the time range is omitted.",
+	"Retrieves detected log patterns from a Loki datasource for a given stream selector and time range. Returns a list of patterns, each containing a pattern string and a total count of occurrences. Patterns help identify common log structures and anomalies. The `logql` parameter must be a stream selector (e.g., `{job=\"nginx\"}`) and does not support line filters or aggregations. Defaults to the last hour if the time range is omitted. **Not supported on VictoriaLogs** datasources — the LogsQL HTTP API has no equivalent of `/loki/api/v1/patterns`; the call returns an error explaining how to approximate it via `list_loki_label_values` or a `| stats` pipeline.",
 	queryLokiPatterns,
 	mcp.WithTitleAnnotation("Query Loki patterns"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/loki_backend.go
+++ b/tools/loki_backend.go
@@ -1,0 +1,144 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// lokiBackend abstracts the differences between datasource types that serve
+// log data through Loki-compatible tools (native Loki, VictoriaLogs, etc.).
+//
+// The tool entry points in loki.go normalize user-provided parameters
+// (defaults, limits, direction) and delegate the actual datasource query to
+// an implementation of this interface. Each backend is responsible for
+// translating the request to its native API and parsing the response back
+// into the shared LogEntry shape.
+type lokiBackend interface {
+	// ListLabelNames returns the available label/field names within the
+	// given time range. Empty start/end means "use server defaults".
+	ListLabelNames(ctx context.Context, start, end time.Time) ([]string, error)
+
+	// ListLabelValues returns the values for a single label/field within
+	// the given time range.
+	ListLabelValues(ctx context.Context, labelName string, start, end time.Time) ([]string, error)
+
+	// QueryLogs runs a log/metric query and returns the raw entries plus
+	// the result type ("streams" | "vector" | "matrix") and (when known)
+	// the total number of lines scanned by the backend.
+	QueryLogs(ctx context.Context, p lokiQueryParams) (*lokiQueryResult, error)
+
+	// QueryStats returns counts about the streams matching a selector.
+	// Backends without an exact equivalent (e.g. VictoriaLogs) populate
+	// only the fields they can produce and leave the rest as zero.
+	QueryStats(ctx context.Context, query string, start, end time.Time) (*Stats, error)
+
+	// QueryPatterns returns detected log patterns. Backends that do not
+	// implement pattern detection should return a clear error.
+	QueryPatterns(ctx context.Context, query, step string, start, end time.Time) ([]Pattern, error)
+}
+
+// lokiQueryParams is the normalized request shape passed to lokiBackend.QueryLogs.
+type lokiQueryParams struct {
+	Query       string
+	QueryType   string // "instant" or "range"
+	Start, End  time.Time
+	Limit       int    // already clamped to the configured max
+	Direction   string // "forward" or "backward"
+	StepSeconds int    // for range metric queries
+}
+
+// lokiQueryResult is the backend's contribution to QueryLokiLogsResult.
+// The tool wrapper layers truncation handling, metadata, and hints on top.
+type lokiQueryResult struct {
+	Entries           []LogEntry
+	ResultType        string // "streams", "vector", "matrix"
+	TotalLinesScanned *int   // nil when the backend doesn't expose stats
+}
+
+// lokiBackendForDatasource resolves a UID to the appropriate backend by
+// inspecting the datasource type. Native Loki is the default; VictoriaLogs
+// is selected when the type matches the victoriametrics-logs-datasource
+// plugin.
+func lokiBackendForDatasource(ctx context.Context, uid string) (lokiBackend, error) {
+	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
+	if err != nil {
+		return nil, err
+	}
+
+	switch ds.Type {
+	case victoriaLogsDatasourceType:
+		return newVictoriaLogsBackend(ctx, uid)
+	default:
+		return newLokiNativeBackend(ctx, uid)
+	}
+}
+
+// lokiNativeBackend wraps the existing Loki HTTP client to satisfy lokiBackend.
+type lokiNativeBackend struct {
+	client *Client
+}
+
+func  newLokiNativeBackend(ctx context.Context, uid string) (*lokiNativeBackend, error) {
+	c, err := newLokiClient(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	return &lokiNativeBackend{client: c}, nil
+}
+
+func formatRFC3339OrEmpty(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}
+
+func (b *lokiNativeBackend) ListLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
+	return b.client.fetchData(ctx, "/loki/api/v1/labels", formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end))
+}
+
+func (b *lokiNativeBackend) ListLabelValues(ctx context.Context, labelName string, start, end time.Time) ([]string, error) {
+	urlPath := fmt.Sprintf("/loki/api/v1/label/%s/values", labelName)
+	return b.client.fetchData(ctx, urlPath, formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end))
+}
+
+func (b *lokiNativeBackend) QueryLogs(ctx context.Context, p lokiQueryParams) (*lokiQueryResult, error) {
+	response, err := b.client.fetchQuery(ctx, fetchQueryParams{
+		Query:       p.Query,
+		QueryType:   p.QueryType,
+		Start:       formatRFC3339OrEmpty(p.Start),
+		End:         formatRFC3339OrEmpty(p.End),
+		Limit:       p.Limit,
+		Direction:   p.Direction,
+		StepSeconds: p.StepSeconds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := parseLokiQueryResponse(response)
+	if err != nil {
+		return nil, err
+	}
+
+	var linesScanned *int
+	if response.Data.Stats != nil {
+		val := response.Data.Stats.Summary.TotalLinesProcessed
+		linesScanned = &val
+	}
+
+	return &lokiQueryResult{
+		Entries:           entries,
+		ResultType:        response.Data.ResultType,
+		TotalLinesScanned: linesScanned,
+	}, nil
+}
+
+func (b *lokiNativeBackend) QueryStats(ctx context.Context, query string, start, end time.Time) (*Stats, error) {
+	return b.client.fetchStats(ctx, query, formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end))
+}
+
+func (b *lokiNativeBackend) QueryPatterns(ctx context.Context, query, step string, start, end time.Time) ([]Pattern, error) {
+	return b.client.fetchPatterns(ctx, query, formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end), step)
+}

--- a/tools/loki_backend.go
+++ b/tools/loki_backend.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
 )
 
 // lokiBackend abstracts the differences between datasource types that serve
@@ -59,7 +61,9 @@ type lokiQueryResult struct {
 // lokiBackendForDatasource resolves a UID to the appropriate backend by
 // inspecting the datasource type. Native Loki is the default; VictoriaLogs
 // is selected when the type matches the victoriametrics-logs-datasource
-// plugin.
+// plugin. The looked-up DataSource is forwarded to the constructors so
+// they don't have to re-fetch it (mirroring backendForDatasource in
+// prom_backend.go).
 func lokiBackendForDatasource(ctx context.Context, uid string) (lokiBackend, error) {
 	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
 	if err != nil {
@@ -68,9 +72,9 @@ func lokiBackendForDatasource(ctx context.Context, uid string) (lokiBackend, err
 
 	switch ds.Type {
 	case victoriaLogsDatasourceType:
-		return newVictoriaLogsBackend(ctx, uid)
+		return newVictoriaLogsBackend(ctx, uid, ds)
 	default:
-		return newLokiNativeBackend(ctx, uid)
+		return newLokiNativeBackend(ctx, uid, ds)
 	}
 }
 
@@ -79,8 +83,8 @@ type lokiNativeBackend struct {
 	client *Client
 }
 
-func  newLokiNativeBackend(ctx context.Context, uid string) (*lokiNativeBackend, error) {
-	c, err := newLokiClient(ctx, uid)
+func newLokiNativeBackend(ctx context.Context, uid string, ds *models.DataSource) (*lokiNativeBackend, error) {
+	c, err := newLokiClient(ctx, uid, ds)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/loki_backend_victorialogs.go
+++ b/tools/loki_backend_victorialogs.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
@@ -32,7 +33,11 @@ type victoriaLogsBackend struct {
 	baseURL    string
 }
 
-func newVictoriaLogsBackend(ctx context.Context, uid string) (*victoriaLogsBackend, error) {
+// newVictoriaLogsBackend constructs the backend. The ds argument is
+// currently unused but accepted to mirror the prom_backend constructor
+// signature and to leave room for per-datasource configuration without
+// churning callers later.
+func newVictoriaLogsBackend(ctx context.Context, uid string, _ *models.DataSource) (*victoriaLogsBackend, error) {
 	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
 	resourcesBase, proxyBase := datasourceProxyPaths(uid)
 	baseURL := trimTrailingSlash(cfg.URL) + proxyBase

--- a/tools/loki_backend_victorialogs.go
+++ b/tools/loki_backend_victorialogs.go
@@ -1,0 +1,439 @@
+package tools
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+// victoriaLogsDatasourceType identifies the VictoriaLogs Grafana plugin.
+const victoriaLogsDatasourceType = "victoriametrics-logs-datasource"
+
+// victoriaLogsAllQuery is the LogsQL "match everything" expression. Used for
+// label/field discovery when the caller did not narrow the search.
+const victoriaLogsAllQuery = "*"
+
+// victoriaLogsBackend implements lokiBackend by talking to a VictoriaLogs
+// datasource through Grafana's datasource resource proxy. VictoriaLogs
+// exposes the LogsQL HTTP API at /select/logsql/* — the shapes are
+// documented at https://docs.victoriametrics.com/victorialogs/querying/.
+type victoriaLogsBackend struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func newVictoriaLogsBackend(ctx context.Context, uid string) (*victoriaLogsBackend, error) {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	resourcesBase, proxyBase := datasourceProxyPaths(uid)
+	baseURL := trimTrailingSlash(cfg.URL) + proxyBase
+
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create custom transport: %w", err)
+	}
+
+	// Mirror the native Loki client: try /proxy first and fall back to
+	// /resources on 403/500 for compatibility with managed Grafana
+	// deployments. See fallback_transport.go for the rationale.
+	rt := newDatasourceFallbackTransport(transport, proxyBase, resourcesBase)
+
+	return &victoriaLogsBackend{
+		httpClient: &http.Client{Transport: rt, Timeout: 30 * time.Second},
+		baseURL:    baseURL,
+	}, nil
+}
+
+// vlValueHits is the VictoriaLogs response shape for /field_names and
+// /field_values: {"values":[{"value":"x","hits":N}, ...]}.
+type vlValueHits struct {
+	Values []struct {
+		Value string `json:"value"`
+		Hits  int64  `json:"hits"`
+	} `json:"values"`
+}
+
+// vlStatsResponse is the Prometheus-style envelope returned by /stats_query.
+type vlStatsResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			Value  []json.RawMessage `json:"value"` // [ts_float, value_string]
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// addVLTimeRange adds RFC3339 start/end to the given values when set. The
+// VictoriaLogs API accepts RFC3339, RFC3339Nano, Unix seconds, and a few
+// other shapes — we normalize on RFC3339 because every caller already
+// supplies (or defaults to) RFC3339.
+func addVLTimeRange(params url.Values, start, end time.Time) {
+	if !start.IsZero() {
+		params.Set("start", start.Format(time.RFC3339))
+	}
+	if !end.IsZero() {
+		params.Set("end", end.Format(time.RFC3339))
+	}
+}
+
+// doRequest issues an HTTP request to a VictoriaLogs endpoint and returns
+// the response body. POST is used for /query (which can carry large LogsQL
+// expressions); everything else is GET.
+func (b *victoriaLogsBackend) doRequest(ctx context.Context, method, urlPath string, params url.Values) ([]byte, error) {
+	fullURL := b.baseURL
+	if !strings.HasSuffix(fullURL, "/") && !strings.HasPrefix(urlPath, "/") {
+		fullURL += "/"
+	}
+	fullURL += urlPath
+
+	var (
+		req *http.Request
+		err error
+	)
+	switch method {
+	case http.MethodPost:
+		body := strings.NewReader(params.Encode())
+		req, err = http.NewRequestWithContext(ctx, method, fullURL, body)
+		if err == nil {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
+	default:
+		u := fullURL
+		if encoded := params.Encode(); encoded != "" {
+			u += "?" + encoded
+		}
+		req, err = http.NewRequestWithContext(ctx, method, u, nil)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("VictoriaLogs API returned status %d: %s", resp.StatusCode, string(body))
+	}
+	return bytes.TrimSpace(body), nil
+}
+
+func (b *victoriaLogsBackend) listValueHits(ctx context.Context, urlPath string, params url.Values) ([]string, error) {
+	body, err := b.doRequest(ctx, http.MethodGet, urlPath, params)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) == 0 {
+		return []string{}, nil
+	}
+
+	var parsed vlValueHits
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshalling VictoriaLogs response (content: %s): %w", string(body), err)
+	}
+
+	out := make([]string, 0, len(parsed.Values))
+	for _, v := range parsed.Values {
+		out = append(out, v.Value)
+	}
+	return out, nil
+}
+
+func (b *victoriaLogsBackend) ListLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
+	params := url.Values{}
+	params.Set("query", victoriaLogsAllQuery)
+	addVLTimeRange(params, start, end)
+	return b.listValueHits(ctx, "/select/logsql/field_names", params)
+}
+
+func (b *victoriaLogsBackend) ListLabelValues(ctx context.Context, labelName string, start, end time.Time) ([]string, error) {
+	params := url.Values{}
+	params.Set("query", victoriaLogsAllQuery)
+	params.Set("field", labelName)
+	addVLTimeRange(params, start, end)
+	return b.listValueHits(ctx, "/select/logsql/field_values", params)
+}
+
+// QueryLogs runs a LogsQL query. Range and instant requests both go through
+// /select/logsql/query; instant is implemented by anchoring the time window
+// to the requested point. Metric-style queries (PromQL-compatible result
+// types from /stats_query) are not exposed here — callers that want
+// aggregations should phrase them as LogsQL `... | stats by (...)` and use
+// the vector returned by the regular log query.
+func (b *victoriaLogsBackend) QueryLogs(ctx context.Context, p lokiQueryParams) (*lokiQueryResult, error) {
+	if p.QueryType != "" && p.QueryType != "range" && p.QueryType != "instant" {
+		return nil, fmt.Errorf("invalid query type: %s", p.QueryType)
+	}
+
+	start, end := p.Start, p.End
+	if p.QueryType == "instant" {
+		// Instant ≈ "value at a point in time". VictoriaLogs has no
+		// dedicated instant endpoint, so we collapse the window to the
+		// chosen instant (preferring End, then Start, then now) and let
+		// the limit cap the result.
+		var anchor time.Time
+		switch {
+		case !end.IsZero():
+			anchor = end
+		case !start.IsZero():
+			anchor = start
+		default:
+			anchor = time.Now()
+		}
+		start, end = anchor, anchor
+	}
+
+	params := url.Values{}
+	params.Set("query", p.Query)
+	addVLTimeRange(params, start, end)
+	if p.Limit > 0 {
+		params.Set("limit", strconv.Itoa(p.Limit))
+	}
+
+	body, err := b.doRequest(ctx, http.MethodPost, "/select/logsql/query", params)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := parseVictoriaLogsNDJSON(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// VictoriaLogs returns log records by recency descending by default.
+	// If the caller asked for forward (oldest first) order, reverse here
+	// so the contract matches the Loki tool's `direction` parameter.
+	if strings.EqualFold(p.Direction, "forward") {
+		for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+			entries[i], entries[j] = entries[j], entries[i]
+		}
+	}
+
+	return &lokiQueryResult{
+		Entries:    entries,
+		ResultType: "streams",
+	}, nil
+}
+
+// QueryStats approximates Loki's /index/stats by running the selector
+// through /stats_query with a `count(*)` aggregation. VictoriaLogs does not
+// expose chunk/byte counts, so those fields stay zero.
+func (b *victoriaLogsBackend) QueryStats(ctx context.Context, query string, start, end time.Time) (*Stats, error) {
+	statsQuery := strings.TrimSpace(query)
+	if statsQuery == "" {
+		statsQuery = victoriaLogsAllQuery
+	}
+	// stats_query requires a stats pipe at the end. If the caller already
+	// supplied one we use the query as-is; otherwise append `count(*)`.
+	if !strings.Contains(strings.ToLower(statsQuery), "| stats") {
+		statsQuery += " | stats count(*) as entries"
+	}
+
+	params := url.Values{}
+	params.Set("query", statsQuery)
+	addVLTimeRange(params, start, end)
+
+	body, err := b.doRequest(ctx, http.MethodPost, "/select/logsql/stats_query", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp vlStatsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshalling VictoriaLogs stats response (content: %s): %w", string(body), err)
+	}
+	if resp.Status != "" && resp.Status != "success" {
+		return nil, fmt.Errorf("VictoriaLogs stats_query returned status %q: %s", resp.Status, string(body))
+	}
+
+	var entries int
+	for _, r := range resp.Data.Result {
+		if len(r.Value) < 2 {
+			continue
+		}
+		// Value is [timestamp, "string-encoded number"].
+		var s string
+		if err := json.Unmarshal(r.Value[1], &s); err != nil {
+			continue
+		}
+		if n, err := strconv.Atoi(s); err == nil {
+			entries += n
+		} else if f, err := strconv.ParseFloat(s, 64); err == nil {
+			entries += int(f)
+		}
+	}
+
+	return &Stats{Entries: entries}, nil
+}
+
+// QueryPatterns is not implemented: VictoriaLogs has no equivalent of
+// Loki's /patterns endpoint. Callers should fall back to label/value
+// exploration or a LogsQL `| stats` pipeline instead.
+func (b *victoriaLogsBackend) QueryPatterns(ctx context.Context, query, step string, start, end time.Time) ([]Pattern, error) {
+	return nil, fmt.Errorf("query_loki_patterns is not supported on VictoriaLogs datasources (no equivalent endpoint); use list_loki_label_values or a LogsQL '| stats' query for similar exploration")
+}
+
+// parseVictoriaLogsNDJSON converts the newline-delimited JSON returned by
+// /select/logsql/query into a slice of LogEntry. Each line is one record;
+// the special fields _time, _msg, and _stream map onto Loki's timestamp/
+// line/labels respectively, while everything else lands in Parsed so the
+// agent still sees parser-extracted fields.
+func parseVictoriaLogsNDJSON(body []byte) ([]LogEntry, error) {
+	entries := []LogEntry{}
+	if len(body) == 0 {
+		return entries, nil
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	// Allow long log lines; the default 64 KiB buffer is too small.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var record map[string]json.RawMessage
+		if err := json.Unmarshal(line, &record); err != nil {
+			// Skip malformed lines — VL occasionally emits trailing
+			// metadata that isn't a log record.
+			continue
+		}
+
+		entry := LogEntry{
+			Labels: map[string]string{},
+			Parsed: map[string]string{},
+		}
+
+		for k, raw := range record {
+			var val string
+			if err := json.Unmarshal(raw, &val); err != nil {
+				val = string(raw) // keep non-string values verbatim
+			}
+			switch k {
+			case "_time":
+				entry.Timestamp = vlTimeToNanos(val)
+			case "_msg":
+				entry.Line = val
+			case "_stream":
+				for sk, sv := range parseVLStream(val) {
+					entry.Labels[sk] = sv
+				}
+			default:
+				entry.Parsed[k] = val
+			}
+		}
+
+		if len(entry.Labels) == 0 {
+			entry.Labels = nil
+		}
+		if len(entry.Parsed) == 0 {
+			entry.Parsed = nil
+		}
+		entries = append(entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading VictoriaLogs response: %w", err)
+	}
+	return entries, nil
+}
+
+// parseVLStream parses VictoriaLogs' _stream value, which is a Loki-shaped
+// label string like `{app="foo",pod="bar"}`. Returns an empty map if the
+// shape is unexpected so the caller can degrade gracefully.
+func parseVLStream(s string) map[string]string {
+	out := map[string]string{}
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") || !strings.HasSuffix(s, "}") {
+		return out
+	}
+	inner := s[1 : len(s)-1]
+	if inner == "" {
+		return out
+	}
+
+	for _, kv := range splitVLLabels(inner) {
+		eq := strings.Index(kv, "=")
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(kv[:eq])
+		val := strings.TrimSpace(kv[eq+1:])
+		if unquoted, err := strconv.Unquote(val); err == nil {
+			val = unquoted
+		}
+		if key != "" {
+			out[key] = val
+		}
+	}
+	return out
+}
+
+// splitVLLabels splits a comma-separated label list while respecting quoted
+// values (so commas inside `name="a,b"` don't break the split).
+func splitVLLabels(s string) []string {
+	var (
+		parts   []string
+		buf     strings.Builder
+		inQuote bool
+		escape  bool
+	)
+	for _, r := range s {
+		switch {
+		case escape:
+			buf.WriteRune(r)
+			escape = false
+		case r == '\\':
+			buf.WriteRune(r)
+			escape = true
+		case r == '"':
+			buf.WriteRune(r)
+			inQuote = !inQuote
+		case r == ',' && !inQuote:
+			parts = append(parts, buf.String())
+			buf.Reset()
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	if buf.Len() > 0 {
+		parts = append(parts, buf.String())
+	}
+	return parts
+}
+
+// vlTimeToNanos converts a VictoriaLogs RFC3339(Nano) timestamp string into
+// the nanoseconds-since-epoch string used by the rest of the Loki tool
+// surface. Falls back to the original value on parse failure so the caller
+// still sees something useful.
+func vlTimeToNanos(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, ts); err == nil {
+			return strconv.FormatInt(t.UnixNano(), 10)
+		}
+	}
+	return ts
+}

--- a/tools/loki_backend_victorialogs_test.go
+++ b/tools/loki_backend_victorialogs_test.go
@@ -1,0 +1,228 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeVLServer routes /select/logsql/* requests to canned responses and
+// records the most recent request so tests can assert URL/body shape.
+type fakeVLServer struct {
+	server      *httptest.Server
+	lastPath    string
+	lastMethod  string
+	lastQuery   url.Values
+	lastForm    url.Values
+	respHandler http.HandlerFunc
+}
+
+func newFakeVLServer(t *testing.T, handler http.HandlerFunc) *fakeVLServer {
+	t.Helper()
+	f := &fakeVLServer{respHandler: handler}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.lastPath = r.URL.Path
+		f.lastMethod = r.Method
+		f.lastQuery = r.URL.Query()
+		if r.Method == http.MethodPost {
+			require.NoError(t, r.ParseForm())
+			f.lastForm = r.PostForm
+		}
+		f.respHandler(w, r)
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func newTestVLBackend(t *testing.T, server *httptest.Server) *victoriaLogsBackend {
+	t.Helper()
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: server.URL})
+	b, err := newVictoriaLogsBackend(ctx, "vl-uid")
+	require.NoError(t, err)
+	// The backend's baseURL targets /api/datasources/proxy/uid/{uid} on the
+	// real Grafana; for tests we point it at the fake server root.
+	b.baseURL = server.URL
+	return b
+}
+
+func TestVictoriaLogsBackend_ListLabelNames(t *testing.T) {
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"values":[{"value":"app","hits":12},{"value":"pod","hits":7}]}`)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	names, err := b.ListLabelNames(context.Background(), time.Time{}, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app", "pod"}, names)
+	assert.Equal(t, "/select/logsql/field_names", fake.lastPath)
+	assert.Equal(t, http.MethodGet, fake.lastMethod)
+	assert.Equal(t, victoriaLogsAllQuery, fake.lastQuery.Get("query"))
+}
+
+func TestVictoriaLogsBackend_ListLabelValues_PassesField(t *testing.T) {
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"values":[{"value":"acme-app","hits":5}]}`)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	start := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	values, err := b.ListLabelValues(context.Background(), "app", start, end)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"acme-app"}, values)
+	assert.Equal(t, "app", fake.lastQuery.Get("field"))
+	assert.Equal(t, start.Format(time.RFC3339), fake.lastQuery.Get("start"))
+	assert.Equal(t, end.Format(time.RFC3339), fake.lastQuery.Get("end"))
+}
+
+func TestVictoriaLogsBackend_QueryLogs_ParsesNDJSON(t *testing.T) {
+	body := strings.Join([]string{
+		`{"_time":"2026-05-10T12:00:00Z","_stream":"{app=\"acme-app\",pod=\"p1\"}","_msg":"hello","level":"info"}`,
+		`{"_time":"2026-05-10T12:00:01Z","_stream":"{app=\"acme-app\",pod=\"p1\"}","_msg":"world","level":"warn"}`,
+	}, "\n")
+
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	res, err := b.QueryLogs(context.Background(), lokiQueryParams{
+		Query:     `{app="acme-app"}`,
+		QueryType: "range",
+		Start:     time.Date(2026, 5, 10, 11, 0, 0, 0, time.UTC),
+		End:       time.Date(2026, 5, 10, 13, 0, 0, 0, time.UTC),
+		Limit:     50,
+		Direction: "backward",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/select/logsql/query", fake.lastPath)
+	assert.Equal(t, http.MethodPost, fake.lastMethod)
+	assert.Equal(t, `{app="acme-app"}`, fake.lastForm.Get("query"))
+	assert.Equal(t, "50", fake.lastForm.Get("limit"))
+
+	require.Equal(t, "streams", res.ResultType)
+	require.Len(t, res.Entries, 2)
+	first := res.Entries[0]
+	assert.Equal(t, "hello", first.Line)
+	assert.Equal(t, map[string]string{"app": "acme-app", "pod": "p1"}, first.Labels)
+	assert.Equal(t, "info", first.Parsed["level"])
+	// Timestamp should be normalized to nanoseconds-since-epoch.
+	assert.NotEmpty(t, first.Timestamp)
+	assert.NotContains(t, first.Timestamp, "T") // not RFC3339 anymore
+}
+
+func TestVictoriaLogsBackend_QueryLogs_ForwardReversesOrder(t *testing.T) {
+	// VL returns newest-first by default; "forward" should reverse so the
+	// caller sees oldest-first.
+	body := strings.Join([]string{
+		`{"_time":"2026-05-10T12:00:02Z","_msg":"newest"}`,
+		`{"_time":"2026-05-10T12:00:01Z","_msg":"middle"}`,
+		`{"_time":"2026-05-10T12:00:00Z","_msg":"oldest"}`,
+	}, "\n")
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	res, err := b.QueryLogs(context.Background(), lokiQueryParams{
+		Query:     "*",
+		QueryType: "range",
+		Direction: "forward",
+		Limit:     10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Entries, 3)
+	assert.Equal(t, "oldest", res.Entries[0].Line)
+	assert.Equal(t, "newest", res.Entries[2].Line)
+}
+
+func TestVictoriaLogsBackend_QueryLogs_InstantCollapsesWindow(t *testing.T) {
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "")
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	end := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	_, err := b.QueryLogs(context.Background(), lokiQueryParams{
+		Query:     "*",
+		QueryType: "instant",
+		End:       end,
+		Limit:     1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, end.Format(time.RFC3339), fake.lastForm.Get("start"))
+	assert.Equal(t, end.Format(time.RFC3339), fake.lastForm.Get("end"))
+}
+
+func TestVictoriaLogsBackend_QueryStats_AppendsCountPipe(t *testing.T) {
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"entries"},"value":[1700000000,"42"]}]}}`)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	stats, err := b.QueryStats(context.Background(), `{app="acme-app"}`, time.Time{}, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, 42, stats.Entries)
+	// Other fields should remain zero — VL does not expose them.
+	assert.Equal(t, 0, stats.Streams)
+	assert.Equal(t, 0, stats.Chunks)
+	assert.Equal(t, 0, stats.Bytes)
+
+	// Confirm we appended a stats pipe.
+	q := fake.lastForm.Get("query")
+	assert.Contains(t, q, "| stats count(*) as entries")
+}
+
+func TestVictoriaLogsBackend_QueryStats_PreservesUserStatsPipe(t *testing.T) {
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	custom := `{app="x"} | stats count() as my_count`
+	_, err := b.QueryStats(context.Background(), custom, time.Time{}, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, custom, fake.lastForm.Get("query"))
+}
+
+func TestVictoriaLogsBackend_QueryPatterns_NotSupported(t *testing.T) {
+	// The backend should refuse without making a request.
+	called := false
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	_, err := b.QueryPatterns(context.Background(), `{job="x"}`, "", time.Time{}, time.Time{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VictoriaLogs")
+	assert.False(t, called)
+}
+
+func TestParseVLStream_QuotedCommas(t *testing.T) {
+	got := parseVLStream(`{app="acme-app",path="/foo,bar",pod="p1"}`)
+	assert.Equal(t, map[string]string{
+		"app":  "acme-app",
+		"path": "/foo,bar",
+		"pod":  "p1",
+	}, got)
+}
+
+func TestVLTimeToNanos_Fallback(t *testing.T) {
+	// Valid RFC3339 → epoch nanos.
+	assert.Equal(t, "1778414400000000000", vlTimeToNanos("2026-05-10T12:00:00Z"))
+	// Unparseable → returned verbatim.
+	assert.Equal(t, "garbage", vlTimeToNanos("garbage"))
+	assert.Equal(t, "", vlTimeToNanos(""))
+}

--- a/tools/loki_backend_victorialogs_test.go
+++ b/tools/loki_backend_victorialogs_test.go
@@ -48,7 +48,7 @@ func newFakeVLServer(t *testing.T, handler http.HandlerFunc) *fakeVLServer {
 func newTestVLBackend(t *testing.T, server *httptest.Server) *victoriaLogsBackend {
 	t.Helper()
 	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: server.URL})
-	b, err := newVictoriaLogsBackend(ctx, "vl-uid")
+	b, err := newVictoriaLogsBackend(ctx, "vl-uid", nil)
 	require.NoError(t, err)
 	// The backend's baseURL targets /api/datasources/proxy/uid/{uid} on the
 	// real Grafana; for tests we point it at the fake server root.


### PR DESCRIPTION
## Summary

- Adds a `lokiBackend` abstraction (mirroring `promBackend`) and routes the existing `list_loki_label_names`, `list_loki_label_values`, `query_loki_logs`, `query_loki_stats`, and `query_loki_patterns` tools through it.
- When the target datasource is `victoriametrics-logs-datasource`, calls go to the LogsQL HTTP API at `/select/logsql/*` and the NDJSON response is parsed into the same `LogEntry` shape Loki produces — `_stream` labels surface as `Labels`, other per-record fields surface as `Parsed`.
- Tool descriptions are updated to call out dual-backend behavior; the LLM-facing tool list is unchanged.

Closes #801. Alternative to #634 — per @sd2k's guidance, this extends the existing tools instead of adding new ones.

## Behavior on VictoriaLogs

- `list_loki_label_names` → `/select/logsql/field_names`
- `list_loki_label_values` → `/select/logsql/field_values`
- `query_loki_logs` → `POST /select/logsql/query` (NDJSON parsed line-by-line). Instant queries collapse the window to the anchor instant; `direction=forward` reverses VL's default newest-first order so the parameter contract matches Loki.
- `query_loki_stats` → `POST /select/logsql/stats_query` with an auto-appended `| stats count(*) as entries` (preserved if the caller already supplied a stats pipe). Only the `entries` field is populated — VL doesn't expose chunks/streams/bytes.
- `query_loki_patterns` → returns a clear "not supported on VictoriaLogs" error (no equivalent endpoint).

## Implementation notes

- `lokiBackendForDatasource` switches on `ds.Type`; native Loki is the default and `victoriametrics-logs-datasource` selects the new backend.
- `lokiNativeBackend` wraps the existing `Client` so the native path is byte-for-byte identical (the parsing helper was just extracted from `queryLokiLogs`).
- VL backend reuses `datasourceFallbackTransport` (proxy → resources fallback) and the 30s HTTP timeout pattern from the VM metrics backend.
- Stream labels in VL are emitted as a Loki-shaped string; the parser respects quoted commas so paths with commas don't split incorrectly.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean.
- [x] `go test -tags unit ./...` passes — covers NDJSON parsing, dispatch, instant-window collapse, direction reversal, stats pipe injection/preservation, the patterns "not supported" error, and quoted-comma stream label parsing.
- [x] `make lint-jsonschema` and `make lint-openapi` pass.
- [x] Verified end-to-end against a real VictoriaLogs deployment via the MCP server: backend dispatch picks the VL backend, `list_loki_label_names` returns LogsQL field names, `list_loki_label_values` returns field values, `query_loki_logs` with a `level:ERROR` filter parses NDJSON correctly (stream labels in `Labels`, per-record fields in `Parsed`, timestamps round-trip to ns-since-epoch), `query_loki_stats` returns `entries` with the other fields zero, and `query_loki_patterns` returns the documented unsupported-on-VL error.

## Out of scope

- A docker-compose-based integration test for VictoriaLogs would slot into the existing `*_integration_test.go` pattern but requires provisioning a VL service (and datasource) in `docker-compose.yaml` and `testdata/provisioning/datasources/datasources.yaml`. Happy to do that as a follow-up PR if maintainers want it before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new datasource-dispatch layer and a VictoriaLogs HTTP/NDJSON parsing backend, which changes how all Loki tool calls are executed and can affect query correctness/ordering and time-range handling across datasources.
> 
> **Overview**
> Adds a `lokiBackend` abstraction and routes the existing Loki tools (`list_loki_label_names/values`, `query_loki_logs`, `query_loki_stats`, `query_loki_patterns`) through datasource-type dispatch (`lokiBackendForDatasource`), so the same tool surface can target multiple Loki-compatible backends.
> 
> Introduces a VictoriaLogs backend for `victoriametrics-logs-datasource` that calls `/select/logsql/*` endpoints, parses NDJSON log responses into the shared `LogEntry` shape (including `_stream` label parsing and timestamp normalization), emulates `instant` queries by collapsing the time window, and reverses results for `direction=forward`.
> 
> Refactors native Loki handling to fit the new interface (extracts `parseLokiQueryResponse`, moves time parsing to `parseRFC3339OrZero`, and wires metadata like `TotalLinesScanned` through backend results) and updates tool descriptions to document Loki vs VictoriaLogs behavior, including patterns being unsupported on VictoriaLogs. 
> 
> Adds unit tests covering VictoriaLogs request shapes, NDJSON parsing, ordering/time-window behavior, stats pipe injection/preservation, and the patterns unsupported error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c4c3cda10bd23ff68f847169804e113086deb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->