### PR TITLE
[docs] Add GH link and brew command

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ aliases: []
 
 # Grafana MCP server
 
-This documentation helps you install the Grafana MCP server, connect MCP-compatible clients, and configure authentication, transports, and tools.
+This documentation helps you install the [Grafana MCP server](https://github.com/grafana/mcp-grafana), connect MCP-compatible clients, and configure authentication, transports, and tools.
 
 The Grafana MCP server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server that gives AI assistants and LLM clients access to your Grafana instance. You can query metrics and logs, search and manage dashboards, manage alert rules, work with Grafana Incident and Sift, and generate deeplinks to Grafana resources.
 

--- a/docs/sources/introduction.md
+++ b/docs/sources/introduction.md
@@ -14,7 +14,7 @@ aliases: []
 
 # Introduction to the Grafana MCP server
 
-This article outlines what the Grafana MCP server is, what it can do, and how authentication and permissions work.
+This article outlines what the [Grafana MCP serve](https://github.com/grafana/mcp-grafana) is, what it can do, and how authentication and permissions work.
 
 ## What you'll achieve
 

--- a/docs/sources/set-up/install-the-binary.md
+++ b/docs/sources/set-up/install-the-binary.md
@@ -19,11 +19,21 @@ Install the Grafana MCP server by downloading a release binary or building from 
 
 You have the `mcp-grafana` binary available so your MCP client can run it directly (typically in stdio mode).
 
-## Before you begin
+## Install with Homebrew
 
-- For source build: a Go toolchain (see [Go install](https://go.dev/doc/install)).
+If you have [Homebrew](https://brew.sh/) installed, install `mcp-grafana` with:
 
-## Download a release
+```bash
+brew install mcp-grafana
+```
+
+Verify that the binary is available:
+
+```bash
+  mcp-grafana --help
+```
+
+## Download a release from GitHub
 
 1. Open the [releases page](https://github.com/grafana/mcp-grafana/releases) on GitHub.
 2. Download the archive for your platform.
@@ -31,7 +41,7 @@ You have the `mcp-grafana` binary available so your MCP client can run it direct
 
 ## Build from source
 
-If you have a Go toolchain installed you can also build and install it from source. Use `go install` and set `GOBIN` so the binary is installed where you want it (for example, a directory in your `$PATH`).
+If you have a [Go toolchain](https://go.dev/doc/install) installed, you can also build and install it from source. Use `go install` and set `GOBIN` so the binary is installed where you want it (for example, a directory in your `$PATH`).
 
 ```bash
 GOBIN="$HOME/go/bin" go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest


### PR DESCRIPTION
Added link to MCP server GitHub in docs when referenced, and add brew install command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates; main risk is minor accuracy/typo issues in the new link text and install instructions.
> 
> **Overview**
> Adds direct links to the `grafana/mcp-grafana` GitHub repo where the Grafana MCP server is referenced in the landing page and introduction.
> 
> Updates `Install the binary` docs to include Homebrew installation and verification steps, and clarifies the GitHub release download heading plus the Go toolchain link for source builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da890743d0415967b0aab76cbcb96a117878c468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->