### PR TITLE
Release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-06-04
+
+### Fixed
+
+- Docker images are again published to `docker.io/grafana/mcp-grafana`. v0.15.0 and v0.15.1 Docker images were never published because the shared Docker Hub credential was restricted to read-only. The release workflow now publishes via Grafana's GAR-based Docker Hub mirror pipeline ([#925](https://github.com/grafana/mcp-grafana/pull/925))
+
 ## [0.15.1] - 2026-06-03
 
 ### Added
@@ -264,6 +270,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.15.2]: https://github.com/grafana/mcp-grafana/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/grafana/mcp-grafana/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/grafana/mcp-grafana/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/grafana/mcp-grafana/compare/v0.13.1...v0.14.0


### PR DESCRIPTION
## Summary

- Bump version to v0.15.2
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.15.2` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visible changes are release documentation only; operational impact depends on the tag-triggered release workflow, not application code in this diff.
> 
> **Overview**
> Documents **v0.15.2** (2026-06-04) in `CHANGELOG.md` and adds the compare link for `v0.15.1...v0.15.2`.
> 
> The release note under **Fixed** explains that Docker images for `docker.io/grafana/mcp-grafana` are publishing again after v0.15.0/v0.15.1 missed Hub pushes due to a read-only credential; publishing now goes through Grafana’s GAR-based Docker Hub mirror pipeline ([#925](https://github.com/grafana/mcp-grafana/pull/925)).
> 
> Merging is intended to cut the `v0.15.2` tag and trigger goreleaser plus Docker builds as described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94db7b29e6a5e8cf1601070e90191971dc38874c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->