### PR TITLE
feat(es): honor datasource timeField for ES and OpenSearch

### DIFF
--- a/testdata/elasticsearch-seed.sh
+++ b/testdata/elasticsearch-seed.sh
@@ -83,4 +83,39 @@ echo "Indexed sample log data."
 # Refresh the index to make documents searchable immediately
 curl -sf -X POST "${ES_URL}/test-logs-2024/_refresh"
 echo ""
+echo "Indexed standard test logs."
+
+# Create index template and seed data using a custom time field (timestamp, not @timestamp)
+curl -sf -X PUT "${ES_URL}/_index_template/custom-time-logs-template" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "index_patterns": ["custom-time-logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    },
+    "mappings": {
+      "properties": {
+        "timestamp": { "type": "date" },
+        "message": { "type": "text" },
+        "level": { "type": "keyword" },
+        "service": { "type": "keyword" }
+      }
+    }
+  }
+}'
+echo ""
+echo "Created custom-time index template."
+
+curl -sf -X POST "${ES_URL}/custom-time-logs-2024/_bulk" \
+  -H 'Content-Type: application/x-ndjson' \
+  -d '{"index":{}}
+{"timestamp":'"${O1}"',"message":"Custom time field log entry","level":"info","service":"custom-service"}
+'
+echo ""
+echo "Indexed custom-time log data."
+
+curl -sf -X POST "${ES_URL}/custom-time-logs-2024/_refresh"
+echo ""
 echo "Elasticsearch seeding complete."

--- a/testdata/opensearch-seed.sh
+++ b/testdata/opensearch-seed.sh
@@ -83,4 +83,39 @@ echo "Indexed sample log data."
 # Refresh the index to make documents searchable immediately
 curl -sf -X POST "${OS_URL}/test-logs-2024/_refresh"
 echo ""
+echo "Indexed standard test logs."
+
+# Create index template and seed data using a custom time field (timestamp, not @timestamp)
+curl -sf -X PUT "${OS_URL}/_index_template/custom-time-logs-template" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "index_patterns": ["custom-time-logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    },
+    "mappings": {
+      "properties": {
+        "timestamp": { "type": "date" },
+        "message": { "type": "text" },
+        "level": { "type": "keyword" },
+        "service": { "type": "keyword" }
+      }
+    }
+  }
+}'
+echo ""
+echo "Created custom-time index template."
+
+curl -sf -X POST "${OS_URL}/custom-time-logs-2024/_bulk" \
+  -H 'Content-Type: application/x-ndjson' \
+  -d '{"index":{}}
+{"timestamp":'"${O1}"',"message":"Custom time field log entry","level":"info","service":"custom-service"}
+'
+echo ""
+echo "Indexed custom-time log data."
+
+curl -sf -X POST "${OS_URL}/custom-time-logs-2024/_refresh"
+echo ""
 echo "OpenSearch seeding complete."

--- a/testdata/provisioning/datasources/datasources.yaml
+++ b/testdata/provisioning/datasources/datasources.yaml
@@ -74,6 +74,15 @@ datasources:
       index: test-logs-*
       timeField: "@timestamp"
       esVersion: 8.17.0
+  - name: Elasticsearch Custom Time
+    uid: elasticsearch-custom-time
+    type: elasticsearch
+    access: proxy
+    url: http://elasticsearch:9200
+    jsonData:
+      index: custom-time-logs-*
+      timeField: timestamp
+      esVersion: 8.17.0
   - name: OpenSearch
     uid: opensearch
     type: grafana-opensearch-datasource
@@ -82,6 +91,17 @@ datasources:
     jsonData:
       database: test-logs-*
       timeField: "@timestamp"
+      flavor: opensearch
+      version: 3.6.0
+      pplEnabled: false
+  - name: OpenSearch Custom Time
+    uid: opensearch-custom-time
+    type: grafana-opensearch-datasource
+    access: proxy
+    url: http://opensearch:9200
+    jsonData:
+      database: custom-time-logs-*
+      timeField: timestamp
       flavor: opensearch
       version: 3.6.0
       pplEnabled: false

--- a/tools/elasticsearch_test.go
+++ b/tools/elasticsearch_test.go
@@ -212,6 +212,29 @@ func TestElasticsearchTools(t *testing.T) {
 			assert.NotEmpty(t, doc.Timestamp, "Documents with @timestamp should have Timestamp set")
 		}
 	})
+
+	t.Run("query elasticsearch with custom timeField", func(t *testing.T) {
+		ctx := newTestContext()
+		now := time.Now().UTC()
+		startTime := now.Add(-24 * time.Hour).Format(time.RFC3339)
+		endTime := now.Add(24 * time.Hour).Format(time.RFC3339)
+
+		result, err := queryElasticsearch(ctx, QueryElasticsearchParams{
+			DatasourceUID: "elasticsearch-custom-time",
+			Index:         "custom-time-logs-*",
+			Query:         "*",
+			StartTime:     startTime,
+			EndTime:       endTime,
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result, "Should return documents filtered by custom timestamp field")
+
+		for _, doc := range result {
+			assert.NotEmpty(t, doc.Timestamp, "Documents with timestamp field should have Timestamp set")
+			assert.Contains(t, doc.Source, "message")
+		}
+	})
 }
 
 func TestOpenSearchViaElasticsearchTools(t *testing.T) {
@@ -361,6 +384,29 @@ func TestOpenSearchViaElasticsearchTools(t *testing.T) {
 
 		for _, doc := range result {
 			assert.NotEmpty(t, doc.Timestamp, "Documents with @timestamp should have Timestamp set")
+		}
+	})
+
+	t.Run("query opensearch with custom timeField", func(t *testing.T) {
+		ctx := newTestContext()
+		now := time.Now().UTC()
+		startTime := now.Add(-24 * time.Hour).Format(time.RFC3339)
+		endTime := now.Add(24 * time.Hour).Format(time.RFC3339)
+
+		result, err := queryElasticsearch(ctx, QueryElasticsearchParams{
+			DatasourceUID: "opensearch-custom-time",
+			Index:         "custom-time-logs-*",
+			Query:         "*",
+			StartTime:     startTime,
+			EndTime:       endTime,
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result, "Should return documents filtered by custom timestamp field")
+
+		for _, doc := range result {
+			assert.NotEmpty(t, doc.Timestamp, "Documents with timestamp field should have Timestamp set")
+			assert.Contains(t, doc.Source, "message")
 		}
 	})
 }

--- a/tools/es_backend.go
+++ b/tools/es_backend.go
@@ -21,6 +21,9 @@ const (
 	// MaxSearchLimit is the maximum number of documents that can be requested
 	MaxSearchLimit = 100
 
+	// Default time field to use when not configured explicitly in a datasource
+	defaultTimeField = "@timestamp"
+
 	elasticsearchDatasourceType = "elasticsearch"
 	openSearchDatasourceType    = "grafana-opensearch-datasource"
 )
@@ -59,10 +62,26 @@ func esBackendForDatasource(ctx context.Context, uid string) (esBackend, error) 
 	}
 }
 
+// timeFieldFromDataSource reads the configured time field from datasource jsonData.
+func timeFieldFromDataSource(ds *models.DataSource) string {
+	if ds == nil {
+		return defaultTimeField
+	}
+	jsonData, ok := ds.JSONData.(map[string]interface{})
+	if !ok {
+		return defaultTimeField
+	}
+	if tf, ok := jsonData["timeField"].(string); ok && tf != "" {
+		return tf
+	}
+	return defaultTimeField
+}
+
 // elasticsearchBackend handles queries to an Elasticsearch datasource via Grafana proxy.
 type elasticsearchBackend struct {
 	httpClient *http.Client
 	baseURL    string
+	timeField  string
 }
 
 func newElasticsearchBackend(ctx context.Context, ds *models.DataSource) (*elasticsearchBackend, error) {
@@ -81,6 +100,7 @@ func newElasticsearchBackend(ctx context.Context, ds *models.DataSource) (*elast
 	return &elasticsearchBackend{
 		httpClient: client,
 		baseURL:    url,
+		timeField:  timeFieldFromDataSource(ds),
 	}, nil
 }
 
@@ -122,7 +142,7 @@ type msearchResponse struct {
 // Search performs a search query against Elasticsearch using the _msearch API.
 // Grafana's datasource proxy only allows POST requests to /_msearch for Elasticsearch.
 func (b *elasticsearchBackend) Search(ctx context.Context, index, query string, startTime, endTime *time.Time, limit int) ([]ElasticsearchDocument, error) {
-	searchQuery := buildElasticsearchQuery(query, startTime, endTime, limit)
+	searchQuery := buildElasticsearchQuery(query, startTime, endTime, limit, b.timeField)
 
 	// Build NDJSON payload for _msearch API
 	header := map[string]interface{}{
@@ -202,7 +222,7 @@ func (b *elasticsearchBackend) Search(ctx context.Context, index, query string, 
 		}
 		if source, ok := hit["_source"].(map[string]interface{}); ok {
 			doc.Source = source
-			switch ts := source["@timestamp"].(type) {
+			switch ts := source[b.timeField].(type) {
 			case string:
 				doc.Timestamp = ts
 			case float64:
@@ -222,12 +242,12 @@ func (b *elasticsearchBackend) Search(ctx context.Context, index, query string, 
 }
 
 // buildElasticsearchQuery constructs an Elasticsearch query DSL JSON object
-func buildElasticsearchQuery(query string, startTime, endTime *time.Time, size int) map[string]interface{} {
+func buildElasticsearchQuery(query string, startTime, endTime *time.Time, size int, timeField string) map[string]interface{} {
 	esQuery := map[string]interface{}{
 		"size": size,
 		"sort": []map[string]interface{}{
 			{
-				"@timestamp": map[string]string{
+				timeField: map[string]string{
 					"order": "desc",
 				},
 			},
@@ -241,13 +261,13 @@ func buildElasticsearchQuery(query string, startTime, endTime *time.Time, size i
 
 		if startTime != nil || endTime != nil {
 			rangeQuery := map[string]interface{}{
-				"@timestamp": map[string]interface{}{},
+				timeField: map[string]interface{}{},
 			}
 			if startTime != nil {
-				rangeQuery["@timestamp"].(map[string]interface{})["gte"] = startTime.Format(time.RFC3339)
+				rangeQuery[timeField].(map[string]interface{})["gte"] = startTime.Format(time.RFC3339)
 			}
 			if endTime != nil {
-				rangeQuery["@timestamp"].(map[string]interface{})["lte"] = endTime.Format(time.RFC3339)
+				rangeQuery[timeField].(map[string]interface{})["lte"] = endTime.Format(time.RFC3339)
 			}
 			mustClauses = append(mustClauses, map[string]interface{}{
 				"range": rangeQuery,

--- a/tools/es_backend_opensearch.go
+++ b/tools/es_backend_opensearch.go
@@ -23,6 +23,7 @@ type openSearchBackend struct {
 	baseURL         string
 	datasourceUID   string
 	configuredIndex string
+	timeField       string
 }
 
 func newOpenSearchBackend(ctx context.Context, ds *models.DataSource) (*openSearchBackend, error) {
@@ -53,6 +54,7 @@ func newOpenSearchBackend(ctx context.Context, ds *models.DataSource) (*openSear
 		baseURL:         baseURL,
 		datasourceUID:   ds.UID,
 		configuredIndex: configuredIndex,
+		timeField:       timeFieldFromDataSource(ds),
 	}, nil
 }
 
@@ -112,7 +114,7 @@ func (b *openSearchBackend) Search(ctx context.Context, index, query string, sta
 		"query":           luceneQuery,
 		"queryType":       "lucene",
 		"luceneQueryType": "RawDocument",
-		"timeField":       "@timestamp",
+		"timeField":       b.timeField,
 		"metrics": []map[string]interface{}{
 			{
 				"id":   "1",
@@ -139,7 +141,7 @@ func (b *openSearchBackend) Search(ctx context.Context, index, query string, sta
 		return nil, fmt.Errorf("opensearch query error: %s", queryResult.Error.Error())
 	}
 
-	return framesToDocuments(queryResult.Frames)
+	return framesToDocuments(queryResult.Frames, b.timeField)
 }
 
 // framesToDocuments converts the OpenSearch plugin's raw_document
@@ -147,8 +149,8 @@ func (b *openSearchBackend) Search(ctx context.Context, index, query string, sta
 //
 // The OpenSearch plugin returns a single frame with one column (named after the refId)
 // of type json.RawMessage. Each value in that column is a complete document object
-// containing _id, _index, _type, @timestamp (as array), and all source fields.
-func framesToDocuments(frames data.Frames) ([]ElasticsearchDocument, error) {
+// containing _id, _index, _type, the configured time field (as array), and all source fields.
+func framesToDocuments(frames data.Frames, timeField string) ([]ElasticsearchDocument, error) {
 	if len(frames) == 0 {
 		return []ElasticsearchDocument{}, nil
 	}
@@ -203,23 +205,24 @@ func framesToDocuments(frames data.Frames) ([]ElasticsearchDocument, error) {
 				if f, ok := val.(float64); ok {
 					doc.Score = &f
 				}
-			case "@timestamp":
-				// The plugin returns @timestamp as an array like ["2024-01-01T00:00:00Z"]
-				if arr, ok := val.([]interface{}); ok && len(arr) > 0 {
-					if ts, ok := arr[0].(string); ok {
+			default:
+				if key == timeField {
+					// The plugin returns timestamp field as an array like ["2024-01-01T00:00:00Z"]
+					if arr, ok := val.([]interface{}); ok && len(arr) > 0 {
+						if ts, ok := arr[0].(string); ok {
+							doc.Timestamp = ts
+							doc.Source[key] = ts
+						}
+					} else if ts, ok := val.(string); ok {
 						doc.Timestamp = ts
 						doc.Source[key] = ts
 					}
-				} else if ts, ok := val.(string); ok {
-					doc.Timestamp = ts
-					doc.Source[key] = ts
-				}
-			default:
-				// Skip unknown _-prefixed metadata fields
-				if strings.HasPrefix(key, "_") {
+				} else if strings.HasPrefix(key, "_") {
+					// Skip unknown `_` prefixed metadata fields
 					continue
+				} else {
+					doc.Source[key] = val
 				}
-				doc.Source[key] = val
 			}
 		}
 

--- a/tools/es_backend_test.go
+++ b/tools/es_backend_test.go
@@ -1,0 +1,114 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeFieldFromDataSource(t *testing.T) {
+	t.Run("configured custom field", func(t *testing.T) {
+		ds := &models.DataSource{
+			JSONData: map[string]interface{}{
+				"timeField": "timestamp",
+			},
+		}
+		assert.Equal(t, "timestamp", timeFieldFromDataSource(ds))
+	})
+
+	t.Run("empty timeField returns default", func(t *testing.T) {
+		ds := &models.DataSource{
+			JSONData: map[string]interface{}{
+				"timeField": "",
+			},
+		}
+		assert.Equal(t, defaultTimeField, timeFieldFromDataSource(ds))
+	})
+
+	t.Run("missing timeField returns default", func(t *testing.T) {
+		ds := &models.DataSource{
+			JSONData: map[string]interface{}{
+				"index": "logs-*",
+			},
+		}
+		assert.Equal(t, defaultTimeField, timeFieldFromDataSource(ds))
+	})
+
+	t.Run("nil JSONData returns default", func(t *testing.T) {
+		ds := &models.DataSource{}
+		assert.Equal(t, defaultTimeField, timeFieldFromDataSource(ds))
+	})
+
+	t.Run("nil datasource returns default", func(t *testing.T) {
+		assert.Equal(t, defaultTimeField, timeFieldFromDataSource(nil))
+	})
+}
+
+func TestBuildElasticsearchQueryTimeField(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	t.Run("custom field in sort and range", func(t *testing.T) {
+		query := buildElasticsearchQuery("*", &start, &end, 10, "timestamp")
+
+		sort, ok := query["sort"].([]map[string]interface{})
+		require.True(t, ok)
+		require.Len(t, sort, 1)
+		assert.Contains(t, sort[0], "timestamp")
+		assert.NotContains(t, sort[0], defaultTimeField)
+
+		queryClause, ok := query["query"].(map[string]interface{})
+		require.True(t, ok)
+		boolClause, ok := queryClause["bool"].(map[string]interface{})
+		require.True(t, ok)
+		must, ok := boolClause["must"].([]map[string]interface{})
+		require.True(t, ok)
+		require.NotEmpty(t, must)
+
+		rangeClause, ok := must[0]["range"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Contains(t, rangeClause, "timestamp")
+		tsRange, ok := rangeClause["timestamp"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, start.Format(time.RFC3339), tsRange["gte"])
+		assert.Equal(t, end.Format(time.RFC3339), tsRange["lte"])
+	})
+
+	t.Run("default field unchanged", func(t *testing.T) {
+		query := buildElasticsearchQuery("", &start, &end, 5, defaultTimeField)
+
+		sort, ok := query["sort"].([]map[string]interface{})
+		require.True(t, ok)
+		require.Len(t, sort, 1)
+		assert.Contains(t, sort[0], defaultTimeField)
+
+		queryBytes, err := json.Marshal(query)
+		require.NoError(t, err)
+		assert.Contains(t, string(queryBytes), `"@timestamp"`)
+	})
+}
+
+func TestFramesToDocumentsTimeField(t *testing.T) {
+	doc := json.RawMessage(`{
+		"_index": "logs-2024",
+		"_id": "1",
+		"timestamp": ["2024-06-15T12:00:00Z"],
+		"message": "hello"
+	}`)
+	frames := data.Frames{
+		data.NewFrame("A",
+			data.NewField("A", nil, []json.RawMessage{doc}),
+		),
+	}
+
+	docs, err := framesToDocuments(frames, "timestamp")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Equal(t, "2024-06-15T12:00:00Z", docs[0].Timestamp)
+	assert.Equal(t, "hello", docs[0].Source["message"])
+}


### PR DESCRIPTION
Existing implementation doesn't honor the `timeField` setting that can be configured at a ES/OS datasource and is hardcoded to use `@timestamp`  as the only possible timestamp field.

This PR has the changes to read the timeField from Grafana datasource configuration and use it for range filters, sort order, and document timestamp extraction. Defaults to `@timestamp` when unset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query behavior for any datasource with a non-default `timeField`; wrong config could break time filtering, though default `@timestamp` behavior is preserved.
> 
> **Overview**
> Elasticsearch and OpenSearch query tools no longer hardcode **`@timestamp`**. They read **`timeField`** from the Grafana datasource **`jsonData`** (falling back to **`@timestamp`** when missing or empty) and use it for time-range filters, sort order, and populating document **`Timestamp`**.
> 
> The Elasticsearch path threads the field through **`buildElasticsearchQuery`** and hit parsing; the OpenSearch path sends it in the **`/api/ds/query`** payload and **`framesToDocuments`** so custom fields like **`timestamp`** are handled the same way as **`@timestamp`**.
> 
> Test support adds **`custom-time-logs-*`** seed data, **Elasticsearch Custom Time** / **OpenSearch Custom Time** provisioned datasources, integration cases for those UIDs, and unit tests for **`timeFieldFromDataSource`**, query DSL shape, and frame conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb636f6e3f1c295b2716e0a100e6b2de6922e2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->