### PR TITLE
feat(rendering): add optional orgId parameter to get_panel_image

### DIFF
--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -67,6 +67,7 @@ func (StringOrSlice) JSONSchema() *jsonschema.Schema {
 type GetPanelImageParams struct {
 	DashboardUID string                   `json:"dashboardUid,omitempty" jsonschema:"description=The UID of a stored dashboard containing the panel. Required unless provisioningPreview is provided."`
 	PanelID      *int                     `json:"panelId,omitempty" jsonschema:"description=The ID of the panel to render. If omitted\\, the entire dashboard is rendered"`
+	OrgID        *int                     `json:"orgId,omitempty" jsonschema:"description=The Grafana organization ID to render the panel in. Defaults to the default org (usually 1)"`
 	Width        *int                     `json:"width,omitempty" jsonschema:"description=Width of the rendered image in pixels. Defaults to 1000"`
 	Height       *int                     `json:"height,omitempty" jsonschema:"description=Height of the rendered image in pixels. Defaults to 500"`
 	TimeRange    *RenderTimeRange         `json:"timeRange,omitempty" jsonschema:"description=Time range for the rendered image"`
@@ -103,6 +104,16 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 		return nil, fmt.Errorf("grafana URL not configured. Please set GRAFANA_URL environment variable")
 	}
 
+	// When a per-call orgId is provided, override the org for this request so the
+	// X-Grafana-Org-Id header added by the transport matches the render URL's
+	// orgId. Without this, a multi-org deployment would render the configured
+	// default org instead of the requested one.
+	reqCtx := ctx
+	if args.OrgID != nil {
+		config.OrgID = int64(*args.OrgID)
+		reqCtx = mcpgrafana.WithGrafanaConfig(ctx, config)
+	}
+
 	// Build the render URL
 	renderURL, err := buildRenderURL(baseURL, args)
 	if err != nil {
@@ -129,7 +140,7 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 	}
 
 	// Create request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, renderURL, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, renderURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -249,6 +260,9 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 			renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
 			params.Set("panelId", strconv.Itoa(*args.PanelID))
 		}
+	}
+	if args.OrgID != nil {
+		params.Set("orgId", strconv.Itoa(*args.OrgID))
 	}
 
 	// Set dimensions

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -262,7 +262,7 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 		}
 	}
 	if args.OrgID != nil {
-		params.Set("orgId", strconv.Itoa(*args.OrgID))
+		params.Set("targetOrgId", strconv.Itoa(*args.OrgID))
 	}
 
 	// Set dimensions

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -67,6 +67,7 @@ func (StringOrSlice) JSONSchema() *jsonschema.Schema {
 type GetPanelImageParams struct {
 	DashboardUID string                   `json:"dashboardUid,omitempty" jsonschema:"description=The UID of a stored dashboard containing the panel. Required unless provisioningPreview is provided."`
 	PanelID      *int                     `json:"panelId,omitempty" jsonschema:"description=The ID of the panel to render. If omitted\\, the entire dashboard is rendered"`
+	OrgID        *int                     `json:"orgId,omitempty" jsonschema:"description=The Grafana organization ID to render the panel in. Defaults to the default org (usually 1)"`
 	Width        *int                     `json:"width,omitempty" jsonschema:"description=Width of the rendered image in pixels. Defaults to 1000"`
 	Height       *int                     `json:"height,omitempty" jsonschema:"description=Height of the rendered image in pixels. Defaults to 500"`
 	TimeRange    *RenderTimeRange         `json:"timeRange,omitempty" jsonschema:"description=Time range for the rendered image"`
@@ -103,6 +104,16 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 		return nil, fmt.Errorf("grafana URL not configured. Please set GRAFANA_URL environment variable or X-Grafana-URL header")
 	}
 
+	// When a per-call orgId is provided, override the org for this request so the
+	// X-Grafana-Org-Id header added by the transport matches the render URL's
+	// orgId. Without this, a multi-org deployment would render the configured
+	// default org instead of the requested one.
+	reqCtx := ctx
+	if args.OrgID != nil {
+		config.OrgID = int64(*args.OrgID)
+		reqCtx = mcpgrafana.WithGrafanaConfig(ctx, config)
+	}
+
 	// Build the render URL
 	renderURL, err := buildRenderURL(baseURL, args)
 	if err != nil {
@@ -129,7 +140,7 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 	}
 
 	// Create request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, renderURL, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, renderURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -249,6 +260,9 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 			renderPath = fmt.Sprintf("/render/d-solo/%s", args.DashboardUID)
 			params.Set("panelId", strconv.Itoa(*args.PanelID))
 		}
+	}
+	if args.OrgID != nil {
+		params.Set("orgId", strconv.Itoa(*args.OrgID))
 	}
 
 	// Set dimensions

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -184,15 +184,21 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 		},
 	}
 
-	// Use the public base URL, not config.URL, which may be an in-cluster
-	// endpoint the browser can't reach.
-	if deeplinkBase, err := grafanaBaseURLFromContext(ctx); err == nil {
-		if deeplink, err := buildDashboardDeeplink(deeplinkBase, args); err == nil {
-			content = append(content, mcp.TextContent{
-				Meta: mcpgrafana.NewUIContentMeta(mcpgrafana.UIContentKindDeeplink),
-				Type: "text",
-				Text: deeplink,
-			})
+	// A browser deeplink cannot safely preserve a per-call org: orgId changes
+	// the user's default org, targetOrgId is ignored by the frontend, and a
+	// browser link cannot set X-Grafana-Org-Id. Omit it rather than risk linking
+	// to a different dashboard with the same UID in the user's current org.
+	if args.OrgID == nil {
+		// Use the public base URL, not config.URL, which may be an in-cluster
+		// endpoint the browser can't reach.
+		if deeplinkBase, err := grafanaBaseURLFromContext(ctx); err == nil {
+			if deeplink, err := buildDashboardDeeplink(deeplinkBase, args); err == nil {
+				content = append(content, mcp.TextContent{
+					Meta: mcpgrafana.NewUIContentMeta(mcpgrafana.UIContentKindDeeplink),
+					Type: "text",
+					Text: deeplink,
+				})
+			}
 		}
 	}
 

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -260,6 +260,18 @@ func TestBuildRenderURL(t *testing.T) {
 			},
 		},
 		{
+			name:    "With org ID",
+			baseURL: "http://localhost:3000",
+			args: GetPanelImageParams{
+				DashboardUID: "abc123",
+				PanelID:      intPtr(5),
+				OrgID:        intPtr(2),
+			},
+			contains: []string{
+				"orgId=2",
+			},
+		},
+		{
 			name:    "URL with trailing slash",
 			baseURL: "http://localhost:3000/",
 			args: GetPanelImageParams{

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -3,9 +3,11 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -995,6 +997,41 @@ func TestGetPanelImage(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+}
+
+func TestGetPanelImagePerCallOrgIDOmitDeeplink(t *testing.T) {
+	testPNGData := []byte("test PNG")
+	grafanaCfg := mcpgrafana.GrafanaConfig{
+		URL:    "http://grafana.test",
+		APIKey: "test-api-key",
+		OrgID:  1,
+		BaseTransport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "2", req.Header.Get("X-Grafana-Org-Id"))
+			assert.Equal(t, "2", req.URL.Query().Get("targetOrgId"))
+			assert.Empty(t, req.URL.Query().Get("orgId"))
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewReader(testPNGData)),
+				Request:    req,
+			}, nil
+		}),
+	}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	result, err := getPanelImage(ctx, GetPanelImageParams{
+		DashboardUID: "test-dash",
+		OrgID:        intPtr(2),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+	image, ok := result.Content[0].(mcp.ImageContent)
+	require.True(t, ok, "only content item should be ImageContent")
+	decoded, err := base64.StdEncoding.DecodeString(image.Data)
+	require.NoError(t, err)
+	assert.Equal(t, testPNGData, decoded)
 }
 
 func TestGetPanelImageToolMeta(t *testing.T) {

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -268,7 +268,7 @@ func TestBuildRenderURL(t *testing.T) {
 				OrgID:        intPtr(2),
 			},
 			contains: []string{
-				"orgId=2",
+				"targetOrgId=2",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Add an optional `orgId` parameter to `get_panel_image` so it can render dashboards that live in non-default Grafana organizations. Rendering previously always fell back to the default org (usually org 1), even when the token had access to others.

## Why this matters

#883: the Grafana MCP server works across multiple orgs, but `get_panel_image` never passed an org to the render request, so panels in other orgs could not be rendered. Grafana's `/render/d` and `/render/d-solo` endpoints read `orgId` from the query string, but the HTTP transport's `OrgIDRoundTripper` also sets the `X-Grafana-Org-Id` header from the configured org. Setting only the URL parameter would conflict with that header in a multi-org deployment and still render the configured default org, so the fix has to keep both in sync.

## Changes

- `GetPanelImageParams` gains an optional `OrgID *int` (json `orgId`).
- `buildRenderURL` appends `orgId` to the render URL when it is set.
- `getPanelImage` propagates `OrgID` into the request's `GrafanaConfig` context so the transport's `X-Grafana-Org-Id` header matches the URL `orgId`; without this the configured default org would override the requested one.

## Testing

`go test -tags unit ./tools/` passes, including a new `TestBuildRenderURL` case asserting `orgId=2` appears in the rendered URL when set. `gofmt` and `go vet -tags unit ./tools/` are clean.

Closes #883

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change to render URL building and per-request org context; existing default-org behavior is unchanged when orgId is omitted.
> 
> **Overview**
> Adds optional **`orgId`** to **`get_panel_image`** so renders can target dashboards in non-default Grafana orgs.
> 
> When **`orgId`** is set, the render URL includes **`orgId`** and the request context’s **`GrafanaConfig.OrgID`** is overridden so **`X-Grafana-Org-Id`** stays aligned with the query param in multi-org setups. A **`TestBuildRenderURL`** case asserts **`orgId=2`** in the URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b618277ec1b37759b93189c893ae37758029c29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->