### PR TITLE
refactor(rendering): use shared transport chain with BaseTransport support

### DIFF
--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -109,18 +109,24 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 		return nil, fmt.Errorf("failed to build render URL: %w", err)
 	}
 
-	// Create HTTP client with TLS configuration if available
-	httpClient, err := createHTTPClient(config)
+	// Build the HTTP transport using the shared middleware chain (TLS, auth,
+	// extra headers, org ID, user-agent, otel). Using config.HTTPTransport()
+	// as the base ensures we respect BaseTransport when set (e.g. the hosted
+	// Cloud MCP server injects a pre-configured transport with custom
+	// instrumentation).
+	transport, err := mcpgrafana.BuildTransport(&config, config.HTTPTransport())
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		return nil, fmt.Errorf("failed to build HTTP transport: %w", err)
 	}
 
-	// Set timeout for rendering
 	timeout := 60 * time.Second
 	if args.Timeout != nil && *args.Timeout > 0 {
 		timeout = time.Duration(*args.Timeout) * time.Second
 	}
-	httpClient.Timeout = timeout
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   timeout,
+	}
 
 	// Create request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, renderURL, nil)
@@ -274,15 +280,6 @@ func buildRenderURL(baseURL string, args GetPanelImageParams) (string, error) {
 	params.Set("kiosk", "true")
 
 	return fmt.Sprintf("%s%s?%s", baseURL, renderPath, params.Encode()), nil
-}
-
-func createHTTPClient(config mcpgrafana.GrafanaConfig) (*http.Client, error) {
-	transport, err := mcpgrafana.BuildTransport(&config, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return &http.Client{Transport: transport}, nil
 }
 
 var GetPanelImage = mcpgrafana.MustTool(

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -792,4 +792,3 @@ func TestGetPanelImage(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
-

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -741,4 +741,55 @@ func TestGetPanelImage(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("BaseTransport is used when configured", func(t *testing.T) {
+		var baseTransportUsed bool
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(testPNGData)
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+			BaseTransport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				baseTransportUsed = true
+				return http.DefaultTransport.RoundTrip(req)
+			}),
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		_, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+		})
+
+		require.NoError(t, err)
+		assert.True(t, baseTransportUsed, "expected BaseTransport to be used as the innermost transport layer")
+	})
+
+	t.Run("User-Agent header is set", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Contains(t, r.Header.Get("User-Agent"), "mcp-grafana/")
+
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(testPNGData)
+		}))
+		defer server.Close()
+
+		grafanaCfg := mcpgrafana.GrafanaConfig{
+			URL:    server.URL,
+			APIKey: "test-api-key",
+		}
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+		_, err := getPanelImage(ctx, GetPanelImageParams{
+			DashboardUID: "test-dash",
+		})
+
+		require.NoError(t, err)
+	})
 }
+


### PR DESCRIPTION
## Summary

- Fix `createHTTPClient` to use `config.HTTPTransport()` as the base transport instead of `nil`, so `BaseTransport` is respected when set (e.g. the hosted Cloud MCP server injects a pre-configured transport with custom instrumentation)
- Remove the `createHTTPClient` helper and inline the transport creation — it was only used once and obscured what base transport was being used
- Add tests verifying `BaseTransport` propagation and `User-Agent` header presence

## Context

Prompted by review of #903. The rendering tool was already using `BuildTransport` for the full middleware chain (auth, org ID, extra headers, user-agent, otel), so this is **not** a large architectural change. The only bug was that `createHTTPClient` passed `nil` as the base transport to `BuildTransport`, which always fell back to `http.DefaultTransport` — even when `config.BaseTransport` was set. In the hosted Cloud MCP server, this meant render requests bypassed the custom base transport that other tools use.

This is orthogonal to #903 (per-call orgId override) and can be merged independently.

## Test plan

- [x] Existing rendering tests pass unchanged
- [x] New test: `BaseTransport is used when configured` — injects a custom `BaseTransport` and asserts it's called
- [x] New test: `User-Agent header is set` — asserts `mcp-grafana/` prefix in UA
- [x] `go vet -tags unit ./tools/` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)