### PR TITLE
refactor(tools): consolidate duplicated /api/ds/query implementations

### DIFF
--- a/tools/athena.go
+++ b/tools/athena.go
@@ -29,6 +29,9 @@ const (
 
 	// AthenaFormatTable requests table-formatted results from the Athena plugin.
 	AthenaFormatTable = 1
+
+	// athenaResponseLimitBytes is the maximum response size (10MB) before truncation.
+	athenaResponseLimitBytes = 1024 * 1024 * 10
 )
 
 var (
@@ -38,6 +41,8 @@ var (
 	athenaLimitRe      = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)`)
 )
 
+// athenaClient is used for Athena plugin resource API calls (catalogs, databases,
+// tables, columns). Query execution goes through the shared doDSQuery path.
 type athenaClient struct {
 	httpClient *http.Client
 	baseURL    string
@@ -98,88 +103,11 @@ func (c *athenaClient) resource(ctx context.Context, path string, body map[strin
 		return nil, fmt.Errorf("athena resource %s returned status %d: %s", path, resp.StatusCode, string(errBody))
 	}
 
-	respBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
+	respBytes, err := readResponseBody(resp.Body, int64(athenaResponseLimitBytes))
 	if err != nil {
 		return nil, fmt.Errorf("reading athena resource %s response: %w", path, err)
 	}
 	return respBytes, nil
-}
-
-type athenaQueryResponse struct {
-	Results map[string]struct {
-		Status int `json:"status,omitempty"`
-		Frames []struct {
-			Schema struct {
-				Name   string `json:"name,omitempty"`
-				RefID  string `json:"refId,omitempty"`
-				Fields []struct {
-					Name     string `json:"name"`
-					Type     string `json:"type"`
-					TypeInfo struct {
-						Frame string `json:"frame,omitempty"`
-					} `json:"typeInfo,omitempty"`
-				} `json:"fields"`
-			} `json:"schema"`
-			Data struct {
-				Values [][]interface{} `json:"values"`
-			} `json:"data"`
-		} `json:"frames,omitempty"`
-		Error string `json:"error,omitempty"`
-	} `json:"results"`
-}
-
-func (c *athenaClient) query(ctx context.Context, rawSQL string, from, to time.Time, connectionArgs map[string]interface{}) (*athenaQueryResponse, error) {
-	queryMap := map[string]interface{}{
-		"datasource": map[string]string{
-			"uid":  c.uid,
-			"type": AthenaDatasourceType,
-		},
-		"rawSql":         rawSQL,
-		"refId":          "A",
-		"format":         AthenaFormatTable,
-		"connectionArgs": connectionArgs,
-	}
-
-	payload := map[string]interface{}{
-		"queries": []map[string]interface{}{queryMap},
-		"from":    strconv.FormatInt(from.UnixMilli(), 10),
-		"to":      strconv.FormatInt(to.UnixMilli(), 10),
-	}
-
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	url := c.baseURL + "/api/ds/query"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("athena query returned status %d: %s", resp.StatusCode, string(errBody))
-	}
-
-	respBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	var queryResp athenaQueryResponse
-	if err := json.Unmarshal(respBytes, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-
-	return &queryResp, nil
 }
 
 func substituteAthenaMacros(query string, from, to time.Time) string {
@@ -301,7 +229,7 @@ func listAthenaCatalogs(ctx context.Context, args ListAthenaCatalogsParams) ([]s
 
 	var catalogs []string
 	if err := json.Unmarshal(respBytes, &catalogs); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
+		return nil, err
 	}
 	return catalogs, nil
 }
@@ -342,7 +270,7 @@ func listAthenaDatabases(ctx context.Context, args ListAthenaDatabasesParams) ([
 
 	var databases []string
 	if err := json.Unmarshal(respBytes, &databases); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
+		return nil, err
 	}
 	return databases, nil
 }
@@ -387,7 +315,7 @@ func listAthenaTables(ctx context.Context, args ListAthenaTablesParams) ([]strin
 
 	var tables []string
 	if err := json.Unmarshal(respBytes, &tables); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
+		return nil, err
 	}
 	return tables, nil
 }
@@ -439,7 +367,7 @@ func describeAthenaTable(ctx context.Context, args DescribeAthenaTableParams) ([
 
 	var columns []string
 	if err := json.Unmarshal(respBytes, &columns); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
+		return nil, err
 	}
 	return columns, nil
 }
@@ -476,9 +404,12 @@ type AthenaQueryResult struct {
 }
 
 func queryAthena(ctx context.Context, args AthenaQueryParams) (*AthenaQueryResult, error) {
-	client, err := newAthenaClient(ctx, args.DatasourceUID)
+	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: args.DatasourceUID})
 	if err != nil {
 		return nil, fmt.Errorf("creating Athena client: %w", err)
+	}
+	if ds.Type != AthenaDatasourceType {
+		return nil, fmt.Errorf("datasource %s is of type %s, not %s", args.DatasourceUID, ds.Type, AthenaDatasourceType)
 	}
 
 	now := time.Now()
@@ -527,47 +458,38 @@ func queryAthena(ctx context.Context, args AthenaQueryParams) (*AthenaQueryResul
 		}
 	}
 
-	resp, err := client.query(ctx, processedQuery, fromTime, toTime, connectionArgs)
+	httpClient, baseURL, err := newDSQueryHTTPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := dsQueryPayload(fromTime, toTime, map[string]interface{}{
+		"datasource": map[string]string{
+			"uid":  args.DatasourceUID,
+			"type": AthenaDatasourceType,
+		},
+		"rawSql":         processedQuery,
+		"refId":          "A",
+		"format":         AthenaFormatTable,
+		"connectionArgs": connectionArgs,
+	})
+
+	resp, err := doDSQuery(ctx, httpClient, baseURL, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	columns, rows, err := framesToTabularRows(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &AthenaQueryResult{
-		Columns:        []string{},
-		Rows:           []map[string]interface{}{},
+		Columns:        columns,
+		Rows:           rows,
+		RowCount:       len(rows),
 		ProcessedQuery: processedQuery,
 	}
-
-	for refID, r := range resp.Results {
-		if r.Error != "" {
-			return nil, fmt.Errorf("query error (refId=%s): %s", refID, r.Error)
-		}
-
-		for _, frame := range r.Frames {
-			columns := make([]string, len(frame.Schema.Fields))
-			for i, field := range frame.Schema.Fields {
-				columns[i] = field.Name
-			}
-			result.Columns = columns
-
-			if len(frame.Data.Values) == 0 {
-				continue
-			}
-
-			rowCount := len(frame.Data.Values[0])
-			for i := 0; i < rowCount; i++ {
-				row := make(map[string]interface{})
-				for colIdx, colName := range columns {
-					if colIdx < len(frame.Data.Values) && i < len(frame.Data.Values[colIdx]) {
-						row[colName] = frame.Data.Values[colIdx][i]
-					}
-				}
-				result.Rows = append(result.Rows, row)
-			}
-		}
-	}
-
-	result.RowCount = len(result.Rows)
 
 	if result.RowCount == 0 {
 		result.Hints = GenerateEmptyResultHints(HintContext{

--- a/tools/athena_test.go
+++ b/tools/athena_test.go
@@ -4,12 +4,16 @@ package tools
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -277,6 +281,15 @@ func TestSubstituteAthenaMacros_IntervalCalculation(t *testing.T) {
 	}
 }
 
+// marshalSDKResponse is a helper to properly marshal a backend.QueryDataResponse
+// for use as an HTTP response body in test servers.
+func marshalSDKResponse(t *testing.T, resp backend.QueryDataResponse) []byte {
+	t.Helper()
+	b, err := json.Marshal(resp)
+	require.NoError(t, err)
+	return b
+}
+
 func TestAthenaResource_CorrectURL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/datasources/uid/test-uid/resources/catalogs", r.URL.Path)
@@ -350,16 +363,21 @@ func TestAthenaQuery_PayloadStructure(t *testing.T) {
 		assert.NotEmpty(t, payload["to"])
 
 		w.Header().Set("Content-Type", "application/json")
-		resp := `{"results":{"A":{"status":200,"frames":[{"schema":{"fields":[{"name":"name","type":"string"},{"name":"age","type":"number"}]},"data":{"values":[["Alice","Bob"],[30,25]]}}]}}}`
-		_, _ = w.Write([]byte(resp))
+		sdkResp := backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": backend.DataResponse{
+					Frames: data.Frames{
+						data.NewFrame("",
+							data.NewField("name", nil, []string{"Alice", "Bob"}),
+							data.NewField("age", nil, []float64{30, 25}),
+						),
+					},
+				},
+			},
+		}
+		_, _ = w.Write(marshalSDKResponse(t, sdkResp))
 	}))
 	t.Cleanup(ts.Close)
-
-	client := &athenaClient{
-		httpClient: http.DefaultClient,
-		baseURL:    ts.URL,
-		uid:        "test-uid",
-	}
 
 	from := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
@@ -369,10 +387,27 @@ func TestAthenaQuery_PayloadStructure(t *testing.T) {
 		"database": "mydb",
 	}
 
-	resp, err := client.query(t.Context(), "SELECT * FROM logs", from, to, connArgs)
+	payload := map[string]interface{}{
+		"queries": []map[string]interface{}{
+			{
+				"datasource": map[string]string{
+					"uid":  "test-uid",
+					"type": AthenaDatasourceType,
+				},
+				"rawSql":         "SELECT * FROM logs",
+				"refId":          "A",
+				"format":         AthenaFormatTable,
+				"connectionArgs": connArgs,
+			},
+		},
+		"from": strconv.FormatInt(from.UnixMilli(), 10),
+		"to":   strconv.FormatInt(to.UnixMilli(), 10),
+	}
+
+	resp, err := doDSQuery(t.Context(), http.DefaultClient, ts.URL, payload)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Len(t, resp.Results, 1)
+	assert.Len(t, resp.Responses, 1)
 }
 
 func TestAthenaQuery_NonOKStatus(t *testing.T) {
@@ -381,73 +416,54 @@ func TestAthenaQuery_NonOKStatus(t *testing.T) {
 	}))
 	t.Cleanup(ts.Close)
 
-	client := &athenaClient{
-		httpClient: http.DefaultClient,
-		baseURL:    ts.URL,
-		uid:        "test-uid",
-	}
-
 	from := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
 
-	_, err := client.query(t.Context(), "SELECT 1", from, to, map[string]interface{}{})
+	payload := map[string]interface{}{
+		"queries": []map[string]interface{}{
+			{
+				"datasource": map[string]string{
+					"uid":  "test-uid",
+					"type": AthenaDatasourceType,
+				},
+				"rawSql": "SELECT 1",
+				"refId":  "A",
+				"format": AthenaFormatTable,
+			},
+		},
+		"from": strconv.FormatInt(from.UnixMilli(), 10),
+		"to":   strconv.FormatInt(to.UnixMilli(), 10),
+	}
+
+	_, err := doDSQuery(t.Context(), http.DefaultClient, ts.URL, payload)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "400")
 }
 
 func TestAthenaQuery_FrameToRows(t *testing.T) {
-	resp := athenaQueryResponse{
-		Results: map[string]struct {
-			Status int `json:"status,omitempty"`
-			Frames []struct {
-				Schema struct {
-					Name   string `json:"name,omitempty"`
-					RefID  string `json:"refId,omitempty"`
-					Fields []struct {
-						Name     string `json:"name"`
-						Type     string `json:"type"`
-						TypeInfo struct {
-							Frame string `json:"frame,omitempty"`
-						} `json:"typeInfo,omitempty"`
-					} `json:"fields"`
-				} `json:"schema"`
-				Data struct {
-					Values [][]interface{} `json:"values"`
-				} `json:"data"`
-			} `json:"frames,omitempty"`
-			Error string `json:"error,omitempty"`
-		}{},
+	// Construct the response using SDK types to ensure proper marshal/unmarshal round-trip.
+	sdkResp := backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": backend.DataResponse{
+				Frames: data.Frames{
+					data.NewFrame("",
+						data.NewField("name", nil, []string{"Alice", "Bob"}),
+						data.NewField("age", nil, []float64{30, 25}),
+					),
+				},
+			},
+		},
 	}
 
-	rawJSON := `{"results":{"A":{"status":200,"frames":[{"schema":{"fields":[{"name":"name","type":"string"},{"name":"age","type":"number"}]},"data":{"values":[["Alice","Bob"],[30,25]]}}]}}}`
-	require.NoError(t, json.Unmarshal([]byte(rawJSON), &resp))
+	// Marshal and unmarshal to simulate JSON round-trip (as in real doDSQuery).
+	rawJSON, err := json.Marshal(sdkResp)
+	require.NoError(t, err)
 
-	var columns []string
-	var rows []map[string]interface{}
+	var resp backend.QueryDataResponse
+	require.NoError(t, json.Unmarshal(rawJSON, &resp))
 
-	for _, r := range resp.Results {
-		for _, frame := range r.Frames {
-			columns = make([]string, len(frame.Schema.Fields))
-			for i, field := range frame.Schema.Fields {
-				columns[i] = field.Name
-			}
-
-			if len(frame.Data.Values) == 0 {
-				continue
-			}
-
-			rowCount := len(frame.Data.Values[0])
-			for i := 0; i < rowCount; i++ {
-				row := make(map[string]interface{})
-				for colIdx, colName := range columns {
-					if colIdx < len(frame.Data.Values) && i < len(frame.Data.Values[colIdx]) {
-						row[colName] = frame.Data.Values[colIdx][i]
-					}
-				}
-				rows = append(rows, row)
-			}
-		}
-	}
+	columns, rows, err := framesToTabularRows(&resp)
+	require.NoError(t, err)
 
 	assert.Equal(t, []string{"name", "age"}, columns)
 	require.Len(t, rows, 2)
@@ -458,25 +474,26 @@ func TestAthenaQuery_FrameToRows(t *testing.T) {
 }
 
 func TestAthenaQuery_EmptyFrame(t *testing.T) {
-	rawJSON := `{"results":{"A":{"status":200,"frames":[{"schema":{"fields":[{"name":"id","type":"number"}]},"data":{"values":[]}}]}}}`
-
-	var resp athenaQueryResponse
-	require.NoError(t, json.Unmarshal([]byte(rawJSON), &resp))
-
-	var rows []map[string]interface{}
-	for _, r := range resp.Results {
-		for _, frame := range r.Frames {
-			if len(frame.Data.Values) == 0 {
-				continue
-			}
-			rowCount := len(frame.Data.Values[0])
-			for i := 0; i < rowCount; i++ {
-				row := make(map[string]interface{})
-				rows = append(rows, row)
-			}
-		}
+	sdkResp := backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": backend.DataResponse{
+				Frames: data.Frames{
+					data.NewFrame("",
+						data.NewField("id", nil, []float64{}),
+					),
+				},
+			},
+		},
 	}
 
+	rawJSON, err := json.Marshal(sdkResp)
+	require.NoError(t, err)
+
+	var resp backend.QueryDataResponse
+	require.NoError(t, json.Unmarshal(rawJSON, &resp))
+
+	_, rows, err := framesToTabularRows(&resp)
+	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
 
@@ -493,16 +510,16 @@ func TestAthenaQuery_ResultReuseInConnectionArgs(t *testing.T) {
 		assert.Equal(t, float64(60), connArgs["resultReuseMaxAgeInMinutes"])
 
 		w.Header().Set("Content-Type", "application/json")
-		resp := `{"results":{"A":{"status":200,"frames":[{"schema":{"fields":[]},"data":{"values":[]}}]}}}`
-		_, _ = w.Write([]byte(resp))
+		sdkResp := backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": backend.DataResponse{
+					Frames: data.Frames{},
+				},
+			},
+		}
+		_, _ = w.Write(marshalSDKResponse(t, sdkResp))
 	}))
 	t.Cleanup(ts.Close)
-
-	client := &athenaClient{
-		httpClient: http.DefaultClient,
-		baseURL:    ts.URL,
-		uid:        "test-uid",
-	}
 
 	from := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
@@ -511,19 +528,46 @@ func TestAthenaQuery_ResultReuseInConnectionArgs(t *testing.T) {
 		"resultReuseMaxAgeInMinutes": 60,
 	}
 
-	resp, err := client.query(t.Context(), "SELECT 1", from, to, connArgs)
+	payload := map[string]interface{}{
+		"queries": []map[string]interface{}{
+			{
+				"datasource": map[string]string{
+					"uid":  "test-uid",
+					"type": AthenaDatasourceType,
+				},
+				"rawSql":         "SELECT 1",
+				"refId":          "A",
+				"format":         AthenaFormatTable,
+				"connectionArgs": connArgs,
+			},
+		},
+		"from": strconv.FormatInt(from.UnixMilli(), 10),
+		"to":   strconv.FormatInt(to.UnixMilli(), 10),
+	}
+
+	resp, err := doDSQuery(t.Context(), http.DefaultClient, ts.URL, payload)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
 
 func TestAthenaQuery_ErrorInResponse(t *testing.T) {
-	rawJSON := `{"results":{"A":{"error":"SYNTAX_ERROR: line 1:1: Table 'nonexistent' does not exist"}}}`
+	// Construct with SDK types, marshal+unmarshal to simulate JSON round-trip.
+	sdkResp := backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": backend.DataResponse{
+				Error: fmt.Errorf("SYNTAX_ERROR: line 1:1: Table 'nonexistent' does not exist"),
+			},
+		},
+	}
 
-	var resp athenaQueryResponse
-	require.NoError(t, json.Unmarshal([]byte(rawJSON), &resp))
+	rawJSON, err := json.Marshal(sdkResp)
+	require.NoError(t, err)
 
-	for _, r := range resp.Results {
-		assert.NotEmpty(t, r.Error)
-		assert.Contains(t, r.Error, "does not exist")
+	var resp backend.QueryDataResponse
+	require.NoError(t, json.Unmarshal(rawJSON, &resp))
+
+	for _, r := range resp.Responses {
+		assert.NotNil(t, r.Error)
+		assert.Contains(t, r.Error.Error(), "does not exist")
 	}
 }

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -1,12 +1,8 @@
 package tools
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -60,121 +56,6 @@ type ClickHouseQueryResult struct {
 	RowCount       int                      `json:"rowCount"`
 	ProcessedQuery string                   `json:"processedQuery,omitempty"`
 	Hints          *EmptyResultHints        `json:"hints,omitempty"`
-}
-
-// clickHouseQueryResponse represents the raw API response from Grafana's /api/ds/query
-type clickHouseQueryResponse struct {
-	Results map[string]struct {
-		Status int `json:"status,omitempty"`
-		Frames []struct {
-			Schema struct {
-				Name   string `json:"name,omitempty"`
-				RefID  string `json:"refId,omitempty"`
-				Fields []struct {
-					Name     string `json:"name"`
-					Type     string `json:"type"`
-					TypeInfo struct {
-						Frame string `json:"frame,omitempty"`
-					} `json:"typeInfo,omitempty"`
-				} `json:"fields"`
-			} `json:"schema"`
-			Data struct {
-				Values [][]interface{} `json:"values"`
-			} `json:"data"`
-		} `json:"frames,omitempty"`
-		Error string `json:"error,omitempty"`
-	} `json:"results"`
-}
-
-// clickHouseClient handles communication with Grafana's ClickHouse datasource
-type clickHouseClient struct {
-	httpClient *http.Client
-	baseURL    string
-}
-
-// newClickHouseClient creates a new ClickHouse client for the given datasource
-func newClickHouseClient(ctx context.Context, uid string) (*clickHouseClient, error) {
-	// Verify the datasource exists and is a ClickHouse datasource
-	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
-	if err != nil {
-		return nil, err
-	}
-
-	if ds.Type != ClickHouseDatasourceType {
-		return nil, fmt.Errorf("datasource %s is of type %s, not %s", uid, ds.Type, ClickHouseDatasourceType)
-	}
-
-	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := cfg.URL
-
-	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create transport: %w", err)
-	}
-
-	client := &http.Client{
-		Transport: transport,
-	}
-
-	return &clickHouseClient{
-		httpClient: client,
-		baseURL:    baseURL,
-	}, nil
-}
-
-// query executes a ClickHouse query via Grafana's /api/ds/query endpoint
-func (c *clickHouseClient) query(ctx context.Context, datasourceUID, rawSQL string, from, to time.Time) (*clickHouseQueryResponse, error) {
-	// Build the query payload
-	payload := map[string]interface{}{
-		"queries": []map[string]interface{}{
-			{
-				"datasource": map[string]string{
-					"uid":  datasourceUID,
-					"type": ClickHouseDatasourceType,
-				},
-				"rawSql": rawSQL,
-				"refId":  "A",
-				"format": ClickHouseFormatTable,
-			},
-		},
-		"from": strconv.FormatInt(from.UnixMilli(), 10),
-		"to":   strconv.FormatInt(to.UnixMilli(), 10),
-	}
-
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	url := c.baseURL + "/api/ds/query"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("ClickHouse query returned status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	var queryResp clickHouseQueryResponse
-	if err := json.Unmarshal(bodyBytes, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-
-	return &queryResp, nil
 }
 
 // substituteClickHouseMacros replaces ClickHouse-specific macros in the query
@@ -261,9 +142,17 @@ func enforceClickHouseLimit(query string, requestedLimit int) string {
 
 // queryClickHouse executes a ClickHouse query via Grafana
 func queryClickHouse(ctx context.Context, args ClickHouseQueryParams) (*ClickHouseQueryResult, error) {
-	client, err := newClickHouseClient(ctx, args.DatasourceUID)
+	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: args.DatasourceUID})
 	if err != nil {
 		return nil, fmt.Errorf("creating ClickHouse client: %w", err)
+	}
+	if ds.Type != ClickHouseDatasourceType {
+		return nil, fmt.Errorf("datasource %s is of type %s, not %s", args.DatasourceUID, ds.Type, ClickHouseDatasourceType)
+	}
+
+	client, baseURL, err := newDSQueryHTTPClient(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Parse time range
@@ -293,65 +182,37 @@ func queryClickHouse(ctx context.Context, args ClickHouseQueryParams) (*ClickHou
 
 	// Process the query
 	processedQuery := args.Query
-
-	// Substitute ClickHouse macros
 	processedQuery = substituteClickHouseMacros(processedQuery, fromTime, toTime)
-
-	// Substitute user variables
 	processedQuery = substituteVariables(processedQuery, args.Variables)
-
-	// Enforce limit
 	processedQuery = enforceClickHouseLimit(processedQuery, args.Limit)
 
-	// Execute query
-	resp, err := client.query(ctx, args.DatasourceUID, processedQuery, fromTime, toTime)
+	payload := dsQueryPayload(fromTime, toTime, map[string]interface{}{
+		"datasource": map[string]string{
+			"uid":  args.DatasourceUID,
+			"type": ClickHouseDatasourceType,
+		},
+		"rawSql": processedQuery,
+		"refId":  "A",
+		"format": ClickHouseFormatTable,
+	})
+
+	resp, err := doDSQuery(ctx, client, baseURL, payload)
 	if err != nil {
 		return nil, err
 	}
 
-	// Process response
+	columns, rows, err := framesToTabularRows(resp)
+	if err != nil {
+		return nil, err
+	}
+
 	result := &ClickHouseQueryResult{
-		Columns:        []string{},
-		Rows:           []map[string]interface{}{},
+		Columns:        columns,
+		Rows:           rows,
+		RowCount:       len(rows),
 		ProcessedQuery: processedQuery,
 	}
 
-	// Check for errors in the response
-	for refID, r := range resp.Results {
-		if r.Error != "" {
-			return nil, fmt.Errorf("query error (refId=%s): %s", refID, r.Error)
-		}
-
-		// Process frames
-		for _, frame := range r.Frames {
-			// Extract column names
-			columns := make([]string, len(frame.Schema.Fields))
-			for i, field := range frame.Schema.Fields {
-				columns[i] = field.Name
-			}
-			result.Columns = columns
-
-			// Convert columnar data to rows
-			if len(frame.Data.Values) == 0 {
-				continue
-			}
-
-			rowCount := len(frame.Data.Values[0])
-			for i := 0; i < rowCount; i++ {
-				row := make(map[string]interface{})
-				for colIdx, colName := range columns {
-					if colIdx < len(frame.Data.Values) && i < len(frame.Data.Values[colIdx]) {
-						row[colName] = frame.Data.Values[colIdx][i]
-					}
-				}
-				result.Rows = append(result.Rows, row)
-			}
-		}
-	}
-
-	result.RowCount = len(result.Rows)
-
-	// Add hints if no data was found
 	if result.RowCount == 0 {
 		result.Hints = GenerateEmptyResultHints(HintContext{
 			DatasourceType: "clickhouse",
@@ -424,21 +285,12 @@ WHERE database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')`
 	// Convert rows to table info
 	tables := make([]ClickHouseTableInfo, 0, len(result.Rows))
 	for _, row := range result.Rows {
-		table := ClickHouseTableInfo{}
-		if v, ok := row["database"].(string); ok {
-			table.Database = v
-		}
-		if v, ok := row["name"].(string); ok {
-			table.Name = v
-		}
-		if v, ok := row["engine"].(string); ok {
-			table.Engine = v
-		}
-		if v, ok := row["total_rows"].(float64); ok {
-			table.TotalRows = int64(v)
-		}
-		if v, ok := row["total_bytes"].(float64); ok {
-			table.TotalBytes = int64(v)
+		table := ClickHouseTableInfo{
+			Database:   toStringFromRow(row["database"]),
+			Name:       toStringFromRow(row["name"]),
+			Engine:     toStringFromRow(row["engine"]),
+			TotalRows:  toInt64FromRow(row["total_rows"]),
+			TotalBytes: toInt64FromRow(row["total_bytes"]),
 		}
 		tables = append(tables, table)
 	}
@@ -511,23 +363,13 @@ ORDER BY position`, database, args.Table)
 	// Convert rows to column info
 	columns := make([]ClickHouseColumnInfo, 0, len(result.Rows))
 	for _, row := range result.Rows {
-		col := ClickHouseColumnInfo{}
-		if v, ok := row["name"].(string); ok {
-			col.Name = v
-		}
-		if v, ok := row["type"].(string); ok {
-			col.Type = v
-		}
-		if v, ok := row["default_type"].(string); ok {
-			col.DefaultType = v
-		}
-		if v, ok := row["default_expression"].(string); ok {
-			col.DefaultExpression = v
-		}
-		if v, ok := row["comment"].(string); ok {
-			col.Comment = v
-		}
-		columns = append(columns, col)
+		columns = append(columns, ClickHouseColumnInfo{
+			Name:              toStringFromRow(row["name"]),
+			Type:              toStringFromRow(row["type"]),
+			DefaultType:       toStringFromRow(row["default_type"]),
+			DefaultExpression: toStringFromRow(row["default_expression"]),
+			Comment:           toStringFromRow(row["comment"]),
+		})
 	}
 
 	return columns, nil

--- a/tools/cloudwatch.go
+++ b/tools/cloudwatch.go
@@ -1,7 +1,6 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -45,32 +46,6 @@ type CloudWatchQueryResult struct {
 	Values     []float64          `json:"values"`
 	Statistics map[string]float64 `json:"statistics,omitempty"`
 	Hints      []string           `json:"hints,omitempty"`
-}
-
-// cloudWatchQueryResponse represents the raw API response from Grafana's /api/ds/query
-type cloudWatchQueryResponse struct {
-	Results map[string]struct {
-		Status int `json:"status,omitempty"`
-		Frames []struct {
-			Schema struct {
-				Name   string `json:"name,omitempty"`
-				RefID  string `json:"refId,omitempty"`
-				Fields []struct {
-					Name     string                 `json:"name"`
-					Type     string                 `json:"type"`
-					Labels   map[string]string      `json:"labels,omitempty"`
-					Config   map[string]interface{} `json:"config,omitempty"`
-					TypeInfo struct {
-						Frame string `json:"frame,omitempty"`
-					} `json:"typeInfo,omitempty"`
-				} `json:"fields"`
-			} `json:"schema"`
-			Data struct {
-				Values [][]interface{} `json:"values"`
-			} `json:"data"`
-		} `json:"frames,omitempty"`
-		Error string `json:"error,omitempty"`
-	} `json:"results"`
 }
 
 // cloudWatchClient handles communication with Grafana's CloudWatch datasource
@@ -110,7 +85,7 @@ func newCloudWatchClient(ctx context.Context, uid string) (*cloudWatchClient, er
 }
 
 // query executes a CloudWatch query via Grafana's /api/ds/query endpoint
-func (c *cloudWatchClient) query(ctx context.Context, args CloudWatchQueryParams, from, to time.Time) (*cloudWatchQueryResponse, error) {
+func (c *cloudWatchClient) query(ctx context.Context, args CloudWatchQueryParams, from, to time.Time) (*backend.QueryDataResponse, error) {
 	// Format dimensions for CloudWatch query
 	// CloudWatch expects dimensions as map[string][]string
 	dimensions := make(map[string][]string)
@@ -155,46 +130,7 @@ func (c *cloudWatchClient) query(ctx context.Context, args CloudWatchQueryParams
 		query["accountId"] = args.AccountId
 	}
 
-	payload := map[string]interface{}{
-		"queries": []map[string]interface{}{query},
-		"from":    strconv.FormatInt(from.UnixMilli(), 10),
-		"to":      strconv.FormatInt(to.UnixMilli(), 10),
-	}
-
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	url := c.baseURL + "/api/ds/query"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("CloudWatch query returned status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	var queryResp cloudWatchQueryResponse
-	if err := json.Unmarshal(bodyBytes, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-
-	return &queryResp, nil
+	return doDSQuery(ctx, c.httpClient, c.baseURL, dsQueryPayload(from, to, query))
 }
 
 // queryCloudWatch executes a CloudWatch query via Grafana
@@ -244,9 +180,9 @@ func queryCloudWatch(ctx context.Context, args CloudWatchQueryParams) (*CloudWat
 	}
 
 	// Check for errors in the response
-	for refID, r := range resp.Results {
-		if r.Error != "" {
-			return nil, fmt.Errorf("query error (refId=%s): %s", refID, r.Error)
+	for refID, r := range resp.Responses {
+		if r.Error != nil {
+			return nil, fmt.Errorf("query error (refId=%s): %s", refID, r.Error.Error())
 		}
 
 		// Process frames - accumulate statistics across all frames
@@ -257,17 +193,15 @@ func queryCloudWatch(ctx context.Context, args CloudWatchQueryParams) (*CloudWat
 		for _, frame := range r.Frames {
 			// Find time and value columns
 			var timeColIdx, valueColIdx = -1, -1
-			for i, field := range frame.Schema.Fields {
-				switch field.Type {
-				case "time":
+			for i, field := range frame.Fields {
+				switch {
+				case field.Type() == data.FieldTypeTime || field.Type() == data.FieldTypeNullableTime:
 					timeColIdx = i
-				case "number":
+				case field.Type().Numeric():
 					valueColIdx = i
 					// Update label if available from field config
-					if field.Config != nil {
-						if displayName, ok := field.Config["displayNameFromDS"].(string); ok && displayName != "" {
-							result.Label = displayName
-						}
+					if field.Config != nil && field.Config.DisplayNameFromDS != "" {
+						result.Label = field.Config.DisplayNameFromDS
 					}
 				}
 			}
@@ -277,52 +211,60 @@ func queryCloudWatch(ctx context.Context, args CloudWatchQueryParams) (*CloudWat
 			}
 
 			// Extract data
-			if len(frame.Data.Values) > timeColIdx && len(frame.Data.Values) > valueColIdx {
-				timeValues := frame.Data.Values[timeColIdx]
-				metricValues := frame.Data.Values[valueColIdx]
-
-				for i := 0; i < len(timeValues) && i < len(metricValues); i++ {
-					// Parse timestamp (can be float64 or int64 from JSON)
-					var ts int64
-					switch v := timeValues[i].(type) {
-					case float64:
-						ts = int64(v)
-					case int64:
-						ts = v
-					default:
+			rowCount := frame.Rows()
+			for i := 0; i < rowCount; i++ {
+				// Parse timestamp (can be float64 or int64 from JSON)
+				var ts int64
+				switch v := frame.At(timeColIdx, i).(type) {
+				case float64:
+					ts = int64(v)
+				case int64:
+					ts = v
+				case time.Time:
+					ts = v.UnixMilli()
+				case *time.Time:
+					if v == nil {
 						continue
 					}
+					ts = v.UnixMilli()
+				default:
+					continue
+				}
 
-					// Parse value
-					var val float64
-					switch v := metricValues[i].(type) {
-					case float64:
-						val = v
-					case int64:
-						val = float64(v)
-					case nil:
-						continue
-					default:
+				// Parse value
+				var val float64
+				switch v := frame.At(valueColIdx, i).(type) {
+				case float64:
+					val = v
+				case int64:
+					val = float64(v)
+				case *float64:
+					if v == nil {
 						continue
 					}
+					val = *v
+				case nil:
+					continue
+				default:
+					continue
+				}
 
-					result.Timestamps = append(result.Timestamps, ts)
-					result.Values = append(result.Values, val)
+				result.Timestamps = append(result.Timestamps, ts)
+				result.Values = append(result.Values, val)
 
-					// Calculate statistics
-					sum += val
-					count++
-					if first {
+				// Calculate statistics
+				sum += val
+				count++
+				if first {
+					min = val
+					max = val
+					first = false
+				} else {
+					if val < min {
 						min = val
+					}
+					if val > max {
 						max = val
-						first = false
-					} else {
-						if val < min {
-							min = val
-						}
-						if val > max {
-							max = val
-						}
 					}
 				}
 			}
@@ -405,7 +347,7 @@ type cloudWatchMetricItem struct {
 func parseCloudWatchResourceResponse(bodyBytes []byte) ([]string, error) {
 	var items []cloudWatchResourceItem
 	if err := json.Unmarshal(bodyBytes, &items); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
+		return nil, err
 	}
 
 	result := make([]string, len(items))
@@ -419,7 +361,7 @@ func parseCloudWatchResourceResponse(bodyBytes []byte) ([]string, error) {
 func parseCloudWatchMetricsResponse(bodyBytes []byte) ([]string, error) {
 	var items []cloudWatchMetricItem
 	if err := json.Unmarshal(bodyBytes, &items); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
+		return nil, err
 	}
 
 	result := make([]string, len(items))
@@ -465,7 +407,7 @@ func listCloudWatchNamespaces(ctx context.Context, args ListCloudWatchNamespaces
 		return nil, fmt.Errorf("CloudWatch namespaces returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	bodyBytes, err := readResponseBody(resp.Body, 1024*1024)
+	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
@@ -525,7 +467,7 @@ func listCloudWatchMetrics(ctx context.Context, args ListCloudWatchMetricsParams
 		return nil, fmt.Errorf("CloudWatch metrics returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	bodyBytes, err := readResponseBody(resp.Body, 1024*1024)
+	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
@@ -587,7 +529,7 @@ func listCloudWatchDimensions(ctx context.Context, args ListCloudWatchDimensions
 		return nil, fmt.Errorf("CloudWatch dimensions returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	bodyBytes, err := readResponseBody(resp.Body, 1024*1024)
+	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}

--- a/tools/cloudwatch_test.go
+++ b/tools/cloudwatch_test.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -249,110 +252,27 @@ func TestParseCloudWatchMetricsResponse(t *testing.T) {
 }
 
 func TestCloudWatchMultiFrameStatistics(t *testing.T) {
-	// Build a cloudWatchQueryResponse with 2 frames to verify statistics
+	// Build a backend.QueryDataResponse with 2 frames to verify statistics
 	// are accumulated across all frames, not just the last one.
-	resp := &cloudWatchQueryResponse{
-		Results: map[string]struct {
-			Status int `json:"status,omitempty"`
-			Frames []struct {
-				Schema struct {
-					Name   string `json:"name,omitempty"`
-					RefID  string `json:"refId,omitempty"`
-					Fields []struct {
-						Name     string                 `json:"name"`
-						Type     string                 `json:"type"`
-						Labels   map[string]string      `json:"labels,omitempty"`
-						Config   map[string]interface{} `json:"config,omitempty"`
-						TypeInfo struct {
-							Frame string `json:"frame,omitempty"`
-						} `json:"typeInfo,omitempty"`
-					} `json:"fields"`
-				} `json:"schema"`
-				Data struct {
-					Values [][]interface{} `json:"values"`
-				} `json:"data"`
-			} `json:"frames,omitempty"`
-			Error string `json:"error,omitempty"`
-		}{},
-	}
+	t1 := time.UnixMilli(1000)
+	t2 := time.UnixMilli(2000)
+	t3 := time.UnixMilli(3000)
+	t4 := time.UnixMilli(4000)
 
-	// Frame type for convenience
-	type frame = struct {
-		Schema struct {
-			Name   string `json:"name,omitempty"`
-			RefID  string `json:"refId,omitempty"`
-			Fields []struct {
-				Name     string                 `json:"name"`
-				Type     string                 `json:"type"`
-				Labels   map[string]string      `json:"labels,omitempty"`
-				Config   map[string]interface{} `json:"config,omitempty"`
-				TypeInfo struct {
-					Frame string `json:"frame,omitempty"`
-				} `json:"typeInfo,omitempty"`
-			} `json:"fields"`
-		} `json:"schema"`
-		Data struct {
-			Values [][]interface{} `json:"values"`
-		} `json:"data"`
-	}
+	f1 := data.NewFrame("",
+		data.NewField("Time", nil, []time.Time{t1, t2}),
+		data.NewField("Value", nil, []float64{10.0, 20.0}),
+	)
 
-	type field = struct {
-		Name     string                 `json:"name"`
-		Type     string                 `json:"type"`
-		Labels   map[string]string      `json:"labels,omitempty"`
-		Config   map[string]interface{} `json:"config,omitempty"`
-		TypeInfo struct {
-			Frame string `json:"frame,omitempty"`
-		} `json:"typeInfo,omitempty"`
-	}
+	f2 := data.NewFrame("",
+		data.NewField("Time", nil, []time.Time{t3, t4}),
+		data.NewField("Value", nil, []float64{5.0, 40.0}),
+	)
 
-	// Frame 1: values 10, 20 (sum=30, min=10, max=20)
-	f1 := frame{}
-	f1.Schema.Fields = []field{
-		{Name: "Time", Type: "time"},
-		{Name: "Value", Type: "number"},
-	}
-	f1.Data.Values = [][]interface{}{
-		{float64(1000), float64(2000)}, // timestamps
-		{float64(10.0), float64(20.0)}, // values
-	}
-
-	// Frame 2: values 5, 40 (sum=45, min=5, max=40)
-	f2 := frame{}
-	f2.Schema.Fields = []field{
-		{Name: "Time", Type: "time"},
-		{Name: "Value", Type: "number"},
-	}
-	f2.Data.Values = [][]interface{}{
-		{float64(3000), float64(4000)}, // timestamps
-		{float64(5.0), float64(40.0)},  // values
-	}
-
-	type resultType = struct {
-		Status int `json:"status,omitempty"`
-		Frames []struct {
-			Schema struct {
-				Name   string `json:"name,omitempty"`
-				RefID  string `json:"refId,omitempty"`
-				Fields []struct {
-					Name     string                 `json:"name"`
-					Type     string                 `json:"type"`
-					Labels   map[string]string      `json:"labels,omitempty"`
-					Config   map[string]interface{} `json:"config,omitempty"`
-					TypeInfo struct {
-						Frame string `json:"frame,omitempty"`
-					} `json:"typeInfo,omitempty"`
-				} `json:"fields"`
-			} `json:"schema"`
-			Data struct {
-				Values [][]interface{} `json:"values"`
-			} `json:"data"`
-		} `json:"frames,omitempty"`
-		Error string `json:"error,omitempty"`
-	}
-
-	resp.Results["A"] = resultType{
-		Frames: []frame{f1, f2},
+	resp := &backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": backend.DataResponse{Frames: data.Frames{f1, f2}},
+		},
 	}
 
 	// Process the response the same way queryCloudWatch does
@@ -363,51 +283,55 @@ func TestCloudWatchMultiFrameStatistics(t *testing.T) {
 		Statistics: make(map[string]float64),
 	}
 
-	for _, r := range resp.Results {
+	for _, r := range resp.Responses {
 		var sum, min, max float64
 		var count int64
 		first := true
 
 		for _, frm := range r.Frames {
 			var timeColIdx, valueColIdx = -1, -1
-			for i, fld := range frm.Schema.Fields {
-				switch fld.Type {
-				case "time":
+			for i, fld := range frm.Fields {
+				switch {
+				case fld.Type() == data.FieldTypeTime || fld.Type() == data.FieldTypeNullableTime:
 					timeColIdx = i
-				case "number":
+				case fld.Type().Numeric():
 					valueColIdx = i
 				}
 			}
 			if timeColIdx == -1 || valueColIdx == -1 {
 				continue
 			}
-			if len(frm.Data.Values) > timeColIdx && len(frm.Data.Values) > valueColIdx {
-				timeValues := frm.Data.Values[timeColIdx]
-				metricValues := frm.Data.Values[valueColIdx]
-				for i := 0; i < len(timeValues) && i < len(metricValues); i++ {
-					ts, ok := timeValues[i].(float64)
-					if !ok {
-						continue
-					}
-					val, ok := metricValues[i].(float64)
-					if !ok {
-						continue
-					}
-					result.Timestamps = append(result.Timestamps, int64(ts))
-					result.Values = append(result.Values, val)
-					sum += val
-					count++
-					if first {
+			rowCount := frm.Rows()
+			for i := 0; i < rowCount; i++ {
+				tsRaw := frm.At(timeColIdx, i)
+				var ts int64
+				switch v := tsRaw.(type) {
+				case time.Time:
+					ts = v.UnixMilli()
+				case float64:
+					ts = int64(v)
+				default:
+					continue
+				}
+
+				val, ok := frm.At(valueColIdx, i).(float64)
+				if !ok {
+					continue
+				}
+				result.Timestamps = append(result.Timestamps, ts)
+				result.Values = append(result.Values, val)
+				sum += val
+				count++
+				if first {
+					min = val
+					max = val
+					first = false
+				} else {
+					if val < min {
 						min = val
+					}
+					if val > max {
 						max = val
-						first = false
-					} else {
-						if val < min {
-							min = val
-						}
-						if val > max {
-							max = val
-						}
 					}
 				}
 			}

--- a/tools/ds_query.go
+++ b/tools/ds_query.go
@@ -120,13 +120,19 @@ func framesToTabularRows(resp *backend.QueryDataResponse) ([]string, []map[strin
 	return columns, rows, nil
 }
 
-// toInt64FromRow extracts an int64 from a row value that may be float64, int64,
-// or their pointer variants depending on the SDK field type.
+// toInt64FromRow extracts an int64 from a row value that may be any of the
+// numeric types (or their pointer variants) the SDK's data.Field can hold.
 func toInt64FromRow(v interface{}) int64 {
 	switch n := v.(type) {
 	case float64:
 		return int64(n)
 	case *float64:
+		if n != nil {
+			return int64(*n)
+		}
+	case float32:
+		return int64(n)
+	case *float32:
 		if n != nil {
 			return int64(*n)
 		}
@@ -136,9 +142,45 @@ func toInt64FromRow(v interface{}) int64 {
 		if n != nil {
 			return *n
 		}
+	case int32:
+		return int64(n)
+	case *int32:
+		if n != nil {
+			return int64(*n)
+		}
+	case int16:
+		return int64(n)
+	case *int16:
+		if n != nil {
+			return int64(*n)
+		}
+	case int8:
+		return int64(n)
+	case *int8:
+		if n != nil {
+			return int64(*n)
+		}
 	case uint64:
 		return int64(n)
 	case *uint64:
+		if n != nil {
+			return int64(*n)
+		}
+	case uint32:
+		return int64(n)
+	case *uint32:
+		if n != nil {
+			return int64(*n)
+		}
+	case uint16:
+		return int64(n)
+	case *uint16:
+		if n != nil {
+			return int64(*n)
+		}
+	case uint8:
+		return int64(n)
+	case *uint8:
 		if n != nil {
 			return int64(*n)
 		}

--- a/tools/ds_query.go
+++ b/tools/ds_query.go
@@ -1,0 +1,161 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+// dsQueryPayload builds the standard /api/ds/query request envelope.
+// Each query map should contain datasource-specific fields (refId, datasource, etc.).
+func dsQueryPayload(from, to time.Time, queries ...map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"queries": queries,
+		"from":    strconv.FormatInt(from.UnixMilli(), 10),
+		"to":      strconv.FormatInt(to.UnixMilli(), 10),
+	}
+}
+
+// doDSQuery posts a payload to Grafana's /api/ds/query endpoint and decodes
+// the response into the SDK's QueryDataResponse type.
+func doDSQuery(ctx context.Context, client *http.Client, baseURL string, payload map[string]interface{}) (*backend.QueryDataResponse, error) {
+	return doDSQueryWithLimit(ctx, client, baseURL, payload, defaultResponseLimitBytes)
+}
+
+// doDSQueryWithLimit is like doDSQuery but allows overriding the response size limit.
+func doDSQueryWithLimit(ctx context.Context, client *http.Client, baseURL string, payload map[string]interface{}, responseLimit int64) (*backend.QueryDataResponse, error) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling query payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	body, err := readResponseBody(resp.Body, responseLimit)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	var queryResp backend.QueryDataResponse
+	if err := json.Unmarshal(body, &queryResp); err != nil {
+		return nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	return &queryResp, nil
+}
+
+func trimTrailingSlash(s string) string {
+	for len(s) > 0 && s[len(s)-1] == '/' {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// newDSQueryHTTPClient builds an *http.Client suitable for calling Grafana's
+// /api/ds/query endpoint, using the Grafana config from the context.
+func newDSQueryHTTPClient(ctx context.Context) (*http.Client, string, error) {
+	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
+	baseURL := trimTrailingSlash(cfg.URL)
+
+	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create transport: %w", err)
+	}
+
+	return &http.Client{Transport: transport, Timeout: 30 * time.Second}, baseURL, nil
+}
+
+// framesToTabularRows converts SDK data frames into row-oriented maps — the
+// common format returned by ClickHouse, Snowflake, and Athena tools.
+func framesToTabularRows(resp *backend.QueryDataResponse) ([]string, []map[string]interface{}, error) {
+	columns := []string{}
+	rows := []map[string]interface{}{}
+
+	for refID, r := range resp.Responses {
+		if r.Error != nil {
+			return nil, nil, fmt.Errorf("query error (refId=%s): %s", refID, r.Error)
+		}
+
+		for _, frame := range r.Frames {
+			cols := make([]string, len(frame.Fields))
+			for i, field := range frame.Fields {
+				cols[i] = field.Name
+			}
+			columns = cols
+
+			rowCount := frame.Rows()
+			for i := 0; i < rowCount; i++ {
+				row := make(map[string]interface{})
+				for colIdx, colName := range cols {
+					row[colName] = frame.At(colIdx, i)
+				}
+				rows = append(rows, row)
+			}
+		}
+	}
+
+	return columns, rows, nil
+}
+
+// toInt64FromRow extracts an int64 from a row value that may be float64, int64,
+// or their pointer variants depending on the SDK field type.
+func toInt64FromRow(v interface{}) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case *float64:
+		if n != nil {
+			return int64(*n)
+		}
+	case int64:
+		return n
+	case *int64:
+		if n != nil {
+			return *n
+		}
+	case uint64:
+		return int64(n)
+	case *uint64:
+		if n != nil {
+			return int64(*n)
+		}
+	}
+	return 0
+}
+
+// toStringFromRow extracts a string from a row value that may be string or
+// *string depending on the SDK field type.
+func toStringFromRow(v interface{}) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case *string:
+		if s != nil {
+			return *s
+		}
+	}
+	return ""
+}

--- a/tools/es_backend_opensearch.go
+++ b/tools/es_backend_opensearch.go
@@ -1,7 +1,6 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
 
@@ -69,7 +69,7 @@ func indexMatchesPattern(pattern, index string) bool {
 	}
 	// If the user's index is itself a pattern (contains wildcards), check
 	// whether the non-wildcard prefix matches the configured pattern's prefix.
-	// e.g., configured="logs-*", user="logs-2024*" → compatible.
+	// e.g., configured="logs-*", user="logs-2024*" -> compatible.
 	patternPrefix := strings.TrimRight(pattern, "*?")
 	indexPrefix := strings.TrimRight(index, "*?")
 	return strings.HasPrefix(indexPrefix, patternPrefix)
@@ -85,18 +85,14 @@ func (b *openSearchBackend) Search(ctx context.Context, index, query string, sta
 		return nil, fmt.Errorf("the requested index %q is not compatible with this datasource's configured index pattern %q; use an index that matches the pattern or choose a different datasource", index, b.configuredIndex)
 	}
 
-	// Determine time range in milliseconds
-	var fromMs, toMs string
+	// Determine time range
+	from := time.Now().Add(-10 * 365 * 24 * time.Hour) // Default: 10 years ago
 	if startTime != nil {
-		fromMs = strconv.FormatInt(startTime.UnixMilli(), 10)
-	} else {
-		// Default to 10 years ago
-		fromMs = strconv.FormatInt(time.Now().Add(-10*365*24*time.Hour).UnixMilli(), 10)
+		from = *startTime
 	}
+	to := time.Now()
 	if endTime != nil {
-		toMs = strconv.FormatInt(endTime.UnixMilli(), 10)
-	} else {
-		toMs = strconv.FormatInt(time.Now().UnixMilli(), 10)
+		to = *endTime
 	}
 
 	// Use the user's query as-is. The OpenSearch plugin searches within the
@@ -107,79 +103,40 @@ func (b *openSearchBackend) Search(ctx context.Context, index, query string, sta
 	}
 
 	// Build the /api/ds/query payload using the OpenSearch plugin's query model
-	payload := map[string]interface{}{
-		"queries": []map[string]interface{}{
+	payload := dsQueryPayload(from, to, map[string]interface{}{
+		"refId": "A",
+		"datasource": map[string]interface{}{
+			"uid":  b.datasourceUID,
+			"type": openSearchDatasourceType,
+		},
+		"query":           luceneQuery,
+		"queryType":       "lucene",
+		"luceneQueryType": "RawDocument",
+		"timeField":       "@timestamp",
+		"metrics": []map[string]interface{}{
 			{
-				"refId": "A",
-				"datasource": map[string]interface{}{
-					"uid":  b.datasourceUID,
-					"type": openSearchDatasourceType,
+				"id":   "1",
+				"type": "raw_document",
+				"settings": map[string]interface{}{
+					"size": strconv.Itoa(limit),
 				},
-				"query":           luceneQuery,
-				"queryType":       "lucene",
-				"luceneQueryType": "RawDocument",
-				"timeField":       "@timestamp",
-				"metrics": []map[string]interface{}{
-					{
-						"id":   "1",
-						"type": "raw_document",
-						"settings": map[string]interface{}{
-							"size": strconv.Itoa(limit),
-						},
-					},
-				},
-				"bucketAggs": []interface{}{},
-				"format":     "table",
 			},
 		},
-		"from": fromMs,
-		"to":   toMs,
-	}
+		"bucketAggs": []interface{}{},
+		"format":     "table",
+	})
 
-	payloadBytes, err := json.Marshal(payload)
+	result, err := doDSQueryWithLimit(ctx, b.httpClient, b.baseURL, payload, 48*1024*1024)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
+		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", b.baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := b.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	bodyBytes, err := readResponseBody(resp.Body, 48*1024*1024)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		var errResult map[string]interface{}
-		if json.Unmarshal(bodyBytes, &errResult) == nil {
-			if errMsg, ok := errResult["message"].(string); ok {
-				return nil, fmt.Errorf("opensearch query failed: %s", errMsg)
-			}
-		}
-		return nil, fmt.Errorf("opensearch query failed with status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	// Parse the /api/ds/query response
-	var result dsQueryResponse
-	if err := json.Unmarshal(bodyBytes, &result); err != nil {
-		return nil, fmt.Errorf("unmarshalling response: %w", err)
-	}
-
-	queryResult, ok := result.Results["A"]
+	queryResult, ok := result.Responses["A"]
 	if !ok {
 		return nil, fmt.Errorf("no result found for refId A")
 	}
-	if queryResult.Error != "" {
-		return nil, fmt.Errorf("opensearch query error: %s", queryResult.Error)
+	if queryResult.Error != nil {
+		return nil, fmt.Errorf("opensearch query error: %s", queryResult.Error.Error())
 	}
 
 	return framesToDocuments(queryResult.Frames)
@@ -191,22 +148,38 @@ func (b *openSearchBackend) Search(ctx context.Context, index, query string, sta
 // The OpenSearch plugin returns a single frame with one column (named after the refId)
 // of type json.RawMessage. Each value in that column is a complete document object
 // containing _id, _index, _type, @timestamp (as array), and all source fields.
-func framesToDocuments(frames []dsQueryFrame) ([]ElasticsearchDocument, error) {
+func framesToDocuments(frames data.Frames) ([]ElasticsearchDocument, error) {
 	if len(frames) == 0 {
 		return []ElasticsearchDocument{}, nil
 	}
 
 	frame := frames[0]
-	if len(frame.Data.Values) == 0 || len(frame.Data.Values[0]) == 0 {
+	if len(frame.Fields) == 0 || frame.Rows() == 0 {
 		return []ElasticsearchDocument{}, nil
 	}
 
-	rawDocs := frame.Data.Values[0]
-	documents := make([]ElasticsearchDocument, 0, len(rawDocs))
+	rowCount := frame.Rows()
+	documents := make([]ElasticsearchDocument, 0, rowCount)
 
-	for _, rawDoc := range rawDocs {
-		docMap, ok := rawDoc.(map[string]interface{})
-		if !ok {
+	for i := 0; i < rowCount; i++ {
+		rawDoc := frame.At(0, i)
+
+		var docMap map[string]interface{}
+		switch v := rawDoc.(type) {
+		case json.RawMessage:
+			if err := json.Unmarshal(v, &docMap); err != nil {
+				continue
+			}
+		case *json.RawMessage:
+			if v == nil {
+				continue
+			}
+			if err := json.Unmarshal(*v, &docMap); err != nil {
+				continue
+			}
+		case map[string]interface{}:
+			docMap = v
+		default:
 			continue
 		}
 

--- a/tools/influxdb.go
+++ b/tools/influxdb.go
@@ -1,13 +1,9 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -55,64 +51,19 @@ type InfluxDBQueryResult struct {
 	Hints     *EmptyResultHints        `json:"hints,omitempty"`
 }
 
-// influxDBQueryResponse mirrors the ClickHouse response shape — Grafana's
-// /api/ds/query returns the same envelope for any datasource.
-type influxDBQueryResponse struct {
-	Results map[string]struct {
-		Status int               `json:"status,omitempty"`
-		Frames []json.RawMessage `json:"frames,omitempty"`
-		Error  string            `json:"error,omitempty"`
-	} `json:"results"`
-}
-
-// influxDBFrame is a structural view of a single data frame, used to flatten
-// columnar frame data into row-oriented results.
-type influxDBFrame struct {
-	Schema struct {
-		Name   string `json:"name,omitempty"`
-		RefID  string `json:"refId,omitempty"`
-		Fields []struct {
-			Name   string            `json:"name"`
-			Type   string            `json:"type,omitempty"`
-			Labels map[string]string `json:"labels,omitempty"`
-		} `json:"fields"`
-	} `json:"schema"`
-	Data struct {
-		Values [][]interface{} `json:"values"`
-	} `json:"data"`
-}
-
-type influxDBClient struct {
-	httpClient *http.Client
-	baseURL    string
-}
-
-// newInfluxDBClient builds the HTTP client plumbing and returns it alongside
-// the resolved datasource. Callers that need datasource metadata (dialect
-// inference, jsonData) should reuse the returned *models.DataSource rather
-// than issuing a second getDatasourceByUID call.
-func newInfluxDBClient(ctx context.Context, uid string) (*influxDBClient, *models.DataSource, error) {
+// newInfluxDBDatasource verifies the datasource exists and is an InfluxDB
+// datasource, returning the datasource metadata for dialect inference.
+func newInfluxDBDatasource(ctx context.Context, uid string) (*models.DataSource, error) {
 	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if ds.Type != InfluxDBDatasourceType {
-		return nil, nil, fmt.Errorf("datasource %s is of type %s, not %s", uid, ds.Type, InfluxDBDatasourceType)
+		return nil, fmt.Errorf("datasource %s is of type %s, not %s", uid, ds.Type, InfluxDBDatasourceType)
 	}
 
-	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := cfg.URL
-
-	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create transport: %w", err)
-	}
-
-	return &influxDBClient{
-		httpClient: &http.Client{Transport: transport},
-		baseURL:    baseURL,
-	}, ds, nil
+	return ds, nil
 }
 
 // resolveInfluxDBDialect returns a canonical dialect string.
@@ -163,88 +114,7 @@ func buildInfluxDBPayload(datasourceUID, dialect, query string, from, to time.Ti
 		"maxDataPoints": maxDataPoints,
 	}
 
-	return map[string]interface{}{
-		"queries": []map[string]interface{}{q},
-		"from":    strconv.FormatInt(from.UnixMilli(), 10),
-		"to":      strconv.FormatInt(to.UnixMilli(), 10),
-	}
-}
-
-func (c *influxDBClient) query(ctx context.Context, payload map[string]interface{}) (*influxDBQueryResponse, error) {
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	url := c.baseURL + "/api/ds/query"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("InfluxDB query returned status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	var queryResp influxDBQueryResponse
-	if err := json.Unmarshal(bodyBytes, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-	return &queryResp, nil
-}
-
-// framesToRows flattens Grafana's columnar frame data into row-oriented maps,
-// matching the ClickHouse tool's output shape.
-func framesToRows(rawFrames []json.RawMessage) ([]string, []map[string]interface{}, error) {
-	var columns []string
-	var rows []map[string]interface{}
-
-	for _, raw := range rawFrames {
-		var frame influxDBFrame
-		if err := json.Unmarshal(raw, &frame); err != nil {
-			return nil, nil, fmt.Errorf("parsing frame: %w", err)
-		}
-
-		fieldNames := make([]string, len(frame.Schema.Fields))
-		for i, f := range frame.Schema.Fields {
-			fieldNames[i] = f.Name
-		}
-		// Columns from the last non-empty frame win. InfluxQL range queries
-		// usually return a single frame; Flux queries may return several, one
-		// per table, but they share the same field schema.
-		if len(fieldNames) > 0 {
-			columns = fieldNames
-		}
-
-		if len(frame.Data.Values) == 0 {
-			continue
-		}
-
-		rowCount := len(frame.Data.Values[0])
-		for i := 0; i < rowCount; i++ {
-			row := make(map[string]interface{}, len(fieldNames))
-			for colIdx, colName := range fieldNames {
-				if colIdx < len(frame.Data.Values) && i < len(frame.Data.Values[colIdx]) {
-					row[colName] = frame.Data.Values[colIdx][i]
-				}
-			}
-			rows = append(rows, row)
-		}
-	}
-	return columns, rows, nil
+	return dsQueryPayload(from, to, q)
 }
 
 func queryInfluxDB(ctx context.Context, args InfluxDBQueryParams) (*InfluxDBQueryResult, error) {
@@ -252,7 +122,7 @@ func queryInfluxDB(ctx context.Context, args InfluxDBQueryParams) (*InfluxDBQuer
 		return nil, fmt.Errorf("query is required")
 	}
 
-	client, ds, err := newInfluxDBClient(ctx, args.DatasourceUID)
+	ds, err := newInfluxDBDatasource(ctx, args.DatasourceUID)
 	if err != nil {
 		return nil, fmt.Errorf("creating InfluxDB client: %w", err)
 	}
@@ -290,43 +160,41 @@ func queryInfluxDB(ctx context.Context, args InfluxDBQueryParams) (*InfluxDBQuer
 	}
 
 	payload := buildInfluxDBPayload(args.DatasourceUID, dialect, args.Query, fromTime, toTime, args.MaxDataPoints)
-	resp, err := client.query(ctx, payload)
+
+	client, baseURL, err := newDSQueryHTTPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := doDSQuery(ctx, client, baseURL, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	columns, rows, err := framesToTabularRows(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &InfluxDBQueryResult{
-		Columns: []string{},
-		Rows:    []map[string]interface{}{},
-		Dialect: dialect,
+		Columns:  columns,
+		Rows:     rows,
+		RowCount: len(rows),
+		Dialect:  dialect,
 	}
 
-	for refID, r := range resp.Results {
-		if r.Error != "" {
-			return nil, fmt.Errorf("query error (refId=%s): %s", refID, r.Error)
+	// Preserve the raw frames so callers that want the native
+	// Grafana shape (timestamps + labels per field) can still get it.
+	for _, r := range resp.Responses {
+		if len(r.Frames) > 0 {
+			rawFramesJSON, err := json.Marshal(r.Frames)
+			if err == nil {
+				result.RawFrames = rawFramesJSON
+			}
+			break
 		}
-		if len(r.Frames) == 0 {
-			continue
-		}
-
-		// Preserve the raw frames so callers that want the native
-		// Grafana shape (timestamps + labels per field) can still get it.
-		rawFramesJSON, err := json.Marshal(r.Frames)
-		if err == nil {
-			result.RawFrames = rawFramesJSON
-		}
-
-		cols, rows, err := framesToRows(r.Frames)
-		if err != nil {
-			return nil, err
-		}
-		if len(cols) > 0 {
-			result.Columns = cols
-		}
-		result.Rows = append(result.Rows, rows...)
 	}
 
-	result.RowCount = len(result.Rows)
 	if result.RowCount == 0 {
 		result.Hints = GenerateEmptyResultHints(HintContext{
 			DatasourceType: "influxdb",

--- a/tools/influxdb_test.go
+++ b/tools/influxdb_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,43 +129,50 @@ func TestBuildInfluxDBPayload_SerializesToValidJSON(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestFramesToRows(t *testing.T) {
-	frame := `{
-		"schema": {
-			"name": "A",
-			"refId": "A",
-			"fields": [
-				{"name": "Time", "type": "time"},
-				{"name": "value", "type": "number"}
-			]
-		},
-		"data": {
-			"values": [
-				[1705312800000, 1705312860000, 1705312920000],
-				[1.0, 2.5, 3.7]
-			]
-		}
-	}`
+func TestFramesToTabularRows_InfluxDB(t *testing.T) {
+	t1 := time.UnixMilli(1705312800000)
+	t2 := time.UnixMilli(1705312860000)
+	t3 := time.UnixMilli(1705312920000)
 
-	cols, rows, err := framesToRows([]json.RawMessage{json.RawMessage(frame)})
+	frame := data.NewFrame("A",
+		data.NewField("Time", nil, []time.Time{t1, t2, t3}),
+		data.NewField("value", nil, []float64{1.0, 2.5, 3.7}),
+	)
+	frame.RefID = "A"
+
+	resp := &backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": backend.DataResponse{
+				Frames: data.Frames{frame},
+			},
+		},
+	}
+
+	cols, rows, err := framesToTabularRows(resp)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"Time", "value"}, cols)
 	require.Len(t, rows, 3)
-	assert.Equal(t, float64(1705312800000), rows[0]["Time"])
+	assert.Equal(t, t1, rows[0]["Time"])
 	assert.Equal(t, 1.0, rows[0]["value"])
 	assert.Equal(t, 3.7, rows[2]["value"])
 }
 
-func TestFramesToRows_EmptyFrame(t *testing.T) {
-	frame := `{"schema": {"fields": [{"name": "Time"}]}, "data": {"values": []}}`
-	cols, rows, err := framesToRows([]json.RawMessage{json.RawMessage(frame)})
+func TestFramesToTabularRows_EmptyFrame(t *testing.T) {
+	frame := data.NewFrame("",
+		data.NewField("Time", nil, []time.Time{}),
+	)
+
+	resp := &backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": backend.DataResponse{
+				Frames: data.Frames{frame},
+			},
+		},
+	}
+
+	cols, rows, err := framesToTabularRows(resp)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"Time"}, cols)
 	assert.Empty(t, rows)
-}
-
-func TestFramesToRows_InvalidJSON(t *testing.T) {
-	_, _, err := framesToRows([]json.RawMessage{json.RawMessage(`{not json`)})
-	require.Error(t, err)
 }

--- a/tools/prom_backend.go
+++ b/tools/prom_backend.go
@@ -1,9 +1,7 @@
 package tools
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -199,49 +197,4 @@ func (rt *postToGetRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}
 
 	return rt.underlying.RoundTrip(cloned)
-}
-
-// doDSQuery posts payload to Grafana's /api/ds/query endpoint and decodes the
-// response. Shared by backends that route queries through the datasource query
-// API instead of a datasource-specific client.
-func doDSQuery(ctx context.Context, client *http.Client, baseURL string, payload map[string]interface{}) (*dsQueryResponse, error) {
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("query returned status %d: %s", resp.StatusCode, string(body[:min(len(body), 1024)]))
-	}
-
-	var queryResp dsQueryResponse
-	if err := json.Unmarshal(body, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-
-	return &queryResp, nil
-}
-
-func trimTrailingSlash(s string) string {
-	for len(s) > 0 && s[len(s)-1] == '/' {
-		s = s[:len(s)-1]
-	}
-	return s
 }

--- a/tools/prom_backend_cloudmonitoring.go
+++ b/tools/prom_backend_cloudmonitoring.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
@@ -116,13 +117,7 @@ func (b *cloudMonitoringBackend) Query(ctx context.Context, expr string, queryTy
 		},
 	}
 
-	payload := map[string]interface{}{
-		"queries": []interface{}{query},
-		"from":    strconv.FormatInt(start.UnixMilli(), 10),
-		"to":      strconv.FormatInt(end.UnixMilli(), 10),
-	}
-
-	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, dsQueryPayload(start, end, query))
 	if err != nil {
 		return nil, err
 	}
@@ -169,13 +164,7 @@ func (b *cloudMonitoringBackend) LabelNames(ctx context.Context, matchers []stri
 		},
 	}
 
-	payload := map[string]interface{}{
-		"queries": []interface{}{query},
-		"from":    strconv.FormatInt(start.UnixMilli(), 10),
-		"to":      strconv.FormatInt(end.UnixMilli(), 10),
-	}
-
-	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, dsQueryPayload(start, end, query))
 	if err != nil {
 		return nil, fmt.Errorf("querying label names: %w", err)
 	}
@@ -274,13 +263,7 @@ func (b *cloudMonitoringBackend) labelValuesViaQuery(ctx context.Context, labelN
 		},
 	}
 
-	payload := map[string]interface{}{
-		"queries": []interface{}{query},
-		"from":    strconv.FormatInt(start.UnixMilli(), 10),
-		"to":      strconv.FormatInt(end.UnixMilli(), 10),
-	}
-
-	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, dsQueryPayload(start, end, query))
 	if err != nil {
 		return nil, fmt.Errorf("querying label values: %w", err)
 	}
@@ -343,44 +326,11 @@ type gcpMetricDescriptor struct {
 	ServiceShortName string `json:"serviceShortName,omitempty"`
 }
 
-// --- /api/ds/query response types ---
-
-type dsQueryResponse struct {
-	Results map[string]dsQueryResult `json:"results"`
-}
-
-type dsQueryResult struct {
-	Status int            `json:"status,omitempty"`
-	Frames []dsQueryFrame `json:"frames,omitempty"`
-	Error  string         `json:"error,omitempty"`
-}
-
-type dsQueryFrame struct {
-	Schema dsQueryFrameSchema `json:"schema"`
-	Data   dsQueryFrameData   `json:"data"`
-}
-
-type dsQueryFrameSchema struct {
-	Name   string              `json:"name,omitempty"`
-	RefID  string              `json:"refId,omitempty"`
-	Fields []dsQueryFrameField `json:"fields"`
-}
-
-type dsQueryFrameField struct {
-	Name   string            `json:"name"`
-	Type   string            `json:"type"`
-	Labels map[string]string `json:"labels,omitempty"`
-}
-
-type dsQueryFrameData struct {
-	Values [][]interface{} `json:"values"`
-}
-
 // --- Frame conversion ---
 
 // framesToPrometheusValue converts /api/ds/query response frames to Prometheus model values.
-func framesToPrometheusValue(resp *dsQueryResponse, queryType string) (model.Value, error) {
-	r, ok := resp.Results["A"]
+func framesToPrometheusValue(resp *backend.QueryDataResponse, queryType string) (model.Value, error) {
+	r, ok := resp.Responses["A"]
 	if !ok {
 		if queryType == "instant" {
 			return model.Vector{}, nil
@@ -388,8 +338,8 @@ func framesToPrometheusValue(resp *dsQueryResponse, queryType string) (model.Val
 		return model.Matrix{}, nil
 	}
 
-	if r.Error != "" {
-		return nil, fmt.Errorf("query error: %s", r.Error)
+	if r.Error != nil {
+		return nil, fmt.Errorf("query error: %s", r.Error.Error())
 	}
 
 	if queryType == "instant" {
@@ -398,32 +348,31 @@ func framesToPrometheusValue(resp *dsQueryResponse, queryType string) (model.Val
 	return framesToMatrix(r.Frames)
 }
 
-func framesToMatrix(frames []dsQueryFrame) (model.Matrix, error) {
+func framesToMatrix(frames data.Frames) (model.Matrix, error) {
 	var matrix model.Matrix
 	for _, frame := range frames {
-		timeIdx, valueIdx := findTimeAndValueFields(frame.Schema.Fields)
+		timeIdx, valueIdx := findTimeAndValueFields(frame.Fields)
 		if timeIdx == -1 || valueIdx == -1 {
 			continue
 		}
-		if len(frame.Data.Values) <= timeIdx || len(frame.Data.Values) <= valueIdx {
+		if len(frame.Fields) <= timeIdx || len(frame.Fields) <= valueIdx {
 			continue
 		}
 
-		metric := buildMetricFromLabels(frame.Schema.Fields[valueIdx].Labels, frame.Schema.Name)
-		timeValues := frame.Data.Values[timeIdx]
-		metricValues := frame.Data.Values[valueIdx]
+		metric := buildMetricFromLabels(frame.Fields[valueIdx].Labels, frame.Name)
 
+		rowCount := frame.Rows()
 		ss := &model.SampleStream{
 			Metric: metric,
-			Values: make([]model.SamplePair, 0, len(timeValues)),
+			Values: make([]model.SamplePair, 0, rowCount),
 		}
 
-		for i := 0; i < len(timeValues) && i < len(metricValues); i++ {
-			ts, tsOk := toMillis(timeValues[i])
+		for i := 0; i < rowCount; i++ {
+			ts, tsOk := toMillis(frame.At(timeIdx, i))
 			if !tsOk {
 				continue
 			}
-			val, valOk := toFloat(metricValues[i])
+			val, valOk := toFloat(frame.At(valueIdx, i))
 			if !valOk {
 				continue
 			}
@@ -441,34 +390,33 @@ func framesToMatrix(frames []dsQueryFrame) (model.Matrix, error) {
 	return matrix, nil
 }
 
-func framesToVector(frames []dsQueryFrame) (model.Vector, error) {
+func framesToVector(frames data.Frames) (model.Vector, error) {
 	var vector model.Vector
 	for _, frame := range frames {
-		timeIdx, valueIdx := findTimeAndValueFields(frame.Schema.Fields)
+		timeIdx, valueIdx := findTimeAndValueFields(frame.Fields)
 		if timeIdx == -1 || valueIdx == -1 {
 			continue
 		}
-		if len(frame.Data.Values) <= timeIdx || len(frame.Data.Values) <= valueIdx {
+		if len(frame.Fields) <= timeIdx || len(frame.Fields) <= valueIdx {
 			continue
 		}
 
-		timeValues := frame.Data.Values[timeIdx]
-		metricValues := frame.Data.Values[valueIdx]
-		if len(timeValues) == 0 || len(metricValues) == 0 {
+		rowCount := frame.Rows()
+		if rowCount == 0 {
 			continue
 		}
 
-		lastIdx := len(timeValues) - 1
-		ts, tsOk := toMillis(timeValues[lastIdx])
+		lastIdx := rowCount - 1
+		ts, tsOk := toMillis(frame.At(timeIdx, lastIdx))
 		if !tsOk {
 			continue
 		}
-		val, valOk := toFloat(metricValues[lastIdx])
+		val, valOk := toFloat(frame.At(valueIdx, lastIdx))
 		if !valOk {
 			continue
 		}
 
-		metric := buildMetricFromLabels(frame.Schema.Fields[valueIdx].Labels, frame.Schema.Name)
+		metric := buildMetricFromLabels(frame.Fields[valueIdx].Labels, frame.Name)
 		vector = append(vector, &model.Sample{
 			Metric:    metric,
 			Timestamp: model.Time(ts),
@@ -481,21 +429,22 @@ func framesToVector(frames []dsQueryFrame) (model.Vector, error) {
 	return vector, nil
 }
 
-func findTimeAndValueFields(fields []dsQueryFrameField) (timeIdx, valueIdx int) {
+func findTimeAndValueFields(fields []*data.Field) (timeIdx, valueIdx int) {
 	timeIdx = -1
 	valueIdx = -1
 	for i, f := range fields {
-		switch f.Type {
-		case "time":
+		ft := f.Type()
+		switch {
+		case ft == data.FieldTypeTime || ft == data.FieldTypeNullableTime:
 			timeIdx = i
-		case "number", "float64", "int64":
+		case ft.Numeric():
 			valueIdx = i
 		}
 	}
 	return
 }
 
-func buildMetricFromLabels(labels map[string]string, name string) model.Metric {
+func buildMetricFromLabels(labels data.Labels, name string) model.Metric {
 	metric := make(model.Metric, len(labels)+1)
 	if name != "" {
 		metric["__name__"] = model.LabelValue(name)
@@ -513,6 +462,13 @@ func toMillis(v interface{}) (int64, bool) {
 	case json.Number:
 		i, err := n.Int64()
 		return i, err == nil
+	case time.Time:
+		return n.UnixMilli(), true
+	case *time.Time:
+		if n == nil {
+			return 0, false
+		}
+		return n.UnixMilli(), true
 	default:
 		return 0, false
 	}
@@ -522,6 +478,18 @@ func toFloat(v interface{}) (float64, bool) {
 	switch n := v.(type) {
 	case float64:
 		return n, true
+	case *float64:
+		if n == nil {
+			return 0, false
+		}
+		return *n, true
+	case int64:
+		return float64(n), true
+	case *int64:
+		if n == nil {
+			return 0, false
+		}
+		return float64(*n), true
 	case json.Number:
 		f, err := n.Float64()
 		return f, err == nil
@@ -533,15 +501,15 @@ func toFloat(v interface{}) (float64, bool) {
 }
 
 // extractLabelNamesFromFrames extracts unique label keys from HEADERS query frames.
-func extractLabelNamesFromFrames(resp *dsQueryResponse) []string {
+func extractLabelNamesFromFrames(resp *backend.QueryDataResponse) []string {
 	seen := make(map[string]bool)
-	r, ok := resp.Results["A"]
+	r, ok := resp.Responses["A"]
 	if !ok {
 		return nil
 	}
 
 	for _, frame := range r.Frames {
-		for _, field := range frame.Schema.Fields {
+		for _, field := range frame.Fields {
 			for k := range field.Labels {
 				if !seen[k] {
 					seen[k] = true
@@ -558,15 +526,15 @@ func extractLabelNamesFromFrames(resp *dsQueryResponse) []string {
 }
 
 // extractLabelValuesFromFrames extracts unique values for a label from HEADERS query frames.
-func extractLabelValuesFromFrames(resp *dsQueryResponse, labelName string) []string {
+func extractLabelValuesFromFrames(resp *backend.QueryDataResponse, labelName string) []string {
 	seen := make(map[string]bool)
-	r, ok := resp.Results["A"]
+	r, ok := resp.Responses["A"]
 	if !ok {
 		return nil
 	}
 
 	for _, frame := range r.Frames {
-		for _, field := range frame.Schema.Fields {
+		for _, field := range frame.Fields {
 			if v, ok := field.Labels[labelName]; ok && !seen[v] {
 				seen[v] = true
 			}

--- a/tools/prom_backend_cloudmonitoring_test.go
+++ b/tools/prom_backend_cloudmonitoring_test.go
@@ -3,9 +3,13 @@
 package tools
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -14,22 +18,13 @@ import (
 
 func TestFramesToMatrix(t *testing.T) {
 	t.Run("single series", func(t *testing.T) {
-		frames := []dsQueryFrame{
-			{
-				Schema: dsQueryFrameSchema{
-					Name: "cpu_usage",
-					Fields: []dsQueryFrameField{
-						{Name: "Time", Type: "time"},
-						{Name: "Value", Type: "number", Labels: map[string]string{"host": "a"}},
-					},
-				},
-				Data: dsQueryFrameData{
-					Values: [][]interface{}{
-						{float64(1000), float64(2000), float64(3000)},
-						{float64(0.5), float64(0.7), float64(0.9)},
-					},
-				},
-			},
+		frames := data.Frames{
+			data.NewFrame("cpu_usage",
+				data.NewField("Time", nil, []time.Time{
+					time.UnixMilli(1000), time.UnixMilli(2000), time.UnixMilli(3000),
+				}),
+				data.NewField("Value", data.Labels{"host": "a"}, []float64{0.5, 0.7, 0.9}),
+			),
 		}
 
 		result, err := framesToMatrix(frames)
@@ -43,21 +38,15 @@ func TestFramesToMatrix(t *testing.T) {
 	})
 
 	t.Run("multiple series", func(t *testing.T) {
-		frames := []dsQueryFrame{
-			{
-				Schema: dsQueryFrameSchema{
-					Name:   "cpu",
-					Fields: []dsQueryFrameField{{Name: "Time", Type: "time"}, {Name: "Value", Type: "number", Labels: map[string]string{"host": "a"}}},
-				},
-				Data: dsQueryFrameData{Values: [][]interface{}{{float64(1000)}, {float64(0.5)}}},
-			},
-			{
-				Schema: dsQueryFrameSchema{
-					Name:   "cpu",
-					Fields: []dsQueryFrameField{{Name: "Time", Type: "time"}, {Name: "Value", Type: "number", Labels: map[string]string{"host": "b"}}},
-				},
-				Data: dsQueryFrameData{Values: [][]interface{}{{float64(1000)}, {float64(0.8)}}},
-			},
+		frames := data.Frames{
+			data.NewFrame("cpu",
+				data.NewField("Time", nil, []time.Time{time.UnixMilli(1000)}),
+				data.NewField("Value", data.Labels{"host": "a"}, []float64{0.5}),
+			),
+			data.NewFrame("cpu",
+				data.NewField("Time", nil, []time.Time{time.UnixMilli(1000)}),
+				data.NewField("Value", data.Labels{"host": "b"}, []float64{0.8}),
+			),
 		}
 
 		result, err := framesToMatrix(frames)
@@ -72,13 +61,10 @@ func TestFramesToMatrix(t *testing.T) {
 	})
 
 	t.Run("frame missing time field", func(t *testing.T) {
-		frames := []dsQueryFrame{
-			{
-				Schema: dsQueryFrameSchema{
-					Fields: []dsQueryFrameField{{Name: "Value", Type: "number"}},
-				},
-				Data: dsQueryFrameData{Values: [][]interface{}{{float64(1.0)}}},
-			},
+		frames := data.Frames{
+			data.NewFrame("",
+				data.NewField("Value", nil, []float64{1.0}),
+			),
 		}
 
 		result, err := framesToMatrix(frames)
@@ -89,22 +75,11 @@ func TestFramesToMatrix(t *testing.T) {
 
 func TestFramesToVector(t *testing.T) {
 	t.Run("single sample", func(t *testing.T) {
-		frames := []dsQueryFrame{
-			{
-				Schema: dsQueryFrameSchema{
-					Name: "up",
-					Fields: []dsQueryFrameField{
-						{Name: "Time", Type: "time"},
-						{Name: "Value", Type: "number", Labels: map[string]string{"job": "prometheus"}},
-					},
-				},
-				Data: dsQueryFrameData{
-					Values: [][]interface{}{
-						{float64(5000)},
-						{float64(1.0)},
-					},
-				},
-			},
+		frames := data.Frames{
+			data.NewFrame("up",
+				data.NewField("Time", nil, []time.Time{time.UnixMilli(5000)}),
+				data.NewField("Value", data.Labels{"job": "prometheus"}, []float64{1.0}),
+			),
 		}
 
 		result, err := framesToVector(frames)
@@ -117,21 +92,13 @@ func TestFramesToVector(t *testing.T) {
 	})
 
 	t.Run("takes last value from multi-point frame", func(t *testing.T) {
-		frames := []dsQueryFrame{
-			{
-				Schema: dsQueryFrameSchema{
-					Fields: []dsQueryFrameField{
-						{Name: "Time", Type: "time"},
-						{Name: "Value", Type: "number"},
-					},
-				},
-				Data: dsQueryFrameData{
-					Values: [][]interface{}{
-						{float64(1000), float64(2000), float64(3000)},
-						{float64(1.0), float64(2.0), float64(3.0)},
-					},
-				},
-			},
+		frames := data.Frames{
+			data.NewFrame("",
+				data.NewField("Time", nil, []time.Time{
+					time.UnixMilli(1000), time.UnixMilli(2000), time.UnixMilli(3000),
+				}),
+				data.NewField("Value", nil, []float64{1.0, 2.0, 3.0}),
+			),
 		}
 
 		result, err := framesToVector(frames)
@@ -150,7 +117,7 @@ func TestFramesToVector(t *testing.T) {
 
 func TestFramesToPrometheusValue(t *testing.T) {
 	t.Run("missing refId returns empty", func(t *testing.T) {
-		resp := &dsQueryResponse{Results: map[string]dsQueryResult{}}
+		resp := &backend.QueryDataResponse{Responses: backend.Responses{}}
 		v, err := framesToPrometheusValue(resp, "range")
 		require.NoError(t, err)
 		assert.Equal(t, model.Matrix{}, v)
@@ -161,8 +128,8 @@ func TestFramesToPrometheusValue(t *testing.T) {
 	})
 
 	t.Run("error in result", func(t *testing.T) {
-		resp := &dsQueryResponse{Results: map[string]dsQueryResult{
-			"A": {Error: "something went wrong"},
+		resp := &backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Error: fmt.Errorf("something went wrong")},
 		}}
 		_, err := framesToPrometheusValue(resp, "range")
 		require.Error(t, err)
@@ -234,34 +201,22 @@ func TestMapGCPMetricKind(t *testing.T) {
 }
 
 func TestExtractLabelValuesFromFrames(t *testing.T) {
-	resp := &dsQueryResponse{
-		Results: map[string]dsQueryResult{
-			"A": {
-				Frames: []dsQueryFrame{
-					{
-						Schema: dsQueryFrameSchema{
-							Fields: []dsQueryFrameField{
-								{Name: "Time", Type: "time"},
-								{Name: "Value", Type: "number", Labels: map[string]string{"zone": "us-east1-b", "project_id": "my-project"}},
-							},
-						},
-					},
-					{
-						Schema: dsQueryFrameSchema{
-							Fields: []dsQueryFrameField{
-								{Name: "Time", Type: "time"},
-								{Name: "Value", Type: "number", Labels: map[string]string{"zone": "us-west1-a", "project_id": "my-project"}},
-							},
-						},
-					},
-					{
-						Schema: dsQueryFrameSchema{
-							Fields: []dsQueryFrameField{
-								{Name: "Time", Type: "time"},
-								{Name: "Value", Type: "number", Labels: map[string]string{"zone": "us-east1-b", "project_id": "other-project"}},
-							},
-						},
-					},
+	resp := &backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": backend.DataResponse{
+				Frames: data.Frames{
+					data.NewFrame("",
+						data.NewField("Time", nil, []time.Time{}),
+						data.NewField("Value", data.Labels{"zone": "us-east1-b", "project_id": "my-project"}, []float64{}),
+					),
+					data.NewFrame("",
+						data.NewField("Time", nil, []time.Time{}),
+						data.NewField("Value", data.Labels{"zone": "us-west1-a", "project_id": "my-project"}, []float64{}),
+					),
+					data.NewFrame("",
+						data.NewField("Time", nil, []time.Time{}),
+						data.NewField("Value", data.Labels{"zone": "us-east1-b", "project_id": "other-project"}, []float64{}),
+					),
 				},
 			},
 		},

--- a/tools/prom_backend_victoriametrics.go
+++ b/tools/prom_backend_victoriametrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -87,13 +86,7 @@ func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryTy
 		"intervalMs": int64(step) * 1000,
 	}
 
-	payload := map[string]interface{}{
-		"queries": []interface{}{query},
-		"from":    strconv.FormatInt(start.UnixMilli(), 10),
-		"to":      strconv.FormatInt(end.UnixMilli(), 10),
-	}
-
-	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, payload)
+	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, dsQueryPayload(start, end, query))
 	if err != nil {
 		return nil, fmt.Errorf("querying VictoriaMetrics %s: %w", queryType, err)
 	}

--- a/tools/prom_backend_victoriametrics_test.go
+++ b/tools/prom_backend_victoriametrics_test.go
@@ -5,6 +5,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -20,15 +23,15 @@ import (
 )
 
 // fakeVMServer captures the most recent /api/ds/query payload and returns a
-// canned dsQueryResponse so tests can assert payload shape and response decoding
+// canned backend.QueryDataResponse so tests can assert payload shape and response decoding
 // independently.
 type fakeVMServer struct {
 	server      *httptest.Server
 	lastPayload map[string]interface{}
-	response    dsQueryResponse
+	response    backend.QueryDataResponse
 }
 
-func newFakeVMServer(t *testing.T, response dsQueryResponse) *fakeVMServer {
+func newFakeVMServer(t *testing.T, response backend.QueryDataResponse) *fakeVMServer {
 	t.Helper()
 	f := &fakeVMServer{response: response}
 	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +43,9 @@ func newFakeVMServer(t *testing.T, response dsQueryResponse) *fakeVMServer {
 		require.NoError(t, json.Unmarshal(body, &f.lastPayload))
 
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(f.response))
+		respBytes, err := json.Marshal(f.response)
+		require.NoError(t, err)
+		_, _ = w.Write(respBytes)
 	}))
 	t.Cleanup(f.server.Close)
 	return f
@@ -89,8 +94,8 @@ func TestVictoriaMetricsBackendQuery_PayloadShape(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
-				"A": {Frames: []dsQueryFrame{}},
+			fake := newFakeVMServer(t, backend.QueryDataResponse{Responses: backend.Responses{
+				"A": backend.DataResponse{Frames: data.Frames{}},
 			}})
 			b := newTestVMBackend(t, fake.server)
 
@@ -123,23 +128,12 @@ func TestVictoriaMetricsBackendQuery_PayloadShape(t *testing.T) {
 }
 
 func TestVictoriaMetricsBackendQuery_DecodesInstantResponse(t *testing.T) {
-	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
-		"A": {Frames: []dsQueryFrame{
-			{
-				Schema: dsQueryFrameSchema{
-					Name: "up",
-					Fields: []dsQueryFrameField{
-						{Name: "Time", Type: "time"},
-						{Name: "Value", Type: "number", Labels: map[string]string{"job": "prometheus"}},
-					},
-				},
-				Data: dsQueryFrameData{
-					Values: [][]interface{}{
-						{float64(1700000000000)},
-						{float64(1)},
-					},
-				},
-			},
+	fake := newFakeVMServer(t, backend.QueryDataResponse{Responses: backend.Responses{
+		"A": backend.DataResponse{Frames: data.Frames{
+			data.NewFrame("up",
+				data.NewField("Time", nil, []time.Time{time.UnixMilli(1700000000000)}),
+				data.NewField("Value", data.Labels{"job": "prometheus"}, []float64{1}),
+			),
 		}},
 	}})
 	b := newTestVMBackend(t, fake.server)
@@ -156,23 +150,15 @@ func TestVictoriaMetricsBackendQuery_DecodesInstantResponse(t *testing.T) {
 }
 
 func TestVictoriaMetricsBackendQuery_DecodesRangeResponseAsMatrix(t *testing.T) {
-	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
-		"A": {Frames: []dsQueryFrame{
-			{
-				Schema: dsQueryFrameSchema{
-					Name: "up",
-					Fields: []dsQueryFrameField{
-						{Name: "Time", Type: "time"},
-						{Name: "Value", Type: "number", Labels: map[string]string{"job": "prometheus"}},
-					},
-				},
-				Data: dsQueryFrameData{
-					Values: [][]interface{}{
-						{float64(1700000000000), float64(1700000060000)},
-						{float64(1), float64(0)},
-					},
-				},
-			},
+	fake := newFakeVMServer(t, backend.QueryDataResponse{Responses: backend.Responses{
+		"A": backend.DataResponse{Frames: data.Frames{
+			data.NewFrame("up",
+				data.NewField("Time", nil, []time.Time{
+					time.UnixMilli(1700000000000),
+					time.UnixMilli(1700000060000),
+				}),
+				data.NewField("Value", data.Labels{"job": "prometheus"}, []float64{1, 0}),
+			),
 		}},
 	}})
 	b := newTestVMBackend(t, fake.server)
@@ -198,8 +184,8 @@ func TestVictoriaMetricsBackendQuery_DecodesRangeResponseAsMatrix(t *testing.T) 
 }
 
 func TestVictoriaMetricsBackendQuery_PropagatesUpstreamError(t *testing.T) {
-	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
-		"A": {Error: "rate: bad expression"},
+	fake := newFakeVMServer(t, backend.QueryDataResponse{Responses: backend.Responses{
+		"A": backend.DataResponse{Error: fmt.Errorf("rate: bad expression")},
 	}})
 	b := newTestVMBackend(t, fake.server)
 
@@ -209,7 +195,7 @@ func TestVictoriaMetricsBackendQuery_PropagatesUpstreamError(t *testing.T) {
 }
 
 func TestVictoriaMetricsBackendQuery_RejectsInvalidQueryType(t *testing.T) {
-	fake := newFakeVMServer(t, dsQueryResponse{})
+	fake := newFakeVMServer(t, backend.QueryDataResponse{})
 	b := newTestVMBackend(t, fake.server)
 
 	_, err := b.Query(context.Background(), "up", "bogus", time.Time{}, time.Unix(1700000000, 0), 0)
@@ -219,8 +205,8 @@ func TestVictoriaMetricsBackendQuery_RejectsInvalidQueryType(t *testing.T) {
 }
 
 func TestVictoriaMetricsBackendQuery_DefaultsToNowWhenBothTimesZero(t *testing.T) {
-	fake := newFakeVMServer(t, dsQueryResponse{Results: map[string]dsQueryResult{
-		"A": {Frames: []dsQueryFrame{}},
+	fake := newFakeVMServer(t, backend.QueryDataResponse{Responses: backend.Responses{
+		"A": backend.DataResponse{Frames: data.Frames{}},
 	}})
 	b := newTestVMBackend(t, fake.server)
 

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -1,12 +1,9 @@
 package tools
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -515,14 +512,7 @@ func executeCloudWatchPanelQuery(ctx context.Context, datasourceUID string, pane
 		target["refId"] = "A"
 	}
 
-	// Build /api/ds/query payload
-	payload := map[string]interface{}{
-		"queries": []map[string]interface{}{target},
-		"from":    fmt.Sprintf("%d", startTime.UnixMilli()),
-		"to":      fmt.Sprintf("%d", endTime.UnixMilli()),
-	}
-
-	return executeGrafanaDSQuery(ctx, payload)
+	return executeGrafanaDSQuery(ctx, dsQueryPayload(startTime, endTime, target))
 }
 
 // executeInfluxDBQuery runs an InfluxDB panel query using queryInfluxDB. The
@@ -545,65 +535,19 @@ func executeInfluxDBQuery(ctx context.Context, datasourceUID string, panelData *
 	})
 }
 
-// executeGrafanaDSQuery executes a query through Grafana's /api/ds/query endpoint
+// executeGrafanaDSQuery executes a query through Grafana's /api/ds/query endpoint.
 func executeGrafanaDSQuery(ctx context.Context, payload map[string]interface{}) (interface{}, error) {
-	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := cfg.URL
-
-	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
+	client, baseURL, err := newDSQueryHTTPClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transport: %w", err)
+		return nil, err
 	}
 
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   30 * time.Second,
-	}
-
-	payloadBytes, err := json.Marshal(payload)
+	resp, err := doDSQuery(ctx, client, baseURL, payload)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
+		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/api/ds/query", bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing query: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		// Try to extract error message from JSON response
-		var errResult map[string]interface{}
-		if json.Unmarshal(bodyBytes, &errResult) == nil {
-			if errMsg, ok := errResult["message"].(string); ok {
-				return nil, fmt.Errorf("query failed: %s", errMsg)
-			}
-		}
-		return nil, fmt.Errorf("query failed with status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	var result map[string]interface{}
-	if err := json.Unmarshal(bodyBytes, &result); err != nil {
-		return nil, fmt.Errorf("decoding response: %w", err)
-	}
-
-	// Return the results from the response
-	if results, ok := result["results"].(map[string]interface{}); ok {
-		return results, nil
-	}
-
-	return result, nil
+	return resp.Responses, nil
 }
 
 // substituteGrafanaMacros substitutes Grafana temporal macros ($__range, $__rate_interval, $__interval)

--- a/tools/snowflake.go
+++ b/tools/snowflake.go
@@ -1,12 +1,8 @@
 package tools
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -68,115 +64,6 @@ type SnowflakeQueryResult struct {
 	Hints          *EmptyResultHints        `json:"hints,omitempty"`
 }
 
-// snowflakeQueryResponse represents the raw API response from Grafana's /api/ds/query
-type snowflakeQueryResponse struct {
-	Results map[string]struct {
-		Status int `json:"status,omitempty"`
-		Frames []struct {
-			Schema struct {
-				Name   string `json:"name,omitempty"`
-				RefID  string `json:"refId,omitempty"`
-				Fields []struct {
-					Name     string `json:"name"`
-					Type     string `json:"type"`
-					TypeInfo struct {
-						Frame string `json:"frame,omitempty"`
-					} `json:"typeInfo,omitempty"`
-				} `json:"fields"`
-			} `json:"schema"`
-			Data struct {
-				Values [][]interface{} `json:"values"`
-			} `json:"data"`
-		} `json:"frames,omitempty"`
-		Error string `json:"error,omitempty"`
-	} `json:"results"`
-}
-
-// snowflakeClient handles communication with Grafana's Snowflake datasource
-type snowflakeClient struct {
-	httpClient *http.Client
-	baseURL    string
-}
-
-// newSnowflakeClient creates a new Snowflake client for the given datasource
-func newSnowflakeClient(ctx context.Context, uid string) (*snowflakeClient, error) {
-	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: uid})
-	if err != nil {
-		return nil, err
-	}
-
-	if ds.Type != SnowflakeDatasourceType {
-		return nil, fmt.Errorf("datasource %s is of type %s, not %s", uid, ds.Type, SnowflakeDatasourceType)
-	}
-
-	cfg := mcpgrafana.GrafanaConfigFromContext(ctx)
-	baseURL := cfg.URL
-
-	transport, err := mcpgrafana.BuildTransport(&cfg, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create transport: %w", err)
-	}
-
-	return &snowflakeClient{
-		httpClient: &http.Client{Transport: transport},
-		baseURL:    baseURL,
-	}, nil
-}
-
-// query executes a Snowflake query via Grafana's /api/ds/query endpoint
-func (c *snowflakeClient) query(ctx context.Context, datasourceUID, rawSQL string, from, to time.Time) (*snowflakeQueryResponse, error) {
-	payload := map[string]interface{}{
-		"queries": []map[string]interface{}{
-			{
-				"datasource": map[string]string{
-					"uid":  datasourceUID,
-					"type": SnowflakeDatasourceType,
-				},
-				"rawSql": rawSQL,
-				"refId":  "A",
-				"format": SnowflakeFormatTable,
-			},
-		},
-		"from": strconv.FormatInt(from.UnixMilli(), 10),
-		"to":   strconv.FormatInt(to.UnixMilli(), 10),
-	}
-
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling query payload: %w", err)
-	}
-
-	url := c.baseURL + "/api/ds/query"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("snowflake query returned status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	bodyBytes, err := readResponseBody(resp.Body, defaultResponseLimitBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
-	}
-
-	var queryResp snowflakeQueryResponse
-	if err := json.Unmarshal(bodyBytes, &queryResp); err != nil {
-		return nil, fmt.Errorf("unmarshaling response: %w", err)
-	}
-
-	return &queryResp, nil
-}
-
 // substituteSnowflakeMacros replaces Snowflake-specific macros in the query.
 // Supported macros:
 //   - $__timeFilter(column) -> column >= TO_TIMESTAMP_NTZ('YYYY-MM-DD HH:MI:SS') AND column <= ...
@@ -211,7 +98,6 @@ func substituteSnowflakeMacros(query string, from, to time.Time) string {
 	})
 
 	// $__timeFrom and $__timeTo - emit TIMESTAMP_NTZ literals.
-	// Replace these before $__from/$__to since "$__timeFrom" contains "$__from" as a prefix substring? No — actually $__from is a different token. Order is fine, but we keep $__timeFrom/$__timeTo first to be explicit.
 	query = strings.ReplaceAll(query, "$__timeFrom", fmt.Sprintf("TO_TIMESTAMP_NTZ('%s')", fromStr))
 	query = strings.ReplaceAll(query, "$__timeTo", fmt.Sprintf("TO_TIMESTAMP_NTZ('%s')", toStr))
 
@@ -257,9 +143,17 @@ func enforceSnowflakeLimit(query string, requestedLimit int) string {
 
 // querySnowflake executes a Snowflake query via Grafana
 func querySnowflake(ctx context.Context, args SnowflakeQueryParams) (*SnowflakeQueryResult, error) {
-	client, err := newSnowflakeClient(ctx, args.DatasourceUID)
+	ds, err := getDatasourceByUID(ctx, GetDatasourceByUIDParams{UID: args.DatasourceUID})
 	if err != nil {
 		return nil, fmt.Errorf("creating Snowflake client: %w", err)
+	}
+	if ds.Type != SnowflakeDatasourceType {
+		return nil, fmt.Errorf("datasource %s is of type %s, not %s", args.DatasourceUID, ds.Type, SnowflakeDatasourceType)
+	}
+
+	client, baseURL, err := newDSQueryHTTPClient(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	now := time.Now()
@@ -291,47 +185,32 @@ func querySnowflake(ctx context.Context, args SnowflakeQueryParams) (*SnowflakeQ
 	processedQuery = substituteVariables(processedQuery, args.Variables)
 	processedQuery = enforceSnowflakeLimit(processedQuery, args.Limit)
 
-	resp, err := client.query(ctx, args.DatasourceUID, processedQuery, fromTime, toTime)
+	payload := dsQueryPayload(fromTime, toTime, map[string]interface{}{
+		"datasource": map[string]string{
+			"uid":  args.DatasourceUID,
+			"type": SnowflakeDatasourceType,
+		},
+		"rawSql": processedQuery,
+		"refId":  "A",
+		"format": SnowflakeFormatTable,
+	})
+
+	resp, err := doDSQuery(ctx, client, baseURL, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	columns, rows, err := framesToTabularRows(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &SnowflakeQueryResult{
-		Columns:        []string{},
-		Rows:           []map[string]interface{}{},
+		Columns:        columns,
+		Rows:           rows,
+		RowCount:       len(rows),
 		ProcessedQuery: processedQuery,
 	}
-
-	for refID, r := range resp.Results {
-		if r.Error != "" {
-			return nil, fmt.Errorf("query error (refId=%s): %s", refID, r.Error)
-		}
-
-		for _, frame := range r.Frames {
-			columns := make([]string, len(frame.Schema.Fields))
-			for i, field := range frame.Schema.Fields {
-				columns[i] = field.Name
-			}
-			result.Columns = columns
-
-			if len(frame.Data.Values) == 0 {
-				continue
-			}
-
-			rowCount := len(frame.Data.Values[0])
-			for i := 0; i < rowCount; i++ {
-				row := make(map[string]interface{})
-				for colIdx, colName := range columns {
-					if colIdx < len(frame.Data.Values) && i < len(frame.Data.Values[colIdx]) {
-						row[colName] = frame.Data.Values[colIdx][i]
-					}
-				}
-				result.Rows = append(result.Rows, row)
-			}
-		}
-	}
-
-	result.RowCount = len(result.Rows)
 
 	if result.RowCount == 0 {
 		result.Hints = GenerateEmptyResultHints(HintContext{
@@ -418,24 +297,13 @@ WHERE TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA')`, from)
 
 	tables := make([]SnowflakeTableInfo, 0, len(result.Rows))
 	for _, row := range result.Rows {
-		t := SnowflakeTableInfo{}
-		if v, ok := row["TABLE_CATALOG"].(string); ok {
-			t.Database = v
-		}
-		if v, ok := row["TABLE_SCHEMA"].(string); ok {
-			t.Schema = v
-		}
-		if v, ok := row["TABLE_NAME"].(string); ok {
-			t.Name = v
-		}
-		if v, ok := row["TABLE_TYPE"].(string); ok {
-			t.Kind = v
-		}
-		if v, ok := row["ROW_COUNT"].(float64); ok {
-			t.RowCount = int64(v)
-		}
-		if v, ok := row["BYTES"].(float64); ok {
-			t.Bytes = int64(v)
+		t := SnowflakeTableInfo{
+			Database: toStringFromRow(row["TABLE_CATALOG"]),
+			Schema:   toStringFromRow(row["TABLE_SCHEMA"]),
+			Name:     toStringFromRow(row["TABLE_NAME"]),
+			Kind:     toStringFromRow(row["TABLE_TYPE"]),
+			RowCount: toInt64FromRow(row["ROW_COUNT"]),
+			Bytes:    toInt64FromRow(row["BYTES"]),
 		}
 		tables = append(tables, t)
 	}
@@ -512,21 +380,12 @@ ORDER BY ORDINAL_POSITION`, from, schema, args.Table)
 
 	columns := make([]SnowflakeColumnInfo, 0, len(result.Rows))
 	for _, row := range result.Rows {
-		col := SnowflakeColumnInfo{}
-		if v, ok := row["COLUMN_NAME"].(string); ok {
-			col.Name = v
-		}
-		if v, ok := row["DATA_TYPE"].(string); ok {
-			col.Type = v
-		}
-		if v, ok := row["IS_NULLABLE"].(string); ok {
-			col.Nullable = v
-		}
-		if v, ok := row["COLUMN_DEFAULT"].(string); ok {
-			col.Default = v
-		}
-		if v, ok := row["COMMENT"].(string); ok {
-			col.Comment = v
+		col := SnowflakeColumnInfo{
+			Name:     toStringFromRow(row["COLUMN_NAME"]),
+			Type:     toStringFromRow(row["DATA_TYPE"]),
+			Nullable: toStringFromRow(row["IS_NULLABLE"]),
+			Default:  toStringFromRow(row["COLUMN_DEFAULT"]),
+			Comment:  toStringFromRow(row["COMMENT"]),
 		}
 		columns = append(columns, col)
 	}


### PR DESCRIPTION
## Summary

- Introduces `tools/ds_query.go` with shared response types, HTTP client setup, query execution, and columnar-to-row conversion for Grafana's `/api/ds/query` endpoint
- Removes all duplicate response struct definitions (`clickHouseQueryResponse`, `snowflakeQueryResponse`, `athenaQueryResponse`, `cloudWatchQueryResponse`, `influxDBQueryResponse`, `influxDBFrame`, etc.)
- Removes all near-identical HTTP execution paths across datasource tools — every `/api/ds/query` caller now goes through `doDSQuery()`
- Eliminates per-datasource client structs that existed solely for `/api/ds/query` calls (ClickHouse, Snowflake, InfluxDB)

## What's shared

| Component | Before | After |
|---|---|---|
| Response types | 7+ copies (inline + named) | 1 set in `ds_query.go` |
| HTTP execution | 8+ copies | `doDSQuery()` / `doDSQueryWithLimit()` |
| HTTP client setup | 6+ copies | `newDSQueryHTTPClient()` |
| Frame→rows conversion | 4 copies | `framesToTabularRows()` |

## What's intentionally kept separate

- **Loki** uses its own API (`/loki/api/v1/*`), not `/api/ds/query`, so it's unaffected
- **CloudWatch** uses the shared types and `doDSQuery()` but has custom time-series response processing (statistics accumulation)
- **Athena** retains `athenaClient` for plugin resource API calls (`/catalogs`, `/databases`, etc.) — only query execution was consolidated
- **OpenSearch** uses `doDSQueryWithLimit()` with a 48MB limit (vs the default 10MB) since raw document queries can be large

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] Unit tests pass (`go test ./tools/... -tags=unit`)
- [x] Short tests pass (`go test ./tools/... -short`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple datasource query paths (Athena/ClickHouse/Snowflake/InfluxDB/CloudWatch/OpenSearch/Prom backends) by centralizing HTTP execution and response decoding, so regressions could affect query results or error handling across integrations. Changes are mostly refactoring, but they alter response parsing to rely on Grafana SDK frame types and adjust response size limits in a few places.
> 
> **Overview**
> **Consolidates Grafana `/api/ds/query` plumbing across tools.** Adds `tools/ds_query.go` with shared helpers for building query envelopes (`dsQueryPayload`), creating the authenticated HTTP client (`newDSQueryHTTPClient`), executing queries with consistent status/error handling (`doDSQuery`/`doDSQueryWithLimit`), and converting SDK frames to tabular rows (`framesToTabularRows`) plus safe row value extraction helpers.
> 
> Refactors Athena/ClickHouse/Snowflake/InfluxDB to remove datasource-specific `/api/ds/query` clients and bespoke response structs, routing all queries through the shared helpers and SDK `backend.QueryDataResponse`. Updates CloudWatch, OpenSearch, and Prometheus-style backends (Cloud Monitoring/VictoriaMetrics) to consume SDK frame types and pointer-friendly value parsing; OpenSearch keeps a larger response limit (48MB), and Athena resource calls use a dedicated 10MB limit. Unit tests are updated to construct/marshal SDK `QueryDataResponse` objects and validate the new shared frame-to-row/statistics paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5321697d538468fcad1ddff406c1278098f6267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->