### PR TITLE
fix: inject version via ldflags so release builds report correct version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
       - linux
       - windows
       - darwin
-    ldflags: "-s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"
+    ldflags: "-s -w -X github.com/grafana/mcp-grafana.version={{.Version}}"
   - id: gemini-cli-extension
     env:
       - CGO_ENABLED=0
@@ -30,7 +30,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    ldflags: "-s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"
+    ldflags: "-s -w -X github.com/grafana/mcp-grafana.version={{.Version}}"
 
 archives:
   - id: default

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"log/slog"
+	"os/exec"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -196,6 +198,43 @@ func TestParseSlowRequestLogLevel(t *testing.T) {
 			}
 			require.NoError(t, err, "unexpected error for input %q", tc.input)
 			assert.Equal(t, tc.wantLevel, got, "unexpected level for input %q", tc.input)
+		})
+	}
+}
+
+func TestVersionOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		ldflags string
+		want    string
+	}{
+		{
+			name: "without ldflags returns devel",
+			want: "(devel)",
+		},
+		{
+			name:    "with ldflags returns injected version",
+			ldflags: "-X github.com/grafana/mcp-grafana.version=v1.2.3",
+			want:    "v1.2.3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"build", "-o", t.TempDir() + "/mcp-grafana"}
+			if tc.ldflags != "" {
+				args = append(args, "-ldflags", tc.ldflags)
+			}
+			args = append(args, ".")
+
+			build := exec.Command("go", args...)
+			out, err := build.CombinedOutput()
+			require.NoError(t, err, "go build failed: %s", out)
+
+			bin := args[2] // the -o path
+			got, err := exec.Command(bin, "--version").Output()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, strings.TrimSpace(string(got)))
 		})
 	}
 }

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -203,40 +203,27 @@ func TestParseSlowRequestLogLevel(t *testing.T) {
 }
 
 func TestVersionOutput(t *testing.T) {
-	tests := []struct {
-		name    string
-		ldflags string
-		want    string
-	}{
-		{
-			name: "without ldflags returns devel",
-			want: "(devel)",
-		},
-		{
-			name:    "with ldflags returns injected version",
-			ldflags: "-X github.com/grafana/mcp-grafana.version=v1.2.3",
-			want:    "v1.2.3",
-		},
-	}
+	t.Run("without ldflags returns non-empty version", func(t *testing.T) {
+		bin := t.TempDir() + "/mcp-grafana"
+		build := exec.Command("go", "build", "-o", bin, ".")
+		out, err := build.CombinedOutput()
+		require.NoError(t, err, "go build failed: %s", out)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			args := []string{"build", "-o", t.TempDir() + "/mcp-grafana"}
-			if tc.ldflags != "" {
-				args = append(args, "-ldflags", tc.ldflags)
-			}
-			args = append(args, ".")
+		got, err := exec.Command(bin, "--version").Output()
+		require.NoError(t, err)
+		assert.NotEmpty(t, strings.TrimSpace(string(got)))
+	})
 
-			build := exec.Command("go", args...)
-			out, err := build.CombinedOutput()
-			require.NoError(t, err, "go build failed: %s", out)
+	t.Run("ldflags version takes precedence", func(t *testing.T) {
+		bin := t.TempDir() + "/mcp-grafana"
+		build := exec.Command("go", "build", "-ldflags", "-X github.com/grafana/mcp-grafana.version=v1.2.3", "-o", bin, ".")
+		out, err := build.CombinedOutput()
+		require.NoError(t, err, "go build failed: %s", out)
 
-			bin := args[2] // the -o path
-			got, err := exec.Command(bin, "--version").Output()
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, strings.TrimSpace(string(got)))
-		})
-	}
+		got, err := exec.Command(bin, "--version").Output()
+		require.NoError(t, err)
+		assert.Equal(t, "v1.2.3", strings.TrimSpace(string(got)))
+	})
 }
 
 // TestHandleFlagsPostParse locks in the precedence invariant that --version

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -399,6 +400,9 @@ var version string
 var Version = sync.OnceValue(func() string {
 	if version != "" {
 		return version
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" {
+		return bi.Main.Version
 	}
 	return "(devel)"
 })

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -14,7 +14,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -389,17 +388,19 @@ func (t *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 	return t.rt.RoundTrip(clonedReq)
 }
 
+// version is set at build time via ldflags:
+//
+//	-X github.com/grafana/mcp-grafana.version=v1.2.3
+var version string
+
 // Version returns the version of the mcp-grafana binary.
-// It uses runtime/debug to fetch version information from the build, returning "(devel)" for local development builds.
-// The version is computed once and cached for performance.
+// It prefers an ldflags-injected value, then falls back to runtime/debug build info,
+// and finally returns "(devel)" for local development builds.
 var Version = sync.OnceValue(func() string {
-	// Default version string returned by `runtime/debug` if built
-	// from the source repository rather than with `go install`.
-	v := "(devel)"
-	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" {
-		v = bi.Main.Version
+	if version != "" {
+		return version
 	}
-	return v
+	return "(devel)"
 })
 
 // UserAgent returns the user agent string for HTTP requests.


### PR DESCRIPTION
## Summary
- Homebrew (and other GoReleaser-built) installs reported `(devel)` instead of the release version because `Version()` relied on `debug.ReadBuildInfo().Main.Version`, which is only set for `go install module@version` — not `go build`
- Added a package-level `var version string` in `mcpgrafana.go` set at build time via `-X github.com/grafana/mcp-grafana.version={{.Version}}`
- Removed dead ldflags (`main.commit`, `main.date`, `main.builtBy`) that had no corresponding variables and were silently ignored

## Test plan
- [x] Added `TestVersionOutput` that builds the binary with and without ldflags and asserts the `--version` output
- [ ] Verify on next release that `mcp-grafana --version` reports the tag version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to build-time version injection and the `Version()` fallback logic, plus tests that compile/execute the binary to assert `--version` output.
> 
> **Overview**
> Release builds now report the correct `--version` by injecting `github.com/grafana/mcp-grafana.version` via GoReleaser `ldflags`, replacing previously unused `main.*` ldflags.
> 
> `Version()` now prefers the ldflags-provided version, then falls back to `debug.ReadBuildInfo()` and finally `(devel)`. A new `TestVersionOutput` builds and runs the CLI with and without ldflags to lock in the precedence and non-empty output behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a18f59d72c1b4f4682a6b5ea5c0888fe0c23010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->