### PR TITLE
feat(rendering): support provisioning preview dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Snowflake tools (`query_snowflake`, `list_snowflake_tables`, `describe_snowflake_table`) for querying Snowflake datasources (Grafana Enterprise plugin `grafana-snowflake-datasource`) through Grafana's `/api/ds/query` endpoint. Supports `$__timeFilter`, `$__timeFrom`/`$__timeTo`, `$__from`/`$__to`, `$__interval`/`$__interval_ms`, and `${varname}` substitution. Disabled by default — opt in with `--enabled-tools=...,snowflake`.
+- `get_panel_image` now accepts an optional `provisioningPreview` parameter (`repo`, `path`, `ref`) for rendering dashboards staged on a provisioning repository branch (e.g. a git-sync PR preview) before they're merged or applied. Mutually exclusive with `dashboardUid`.
 
 ## [0.14.0] - 2026-05-08
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Scopes define the specific resources that permissions apply to. Each action requ
 | `create_annotation`               | Annotations | Create a new annotation (standard or Graphite format)               | `annotations:write`                     | `annotations:*`                                     |
 | `update_annotation`               | Annotations | Update specific fields of an annotation (partial update)            | `annotations:write`                     | `annotations:*`                                     |
 | `get_annotation_tags`             | Annotations | List annotation tags with optional filtering                        | `annotations:read`                      | `annotations:*`                                     |
-| `get_panel_image`                 | Rendering   | Render a dashboard panel or full dashboard as a PNG image           | `dashboards:read`                       | `dashboards:uid:abc123`                             |
+| `get_panel_image`                 | Rendering   | Render a stored dashboard or panel — or a provisioning preview from a repository branch — as a PNG image | `dashboards:read`                       | `dashboards:uid:abc123`                             |
 
 _* Disabled by default. Add category to `--enabled-tools` to enable._
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Queries go through Grafana's Snowflake datasource (Grafana Enterprise plugin `gr
 
 ### Rendering
 
-- **Get panel or dashboard image:** Render a Grafana dashboard panel or full dashboard as a PNG image. Returns the image as base64 encoded data for use in reports, alerts, or presentations. Supports customizing dimensions, time range, theme, scale, and dashboard variables.
+- **Get panel or dashboard image:** Render a Grafana dashboard panel or full dashboard as a PNG image. Returns the image as base64 encoded data for use in reports, alerts, or presentations. Supports customizing dimensions, time range, theme, scale, and dashboard variables. Also supports rendering not-yet-applied dashboards from a provisioning repository branch (e.g. a git-sync PR preview) via the optional `provisioningPreview` parameter.
   - _Note: Requires the [Grafana Image Renderer](https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/) service to be installed and configured._
 
 The list of tools is configurable, so you can choose which tools you want to make available to the MCP client.

--- a/docs/sources/reference/mcp-tools-table.md
+++ b/docs/sources/reference/mcp-tools-table.md
@@ -106,7 +106,7 @@ The following table lists MCP tools, required RBAC permissions, and typical scop
 | `create_annotation`               | Annotations | Create a new annotation (standard or Graphite format)               | `annotations:write`                     | `annotations:*`                                     |
 | `update_annotation`               | Annotations | Update specific fields of an annotation (partial update)            | `annotations:write`                     | `annotations:*`                                     |
 | `get_annotation_tags`             | Annotations | List annotation tags with optional filtering                        | `annotations:read`                      | `annotations:*`                                     |
-| `get_panel_image`                 | Rendering   | Render a dashboard panel or full dashboard as a PNG image           | `dashboards:read`                       | `dashboards:uid:abc123`                             |
+| `get_panel_image`                 | Rendering   | Render a stored dashboard or panel — or a provisioning preview from a repository branch — as a PNG image | `dashboards:read`                       | `dashboards:uid:abc123`                             |
 
 _* Categories marked with `*` are off until you add them to `--enabled-tools`._
 

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -91,7 +91,7 @@ type RenderTimeRange struct {
 // instead of looking it up by UID.
 type ProvisioningPreview struct {
 	Repo string `json:"repo" jsonschema:"required,description=Provisioning repository slug. List repositories via /apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories if unknown."`
-	Path string `json:"path" jsonschema:"required,description=Path to the dashboard file within the repository, relative to its root."`
+	Path string `json:"path" jsonschema:"required,description=Path to the dashboard file within the repository\\, relative to its root."`
 	Ref  string `json:"ref,omitempty" jsonschema:"description=Branch or commit SHA to render from. Defaults to the repository's main branch when omitted."`
 }
 

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -185,6 +185,20 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 		if args.ProvisioningPreview.Path == "" {
 			return "", fmt.Errorf("provisioningPreview.path is required")
 		}
+		// Reject path-traversal vectors. Even with proper percent-encoding,
+		// HTTP intermediaries can collapse .. segments before the request
+		// reaches Grafana, redirecting the render to a different route.
+		if strings.ContainsAny(args.ProvisioningPreview.Repo, `/\`) {
+			return "", fmt.Errorf("provisioningPreview.repo must not contain path separators")
+		}
+		if args.ProvisioningPreview.Repo == ".." {
+			return "", fmt.Errorf("provisioningPreview.repo must not be ..")
+		}
+		for _, seg := range strings.Split(args.ProvisioningPreview.Path, "/") {
+			if seg == ".." {
+				return "", fmt.Errorf("provisioningPreview.path must not contain .. segments")
+			}
+		}
 	}
 
 	// Strip trailing slashes from base URL for consistent URL construction

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -200,11 +200,18 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 	// via the standard kiosk/viewPanel mechanism.
 	var renderPath string
 	if hasPreview {
-		renderPath = fmt.Sprintf(
-			"/render/dashboard/provisioning/%s/preview/%s",
-			args.ProvisioningPreview.Repo,
-			args.ProvisioningPreview.Path,
-		)
+		// Use url.URL.EscapedPath() so characters like ?, #, or spaces in the
+		// repo slug or dashboard file path don't produce a malformed render
+		// URL. EscapedPath preserves the structural / between segments while
+		// percent-encoding everything else that isn't valid in a URL path.
+		previewURL := url.URL{
+			Path: fmt.Sprintf(
+				"/render/dashboard/provisioning/%s/preview/%s",
+				args.ProvisioningPreview.Repo,
+				args.ProvisioningPreview.Path,
+			),
+		}
+		renderPath = previewURL.EscapedPath()
 		if args.ProvisioningPreview.Ref != "" {
 			params.Set("ref", args.ProvisioningPreview.Ref)
 		}

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -192,11 +192,11 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 			return "", fmt.Errorf("provisioningPreview.repo must not contain path separators")
 		}
 		if args.ProvisioningPreview.Repo == ".." {
-			return "", fmt.Errorf("provisioningPreview.repo must not be ..")
+			return "", fmt.Errorf("provisioningPreview.repo must not be the parent-directory reference")
 		}
 		for _, seg := range strings.Split(args.ProvisioningPreview.Path, "/") {
 			if seg == ".." {
-				return "", fmt.Errorf("provisioningPreview.path must not contain .. segments")
+				return "", fmt.Errorf("provisioningPreview.path must not contain parent-directory segments")
 			}
 		}
 	}

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -65,7 +65,7 @@ func (StringOrSlice) JSONSchema() *jsonschema.Schema {
 }
 
 type GetPanelImageParams struct {
-	DashboardUID string                   `json:"dashboardUid" jsonschema:"required,description=The UID of the dashboard containing the panel"`
+	DashboardUID string                   `json:"dashboardUid,omitempty" jsonschema:"description=The UID of a stored dashboard containing the panel. Required unless provisioningPreview is provided."`
 	PanelID      *int                     `json:"panelId,omitempty" jsonschema:"description=The ID of the panel to render. If omitted\\, the entire dashboard is rendered"`
 	Width        *int                     `json:"width,omitempty" jsonschema:"description=Width of the rendered image in pixels. Defaults to 1000"`
 	Height       *int                     `json:"height,omitempty" jsonschema:"description=Height of the rendered image in pixels. Defaults to 500"`
@@ -74,11 +74,25 @@ type GetPanelImageParams struct {
 	Theme        *string                  `json:"theme,omitempty" jsonschema:"description=Theme for the rendered image: light or dark. Defaults to dark"`
 	Scale        *int                     `json:"scale,omitempty" jsonschema:"description=Scale factor for the image (1-3). Defaults to 1"`
 	Timeout      *int                     `json:"timeout,omitempty" jsonschema:"description=Rendering timeout in seconds. Defaults to 60"`
+	// ProvisioningPreview renders a dashboard from a provisioning repository
+	// branch that has not yet been merged or applied. Mutually exclusive with
+	// dashboardUid.
+	ProvisioningPreview *ProvisioningPreview `json:"provisioningPreview,omitempty" jsonschema:"description=Render a dashboard from a provisioning repository branch (e.g. a git-sync PR preview). Mutually exclusive with dashboardUid."`
 }
 
 type RenderTimeRange struct {
 	From string `json:"from" jsonschema:"description=Start time (e.g.\\, 'now-1h'\\, '2024-01-01T00:00:00Z')"`
 	To   string `json:"to" jsonschema:"description=End time (e.g.\\, 'now'\\, '2024-01-01T12:00:00Z')"`
+}
+
+// ProvisioningPreview identifies a not-yet-applied dashboard inside a
+// provisioning repository, e.g. one staged on a feature branch via git-sync.
+// The renderer loads the dashboard at /dashboard/provisioning/<repo>/preview/<path>
+// instead of looking it up by UID.
+type ProvisioningPreview struct {
+	Repo string `json:"repo" jsonschema:"required,description=Provisioning repository slug. List repositories via /apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories if unknown."`
+	Path string `json:"path" jsonschema:"required,description=Path to the dashboard file within the repository, relative to its root."`
+	Ref  string `json:"ref,omitempty" jsonschema:"description=Branch or commit SHA to render from. Defaults to the repository's main branch when omitted."`
 }
 
 func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallToolResult, error) {
@@ -155,19 +169,54 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 }
 
 func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
+	// Validate that exactly one source is set.
+	hasUID := args.DashboardUID != ""
+	hasPreview := args.ProvisioningPreview != nil
+	if hasUID == hasPreview {
+		if hasUID {
+			return "", fmt.Errorf("dashboardUid and provisioningPreview are mutually exclusive; pass exactly one")
+		}
+		return "", fmt.Errorf("either dashboardUid or provisioningPreview must be set")
+	}
+	if hasPreview {
+		if args.ProvisioningPreview.Repo == "" {
+			return "", fmt.Errorf("provisioningPreview.repo is required")
+		}
+		if args.ProvisioningPreview.Path == "" {
+			return "", fmt.Errorf("provisioningPreview.path is required")
+		}
+	}
+
 	// Strip trailing slashes from base URL for consistent URL construction
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	// Build query parameters
 	params := url.Values{}
 
-	// Single-panel renders use the purpose-built /d-solo route (lighter than loading
-	// the full dashboard with viewPanel). Full dashboard renders use /d as default.
-	renderPath := fmt.Sprintf("/render/d/%s", args.DashboardUID)
-
-	if args.PanelID != nil {
-		renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
-		params.Set("panelId", strconv.Itoa(*args.PanelID))
+	// Choose render path. For stored dashboards we use the purpose-built /d-solo
+	// route for single-panel renders (lighter than loading the full dashboard
+	// with viewPanel); full dashboard renders use /d. For provisioning previews
+	// the same route is used for both since the preview UI handles ?panelId
+	// via the standard kiosk/viewPanel mechanism.
+	var renderPath string
+	if hasPreview {
+		renderPath = fmt.Sprintf(
+			"/render/dashboard/provisioning/%s/preview/%s",
+			args.ProvisioningPreview.Repo,
+			args.ProvisioningPreview.Path,
+		)
+		if args.ProvisioningPreview.Ref != "" {
+			params.Set("ref", args.ProvisioningPreview.Ref)
+		}
+		if args.PanelID != nil {
+			params.Set("viewPanel", strconv.Itoa(*args.PanelID))
+		}
+	} else {
+		renderPath = fmt.Sprintf("/render/d/%s", args.DashboardUID)
+		if args.PanelID != nil {
+			renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
+			params.Set("panelId", strconv.Itoa(*args.PanelID))
+		}
 	}
 
 	// Set dimensions
@@ -228,7 +277,9 @@ func createHTTPClient(config mcpgrafana.GrafanaConfig) (*http.Client, error) {
 
 var GetPanelImage = mcpgrafana.MustTool(
 	"get_panel_image",
-	"Render a Grafana dashboard panel or full dashboard as a PNG image. Returns the image as base64 encoded data. Requires the Grafana Image Renderer service to be installed. Use this for generating visual snapshots of dashboards for reports\\, alerts\\, or presentations.",
+	"Render a Grafana dashboard panel or full dashboard as a PNG image. Returns the image as base64 encoded data. Requires the Grafana Image Renderer service to be installed. "+
+		"Either dashboardUid (for stored dashboards) or provisioningPreview (for dashboards staged on a provisioning repository branch, e.g. a git-sync PR) must be supplied. "+
+		"Use this for generating visual snapshots of dashboards for reports, alerts, or presentations.",
 	getPanelImage,
 	mcp.WithTitleAnnotation("Get panel or dashboard image"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -153,6 +153,7 @@ func TestBuildRenderURL(t *testing.T) {
 		args        GetPanelImageParams
 		contains    []string
 		notContains []string
+		expectError bool
 	}{
 		{
 			name:    "Basic dashboard render",
@@ -264,11 +265,109 @@ func TestBuildRenderURL(t *testing.T) {
 				"http://localhost:3000/render/d/abc123",
 			},
 		},
+		{
+			name:    "Provisioning preview renders the preview path with ref",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "my-repo",
+					Path: "folder/dashboard.json",
+					Ref:  "feature-branch",
+				},
+			},
+			contains: []string{
+				"http://localhost:3000/render/dashboard/provisioning/my-repo/preview/folder/dashboard.json",
+				"ref=feature-branch",
+				"kiosk=true",
+			},
+			notContains: []string{
+				"/render/d/",
+				"/render/d-solo/",
+			},
+		},
+		{
+			name:    "Provisioning preview without ref omits the ref query param",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "my-repo",
+					Path: "dashboard.json",
+				},
+			},
+			contains: []string{
+				"http://localhost:3000/render/dashboard/provisioning/my-repo/preview/dashboard.json",
+			},
+			notContains: []string{
+				"ref=",
+			},
+		},
+		{
+			name:    "Provisioning preview with panel ID uses viewPanel (not d-solo)",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "my-repo",
+					Path: "dashboard.json",
+					Ref:  "feature-branch",
+				},
+				PanelID: intPtr(7),
+			},
+			contains: []string{
+				"http://localhost:3000/render/dashboard/provisioning/my-repo/preview/dashboard.json",
+				"viewPanel=7",
+			},
+			notContains: []string{
+				"panelId=",
+				"/render/d-solo/",
+			},
+		},
+		{
+			name:        "Error: neither dashboardUid nor provisioningPreview",
+			baseURL:     "http://localhost:3000",
+			args:        GetPanelImageParams{},
+			expectError: true,
+		},
+		{
+			name:    "Error: both dashboardUid and provisioningPreview",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				DashboardUID: "abc123",
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "my-repo",
+					Path: "dashboard.json",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:    "Error: provisioningPreview missing repo",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Path: "dashboard.json",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:    "Error: provisioningPreview missing path",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "my-repo",
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := buildRenderURL(tt.baseURL, tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			for _, expected := range tt.contains {

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -377,6 +377,61 @@ func TestBuildRenderURL(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name:    "Error: provisioningPreview repo with slash",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "evil/../../d",
+					Path: "dashboard.json",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:    "Error: provisioningPreview repo with backslash",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: `evil\..\d`,
+					Path: "dashboard.json",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:    "Error: provisioningPreview repo equals ..",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "..",
+					Path: "dashboard.json",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:    "Error: provisioningPreview path with .. segment",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "my-repo",
+					Path: "folder/../../etc/passwd",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:    "Error: provisioningPreview path is exactly ..",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "my-repo",
+					Path: "..",
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -302,6 +302,24 @@ func TestBuildRenderURL(t *testing.T) {
 			},
 		},
 		{
+			name:    "Provisioning preview escapes special characters in repo and path",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				ProvisioningPreview: &ProvisioningPreview{
+					Repo: "repo with space",
+					Path: "folder/dash?name#frag.json",
+				},
+			},
+			contains: []string{
+				"/render/dashboard/provisioning/repo%20with%20space/preview/folder/dash%3Fname%23frag.json",
+			},
+			notContains: []string{
+				"repo with space",
+				"dash?name",
+				"#frag",
+			},
+		},
+		{
 			name:    "Provisioning preview with panel ID uses viewPanel (not d-solo)",
 			baseURL: "http://localhost:3000",
 			args: GetPanelImageParams{


### PR DESCRIPTION
## Summary

  Adds optional `provisioningPreview` parameter to `get_panel_image` so it can
  render dashboards staged on a provisioning repository branch (e.g. a git-sync
  PR preview) before they're merged or applied.

  Either `dashboardUid` (existing, for stored dashboards) or `provisioningPreview`
  must be supplied; passing both is rejected. When `provisioningPreview` is used
  the render URL becomes
  `/render/dashboard/provisioning/<repo>/preview/<path>` with `?ref=<ref>` for
  branch/SHA targeting and `?viewPanel=<id>` for single-panel renders.

  ## Motivation

  Closes a gap in the LLM-driven dashboard development loop on top of git-sync:
  the agent writes the dashboard JSON, commits, opens a PR — but until this
  change there was no way for the agent to self-check by rendering its own work
  short of waiting for the PR to merge and the dashboard to provision. With
  `provisioningPreview` the agent can render a dashboard from any branch
  immediately, see whether it loads, whether each panel returns the expected
  shape of data, and iterate without round-tripping through human review.

  ## Test plan

  - `go test -tags=unit ./tools/ -run 'TestBuildRenderURL|TestGetPanelImage' -v`
    passes. Added tests cover: render with ref, render without ref, single panel
    via `viewPanel`, and four error paths (neither source set, both set, missing
    repo, missing path).
  - Verified end-to-end on a staging instance:
    - [x] stored dashboard, full
    - [x] stored dashboard, single panel
    - [x] provisioning preview, full (5 panels rendered with data)
    - [x] provisioning preview, single panel via `viewPanel`

  ## Notes

  The Grafana service account needs read access on the provisioning files
  subresource, i.e. ≥ Viewer with the per-verb fallback from
  grafana/grafana#123867 (in 13.0.2+). Earlier versions reject the preview
  render with `admin role is required`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL construction and validation for the `get_panel_image` rendering flow and introduces new inputs that affect which Grafana routes are called; mistakes could break rendering or allow unexpected path handling (partly mitigated by new traversal checks and escaping).
> 
> **Overview**
> Enables `get_panel_image` to render dashboards that haven’t been applied yet by accepting a new optional `provisioningPreview` (`repo`, `path`, `ref`) parameter and building requests to `/render/dashboard/provisioning/<repo>/preview/<path>` (with optional `ref` and `viewPanel` for panel renders).
> 
> Tightens parameter validation so **exactly one** of `dashboardUid` or `provisioningPreview` must be provided, adds path traversal hardening + URL path escaping for preview inputs, and updates docs/changelog plus unit tests to cover the new preview and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656efee1aea669458e964581c0d3d98279de70f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->