### PR TITLE
feat: add --server-instructions-file and --server-instructions-mode flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 **Session Management:**
 - `--session-idle-timeout-minutes`: Session idle timeout in minutes. Sessions with no activity for this duration are automatically reaped - default: `30`. Set to `0` to disable session reaping. Only relevant for SSE and streamable-http transports.
 
+**Server Instructions:**
+- `--server-instructions-file`: Path to a text or Markdown file containing custom MCP server instructions
+- `--server-instructions-mode`: Controls how `--server-instructions-file` is applied (`append` or `replace`) - default: `append`
+
 **Tool Configuration:**
 - `--enabled-tools`: Comma-separated list of enabled categories - default: all categories except `admin`, `athena`, `clickhouse`, `cloudwatch`, `elasticsearch`, `examples`, `graphite`, `runpanelquery`, and `snowflake`. To enable disabled categories, add them to the list (e.g., `"search,datasource,...,snowflake"`)
 - `--max-loki-log-limit`: Maximum number of log lines returned per `query_loki_logs` call - default: `100`. Note: Set this at least 1 below Loki's server-side `max_entries_limit_per_query` to allow truncation detection (the tool requests `limit+1` internally to detect if more data exists).
@@ -439,6 +443,24 @@ When `--disable-write` is enabled, the following write operations are disabled:
 - `find_slow_requests` (creates investigations)
 
 All read operations remain available, allowing you to query dashboards, run PromQL/LogQL queries, list resources, and retrieve data.
+
+### Server Instructions
+
+The server provides generated instructions that describe the enabled Grafana tool categories and timestamp handling. You can add custom instructions from a file for organization-specific guidance or deployment-specific usage notes:
+
+```bash
+mcp-grafana \
+  --transport=streamable-http \
+  --server-instructions-file=/etc/mcp-grafana/instructions.md \
+  --server-instructions-mode=append
+```
+
+The `--server-instructions-mode` flag controls how the file is applied:
+
+- `append` keeps the generated Grafana capability and timestamp guidance, then appends the file contents.
+- `replace` uses only the file contents as the MCP server instructions.
+
+If `--server-instructions-file` is omitted, the generated instructions are unchanged. If the file is configured but cannot be read, startup fails.
 
 **Client TLS Configuration (for Grafana connections):**
 - `--tls-cert-file`: Path to TLS certificate file for client authentication

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -255,6 +255,27 @@ func parseServerInstructionsMode(s string) (serverInstructionsMode, error) {
 	}
 }
 
+// withInstructionsReminder returns a tool handler middleware that appends the
+// server instructions to every tool result. This ensures the LLM sees the
+// instructions on every tool call regardless of whether the MCP client injects
+// the instructions field from the initialize response into the system prompt.
+func withInstructionsReminder(instructions string) server.ServerOption {
+	if instructions == "" {
+		return func(_ *server.MCPServer) {}
+	}
+	reminder := "\n\n---\n**Server instructions (follow at all times):**\n" + instructions
+	return server.WithToolHandlerMiddleware(func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			result, err := next(ctx, req)
+			if err != nil || result == nil {
+				return result, err
+			}
+			result.Content = append(result.Content, mcp.NewTextContent(reminder))
+			return result, nil
+		}
+	})
+}
+
 func applyServerInstructions(generated string, filePath string, mode serverInstructionsMode) (string, error) {
 	if filePath == "" {
 		return generated, nil
@@ -349,6 +370,7 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 	s = server.NewMCPServer("mcp-grafana", mcpgrafana.Version(),
 		server.WithInstructions(instructions),
 		server.WithHooks(hooks),
+		withInstructionsReminder(instructions),
 	)
 
 	// Initialize ToolManager now that server is created
@@ -434,9 +456,15 @@ func runMetricsServer(addr string, o *observability.Observability) {
 	}
 }
 
-func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, obs observability.Config, sessionIdleTimeoutMinutes int, instructions string) error {
+func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, obs observability.Config, sessionIdleTimeoutMinutes int, instructions string, serverInstructionsFile string, serverInstructionsMode serverInstructionsMode) error {
 	stderrHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
 	slog.SetDefault(slog.New(stderrHandler))
+
+	slog.Debug("MCP server instructions resolved",
+		"file", serverInstructionsFile,
+		"mode", serverInstructionsMode,
+		"instructions", instructions,
+	)
 
 	o, err := observability.Setup(obs)
 	if err != nil {
@@ -658,13 +686,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to apply server instructions: %v\n", err)
 		os.Exit(2)
 	}
-	slog.Debug("MCP server instructions resolved",
-		"file", *serverInstructionsFile,
-		"mode", serverInstructionsMode,
-		"instructions", instructions,
-	)
 
-	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig, tls, obs, *sessionIdleTimeoutMinutes, instructions); err != nil {
+	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig, tls, obs, *sessionIdleTimeoutMinutes, instructions, *serverInstructionsFile, serverInstructionsMode); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -101,6 +101,13 @@ type grafanaConfig struct {
 	maxLokiLogLimit int
 }
 
+type serverInstructionsMode string
+
+const (
+	serverInstructionsModeAppend  serverInstructionsMode = "append"
+	serverInstructionsModeReplace serverInstructionsMode = "replace"
+)
+
 func (dt *disabledTools) addFlags() {
 	flag.StringVar(&dt.enabledTools, "enabled-tools", "search,datasource,incident,prometheus,loki,alerting,dashboard,folder,oncall,asserts,sift,pyroscope,navigation,proxied,annotations,rendering,plugin,api", "A comma separated list of tools enabled for this server. Can be overwritten entirely or by disabling specific components, e.g. --disable-search.")
 	flag.BoolVar(&dt.search, "disable-search", false, "Disable search tools")
@@ -237,7 +244,42 @@ func (dt *disabledTools) buildInstructions() string {
 	return b.String()
 }
 
-func newServer(transport string, dt disabledTools, obs *observability.Observability, sessionIdleTimeoutMinutes int) (*server.MCPServer, *mcpgrafana.ToolManager, *mcpgrafana.SessionManager) {
+func parseServerInstructionsMode(s string) (serverInstructionsMode, error) {
+	switch serverInstructionsMode(s) {
+	case "", serverInstructionsModeAppend:
+		return serverInstructionsModeAppend, nil
+	case serverInstructionsModeReplace:
+		return serverInstructionsModeReplace, nil
+	default:
+		return "", fmt.Errorf("must be \"append\" or \"replace\", got %q", s)
+	}
+}
+
+func applyServerInstructions(generated string, filePath string, mode serverInstructionsMode) (string, error) {
+	if filePath == "" {
+		return generated, nil
+	}
+
+	customBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("read server instructions file: %w", err)
+	}
+	custom := string(customBytes)
+
+	switch mode {
+	case "", serverInstructionsModeAppend:
+		if custom == "" {
+			return generated, nil
+		}
+		return generated + "\n\n" + custom, nil
+	case serverInstructionsModeReplace:
+		return custom, nil
+	default:
+		return "", fmt.Errorf("invalid server instructions mode %q: must be append or replace", mode)
+	}
+}
+
+func newServer(transport string, dt disabledTools, obs *observability.Observability, sessionIdleTimeoutMinutes int, instructions string) (*server.MCPServer, *mcpgrafana.ToolManager, *mcpgrafana.SessionManager) {
 	sm := mcpgrafana.NewSessionManager(
 		mcpgrafana.WithSessionTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute),
 	)
@@ -299,13 +341,11 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 	// Merge observability hooks with existing hooks
 	hooks = observability.MergeHooks(hooks, obs.MCPHooks())
 
-	// Register tools and build the instruction string from enabled categories.
+	// Register tools and use the instruction string from enabled categories.
 	// processTools both registers tools on the server and collects descriptions
 	// of enabled categories, so we need a temporary nil server reference first.
-	// Instead, we split: compute instructions from flags, then create server,
+	// Instead, we split: compute instructions before creating the server,
 	// then register tools.
-	instructions := dt.buildInstructions()
-
 	s = server.NewMCPServer("mcp-grafana", mcpgrafana.Version(),
 		server.WithInstructions(instructions),
 		server.WithHooks(hooks),
@@ -394,7 +434,7 @@ func runMetricsServer(addr string, o *observability.Observability) {
 	}
 }
 
-func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, obs observability.Config, sessionIdleTimeoutMinutes int) error {
+func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, obs observability.Config, sessionIdleTimeoutMinutes int, instructions string) error {
 	stderrHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
 	slog.SetDefault(slog.New(stderrHandler))
 
@@ -429,7 +469,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		defer clientCache.Close()
 	}
 
-	s, tm, sm := newServer(transport, dt, o, sessionIdleTimeoutMinutes)
+	s, tm, sm := newServer(transport, dt, o, sessionIdleTimeoutMinutes, instructions)
 	defer sm.Close()
 
 	// Create a context that will be cancelled on shutdown
@@ -564,15 +604,20 @@ func main() {
 	flag.DurationVar(&obs.SlowRequestThreshold, "slow-request-threshold", 0, "Log an event when any MCP request (tool invocation, list, resource read, etc.) takes longer than this threshold. Accepts Go duration strings, e.g. 500ms, 5s. Default 0 disables slow-request logging.")
 	var slowRequestLogLevelStr string
 	flag.StringVar(&slowRequestLogLevelStr, "slow-request-log-level", "warn", "Log level for slow-request events. One of \"info\" or \"warn\". Default \"warn\".")
+	serverInstructionsFile := flag.String("server-instructions-file", "", "Path to a file containing custom MCP server instructions")
+	serverInstructionsModeStr := flag.String("server-instructions-mode", "append", "How to apply custom MCP server instructions. One of \"append\" or \"replace\". Default \"append\".")
 	flag.Parse()
 
-	action, slowLevel, err := handleFlagsPostParse(*showVersion, slowRequestLogLevelStr)
+	action, slowLevel, serverInstructionsMode, err := handleFlagsPostParse(*showVersion, slowRequestLogLevelStr, *serverInstructionsModeStr)
 	switch action {
 	case flagActionVersion:
 		fmt.Println(mcpgrafana.Version())
 		os.Exit(0)
 	case flagActionInvalidSlowLevel:
 		fmt.Fprintf(os.Stderr, "invalid --slow-request-log-level: %v\n", err)
+		os.Exit(2)
+	case flagActionInvalidServerInstructionsMode:
+		fmt.Fprintf(os.Stderr, "invalid --server-instructions-mode: %v\n", err)
 		os.Exit(2)
 	case flagActionContinue:
 		obs.SlowRequestLogLevel = slowLevel
@@ -608,7 +653,18 @@ func main() {
 		obs.NetworkTransport = mcpconv.NetworkTransportTCP
 	}
 
-	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig, tls, obs, *sessionIdleTimeoutMinutes); err != nil {
+	instructions, err := applyServerInstructions(dt.buildInstructions(), *serverInstructionsFile, serverInstructionsMode)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to apply server instructions: %v\n", err)
+		os.Exit(2)
+	}
+	slog.Debug("MCP server instructions resolved",
+		"file", *serverInstructionsFile,
+		"mode", serverInstructionsMode,
+		"instructions", instructions,
+	)
+
+	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig, tls, obs, *sessionIdleTimeoutMinutes, instructions); err != nil {
 		panic(err)
 	}
 }
@@ -653,6 +709,7 @@ const (
 	flagActionContinue
 	flagActionVersion
 	flagActionInvalidSlowLevel
+	flagActionInvalidServerInstructionsMode
 )
 
 // handleFlagsPostParse decides what main() should do after flag.Parse().
@@ -660,15 +717,20 @@ const (
 // short-circuits before slow-request-log-level validation so it prints
 // regardless of other flags' values (matches pre-#756 behavior).
 //
-// The returned slog.Level is only meaningful when action == flagActionContinue;
-// the other branches return a zero level that the caller must not read.
-func handleFlagsPostParse(showVersion bool, slowLevelStr string) (flagAction, slog.Level, error) {
+// The returned slog.Level and serverInstructionsMode are only meaningful when
+// action == flagActionContinue; the other branches return zero values that the
+// caller must not read.
+func handleFlagsPostParse(showVersion bool, slowLevelStr string, serverInstructionsModeStr string) (flagAction, slog.Level, serverInstructionsMode, error) {
 	if showVersion {
-		return flagActionVersion, 0, nil
+		return flagActionVersion, 0, "", nil
 	}
 	slowLevel, err := parseSlowRequestLogLevel(slowLevelStr)
 	if err != nil {
-		return flagActionInvalidSlowLevel, 0, err
+		return flagActionInvalidSlowLevel, 0, "", err
 	}
-	return flagActionContinue, slowLevel, nil
+	serverInstructionsMode, err := parseServerInstructionsMode(serverInstructionsModeStr)
+	if err != nil {
+		return flagActionInvalidServerInstructionsMode, 0, "", err
+	}
+	return flagActionContinue, slowLevel, serverInstructionsMode, nil
 }

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -37,7 +39,8 @@ func newTestObservability(t *testing.T) *observability.Observability {
 func TestNewServer_SessionIdleTimeoutZeroDisablesReaping(t *testing.T) {
 	obs := newTestObservability(t)
 	synctest.Test(t, func(t *testing.T) {
-		_, _, sm := newServer("stdio", disabledTools{enabledTools: "search"}, obs, 0)
+		dt := disabledTools{enabledTools: "search"}
+		_, _, sm := newServer("stdio", dt, obs, 0, dt.buildInstructions())
 		defer sm.Close()
 
 		session := &testClientSession{id: "should-persist"}
@@ -145,10 +148,88 @@ func TestBuildInstructions_TimestampNote(t *testing.T) {
 	assert.Contains(t, instructions, "Timestamp parameters without a timezone offset are interpreted as UTC")
 }
 
+func TestApplyServerInstructions(t *testing.T) {
+	generated := "generated instructions"
+	custom := "custom instructions\nwith multiple lines"
+	customFile := filepath.Join(t.TempDir(), "instructions.md")
+	require.NoError(t, os.WriteFile(customFile, []byte(custom), 0o600))
+	emptyFile := filepath.Join(t.TempDir(), "empty.md")
+	require.NoError(t, os.WriteFile(emptyFile, nil, 0o600))
+	missingFile := filepath.Join(t.TempDir(), "missing.md")
+
+	tests := []struct {
+		name          string
+		filePath      string
+		mode          serverInstructionsMode
+		want          string
+		wantErrSubstr string
+	}{
+		{
+			name: "no file returns generated instructions unchanged",
+			want: generated,
+		},
+		{
+			name:     "empty mode defaults to append",
+			filePath: customFile,
+			want:     generated + "\n\n" + custom,
+		},
+		{
+			name:     "append mode appends custom instructions",
+			filePath: customFile,
+			mode:     serverInstructionsModeAppend,
+			want:     generated + "\n\n" + custom,
+		},
+		{
+			name:     "replace mode returns custom instructions only",
+			filePath: customFile,
+			mode:     serverInstructionsModeReplace,
+			want:     custom,
+		},
+		{
+			name:     "empty file is valid in append mode",
+			filePath: emptyFile,
+			mode:     serverInstructionsModeAppend,
+			want:     generated,
+		},
+		{
+			name:     "empty file is valid in replace mode",
+			filePath: emptyFile,
+			mode:     serverInstructionsModeReplace,
+			want:     "",
+		},
+		{
+			name:          "missing file returns error",
+			filePath:      missingFile,
+			mode:          serverInstructionsModeAppend,
+			wantErrSubstr: "read server instructions file",
+		},
+		{
+			name:          "invalid mode returns error",
+			filePath:      customFile,
+			mode:          serverInstructionsMode("overwrite"),
+			wantErrSubstr: "invalid server instructions mode",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := applyServerInstructions(generated, tc.filePath, tc.mode)
+			if tc.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestNewServer_SessionIdleTimeoutCustomValue(t *testing.T) {
 	obs := newTestObservability(t)
 	synctest.Test(t, func(t *testing.T) {
-		_, _, sm := newServer("stdio", disabledTools{enabledTools: "search"}, obs, 1)
+		dt := disabledTools{enabledTools: "search"}
+		_, _, sm := newServer("stdio", dt, obs, 1, dt.buildInstructions())
 		defer sm.Close()
 
 		session := &testClientSession{id: "custom-ttl"}
@@ -212,6 +293,7 @@ func TestHandleFlagsPostParse(t *testing.T) {
 		slowLevelStr  string
 		wantAction    flagAction
 		wantLevel     slog.Level
+		wantMode      serverInstructionsMode
 		wantErr       bool
 		wantErrSubstr []string
 	}{
@@ -231,11 +313,18 @@ func TestHandleFlagsPostParse(t *testing.T) {
 			wantAction:   flagActionVersion,
 		},
 		{
+			name:         "--version wins over bad instructions mode",
+			showVersion:  true,
+			slowLevelStr: "warn",
+			wantAction:   flagActionVersion,
+		},
+		{
 			name:         "no --version, warn slow-level",
 			showVersion:  false,
 			slowLevelStr: "warn",
 			wantAction:   flagActionContinue,
 			wantLevel:    slog.LevelWarn,
+			wantMode:     serverInstructionsModeAppend,
 		},
 		{
 			name:         "no --version, info slow-level",
@@ -243,6 +332,15 @@ func TestHandleFlagsPostParse(t *testing.T) {
 			slowLevelStr: "info",
 			wantAction:   flagActionContinue,
 			wantLevel:    slog.LevelInfo,
+			wantMode:     serverInstructionsModeAppend,
+		},
+		{
+			name:         "replace server instructions mode",
+			showVersion:  false,
+			slowLevelStr: "warn",
+			wantAction:   flagActionContinue,
+			wantLevel:    slog.LevelWarn,
+			wantMode:     serverInstructionsModeReplace,
 		},
 		{
 			name:          "no --version, bogus slow-level",
@@ -260,14 +358,31 @@ func TestHandleFlagsPostParse(t *testing.T) {
 			wantErr:       true,
 			wantErrSubstr: []string{"must be"},
 		},
+		{
+			name:          "no --version, bogus server instructions mode",
+			showVersion:   false,
+			slowLevelStr:  "warn",
+			wantAction:    flagActionInvalidServerInstructionsMode,
+			wantErr:       true,
+			wantErrSubstr: []string{"append", "replace", "bogus"},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			action, level, err := handleFlagsPostParse(tc.showVersion, tc.slowLevelStr)
+			instructionsModeStr := ""
+			if tc.name == "replace server instructions mode" {
+				instructionsModeStr = "replace"
+			}
+			if tc.name == "no --version, bogus server instructions mode" || tc.name == "--version wins over bad instructions mode" {
+				instructionsModeStr = "bogus"
+			}
+
+			action, level, mode, err := handleFlagsPostParse(tc.showVersion, tc.slowLevelStr, instructionsModeStr)
 			assert.Equal(t, tc.wantAction, action, "unexpected action")
 			if tc.wantAction == flagActionContinue {
 				assert.Equal(t, tc.wantLevel, level, "unexpected level")
+				assert.Equal(t, tc.wantMode, mode, "unexpected server instructions mode")
 			}
 			if tc.wantErr {
 				require.Error(t, err, "expected an error")


### PR DESCRIPTION
Adds support for injecting custom MCP server instructions from a file.

* New flag --server-instructions-file: path to a text/Markdown file
* New flag --server-instructions-mode: append (default) or replace
  * append mode appends file contents after generated capability instructions
  * replace mode uses only the file contents as server instructions
* Missing/unreadable file fails startup with a clear error
* Logs resolved instructions at DEBUG level on startup for verification
* Unit tests cover all modes, empty file, missing file, and invalid mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the MCP server initialization flow and alters every tool response by appending an instructions reminder, which could affect client prompting behavior and increase response size. Startup now also fails fast on unreadable instruction files or invalid modes, potentially breaking misconfigured deployments.
> 
> **Overview**
> Adds **customizable MCP server instructions** via new CLI flags `--server-instructions-file` and `--server-instructions-mode` (`append`/`replace`), with validation and fail-fast startup if the file can’t be read.
> 
> Updates server startup to compute/apply the resolved instructions before `server.NewMCPServer`, logs the resolved instructions at debug level, and installs middleware to append an instructions *reminder* to every `tools/call` result. Includes README docs plus unit tests covering mode parsing and file handling (empty/missing/invalid mode) and updates existing server tests for the new `newServer` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40fa817778876164edc23d375748fbf1d277875a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->