### PR TITLE
Add Neo4j cypher query & Run generic panel queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ wheels/
 .vscode/
 .env
 .cursor/
+.idea/
 
 # Virtual environments
 .venv

--- a/tools/dashboard_helpers.go
+++ b/tools/dashboard_helpers.go
@@ -251,11 +251,12 @@ func extractPanelQueries(panel map[string]interface{}, dashboardVars map[string]
 func extractQueryExpression(target map[string]interface{}) string {
 	// Try common query field names
 	queryFields := []string{
-		"expr",       // Prometheus
-		"query",      // Loki, ClickHouse, generic
-		"expression", // CloudWatch
-		"rawSql",     // SQL databases
-		"rawQuery",   // Some datasources
+		"expr",        // Prometheus
+		"query",       // Loki, ClickHouse, generic
+		"expression",  // CloudWatch
+		"rawSql",      // SQL databases
+		"rawQuery",    // Some datasources
+		"cypherQuery", // Neo4j cypher query
 	}
 
 	for _, field := range queryFields {

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -226,7 +226,7 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 	case "influxdb":
 		results, err = executeInfluxDBQuery(ctx, datasourceUID, panelData, query, params.Start, params.End)
 	default:
-		return nil, fmt.Errorf("datasource type '%s' is not supported by run_panel_query; use the native query tool (e.g. query_prometheus\\, query_loki_logs\\, query_clickhouse\\, query_cloudwatch\\, query_influxdb) directly", datasourceType)
+		results, err = executeGenericPanelQuery(ctx, datasourceType, datasourceUID, panelData, params.Start, params.End, vars)
 	}
 
 	if err != nil {
@@ -248,6 +248,42 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 		Results:        results,
 		Hints:          hints,
 	}, nil
+}
+
+func executeGenericPanelQuery(ctx context.Context, datasourceType, datasourceUID string, panelData *panelInfo, start, end string, variables map[string]string) (interface{}, error) {
+	if panelData.RawTarget == nil {
+		return nil, fmt.Errorf("panel target not available")
+	}
+
+	// Parse time range
+	startTime, err := parseTime(start)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
+	}
+	endTime, err := parseTime(end)
+	if err != nil {
+		return nil, fmt.Errorf("parsing end time: %w", err)
+	}
+
+	// Deep copy and substitute variables in target fields
+	target := substituteTemplateVariablesInMap(panelData.RawTarget, variables)
+
+	// Ensure datasource is set correctly
+	target["datasource"] = map[string]interface{}{"uid": datasourceUID, "type": datasourceType}
+
+	// Ensure refId is set
+	if safeString(target, "refId") == "" {
+		target["refId"] = "A"
+	}
+
+	// Build /api/ds/query payload
+	payload := map[string]interface{}{
+		"queries": []map[string]interface{}{target},
+		"from":    fmt.Sprintf("%d", startTime.UnixMilli()),
+		"to":      fmt.Sprintf("%d", endTime.UnixMilli()),
+	}
+
+	return executeGrafanaDSQuery(ctx, payload)
 }
 
 // substituteTemplateVariables replaces template variables in a query string
@@ -807,7 +843,7 @@ func truncateString(s string, maxLen int) string {
 // RunPanelQuery is the tool definition for running panel queries
 var RunPanelQuery = mcpgrafana.MustTool(
 	"run_panel_query",
-	"Executes one or more dashboard panel queries with optional time range and variable overrides. Accepts an array of panel IDs to query in a single call. Fetches the dashboard\\, extracts queries from the specified panels\\, substitutes template variables and Grafana macros ($__range\\, $__rate_interval\\, $__interval)\\, and routes to the appropriate datasource (Prometheus\\, Loki\\, ClickHouse\\, CloudWatch\\, or InfluxDB). Returns results keyed by panel ID - partial failures are allowed (some panels can succeed while others fail). Use get_dashboard_summary first to find panel IDs. If a panel uses a template variable datasource you cannot access\\, provide datasourceUid and datasourceType to override.",
+	"Executes one or more dashboard panel queries with optional time range and variable overrides. Accepts an array of panel IDs to query in a single call. Fetches the dashboard\\, extracts queries from the specified panels\\, substitutes template variables and Grafana macros ($__range\\, $__rate_interval\\, $__interval)\\, and routes to the appropriate datasource (e.g. Prometheus\\, Loki\\, ClickHouse\\, CloudWatch\\, InfluxDB). Returns results keyed by panel ID - partial failures are allowed (some panels can succeed while others fail). Use get_dashboard_summary first to find panel IDs. If a panel uses a template variable datasource you cannot access\\, provide datasourceUid and datasourceType to override.",
 	runPanelQuery,
 	mcp.WithTitleAnnotation("Run panel query"),
 	mcp.WithIdempotentHintAnnotation(true),


### PR DESCRIPTION
This PR is to support Neo4j DataSources from this plugin:
https://github.com/denniskniep/grafana-datasource-plugin-neo4j

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broadens which datasources run_panel_query can execute via Grafana’s query API (still read-only) without new tests visible in the diff; behavior for previously unsupported types changes from error to live query execution.
> 
> **Overview**
> **`run_panel_query`** no longer fails on datasource types outside the Prometheus/Loki/ClickHouse/CloudWatch/InfluxDB switch. Unsupported types now go through **`executeGenericPanelQuery`**, which substitutes dashboard variables on the panel’s raw target, builds a `/api/ds/query` payload (with time range and datasource UID/type), and returns Grafana’s results—same pattern as the existing CloudWatch panel path.
> 
> Dashboard query extraction now recognizes Neo4j panels via the **`cypherQuery`** field in **`extractQueryExpression`**. The MCP tool description is softened to “e.g.” supported types instead of implying only those five work. **`.gitignore`** adds **`.idea/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 701be75484839cbf20eb7d7f89532f6373283183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->