### PR TITLE
chore(ci): bump create-github-app-token action to v0.3.0

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@795f748a236f9de024b7514efc9a208456e7e468 # create-github-app-token/v0.3.0
         with:
           github_app: grafana-mcp-delivery-bot
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single dependency pin in CI with no application or auth logic changes in this repo.
> 
> **Overview**
> Updates the **auto-tag release** workflow to use **`create-github-app-token` v0.3.0** (new commit pin) instead of v0.3.0’s predecessor v0.2.3. The **`grafana-mcp-delivery-bot`** app and all other steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715e6fa0a87e94559ee03fc32c62f04cbdcaf2a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->