### PR TITLE
feat(plugin): use hosted MCP server with user-prompted Grafana URL and token

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,10 +8,39 @@
   "homepage": "https://github.com/grafana/mcp-grafana",
   "repository": "https://github.com/grafana/mcp-grafana",
   "license": "Apache-2.0",
+  "keywords": [
+    "grafana",
+    "observability",
+    "prometheus",
+    "loki",
+    "tempo",
+    "pyroscope",
+    "mcp",
+    "sre"
+  ],
+  "userConfig": {
+    "grafana_url": {
+      "type": "string",
+      "title": "Grafana instance URL",
+      "description": "Your Grafana instance URL. For Grafana Cloud: https://<stack>.grafana.net. For self-hosted Grafana: a publicly reachable URL (the remote MCP server at mcp.grafana.com must be able to reach it). For private/firewalled instances, use the local binary install path instead — see README.",
+      "required": true
+    },
+    "grafana_service_account_token": {
+      "type": "string",
+      "title": "Grafana service account token",
+      "description": "Create a service account token at <your-grafana-url>/org/serviceaccounts. Required scopes depend on which tools you use; see README for details.",
+      "required": true,
+      "sensitive": true
+    }
+  },
   "mcpServers": {
     "grafana": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/.claude-plugin/install-binary.mjs"]
+      "type": "http",
+      "url": "https://mcp.grafana.com/mcp",
+      "headers": {
+        "X-Grafana-URL": "${user_config.grafana_url}",
+        "Authorization": "Bearer ${user_config.grafana_service_account_token}"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Requires [uv](https://docs.astral.sh/uv/getting-started/installation/). Add the 
 
 For Grafana Cloud, replace `GRAFANA_URL` with your instance URL (e.g. `https://myinstance.grafana.net`). See [Usage](#usage) for more installation options including Docker, binary, and Helm.
 
+### Claude Code
+
+Claude Code has native plugin support and can install this server with no binary download. Add the marketplace and install the `grafana` plugin:
+
+```bash
+/plugin marketplace add grafana/mcp-grafana
+/plugin install grafana@mcp-grafana
+```
+
+Claude Code will prompt you at enable time for:
+
+- **Grafana instance URL** — Grafana Cloud (`https://<stack>.grafana.net`) or a publicly reachable self-hosted URL
+- **Service account token** — stored in your system keychain
+
+The plugin uses the hosted streamable-http MCP server at `https://mcp.grafana.com/mcp` and passes your URL and token as headers. For private or firewalled Grafana instances that the hosted server cannot reach, install the local binary instead (see [Usage](#usage)).
+
 ## Requirements
 
 - **Grafana version 9.0 or later** is required for full functionality. Some features, particularly datasource-related operations, may not work correctly with earlier versions due to missing API endpoints.


### PR DESCRIPTION
## Summary

- Switches the Claude Code plugin from local-binary stdio transport to the hosted streamable-http endpoint at `https://mcp.grafana.com/mcp`.
- Adds a `userConfig` block to `.claude-plugin/plugin.json` so Claude Code prompts users for their Grafana instance URL and service account token at enable time. Sensitive token is stored in the system keychain.
- Adds a Claude Code section to the README install instructions and populates the `keywords` field for marketplace discovery.

The same configuration is intended to cover both audiences:
- **Grafana Cloud** — user supplies `https://<stack>.grafana.net`
- **Self-hosted (publicly reachable)** — user supplies their Grafana URL; the hosted server must be able to reach it
- **Self-hosted (private/firewalled)** — falls back to the local binary install path documented in the README

This means users no longer need to download the binary to use the Claude Code plugin in the common case.

## Items needing reviewer confirmation

Opening as a **draft** because I made assumptions that someone on the team (@grafana/grafana-assistant-loop) who owns `mcp.grafana.com` should verify against the actual server behavior:

1. **MCP transport type string in plugin.json.** I used `"type": "http"`. The Claude Code plugins reference does not show a remote-MCP example in `mcpServers`; this is the conventional Claude Code form. If the current Claude Code release expects `"type": "streamable-http"` or `"transport"` instead of `"type"`, this needs to change.
2. **Auth header.** I used `Authorization: Bearer <service-account-token>`. `server.json` does not document the auth header convention for the hosted endpoint; please confirm this matches what `mcp.grafana.com/mcp` accepts (it may expect a different header name, or token-derived stack routing instead of `X-Grafana-URL`).
3. **`X-Grafana-URL` header.** Wired from `${user_config.grafana_url}`. `server.json` marks this as not required for the hosted endpoint; confirm it's still the right way to route to a user's instance, or whether the hosted server resolves the stack from the token alone.
4. **`install-binary.mjs`.** No longer referenced by `plugin.json`. Left in the repo — happy to remove in this PR or a follow-up, whichever you prefer.
5. **Version bump.** Left `version` at `0.7.6` since the plugin version tracks the MCP server release. Bump (or independent versioning) is a maintainer call.

## Test plan

- [ ] Reviewer confirms transport type, auth header, and URL header conventions against the hosted server
- [ ] `claude plugin validate ./.claude-plugin/plugin.json --strict` passes
- [ ] Local install with `--plugin-dir` prompts for both fields and successfully calls a tool against a real Grafana Cloud stack
- [ ] Local install successfully calls a tool against a publicly reachable self-hosted Grafana
- [ ] Sensitive token visibly masked in the install prompt and not present in `settings.json`

## Context

Builds on #333 which added the initial plugin manifest. Goal is to get this ready for submission to the Claude Code community marketplace (`anthropics/claude-plugins-community`) by replacing the binary-download install with the smoother hosted-MCP install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install flow now routes service account tokens to a remote MCP endpoint via headers; correctness depends on hosted server auth/transport conventions that the PR flags for reviewer verification.
> 
> **Overview**
> The Claude Code plugin **stops launching a local Node binary** and instead points `mcpServers.grafana` at the **hosted** endpoint `https://mcp.grafana.com/mcp` with HTTP transport, sending **`X-Grafana-URL`** and **`Authorization: Bearer`** from new install-time **`userConfig`** fields (URL + sensitive service account token).
> 
> The manifest also gains **marketplace `keywords`** and richer field descriptions (Cloud vs public self-hosted vs private instances falling back to local install). The **README** adds a **Claude Code** quick path: marketplace add/install commands and what users are prompted for at enable time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda26ed5dc2d82a5ebe3f860299f9124cf40b3bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->