### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-06-03
+
 ### Added
 
-- `get_panel_image` now accepts an optional `provisioningPreview` parameter (`repo`, `path`, `ref`) for rendering dashboards staged on a provisioning repository branch (e.g. a git-sync PR preview) before they're merged or applied. Mutually exclusive with `dashboardUid`.
-- New `provisioning` tool category with `list_provisioning_repositories` — returns each repository's slug, source URL/branch/path, sync state, and health, so agents can discover the `repo` value to pass to `get_panel_image`'s `provisioningPreview`.
-- `validate_provisioning_file` dry-run-applies a file from a provisioning repository at a given branch/commit and returns whether it would be accepted, the resource action (create/update), the target resource type, and any structured validation errors — the same admission surface Grafana's PR commenter reports.
-- `generate_deeplink` now accepts a `provisioningPreview` parameter (`repo`, `path`, optional `ref` and `pullRequestUrl`) for the `dashboard` and `panel` resource types, returning a link to a dashboard staged on a provisioning repository branch (e.g. a git-sync PR preview). Mutually exclusive with `dashboardUid`.
+- `shorten_url` tool for creating Grafana short links from long dashboard or explore URLs ([#899](https://github.com/grafana/mcp-grafana/pull/899))
+- Provisioning workflow tools: `list_provisioning_repositories` for discovering connected repositories, `validate_provisioning_file` for dry-run validation of provisioning files, and provisioning preview support in `get_panel_image` and `generate_deeplink` for rendering dashboards from PR branches before merge ([#900](https://github.com/grafana/mcp-grafana/pull/900))
+
+### Changed
+
+- Rendering tools now use a shared transport chain with `BaseTransport` support for consistent HTTP middleware ([#918](https://github.com/grafana/mcp-grafana/pull/918))
+
+### Security
+
+- Redact credentials from debug transport logs to prevent accidental exposure ([#920](https://github.com/grafana/mcp-grafana/pull/920))
+- Update Go to 1.26.3 to fix CVE-2026-33810 and bump litellm dependency ([#916](https://github.com/grafana/mcp-grafana/pull/916))
 
 ## [0.15.0] - 2026-06-01
 
@@ -255,6 +264,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.15.1]: https://github.com/grafana/mcp-grafana/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/grafana/mcp-grafana/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/grafana/mcp-grafana/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/grafana/mcp-grafana/compare/v0.13.0...v0.13.1


### PR DESCRIPTION
## Summary

- Bump version to v0.15.1
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.15.1` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release notes with no runtime or code changes in this diff.
> 
> **Overview**
> Prepares **v0.15.1** (2026-06-03) in `CHANGELOG.md` by moving release notes out of `[Unreleased]` and adding the compare link `v0.15.0...v0.15.1`.
> 
> The new section documents shipped work: **`shorten_url`**, provisioning tools and preview support in **`get_panel_image`** / **`generate_deeplink`**, shared rendering transport via **`BaseTransport`**, credential redaction in debug logs, and Go **1.26.3** / litellm bumps for **CVE-2026-33810**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5592933c5e4a9215eb5b41373ee786c305b85268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->