### PR TITLE
ci(docker): publish via GAR with Docker Hub mirror

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,13 +64,14 @@ jobs:
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-      - name: Build and Push to Docker Hub
+      - name: Build and Push to GAR (mirrored to Docker Hub)
         uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         with:
           context: .
           file: ./Dockerfile
-          dockerhub-repository: grafana/mcp-grafana
-          registries: dockerhub
+          registries: gar
+          gar-environment: prod
+          gar-repository: dockerhub-mcp-grafana-prod-mirror
           platforms: ${{ needs.prepare.outputs.platforms }}
           tags: |
             ${{ needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.is_stable == 'true' && 'latest' || '' }}
@@ -85,13 +86,14 @@ jobs:
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-      - name: Build and Push Alpine to Docker Hub
+      - name: Build and Push Alpine to GAR (mirrored to Docker Hub)
         uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         with:
           context: .
           file: ./Dockerfile.alpine
-          dockerhub-repository: grafana/mcp-grafana
-          registries: dockerhub
+          registries: gar
+          gar-environment: prod
+          gar-repository: dockerhub-mcp-grafana-prod-mirror
           platforms: ${{ needs.prepare.outputs.platforms }}
           tags: |
             ${{ needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.is_stable == 'true' && 'alpine' || '' }}


### PR DESCRIPTION
The shared Docker Hub PAT was rotated to read-only, breaking v0.15.0 / v0.15.1 with `401 access token has insufficient scopes`. Platform team has confirmed  [`gar-image-mirror`](https://github.com/grafana/deployment_tools/blob/master/docs/platform/gar-image-mirror.md) is the supported path. 

Pushes now go to `us-docker.pkg.dev/grafanalabs-global/dockerhub-mcp-grafana-prod-mirror`; the mirror service copies to `docker.io/grafana/mcp-grafana`. User-facing pull URL, tag scheme, `server.json`, and `mcp-registry` job are unchanged.

Closes #923.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release publish path for production container images; a misconfigured GAR repo or mirror would block new tags from reaching Docker Hub until fixed.
> 
> **Overview**
> Release image builds no longer push directly to Docker Hub. Both the default and Alpine **`docker-build-push-image`** steps now use **`registries: gar`** with **`gar-environment: prod`** and **`gar-repository: dockerhub-mcp-grafana-prod-mirror`**, replacing **`registries: dockerhub`** and **`dockerhub-repository: grafana/mcp-grafana`**. Step titles were updated to note that GAR is the push target and Docker Hub is filled via the platform mirror.
> 
> Tag rules, **`push`** gating on tag releases, and the downstream **`mcp-registry`** job are unchanged in this diff; consumers still pull **`docker.io/grafana/mcp-grafana`** after the mirror syncs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3064f5d123f2b226f145a4214af74ebe77e14260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->