### PR TITLE
feat(search): add search_dashboards_deep tool

### DIFF
--- a/tools/search.go
+++ b/tools/search.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -139,7 +140,190 @@ var SearchFolders = mcpgrafana.MustTool(
 	mcp.WithReadOnlyHintAnnotation(true),
 )
 
+type dashboardSearchHitWithPath struct {
+	dashboardSearchHit
+	FolderPath string `json:"folderPath,omitempty"`
+}
+
+type SearchDashboardsDeepParams struct {
+	Query      string   `json:"query" jsonschema:"description=Query matched case-insensitively against title\\, description\\, tags\\, folder title\\, and reconstructed folder path. Empty string returns all dashboards."`
+	FolderPath string   `json:"folderPath,omitempty" jsonschema:"description=Optional. Limit results to dashboards inside this folder path (e.g. '/Ops/Production'). Includes all subfolders. Case insensitive."`
+	Tags       []string `json:"tags,omitempty" jsonschema:"description=Optional. Limit results to dashboards that have all of these tags (AND logic). Case insensitive."`
+}
+
+type SearchDashboardsDeepResult struct {
+	Dashboards []dashboardSearchHitWithPath `json:"dashboards"`
+	Total      int                          `json:"total"`
+}
+
+func fetchAllFolders(ctx context.Context) (map[string]*models.Hit, error) {
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	folderMap := make(map[string]*models.Hit)
+	page := int64(1)
+	limit := int64(500)
+	for {
+		params := search.NewSearchParamsWithContext(ctx)
+		params.SetType(&folderTypeStr)
+		params.SetLimit(&limit)
+		params.SetPage(&page)
+		resp, err := c.Search.Search(params)
+		if err != nil {
+			return nil, fmt.Errorf("fetch folders page %d: %w", page, err)
+		}
+		for _, hit := range resp.Payload {
+			folderMap[hit.UID] = hit
+		}
+		if len(resp.Payload) == 0 {
+			break
+		}
+		page++
+	}
+	return folderMap, nil
+}
+
+func fetchAllDashboards(ctx context.Context) ([]*models.Hit, error) {
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	var dashboards []*models.Hit
+	page := int64(1)
+	limit := int64(500)
+	for {
+		params := search.NewSearchParamsWithContext(ctx)
+		params.SetType(&dashboardTypeStr)
+		params.SetLimit(&limit)
+		params.SetPage(&page)
+		resp, err := c.Search.Search(params)
+		if err != nil {
+			return nil, fmt.Errorf("fetch dashboards page %d: %w", page, err)
+		}
+		dashboards = append(dashboards, resp.Payload...)
+		if len(resp.Payload) == 0 {
+			break
+		}
+		page++
+	}
+	return dashboards, nil
+}
+
+// buildFolderPath walks up the folder tree via folderMap and returns a slash-separated path.
+func buildFolderPath(folderUID string, folderMap map[string]*models.Hit) string {
+	if folderUID == "" {
+		return ""
+	}
+	var parts []string
+	uid := folderUID
+	for uid != "" {
+		folder, ok := folderMap[uid]
+		if !ok {
+			break
+		}
+		parts = append([]string{folder.Title}, parts...)
+		uid = folder.FolderUID
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "/" + strings.Join(parts, "/")
+}
+
+func hasAllTags(dashboardTags []string, filterTags []string) bool {
+	for _, ft := range filterTags {
+		found := false
+		for _, dt := range dashboardTags {
+			if strings.ToLower(dt) == ft {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesDashboardQuery(query string, hit dashboardSearchHitWithPath) bool {
+	if strings.Contains(strings.ToLower(hit.Title), query) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(hit.Description), query) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(hit.FolderTitle), query) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(hit.FolderPath), query) {
+		return true
+	}
+	for _, tag := range hit.Tags {
+		if strings.Contains(strings.ToLower(tag), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func searchDashboardsDeep(ctx context.Context, args SearchDashboardsDeepParams) (*SearchDashboardsDeepResult, error) {
+	folderMap, err := fetchAllFolders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dashboards, err := fetchAllDashboards(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	query := strings.ToLower(args.Query)
+	folderFilter := ""
+	if args.FolderPath != "" {
+		folderFilter = strings.TrimRight(strings.ToLower(args.FolderPath), "/")
+	}
+	tagFilter := make([]string, len(args.Tags))
+	for i, t := range args.Tags {
+		tagFilter[i] = strings.ToLower(t)
+	}
+	var results []dashboardSearchHitWithPath
+	for _, d := range dashboards {
+		folderPath := buildFolderPath(d.FolderUID, folderMap)
+		hit := dashboardSearchHitWithPath{
+			dashboardSearchHit: dashboardSearchHit{
+				UID:         d.UID,
+				Title:       d.Title,
+				URL:         d.URL,
+				Type:        string(d.Type),
+				FolderUID:   d.FolderUID,
+				FolderTitle: d.FolderTitle,
+				Tags:        d.Tags,
+				Description: d.Description,
+			},
+			FolderPath: folderPath,
+		}
+		if folderFilter != "" && !strings.HasPrefix(strings.TrimRight(strings.ToLower(folderPath), "/")+"/", folderFilter+"/") {
+			continue
+		}
+		if !hasAllTags(hit.Tags, tagFilter) {
+			continue
+		}
+		if query == "" || matchesDashboardQuery(query, hit) {
+			results = append(results, hit)
+		}
+	}
+	return &SearchDashboardsDeepResult{
+		Dashboards: results,
+		Total:      len(results),
+	}, nil
+}
+
+var SearchDashboardsDeep = mcpgrafana.MustTool(
+	"search_dashboards_deep",
+	"Search for Grafana dashboards by a query string. Every attribute of the dashboard, tags and the folderPath will be checked if it contains the case insensitive query string. Returns a list of matching dashboards with details like title, UID, folder, tags, URL and folderPath.",
+	searchDashboardsDeep,
+	mcp.WithTitleAnnotation("Search dashboards deep"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
 func AddSearchTools(mcp *server.MCPServer) {
 	SearchDashboards.Register(mcp)
 	SearchFolders.Register(mcp)
+	SearchDashboardsDeep.Register(mcp)
 }

--- a/tools/search_unit_test.go
+++ b/tools/search_unit_test.go
@@ -146,3 +146,283 @@ func TestSearchDashboards_Pagination(t *testing.T) {
 		assert.Len(t, result.Dashboards, 5)
 	})
 }
+
+func TestBuildFolderPath(t *testing.T) {
+	folderMap := map[string]*models.Hit{
+		"root":       {UID: "root", Title: "Root"},
+		"child":      {UID: "child", Title: "Child", FolderUID: "root"},
+		"grandchild": {UID: "grandchild", Title: "Grandchild", FolderUID: "child"},
+	}
+
+	t.Run("empty folderUID returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", buildFolderPath("", folderMap))
+	})
+
+	t.Run("single level", func(t *testing.T) {
+		assert.Equal(t, "/Root", buildFolderPath("root", folderMap))
+	})
+
+	t.Run("two levels", func(t *testing.T) {
+		assert.Equal(t, "/Root/Child", buildFolderPath("child", folderMap))
+	})
+
+	t.Run("three levels", func(t *testing.T) {
+		assert.Equal(t, "/Root/Child/Grandchild", buildFolderPath("grandchild", folderMap))
+	})
+
+	t.Run("unknown folderUID returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", buildFolderPath("unknown", folderMap))
+	})
+}
+
+func TestMatchesDashboardQuery(t *testing.T) {
+	hit := dashboardSearchHitWithPath{
+		dashboardSearchHit: dashboardSearchHit{
+			Title:       "My Dashboard",
+			Description: "Some metrics here",
+			FolderTitle: "Production",
+			Tags:        []string{"prod", "infra"},
+		},
+		FolderPath: "/Ops/Production",
+	}
+
+	// matchesDashboardQuery expects a pre-lowercased query (as produced by searchDashboardsDeep)
+	t.Run("matches title", func(t *testing.T) {
+		assert.True(t, matchesDashboardQuery("my dashboard", hit))
+	})
+
+	t.Run("matches description", func(t *testing.T) {
+		assert.True(t, matchesDashboardQuery("metrics", hit))
+	})
+
+	t.Run("matches folderTitle", func(t *testing.T) {
+		assert.True(t, matchesDashboardQuery("production", hit))
+	})
+
+	t.Run("matches folderPath", func(t *testing.T) {
+		assert.True(t, matchesDashboardQuery("/ops/production", hit))
+	})
+
+	t.Run("matches tag", func(t *testing.T) {
+		assert.True(t, matchesDashboardQuery("infra", hit))
+	})
+
+	t.Run("partial match", func(t *testing.T) {
+		assert.True(t, matchesDashboardQuery("dash", hit))
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		assert.False(t, matchesDashboardQuery("grafana", hit))
+	})
+}
+
+// mockDeepSearchServer returns a test server that serves folders on type=dash-folder
+// and dashboards on type=dash-db, with a single page of results each.
+func mockDeepSearchServer(t *testing.T, folders models.HitList, dashboards models.HitList) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// Return results only on page 1; empty page 2 terminates the loop.
+		if q.Get("page") != "1" {
+			_ = json.NewEncoder(w).Encode(models.HitList{})
+			return
+		}
+		switch q.Get("type") {
+		case "dash-folder":
+			_ = json.NewEncoder(w).Encode(folders)
+		case "dash-db":
+			_ = json.NewEncoder(w).Encode(dashboards)
+		default:
+			_ = json.NewEncoder(w).Encode(models.HitList{})
+		}
+	}))
+}
+
+func TestSearchDashboardsDeep(t *testing.T) {
+	folders := models.HitList{
+		{UID: "ops", Title: "Ops", Type: "dash-folder"},
+		{UID: "prod", Title: "Production", FolderUID: "ops", Type: "dash-folder"},
+	}
+	dashboards := models.HitList{
+		{UID: "d1", Title: "CPU Usage", FolderUID: "prod", FolderTitle: "Production", Type: "dash-db", URL: "/d/d1"},
+		{UID: "d2", Title: "Memory Overview", FolderUID: "ops", FolderTitle: "Ops", Type: "dash-db", URL: "/d/d2"},
+		{UID: "d3", Title: "Unrelated", Type: "dash-db", URL: "/d/d3"},
+	}
+
+	t.Run("empty query returns all dashboards", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{})
+		require.NoError(t, err)
+		assert.Equal(t, 3, result.Total)
+		assert.Len(t, result.Dashboards, 3)
+	})
+
+	t.Run("filters by title", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Query: "cpu"})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+
+	t.Run("filters by folderPath", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Query: "/ops/production"})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+
+	t.Run("folderPath is reconstructed and returned", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Query: "cpu"})
+		require.NoError(t, err)
+		require.Len(t, result.Dashboards, 1)
+		assert.Equal(t, "/Ops/Production", result.Dashboards[0].FolderPath)
+	})
+
+	t.Run("matching is case insensitive", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Query: "CPU USAGE"})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+	})
+
+	t.Run("no match returns empty list", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Query: "/nonexistent"})
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.Total)
+		assert.Empty(t, result.Dashboards)
+	})
+
+	t.Run("folderPath filter limits to exact folder", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{FolderPath: "/Ops/Production"})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+
+	t.Run("folderPath filter includes subfolders", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		// "Ops" should match d1 (Ops/Production) and d2 (Ops)
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{FolderPath: "/Ops"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Total)
+		uids := []string{result.Dashboards[0].UID, result.Dashboards[1].UID}
+		assert.ElementsMatch(t, []string{"d1", "d2"}, uids)
+	})
+
+	t.Run("folderPath filter is case insensitive", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{FolderPath: "/ops/production"})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+
+	t.Run("folderPath filter does not match partial folder name", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		// "Op" is a prefix of "Ops" but not a valid path segment boundary
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{FolderPath: "/Op"})
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.Total)
+	})
+
+	t.Run("tags filter restricts results", func(t *testing.T) {
+		taggedDashboards := models.HitList{
+			{UID: "d1", Title: "CPU Usage", FolderUID: "prod", FolderTitle: "Production", Type: "dash-db", Tags: []string{"infra", "prod"}},
+			{UID: "d2", Title: "Memory", FolderUID: "ops", FolderTitle: "Ops", Type: "dash-db", Tags: []string{"infra"}},
+			{UID: "d3", Title: "Requests", Type: "dash-db", Tags: []string{"app"}},
+		}
+		server := mockDeepSearchServer(t, folders, taggedDashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Tags: []string{"prod"}})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+
+	t.Run("tags filter is case insensitive", func(t *testing.T) {
+		taggedDashboards := models.HitList{
+			{UID: "d1", Title: "CPU Usage", Type: "dash-db", Tags: []string{"Infra"}},
+		}
+		server := mockDeepSearchServer(t, folders, taggedDashboards)
+		defer server.Close()
+
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Tags: []string{"infra"}})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+	})
+
+	t.Run("tags filter AND logic requires all tags", func(t *testing.T) {
+		taggedDashboards := models.HitList{
+			{UID: "d1", Title: "CPU Usage", Type: "dash-db", Tags: []string{"infra", "prod"}},
+			{UID: "d2", Title: "Memory", Type: "dash-db", Tags: []string{"infra"}},
+		}
+		server := mockDeepSearchServer(t, folders, taggedDashboards)
+		defer server.Close()
+
+		// Only d1 has both tags
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{Tags: []string{"infra", "prod"}})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+
+	t.Run("tags filter combined with folderPath and query (AND logic)", func(t *testing.T) {
+		taggedDashboards := models.HitList{
+			{UID: "d1", Title: "CPU Usage", FolderUID: "prod", Type: "dash-db", Tags: []string{"infra"}},
+			{UID: "d2", Title: "CPU Idle", FolderUID: "ops", Type: "dash-db", Tags: []string{"infra"}},
+			{UID: "d3", Title: "CPU Requests", FolderUID: "prod", Type: "dash-db", Tags: []string{"app"}},
+		}
+		server := mockDeepSearchServer(t, folders, taggedDashboards)
+		defer server.Close()
+
+		// Only d1 matches all three: query="cpu", folderPath="/Ops/Production", tags=["infra"]
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{
+			Query:      "cpu",
+			FolderPath: "/Ops/Production",
+			Tags:       []string{"infra"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+
+	t.Run("folderPath filter combined with query", func(t *testing.T) {
+		server := mockDeepSearchServer(t, folders, dashboards)
+		defer server.Close()
+
+		// Within "Ops", only d1 matches "cpu"
+		result, err := searchDashboardsDeep(mockSearchCtx(server), SearchDashboardsDeepParams{FolderPath: "/Ops", Query: "cpu"})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Total)
+		assert.Equal(t, "d1", result.Dashboards[0].UID)
+	})
+}


### PR DESCRIPTION
Adds a new MCP tool that retrieves all dashboards from the server. It resolves the full folder path (e.g. "Ops/Production/Services") for each dashboard and matches the query case-insensitively against all attributes including all tags and the folder path.

Optional AND-combined filters narrow results:
  - **query**: case-insensitive substring match against title, description,
    tags, folder title, and folder path
  - **folderPath**: restricts to a specific folder and all its subfolders,
    matched on path segment boundaries ("/Op" does not match "/Ops")
  - **tags**: all specified tags must be present on the dashboard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Read-only, but it paginates through the full folder and dashboard catalogs on every call, which may stress large Grafana instances or hit API limits.
> 
> **Overview**
> Adds a new read-only MCP tool **`search_dashboards_deep`** that loads **all** folders and dashboards (paginated at 500 per page), builds each dashboard’s **`folderPath`** from the folder tree, and filters in-process instead of relying on Grafana’s search API alone.
> 
> Results can be narrowed with an optional case-insensitive **`query`** (substring match on title, description, folder title, tags, and reconstructed path), optional **`folderPath`** (prefix match including subfolders, segment-aware), and optional **`tags`** (AND, case-insensitive). Each hit includes the usual dashboard metadata plus **`folderPath`**. The tool is registered alongside the existing search tools in **`AddSearchTools`**.
> 
> Unit tests cover path building, query matching, folder/tag filters, and combined filters via a mock search server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3d28a117ce79340ac4c306547f87ebfc158a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->