### PR TITLE
fix: scope datasource fallback cache by request path

### DIFF
--- a/tools/fallback_transport.go
+++ b/tools/fallback_transport.go
@@ -23,7 +23,8 @@ type datasourceFallbackTransport struct {
 }
 
 // fallbackEndpoints caches which datasource proxy paths need the fallback
-// endpoint. Key is the primary base path, value is true if fallback is needed.
+// endpoint. Key is the primary base path plus request path suffix, value is
+// true if fallback is needed.
 var fallbackEndpoints sync.Map
 
 func newDatasourceFallbackTransport(wrapped http.RoundTripper, primaryBase, fallbackBase string) http.RoundTripper {
@@ -35,8 +36,10 @@ func newDatasourceFallbackTransport(wrapped http.RoundTripper, primaryBase, fall
 }
 
 func (t *datasourceFallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cacheKey := t.fallbackCacheKey(req)
+
 	// Check cache: if we already know the fallback works, use it directly.
-	if useFallback, ok := fallbackEndpoints.Load(t.primaryBase); ok && useFallback.(bool) {
+	if useFallback, ok := fallbackEndpoints.Load(cacheKey); ok && useFallback.(bool) {
 		return t.wrapped.RoundTrip(t.rewriteRequest(req, t.primaryBase, t.fallbackBase))
 	}
 
@@ -50,6 +53,7 @@ func (t *datasourceFallbackTransport) RoundTrip(req *http.Request) (*http.Respon
 			return nil, fmt.Errorf("buffering request body for fallback: %w", err)
 		}
 		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.ContentLength = int64(len(bodyBytes))
 	}
 
 	resp, err := t.wrapped.RoundTrip(req)
@@ -80,10 +84,24 @@ func (t *datasourceFallbackTransport) RoundTrip(req *http.Request) (*http.Respon
 	// is working for this particular request; caching it would silently break
 	// all subsequent calls that would otherwise succeed via the primary path.
 	if retryResp.StatusCode >= 200 && retryResp.StatusCode < 300 {
-		fallbackEndpoints.Store(t.primaryBase, true)
+		fallbackEndpoints.Store(cacheKey, true)
 	}
 
 	return retryResp, nil
+}
+
+func (t *datasourceFallbackTransport) fallbackCacheKey(req *http.Request) string {
+	path := req.URL.EscapedPath()
+	if path == "" {
+		path = req.URL.Path
+	}
+
+	suffix, ok := strings.CutPrefix(path, t.primaryBase)
+	if !ok {
+		return t.primaryBase + "\x00" + path
+	}
+
+	return t.primaryBase + suffix
 }
 
 func (t *datasourceFallbackTransport) rewriteRequest(req *http.Request, from, to string) *http.Request {

--- a/tools/fallback_transport_test.go
+++ b/tools/fallback_transport_test.go
@@ -33,6 +33,12 @@ func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found"))}, nil
 }
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func newMockResponse(status int) *http.Response {
 	return &http.Response{
 		StatusCode: status,
@@ -109,7 +115,7 @@ func TestDatasourceFallbackTransport_FallbackOn500(t *testing.T) {
 	assert.Len(t, mock.requests, 2, "should retry with fallback on 500")
 }
 
-func TestDatasourceFallbackTransport_CachesFallback(t *testing.T) {
+func TestDatasourceFallbackTransport_CachesFallbackPerRequestPath(t *testing.T) {
 	resetFallbackCache()
 
 	mock := &mockTransport{
@@ -130,13 +136,67 @@ func TestDatasourceFallbackTransport_CachesFallback(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, mock.requests, 2)
 
-	// Second request: uses cached fallback directly (1 round trip).
-	req2, _ := http.NewRequest("GET", "http://grafana.example.com/api/datasources/uid/test-uid/resources/api/v1/query", nil)
+	// Same request path: uses cached fallback directly (1 round trip).
+	req2, _ := http.NewRequest("GET", "http://grafana.example.com/api/datasources/uid/test-uid/resources/api/v1/labels", nil)
 	resp, err := rt.RoundTrip(req2)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Len(t, mock.requests, 3, "cached fallback should skip the primary attempt")
-	assert.Contains(t, mock.requests[2].URL.Path, "/api/datasources/proxy/uid/test-uid/api/v1/query")
+	assert.Len(t, mock.requests, 3, "same path should use cached fallback")
+	assert.Contains(t, mock.requests[2].URL.Path, "/api/datasources/proxy/uid/test-uid/api/v1/labels")
+
+	// Different request path: tries primary first because /resources and /proxy
+	// compatibility can differ between datasource API endpoints.
+	req3, _ := http.NewRequest("GET", "http://grafana.example.com/api/datasources/uid/test-uid/resources/api/v1/query", nil)
+	resp, err = rt.RoundTrip(req3)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, mock.requests, 5, "different path should not inherit fallback cache")
+	assert.Contains(t, mock.requests[3].URL.Path, "/api/datasources/uid/test-uid/resources/api/v1/query")
+	assert.Contains(t, mock.requests[4].URL.Path, "/api/datasources/proxy/uid/test-uid/api/v1/query")
+}
+
+func TestDatasourceFallbackTransport_LokiPatternsDoesNotInheritFallback(t *testing.T) {
+	resetFallbackCache()
+
+	var requests []*http.Request
+	mock := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req)
+
+		switch {
+		case strings.Contains(req.URL.Path, "/api/datasources/proxy/uid/test-uid/api/v1/labels"):
+			return newMockResponse(http.StatusForbidden), nil
+		case strings.Contains(req.URL.Path, "/api/datasources/uid/test-uid/resources/api/v1/labels"):
+			return newMockResponse(http.StatusOK), nil
+		case strings.Contains(req.URL.Path, "/api/datasources/proxy/uid/test-uid/loki/api/v1/patterns"):
+			return newMockResponse(http.StatusOK), nil
+		case strings.Contains(req.URL.Path, "/api/datasources/uid/test-uid/resources/loki/api/v1/patterns"):
+			return newMockResponse(http.StatusNotFound), nil
+		default:
+			return newMockResponse(http.StatusNotFound), nil
+		}
+	})
+
+	rt := newDatasourceFallbackTransport(mock,
+		"/api/datasources/proxy/uid/test-uid",
+		"/api/datasources/uid/test-uid/resources",
+	)
+
+	// First request: discovers fallback is needed for labels.
+	req1, _ := http.NewRequest("GET", "http://grafana.example.com/api/datasources/proxy/uid/test-uid/api/v1/labels", nil)
+	resp, err := rt.RoundTrip(req1)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, requests, 2)
+
+	// A different Loki path must still try the primary path. Caching the
+	// fallback only by datasource base would incorrectly route this directly to
+	// /resources, which is not equivalent for the patterns endpoint.
+	req2, _ := http.NewRequest("GET", "http://grafana.example.com/api/datasources/proxy/uid/test-uid/loki/api/v1/patterns", nil)
+	resp, err = rt.RoundTrip(req2)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, requests, 3)
+	assert.Contains(t, requests[2].URL.Path, "/api/datasources/proxy/uid/test-uid/loki/api/v1/patterns")
 }
 
 func TestDatasourceFallbackTransport_BothFail(t *testing.T) {


### PR DESCRIPTION
## Summary
- scope datasource fallback cache entries by request path instead of only the datasource base path
- keep cached fallback behavior for repeated requests to the same endpoint
- add a regression test covering Loki patterns when another Loki endpoint falls back to `/resources`

## Why
Some Grafana datasource endpoints are not interchangeable between `/proxy` and `/resources`. A fallback learned for one endpoint can currently be reused for a different Loki endpoint, causing `query_loki_patterns` to be routed to `/api/datasources/uid/<uid>/resources/loki/api/v1/patterns`, which can return 404 even when `/api/datasources/proxy/uid/<uid>/loki/api/v1/patterns` works.

Minimal repro on a proxied Loki datasource:
- `list_loki_label_names({ datasourceUid: "loki" })`
- `query_loki_patterns({ datasourceUid: "loki", logql: "{}" })`

Related to the same `/resources` path compatibility class as #721.

## Testing
- `GOPROXY=direct go mod download`
- `go test ./tools -run 'TestDatasourceFallbackTransport' -count=1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP routing for all datasource proxy calls; low blast radius but can alter which Grafana path is used per endpoint.
> 
> **Overview**
> **Scopes datasource proxy fallback caching per request path** instead of per datasource base URL, so a successful fallback on one Grafana/Loki API route is not reused for unrelated routes where `/proxy` and `/resources` behave differently.
> 
> `datasourceFallbackTransport` now builds a per-path `fallbackCacheKey`, still caches only after a **2xx** fallback, and sets **`ContentLength`** when replaying buffered POST bodies. Tests cover per-path cache hits, cross-endpoint isolation, and a **Loki patterns** regression where `/resources` 404s but `/proxy` works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed6574fa21163df19a87f9d9273cf99447dbe95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->