### PR TITLE
feat(dashboard): add get_dashboard_intent + list_dashboard_intent tools

### DIFF
--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -797,4 +797,5 @@ func AddDashboardTools(mcp *server.MCPServer, enableWriteTools bool) {
 	GetDashboardPanelQueries.Register(mcp)
 	GetDashboardProperty.Register(mcp)
 	GetDashboardSummary.Register(mcp)
+	AddDashboardIntentTools(mcp)
 }

--- a/tools/dashboard_intent.go
+++ b/tools/dashboard_intent.go
@@ -1,0 +1,289 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+// Dashboard intent (https://grafana.com — Grafana Assistant Dashboard
+// Intent feature) lives inside the dashboard JSON itself as a top-level
+// `intent` block and as a per-panel `panels[].intent` block. These
+// tools project that block into a normalized, snake_case shape so MCP
+// clients (Cursor, incident bots, CI pipelines, etc.) don't have to
+// re-walk the dashboard JSON to read it.
+//
+// The on-disk JSON uses camelCase (`expectedBehavior`, `failureModes`,
+// `relatedSlos`, `lastVerifiedAt`) to match the rest of the dashboard
+// schema. The MCP surface here is snake_case to match the assistant
+// API and other MCP tools that expose dashboard data.
+//
+// Provenance map keys are also snake_case and pass through unchanged
+// from the dashboard JSON (e.g. `expected_behavior.normal_range`,
+// `failure_modes`).
+
+const dashboardIntentSchemaVersionCurrent = 1
+
+// DashboardIntent is the normalized shape an MCP client sees for a
+// dashboard or panel intent block.
+type DashboardIntent struct {
+	DashboardUID     string            `json:"dashboard_uid"`
+	PanelID          *int              `json:"panel_id,omitempty"`
+	SchemaVersion    int               `json:"schema_version"`
+	Purpose          string            `json:"purpose,omitempty"`
+	Owner            string            `json:"owner,omitempty"`
+	ExpectedBehavior *ExpectedBehavior `json:"expected_behavior,omitempty"`
+	FailureModes     []FailureMode     `json:"failure_modes,omitempty"`
+	RelatedSLOs      []RelatedSLO      `json:"related_slos,omitempty"`
+	Runbooks         []Runbook         `json:"runbooks,omitempty"`
+	Provenance       map[string]string `json:"provenance,omitempty"`
+	LastVerifiedAt   *time.Time        `json:"last_verified_at,omitempty"`
+}
+
+type ExpectedBehavior struct {
+	NormalRange    string `json:"normal_range,omitempty"`
+	AlertThreshold string `json:"alert_threshold,omitempty"`
+	Notes          string `json:"notes,omitempty"`
+}
+
+type FailureMode struct {
+	Tag         string `json:"tag"`
+	Description string `json:"description,omitempty"`
+}
+
+type RelatedSLO struct {
+	Name   string `json:"name"`
+	Target string `json:"target,omitempty"`
+	URL    string `json:"url,omitempty"`
+}
+
+type Runbook struct {
+	Title string `json:"title"`
+	URL   string `json:"url,omitempty"`
+}
+
+// GetDashboardIntentParams addresses a single intent block — dashboard-
+// level when `panel_id` is omitted, panel-level otherwise.
+type GetDashboardIntentParams struct {
+	UID     string `json:"uid" jsonschema:"required,description=The UID of the dashboard whose intent to fetch."`
+	PanelID *int   `json:"panel_id,omitempty" jsonschema:"description=Optional panel ID. When set\\, returns the panel's intent block. When omitted\\, returns the dashboard-level intent block."`
+}
+
+func getDashboardIntent(ctx context.Context, args GetDashboardIntentParams) (*DashboardIntent, error) {
+	dashboard, err := getDashboardByUID(ctx, GetDashboardByUIDParams{UID: args.UID})
+	if err != nil {
+		return nil, fmt.Errorf("get dashboard by uid %s: %w", args.UID, err)
+	}
+	db, ok := dashboard.Dashboard.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("dashboard %s JSON is not an object", args.UID)
+	}
+
+	if args.PanelID == nil {
+		raw, ok := db["intent"]
+		if !ok || raw == nil {
+			return nil, fmt.Errorf("dashboard %s has no intent block", args.UID)
+		}
+		intent, err := projectIntent(raw, args.UID, nil)
+		if err != nil {
+			return nil, err
+		}
+		return intent, nil
+	}
+
+	panel, err := findPanelByID(db, *args.PanelID)
+	if err != nil {
+		return nil, err
+	}
+	raw, ok := panel["intent"]
+	if !ok || raw == nil {
+		return nil, fmt.Errorf("panel %d on dashboard %s has no intent block", *args.PanelID, args.UID)
+	}
+	return projectIntent(raw, args.UID, args.PanelID)
+}
+
+var GetDashboardIntent = mcpgrafana.MustTool(
+	"get_dashboard_intent",
+	"Get author-declared dashboard intent (purpose\\, owner\\, expected behavior\\, failure modes\\, related SLOs\\, runbooks\\, per-field provenance) for a Grafana dashboard or one of its panels. Reads from the `intent` block embedded in the dashboard JSON. Returns an error when the dashboard has no intent block — callers can treat that the same as 'no authored intent yet'. Provenance values explain whether each field was author-written\\, lifted from an alert rule/SLO\\, computed from history\\, or drafted by an assistant.",
+	getDashboardIntent,
+	mcp.WithTitleAnnotation("Get dashboard intent"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// ListDashboardIntentParams addresses a full intent bundle for the
+// dashboard — the dashboard-level block (when present) plus one entry
+// per panel that has an intent block.
+type ListDashboardIntentParams struct {
+	UID string `json:"uid" jsonschema:"required,description=The UID of the dashboard whose intent bundle to fetch."`
+}
+
+// DashboardIntentBundle is the full picture of authored intent for a
+// dashboard in one call — preferred over repeatedly calling
+// get_dashboard_intent for every panel.
+type DashboardIntentBundle struct {
+	DashboardUID string             `json:"dashboard_uid"`
+	Dashboard    *DashboardIntent   `json:"dashboard,omitempty"`
+	Panels       []DashboardIntent  `json:"panels"`
+}
+
+func listDashboardIntent(ctx context.Context, args ListDashboardIntentParams) (*DashboardIntentBundle, error) {
+	dashboard, err := getDashboardByUID(ctx, GetDashboardByUIDParams{UID: args.UID})
+	if err != nil {
+		return nil, fmt.Errorf("get dashboard by uid %s: %w", args.UID, err)
+	}
+	db, ok := dashboard.Dashboard.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("dashboard %s JSON is not an object", args.UID)
+	}
+
+	bundle := &DashboardIntentBundle{
+		DashboardUID: args.UID,
+		Panels:       []DashboardIntent{},
+	}
+
+	if raw, ok := db["intent"]; ok && raw != nil {
+		dashIntent, err := projectIntent(raw, args.UID, nil)
+		if err != nil {
+			return nil, err
+		}
+		bundle.Dashboard = dashIntent
+	}
+
+	for _, panel := range collectAllPanels(db) {
+		raw, ok := panel["intent"]
+		if !ok || raw == nil {
+			continue
+		}
+		pid := safeInt(panel, "id")
+		if pid == 0 {
+			continue
+		}
+		panelID := pid
+		panelIntent, err := projectIntent(raw, args.UID, &panelID)
+		if err != nil {
+			return nil, err
+		}
+		bundle.Panels = append(bundle.Panels, *panelIntent)
+	}
+
+	return bundle, nil
+}
+
+var ListDashboardIntent = mcpgrafana.MustTool(
+	"list_dashboard_intent",
+	"Get the full authored-intent bundle for a Grafana dashboard in one call: the dashboard-level intent block (when present) plus every panel-level intent block discovered while walking the dashboard's panels. Prefer this over repeatedly calling get_dashboard_intent for each panel when you want the whole picture. Returns an empty bundle (no error) for dashboards without any authored intent.",
+	listDashboardIntent,
+	mcp.WithTitleAnnotation("List dashboard intent bundle"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+// AddDashboardIntentTools registers the dashboard-intent MCP tools on
+// the given server. Both are read-only and unconditionally available;
+// dashboards without an `intent` block return a clean error (single-
+// resource get) or an empty bundle (list).
+func AddDashboardIntentTools(mcp *server.MCPServer) {
+	GetDashboardIntent.Register(mcp)
+	ListDashboardIntent.Register(mcp)
+}
+
+// projectIntent converts the raw camelCase intent block from the
+// dashboard JSON into the normalized snake_case shape MCP clients see.
+// The two shapes mostly differ in casing; the fields kept in the same
+// form (provenance map keys, `tag`, `name`, `title`) are passed through
+// unchanged.
+func projectIntent(raw interface{}, uid string, panelID *int) (*DashboardIntent, error) {
+	block, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("intent block on dashboard %s is not an object", uid)
+	}
+
+	intent := &DashboardIntent{
+		DashboardUID:  uid,
+		PanelID:       panelID,
+		SchemaVersion: safeInt(block, "schemaVersion"),
+		Purpose:       safeString(block, "purpose"),
+		Owner:         safeString(block, "owner"),
+	}
+	if intent.SchemaVersion == 0 {
+		intent.SchemaVersion = dashboardIntentSchemaVersionCurrent
+	}
+
+	if eb := safeObject(block, "expectedBehavior"); eb != nil {
+		intent.ExpectedBehavior = &ExpectedBehavior{
+			NormalRange:    safeString(eb, "normalRange"),
+			AlertThreshold: safeString(eb, "alertThreshold"),
+			Notes:          safeString(eb, "notes"),
+		}
+	}
+
+	for _, raw := range safeArray(block, "failureModes") {
+		fm, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		tag := safeString(fm, "tag")
+		if tag == "" {
+			continue
+		}
+		intent.FailureModes = append(intent.FailureModes, FailureMode{
+			Tag:         tag,
+			Description: safeString(fm, "description"),
+		})
+	}
+
+	for _, raw := range safeArray(block, "relatedSlos") {
+		slo, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name := safeString(slo, "name")
+		if name == "" {
+			continue
+		}
+		intent.RelatedSLOs = append(intent.RelatedSLOs, RelatedSLO{
+			Name:   name,
+			Target: safeString(slo, "target"),
+			URL:    safeString(slo, "url"),
+		})
+	}
+
+	for _, raw := range safeArray(block, "runbooks") {
+		rb, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		title := safeString(rb, "title")
+		if title == "" {
+			continue
+		}
+		intent.Runbooks = append(intent.Runbooks, Runbook{
+			Title: title,
+			URL:   safeString(rb, "url"),
+		})
+	}
+
+	if prov := safeObject(block, "provenance"); prov != nil {
+		intent.Provenance = map[string]string{}
+		for k, v := range prov {
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				intent.Provenance[k] = s
+			}
+		}
+	}
+
+	if lv := safeString(block, "lastVerifiedAt"); lv != "" {
+		if t, err := time.Parse(time.RFC3339, lv); err == nil {
+			intent.LastVerifiedAt = &t
+		}
+	}
+
+	return intent, nil
+}

--- a/tools/dashboard_intent.go
+++ b/tools/dashboard_intent.go
@@ -55,6 +55,10 @@ type ExpectedBehavior struct {
 type FailureMode struct {
 	Tag         string `json:"tag"`
 	Description string `json:"description,omitempty"`
+	// AlertRuleUID references the Grafana alert rule whose firing state drives
+	// this failure mode's badge in the dashboard UI. Empty when the mode is
+	// declared-only (not tied to a rule).
+	AlertRuleUID string `json:"alert_rule_uid,omitempty"`
 }
 
 type RelatedSLO struct {
@@ -128,9 +132,9 @@ type ListDashboardIntentParams struct {
 // dashboard in one call — preferred over repeatedly calling
 // get_dashboard_intent for every panel.
 type DashboardIntentBundle struct {
-	DashboardUID string             `json:"dashboard_uid"`
-	Dashboard    *DashboardIntent   `json:"dashboard,omitempty"`
-	Panels       []DashboardIntent  `json:"panels"`
+	DashboardUID string            `json:"dashboard_uid"`
+	Dashboard    *DashboardIntent  `json:"dashboard,omitempty"`
+	Panels       []DashboardIntent `json:"panels"`
 }
 
 func listDashboardIntent(ctx context.Context, args ListDashboardIntentParams) (*DashboardIntentBundle, error) {
@@ -234,8 +238,9 @@ func projectIntent(raw interface{}, uid string, panelID *int) (*DashboardIntent,
 			continue
 		}
 		intent.FailureModes = append(intent.FailureModes, FailureMode{
-			Tag:         tag,
-			Description: safeString(fm, "description"),
+			Tag:          tag,
+			Description:  safeString(fm, "description"),
+			AlertRuleUID: safeString(fm, "alertRuleUid"),
 		})
 	}
 

--- a/tools/dashboard_intent_unit_test.go
+++ b/tools/dashboard_intent_unit_test.go
@@ -1,0 +1,182 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectIntent_FullBlock(t *testing.T) {
+	// A representative dashboard-level intent block — every field populated,
+	// camelCase as it appears in the dashboard JSON, with snake_case
+	// provenance keys (which pass through unchanged from the assistant API).
+	raw := map[string]interface{}{
+		"schemaVersion": float64(1),
+		"purpose":       "Track checkout p99 latency.",
+		"owner":         "@checkout-team",
+		"expectedBehavior": map[string]interface{}{
+			"normalRange":    "p99 < 250ms",
+			"alertThreshold": "p99 > 500ms for 5m",
+			"notes":          "Watch for deploy regressions.",
+		},
+		"failureModes": []interface{}{
+			map[string]interface{}{"tag": "db-slow", "description": "DB latency spike."},
+			map[string]interface{}{"tag": "pod-oom"},
+		},
+		"relatedSlos": []interface{}{
+			map[string]interface{}{"name": "Checkout availability", "target": "99.9%", "url": "https://slo/x"},
+		},
+		"runbooks": []interface{}{
+			map[string]interface{}{"title": "Checkout runbook", "url": "https://wiki/checkout"},
+		},
+		"provenance": map[string]interface{}{
+			"purpose":                            "author-written",
+			"expected_behavior.normal_range":     "author-written",
+			"expected_behavior.alert_threshold":  "lifted-from-alert",
+			"failure_modes":                      "assistant-unconfirmed",
+		},
+		"lastVerifiedAt": "2026-05-21T11:00:00Z",
+	}
+
+	intent, err := projectIntent(raw, "dash-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "dash-1", intent.DashboardUID)
+	assert.Nil(t, intent.PanelID)
+	assert.Equal(t, 1, intent.SchemaVersion)
+	assert.Equal(t, "Track checkout p99 latency.", intent.Purpose)
+	assert.Equal(t, "@checkout-team", intent.Owner)
+	require.NotNil(t, intent.ExpectedBehavior)
+	assert.Equal(t, "p99 < 250ms", intent.ExpectedBehavior.NormalRange)
+	assert.Equal(t, "p99 > 500ms for 5m", intent.ExpectedBehavior.AlertThreshold)
+	require.Len(t, intent.FailureModes, 2)
+	assert.Equal(t, "db-slow", intent.FailureModes[0].Tag)
+	assert.Equal(t, "DB latency spike.", intent.FailureModes[0].Description)
+	assert.Equal(t, "pod-oom", intent.FailureModes[1].Tag)
+	require.Len(t, intent.RelatedSLOs, 1)
+	assert.Equal(t, "99.9%", intent.RelatedSLOs[0].Target)
+	require.Len(t, intent.Runbooks, 1)
+	assert.Equal(t, "https://wiki/checkout", intent.Runbooks[0].URL)
+	assert.Equal(t, "lifted-from-alert", intent.Provenance["expected_behavior.alert_threshold"])
+	require.NotNil(t, intent.LastVerifiedAt)
+}
+
+func TestProjectIntent_DefaultsSchemaVersion(t *testing.T) {
+	// Older blocks may have been written without a schemaVersion; the
+	// projector should default to the current version so downstream
+	// consumers don't need to special-case missing values.
+	raw := map[string]interface{}{
+		"purpose": "stale block, no schemaVersion",
+	}
+	intent, err := projectIntent(raw, "dash-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, dashboardIntentSchemaVersionCurrent, intent.SchemaVersion)
+}
+
+func TestProjectIntent_PanelLevelSetsPanelID(t *testing.T) {
+	raw := map[string]interface{}{"purpose": "panel"}
+	pid := 42
+	intent, err := projectIntent(raw, "dash-1", &pid)
+	require.NoError(t, err)
+	require.NotNil(t, intent.PanelID)
+	assert.Equal(t, 42, *intent.PanelID)
+}
+
+func TestProjectIntent_RejectsNonObject(t *testing.T) {
+	_, err := projectIntent("not an object", "dash-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an object")
+}
+
+func TestProjectIntent_SkipsMalformedEntries(t *testing.T) {
+	// Defensive: a hand-edited dashboard JSON could carry a failure mode
+	// without a tag, or a runbook without a title. The projector should
+	// drop those entries silently rather than surface a half-populated
+	// record that downstream consumers can't reason about.
+	raw := map[string]interface{}{
+		"failureModes": []interface{}{
+			map[string]interface{}{"tag": ""},
+			map[string]interface{}{"tag": "valid"},
+			"not-an-object",
+		},
+		"runbooks": []interface{}{
+			map[string]interface{}{"title": "", "url": "https://x"},
+			map[string]interface{}{"title": "ok"},
+		},
+		"provenance": map[string]interface{}{
+			"purpose": "  ", // whitespace-only — drop
+			"owner":   "author-written",
+		},
+	}
+
+	intent, err := projectIntent(raw, "dash-1", nil)
+	require.NoError(t, err)
+	require.Len(t, intent.FailureModes, 1)
+	assert.Equal(t, "valid", intent.FailureModes[0].Tag)
+	require.Len(t, intent.Runbooks, 1)
+	assert.Equal(t, "ok", intent.Runbooks[0].Title)
+	assert.Equal(t, map[string]string{"owner": "author-written"}, intent.Provenance)
+}
+
+func TestListDashboardIntent_WalksPanels(t *testing.T) {
+	// Inline walk of the projector against a synthetic dashboard map —
+	// gives us coverage of the panel walking logic without needing a
+	// live Grafana. The full HTTP wiring is exercised by the dashboard
+	// integration tests.
+	db := map[string]interface{}{
+		"intent": map[string]interface{}{
+			"purpose": "dashboard-level",
+		},
+		"panels": []interface{}{
+			map[string]interface{}{
+				"id":     float64(1),
+				"intent": map[string]interface{}{"purpose": "p1"},
+			},
+			map[string]interface{}{
+				"id": float64(2),
+				// no intent block
+			},
+			map[string]interface{}{
+				"id":   float64(3),
+				"type": "row",
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":     float64(4),
+						"intent": map[string]interface{}{"purpose": "nested"},
+					},
+				},
+			},
+		},
+	}
+
+	bundle := &DashboardIntentBundle{DashboardUID: "dash-1", Panels: []DashboardIntent{}}
+	if raw, ok := db["intent"]; ok && raw != nil {
+		di, err := projectIntent(raw, "dash-1", nil)
+		require.NoError(t, err)
+		bundle.Dashboard = di
+	}
+	for _, panel := range collectAllPanels(db) {
+		raw, ok := panel["intent"]
+		if !ok || raw == nil {
+			continue
+		}
+		pid := safeInt(panel, "id")
+		if pid == 0 {
+			continue
+		}
+		panelID := pid
+		di, err := projectIntent(raw, "dash-1", &panelID)
+		require.NoError(t, err)
+		bundle.Panels = append(bundle.Panels, *di)
+	}
+
+	require.NotNil(t, bundle.Dashboard)
+	assert.Equal(t, "dashboard-level", bundle.Dashboard.Purpose)
+	// Both the top-level panel (id=1) and the row-nested panel (id=4)
+	// should appear; the panel with no intent (id=2) is skipped.
+	require.Len(t, bundle.Panels, 2)
+	assert.Equal(t, 1, *bundle.Panels[0].PanelID)
+	assert.Equal(t, "p1", bundle.Panels[0].Purpose)
+	assert.Equal(t, 4, *bundle.Panels[1].PanelID)
+	assert.Equal(t, "nested", bundle.Panels[1].Purpose)
+}

--- a/tools/dashboard_intent_unit_test.go
+++ b/tools/dashboard_intent_unit_test.go
@@ -21,7 +21,7 @@ func TestProjectIntent_FullBlock(t *testing.T) {
 			"notes":          "Watch for deploy regressions.",
 		},
 		"failureModes": []interface{}{
-			map[string]interface{}{"tag": "db-slow", "description": "DB latency spike."},
+			map[string]interface{}{"tag": "db-slow", "description": "DB latency spike.", "alertRuleUid": "rule-db-slow"},
 			map[string]interface{}{"tag": "pod-oom"},
 		},
 		"relatedSlos": []interface{}{
@@ -31,10 +31,10 @@ func TestProjectIntent_FullBlock(t *testing.T) {
 			map[string]interface{}{"title": "Checkout runbook", "url": "https://wiki/checkout"},
 		},
 		"provenance": map[string]interface{}{
-			"purpose":                            "author-written",
-			"expected_behavior.normal_range":     "author-written",
-			"expected_behavior.alert_threshold":  "lifted-from-alert",
-			"failure_modes":                      "assistant-unconfirmed",
+			"purpose":                           "author-written",
+			"expected_behavior.normal_range":    "author-written",
+			"expected_behavior.alert_threshold": "lifted-from-alert",
+			"failure_modes":                     "assistant-unconfirmed",
 		},
 		"lastVerifiedAt": "2026-05-21T11:00:00Z",
 	}
@@ -52,7 +52,9 @@ func TestProjectIntent_FullBlock(t *testing.T) {
 	require.Len(t, intent.FailureModes, 2)
 	assert.Equal(t, "db-slow", intent.FailureModes[0].Tag)
 	assert.Equal(t, "DB latency spike.", intent.FailureModes[0].Description)
+	assert.Equal(t, "rule-db-slow", intent.FailureModes[0].AlertRuleUID)
 	assert.Equal(t, "pod-oom", intent.FailureModes[1].Tag)
+	assert.Empty(t, intent.FailureModes[1].AlertRuleUID)
 	require.Len(t, intent.RelatedSLOs, 1)
 	assert.Equal(t, "99.9%", intent.RelatedSLOs[0].Target)
 	require.Len(t, intent.Runbooks, 1)


### PR DESCRIPTION
## Summary

Surface author-declared dashboard intent (purpose, owner, expected behavior, failure modes, related SLOs, runbooks, per-field provenance) to MCP clients.

The Grafana Assistant **Dashboard Intent** feature stores intent inside the dashboard JSON — a top-level \`intent\` block and per-panel \`panels[].intent\` blocks. These tools project that on-disk camelCase shape into a normalized, snake_case shape so external agents (Cursor, incident bots, status pages, CI pipelines) don't have to re-walk the dashboard JSON to read it.

- \`get_dashboard_intent(uid, panel_id?)\` — returns the intent block for a dashboard (\`panel_id\` omitted) or one of its panels. Errors when the addressed block is absent so callers can treat that the same as \"no authored intent yet\".
- \`list_dashboard_intent(uid)\` — returns the full bundle in one call: the dashboard-level block (when present) plus every panel-level block discovered while walking the dashboard's panels (including row-nested panels). Returns an empty bundle for dashboards with no authored intent.

Both tools are **read-only** and built on the existing \`GetDashboardByUID\` path, so they work against any Grafana the MCP client is authenticated to — they do **not** require the Grafana Assistant plugin to be installed on the target Grafana.

## Why now

The Dashboard Intent feature recently switched from an assistant-side DB to dashboard-JSON-native storage (canonical source of truth lives in the dashboard JSON itself). With the JSON shape stable, external MCP clients are the next natural surface to plug in.

## Test plan

- [x] \`go test ./tools/ -run TestProjectIntent -count=1\` — projection helper (full block, schema-version default, panel addressing, malformed-entry skip)
- [x] \`go test ./tools/ -run TestListDashboardIntent -count=1\` — bundle walk (dashboard + row-nested panels)
- [x] \`go test ./tools/ -short -count=1\` — full short-test suite still green
- [ ] Manual: connect the MCP server to a Grafana running the Assistant app with intent authored on at least one dashboard, and call \`get_dashboard_intent\` / \`list_dashboard_intent\` from an MCP client (Cursor / Claude Desktop).

## Related

- Grafana Assistant App: dashboard-intent JSON-native storage (PR [#6793](https://github.com/grafana/grafana-assistant-app/pull/6793))
- grafana/grafana: UI surfaces (PR [#125200](https://github.com/grafana/grafana/pull/125200))

Made with [Cursor](https://cursor.com)