### PR TITLE
feat(prometheus): support optional time range for list_prometheus_metric_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window
+
 ## [0.15.2] - 2026-06-04
 
 ### Fixed

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -180,6 +180,8 @@ type ListPrometheusMetricNamesParams struct {
 	Regex         string `json:"regex" jsonschema:"description=The regex to match against the metric names"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"default=10,description=The maximum number of results to return"`
 	Page          int    `json:"page,omitempty" jsonschema:"default=1,description=The page number to return"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the time range to filter the results by"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the time range to filter the results by"`
 	ProjectName   string `json:"projectName,omitempty" jsonschema:"description=GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource."`
 }
 
@@ -199,8 +201,20 @@ func listPrometheusMetricNames(ctx context.Context, args ListPrometheusMetricNam
 		page = 1
 	}
 
+	var startTime, endTime time.Time
+	if args.StartRFC3339 != "" {
+		if startTime, err = time.Parse(time.RFC3339, args.StartRFC3339); err != nil {
+			return nil, fmt.Errorf("parsing start time: %w", err)
+		}
+	}
+	if args.EndRFC3339 != "" {
+		if endTime, err = time.Parse(time.RFC3339, args.EndRFC3339); err != nil {
+			return nil, fmt.Errorf("parsing end time: %w", err)
+		}
+	}
+
 	// Get all metric names via the backend
-	allNames, err := backend.LabelValues(ctx, "__name__", nil, time.Time{}, time.Time{})
+	allNames, err := backend.LabelValues(ctx, "__name__", nil, startTime, endTime)
 	if err != nil {
 		return nil, fmt.Errorf("listing Prometheus metric names: %w", err)
 	}
@@ -237,7 +251,7 @@ func listPrometheusMetricNames(ctx context.Context, args ListPrometheusMetricNam
 
 var ListPrometheusMetricNames = mcpgrafana.MustTool(
 	"list_prometheus_metric_names",
-	"DISCOVERY: Call this first to find available metrics before querying. Lists metric names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Retrieves all metric names and filters them using the provided regex. Supports pagination.",
+	"DISCOVERY: Call this first to find available metrics before querying. Lists metric names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Retrieves all metric names and filters them using the provided regex. Supports pagination and an optional time range to restrict results to metrics active within that window.",
 	listPrometheusMetricNames,
 	mcp.WithTitleAnnotation("List Prometheus metric names"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/prometheus_test.go
+++ b/tools/prometheus_test.go
@@ -37,6 +37,19 @@ func TestPrometheusTools(t *testing.T) {
 		assert.Len(t, result, 10)
 	})
 
+	t.Run("list prometheus metric names with time range", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listPrometheusMetricNames(ctx, ListPrometheusMetricNamesParams{
+			DatasourceUID: "prometheus",
+			Regex:         ".*",
+			Limit:         10,
+			StartRFC3339:  time.Now().Add(-time.Hour).Format(time.RFC3339),
+			EndRFC3339:    time.Now().Format(time.RFC3339),
+		})
+		require.NoError(t, err)
+		assert.Len(t, result, 10)
+	})
+
 	t.Run("list prometheus label names", func(t *testing.T) {
 		ctx := newTestContext()
 		result, err := listPrometheusLabelNames(ctx, ListPrometheusLabelNamesParams{


### PR DESCRIPTION
Add optional startRfc3339/endRfc3339 parameters to list_prometheus_metric_names, mirroring the existing label name/value tools. Previously the __name__ label values were always fetched with unbounded times; the new params let callers restrict results to metrics active within a window. Empty values preserve the prior unbounded behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only MCP tool extension with backward-compatible defaults; only changes how optional time bounds are forwarded to Prometheus label value APIs.
> 
> **Overview**
> **`list_prometheus_metric_names`** now accepts optional **`startRfc3339`** and **`endRfc3339`**, aligned with the existing label name/value discovery tools.
> 
> When set, those bounds are parsed as RFC3339 and passed into **`LabelValues`** for **`__name__`**, so callers can limit discovery to metrics that had series in that window instead of always using an unbounded range. Omitting either parameter keeps the previous zero-time (unbounded) behavior. The tool description and changelog are updated accordingly, and an integration test covers listing with a one-hour window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c195b50df5d9661468b685a5a99c58bfaf8df12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->