### PR TITLE
fix(security): redact credentials in debug transport logs

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -614,7 +614,12 @@ func main() {
 		obs.NetworkTransport = mcpconv.NetworkTransportTCP
 	}
 
-	if err := run(transport, *addr, *basePath, *endpointPath, parseLevel(*logLevel), dt, grafanaConfig, tls, obs, *sessionIdleTimeoutMinutes); err != nil {
+	level := parseLevel(*logLevel)
+	if grafanaConfig.Debug && level > slog.LevelDebug {
+		level = slog.LevelDebug
+	}
+
+	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, obs, *sessionIdleTimeoutMinutes); err != nil {
 		panic(err)
 	}
 }

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -545,6 +546,56 @@ func NewAuthRoundTripper(rt http.RoundTripper, accessToken, idToken, apiKey stri
 	}
 }
 
+// sensitiveHeaders lists HTTP header names whose values must be redacted in
+// debug logs to prevent credential leakage (see #919).
+var sensitiveHeaders = map[string]bool{
+	"Authorization":  true,
+	"X-Access-Token": true,
+	"X-Grafana-Id":   true,
+	"Cookie":         true,
+}
+
+// redactHeaderValue masks the middle portion of a credential value,
+// preserving the first 4 and last 4 characters for identification.
+// Values shorter than 12 characters are fully replaced.
+func redactHeaderValue(v string) string {
+	if len(v) < 12 {
+		return "[REDACTED]"
+	}
+	return v[:4] + "***" + v[len(v)-4:]
+}
+
+// debugLoggingRoundTripper logs HTTP requests and responses with sensitive
+// headers redacted. It replaces the go-openapi Debug flag, which uses
+// httputil.DumpRequestOut and exposes credentials in plaintext.
+type debugLoggingRoundTripper struct {
+	underlying http.RoundTripper
+	logger     *slog.Logger
+}
+
+func (rt *debugLoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	redacted := req.Clone(req.Context())
+	redacted.Body = nil
+	for name := range sensitiveHeaders {
+		if v := redacted.Header.Get(name); v != "" {
+			redacted.Header.Set(name, redactHeaderValue(v))
+		}
+	}
+	if dump, err := httputil.DumpRequestOut(redacted, false); err == nil {
+		rt.logger.Debug(string(dump))
+	}
+
+	resp, err := rt.underlying.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if dump, dumpErr := httputil.DumpResponse(resp, false); dumpErr == nil {
+		rt.logger.Debug(string(dump))
+	}
+	return resp, nil
+}
+
 // transportOptions controls which middleware layers BuildTransport includes.
 type transportOptions struct {
 	withoutAuth      bool
@@ -580,10 +631,15 @@ func WithoutUserAgent() TransportOption {
 // BuildTransport constructs an http.RoundTripper with the standard middleware
 // chain derived from cfg. The default chain (innermost to outermost) is:
 //
-//	base → TLS → Auth → ExtraHeaders → OrgID → UserAgent → otelhttp
+//	base → TLS → debugLogging → Auth → ExtraHeaders → OrgID → UserAgent → otelhttp
 //
 // Auth is innermost among the header-setting layers so that credentials take
 // precedence over any forwarded/extra headers with the same keys.
+//
+// When cfg.Debug is true a debug-logging layer is added just above the base
+// transport. It sees the fully-decorated request (all headers set by outer
+// layers) and redacts sensitive values (Authorization, X-Access-Token, etc.)
+// before writing request/response details to the logger.
 //
 // Individual layers can be disabled with WithoutAuth, WithoutOrgID, etc.
 func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...TransportOption) (http.RoundTripper, error) {
@@ -607,6 +663,15 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 		transport, err = cfg.TLSConfig.HTTPTransport(t)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create TLS transport: %w", err)
+		}
+	}
+
+	// Debug logging with redacted credentials (innermost among the
+	// non-TLS layers so it sees the final request with all headers).
+	if cfg.Debug {
+		transport = &debugLoggingRoundTripper{
+			underlying: transport,
+			logger:     cfg.LoggerOrDefault(),
 		}
 	}
 
@@ -907,7 +972,10 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
-	cfg.Debug = config.Debug
+	// NOTE: we intentionally do NOT set cfg.Debug here. The go-openapi
+	// runtime's Debug mode uses httputil.DumpRequestOut which prints
+	// credentials in plaintext. Instead, BuildTransport adds a redacting
+	// debug-logging layer when config.Debug is true (see #919).
 
 	if config.OrgID > 0 {
 		cfg.OrgID = config.OrgID
@@ -986,6 +1054,8 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 						OrgID:        config.OrgID,
 						TLSConfig:    config.TLSConfig,
 						ExtraHeaders: config.ExtraHeaders,
+						Debug:        config.Debug,
+						Logger:       config.Logger,
 					}
 					// Panic matches the existing TLS error handling above
 					// (line ~887). The only realistic failure is a TLS

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -1,6 +1,7 @@
 package mcpgrafana
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"net/http"
@@ -1088,6 +1089,110 @@ func TestBuildTransport(t *testing.T) {
 		assert.Empty(t, capturedReq.Header.Get("Authorization"))
 		assert.Empty(t, capturedReq.Header.Get("X-Grafana-Org-Id"))
 	})
+}
+
+func TestRedactHeaderValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"short", "[REDACTED]"},
+		{"exactly11ch", "[REDACTED]"},
+		{"exactly12char", "exac***char"},
+		{"glsa_1234567890abcdef", "glsa***cdef"},
+		{"Bearer glsa_abcdefghij", "Bear***ghij"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, redactHeaderValue(tt.input))
+		})
+	}
+}
+
+func TestDebugLoggingRedactsSensitiveHeaders(t *testing.T) {
+	var capturedReq *http.Request
+	mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+		capturedReq = req
+		return &http.Response{StatusCode: 200, Header: http.Header{}}, nil
+	}}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	cfg := &GrafanaConfig{
+		APIKey: "glsa_supersecrettoken1234",
+		Debug:  true,
+		Logger: logger,
+	}
+	transport, err := BuildTransport(cfg, mock, WithoutOtel())
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/search", nil)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	// The actual request to the server must still carry the real token.
+	assert.Equal(t, "Bearer glsa_supersecrettoken1234", capturedReq.Header.Get("Authorization"))
+
+	// The debug log output must NOT contain the full token.
+	logOutput := buf.String()
+	assert.NotContains(t, logOutput, "glsa_supersecrettoken1234")
+	// But it should contain the redacted version.
+	assert.Contains(t, logOutput, "Bear***1234")
+}
+
+func TestDebugLoggingRedactsOBOTokens(t *testing.T) {
+	var capturedReq *http.Request
+	mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+		capturedReq = req
+		return &http.Response{StatusCode: 200, Header: http.Header{}}, nil
+	}}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	cfg := &GrafanaConfig{
+		AccessToken: "access_secret_token_val",
+		IDToken:     "id_secret_token_value",
+		Debug:       true,
+		Logger:      logger,
+	}
+	transport, err := BuildTransport(cfg, mock, WithoutOtel())
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/search", nil)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	// Real tokens must reach the server.
+	assert.Equal(t, "access_secret_token_val", capturedReq.Header.Get("X-Access-Token"))
+	assert.Equal(t, "id_secret_token_value", capturedReq.Header.Get("X-Grafana-Id"))
+
+	logOutput := buf.String()
+	assert.NotContains(t, logOutput, "access_secret_token_val")
+	assert.NotContains(t, logOutput, "id_secret_token_value")
+}
+
+func TestDebugLoggingDisabledByDefault(t *testing.T) {
+	mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: http.Header{}}, nil
+	}}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	cfg := &GrafanaConfig{
+		APIKey: "glsa_supersecrettoken1234",
+		Logger: logger,
+	}
+	transport, err := BuildTransport(cfg, mock, WithoutOtel())
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/search", nil)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Empty(t, buf.String())
 }
 
 func TestExtractGrafanaInfoWithExtraHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #919 — debug logging (`-debug` flag) exposed Grafana SA tokens in plaintext via the go-openapi runtime's `httputil.DumpRequestOut`.

- **Removed** the `cfg.Debug = config.Debug` pass-through to the go-openapi runtime, which dumps full HTTP requests including `Authorization: Bearer <token>` headers
- **Added** a `debugLoggingRoundTripper` in the transport chain that redacts sensitive headers (`Authorization`, `X-Access-Token`, `X-Grafana-Id`, `Cookie`) before logging
- Tokens longer than 12 characters show first 4 and last 4 characters (e.g. `Bear***1234`); shorter values show `[REDACTED]`
- Real credentials are still passed to the server — only log output is redacted

## Test plan

- [x] `TestRedactHeaderValue` — verifies masking logic for various token lengths
- [x] `TestDebugLoggingRedactsSensitiveHeaders` — verifies API key auth is redacted in logs but real token reaches server
- [x] `TestDebugLoggingRedactsOBOTokens` — verifies OBO access/ID tokens are redacted
- [x] `TestDebugLoggingDisabledByDefault` — verifies no debug output when `Debug` is false
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet` and `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix for credential leakage in logs; behavior change for operators using `-debug` (redacted output, no OpenAPI runtime dumps). Real auth headers unchanged on the wire.
> 
> **Overview**
> Fixes **#919** by stopping go-openapi’s debug mode from dumping full HTTP requests (including `Authorization` and other secrets) and replacing it with transport-level debug logging that **redacts** sensitive headers before they hit logs.
> 
> **Grafana transport:** A new `debugLoggingRoundTripper` in `BuildTransport` logs request/response dumps via `httputil` after masking `Authorization`, `X-Access-Token`, `X-Grafana-Id`, and `Cookie` (short values → `[REDACTED]`; longer values keep first/last four characters). Outbound requests still send real credentials. `NewGrafanaClient` no longer sets the OpenAPI client’s `Debug` flag; OBO transport wrapping now passes `Debug` and `Logger` into `BuildTransport`.
> 
> **CLI:** When `-debug` is on, log level is bumped to at least **debug** so redacted transport logs are visible.
> 
> Tests cover redaction helpers, API key/OBO cases, and no logging when debug is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a296ce198a9f05bacfd27d7527ea7fee40e944e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->