### PR TITLE
docs(alerting): correct minimum Grafana version for FolderUID filter (10.0 → 11.4)

### DIFF
--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -90,7 +90,8 @@ const (
 
 // GetRulesOpts contains optional server-side filtering parameters for the
 // Prometheus rules API endpoint.
-// FolderUID, RuleGroup, States, LimitAlerts are available since Grafana 10.0.
+// RuleGroup, States, LimitAlerts are available since Grafana 10.0.
+// FolderUID requires Grafana 11.4+.
 // SearchFolder, RuleName, RuleType, RuleLimit, Matchers require Grafana 12.4+.
 type GetRulesOpts struct {
 	FolderUID    string   // Filter by folder UID


### PR DESCRIPTION
## Summary

Correct the `GetRulesOpts` docstring in `tools/alerting_client.go` to reflect the actual minimum Grafana version for the `FolderUID` filter.

Currently the comment claims:
> `FolderUID, RuleGroup, States, LimitAlerts are available since Grafana 10.0.`

But Grafana's `/api/prometheus/grafana/api/v1/rules` endpoint only began reading `folder_uid` from the query string in **v11.4.0**. On older versions the filter is silently dropped server-side — the caller gets the entire instance's rules back with no error surface.

This PR separates `FolderUID` from the rest of the 10.0+ block so users see the correct floor.

## Diff

```diff
 // GetRulesOpts contains optional server-side filtering parameters for the
 // Prometheus rules API endpoint.
-// FolderUID, RuleGroup, States, LimitAlerts are available since Grafana 10.0.
+// RuleGroup, States, LimitAlerts are available since Grafana 10.0.
+// FolderUID requires Grafana 11.4+.
 // SearchFolder, RuleName, RuleType, RuleLimit, Matchers require Grafana 12.4+.
```

## Evidence

Counted `opts.Query.Get("folder_uid")` occurrences in `pkg/services/ngalert/api/api_prometheus.go` across Grafana release tags:

| Tag | occurrences |
|---|---|
| v10.0.0 | 0 |
| v10.4.0 | 0 |
| v11.0.0 | 0 |
| **v11.4.0** | **1** ← first appearance |
| v12.0.0 | 1 |
| v12.4.0 | 2 |

Full evidence (including reproduction steps showing byte-identical responses for two different folder UIDs on a Grafana 9 instance) is in the issue.

## Scope

This PR is intentionally scoped to the `FolderUID` claim only — that's what I verified against Grafana source across tags. The other minimum-version claims (`RuleGroup`, `States`, `LimitAlerts`) are left unchanged; if any of those are also wrong, that's a follow-up.

The runtime-warning suggestion in the issue (query `/api/health` once per session and warn on version-mismatched params) is **not** included here — that needs design discussion before code.

## Test plan

- [x] `go build ./tools/...` — exit 0
- [x] `go vet ./tools/...` — exit 0
- [x] No code paths changed; comment-only correction

Fixes #890

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only documentation change with no runtime behavior or API contract modifications.
> 
> **Overview**
> Corrects the `GetRulesOpts` doc comment in `tools/alerting_client.go` by separating `FolderUID` from the Grafana 10.0+ filter set and documenting that `FolderUID` filtering requires Grafana 11.4+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d308da94e06f548c02c154253732b5055d3a533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->