### PR TITLE
fix: use io.LimitReader in error-reading paths across all clients

### DIFF
--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -73,7 +73,7 @@ func (c *alertingClient) makeRequest(ctx context.Context, path string, params ur
 		return nil, fmt.Errorf("failed to execute request to %s: %w", p, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		_ = resp.Body.Close() //nolint:errcheck
 		return nil, fmt.Errorf("grafana API returned status code %d: %s", resp.StatusCode, string(bodyBytes))
 	}

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -160,7 +160,7 @@ func (c *clickHouseClient) query(ctx context.Context, datasourceUID, rawSQL stri
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("ClickHouse query returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 

--- a/tools/cloudwatch.go
+++ b/tools/cloudwatch.go
@@ -180,7 +180,7 @@ func (c *cloudWatchClient) query(ctx context.Context, args CloudWatchQueryParams
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("CloudWatch query returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
@@ -464,7 +464,7 @@ func listCloudWatchNamespaces(ctx context.Context, args ListCloudWatchNamespaces
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("CloudWatch namespaces returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
@@ -526,7 +526,7 @@ func listCloudWatchMetrics(ctx context.Context, args ListCloudWatchMetricsParams
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("CloudWatch metrics returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
@@ -590,7 +590,7 @@ func listCloudWatchDimensions(ctx context.Context, args ListCloudWatchDimensions
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("CloudWatch dimensions returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 

--- a/tools/es_backend.go
+++ b/tools/es_backend.go
@@ -163,7 +163,7 @@ func (b *elasticsearchBackend) Search(ctx context.Context, index, query string, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("elasticsearch API returned status code %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 

--- a/tools/influxdb.go
+++ b/tools/influxdb.go
@@ -190,7 +190,7 @@ func (c *influxDBClient) query(ctx context.Context, payload map[string]interface
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("InfluxDB query returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -135,7 +135,7 @@ func (c *Client) makeRequest(ctx context.Context, method, urlPath string, params
 
 	// Check for non-200 status code
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("loki API returned status code %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 

--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -96,7 +96,7 @@ func extractNextPath(rawURL string) (string, error) {
 }
 
 func handleProxyErrorResponse(resp *http.Response) error {
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
 	if err != nil {
 		return fmt.Errorf("request failed with status %d (could not read body: %w)", resp.StatusCode, err)
 	}

--- a/tools/pyroscope.go
+++ b/tools/pyroscope.go
@@ -304,7 +304,7 @@ func (c *pyroscopeClient) get(ctx context.Context, path string, params url.Value
 	}()
 
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		body, err := io.ReadAll(res.Body)
+		body, err := io.ReadAll(io.LimitReader(res.Body, 1024))
 		if err != nil {
 			return nil, fmt.Errorf("pyroscope API failed with status code %d", res.StatusCode)
 		}

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -127,7 +127,7 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("image renderer not available. Ensure the Grafana Image Renderer service is installed and configured. See https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/")
 		}

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -456,7 +456,7 @@ func (c *siftClient) makeRequest(ctx context.Context, method, path string, body 
 
 	// Check for non-200 status code (matching Loki client's logic)
 	if response.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(response.Body) // Read full body on error
+		bodyBytes, _ := io.ReadAll(io.LimitReader(response.Body, 1024))
 		return nil, fmt.Errorf("API request returned status code %d: %s", response.StatusCode, string(bodyBytes))
 	}
 

--- a/tools/snowflake.go
+++ b/tools/snowflake.go
@@ -160,7 +160,7 @@ func (c *snowflakeClient) query(ctx context.Context, datasourceUID, rawSQL strin
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("snowflake query returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 


### PR DESCRIPTION
## Summary

- Wrap all error-path `io.ReadAll(resp.Body)` calls with `io.LimitReader(resp.Body, 1024)`, capping error body reads to 1KB
- Prevents excessive memory allocation if a server returns a very large error response body
- Consistent with the existing pattern in `graphite.go` which already limits error bodies to 1KB

## Affected clients

alerting, clickhouse, cloudwatch (4 paths), elasticsearch, influxdb, loki, oncall, pyroscope, rendering, sift, snowflake

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior only changes for non-200 HTTP responses by truncating error-body reads, reducing potential memory use without affecting successful response handling.
> 
> **Overview**
> Adds a consistent **1KB cap** on reading HTTP response bodies in *error paths* across multiple tool clients by wrapping `resp.Body` with `io.LimitReader(..., 1024)` before `io.ReadAll`.
> 
> This prevents large error responses from causing excessive memory allocation while keeping existing success-path response limits/handling unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6add35c292bb87aeb4be8e04c6d2b16a6f26ae1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->