### PR TITLE
feat(run_panel_query): add BigQuery datasource support

### DIFF
--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -24,7 +24,7 @@ type RunPanelQueryParams struct {
 	End            string            `json:"end" jsonschema:"description=Override end time (e.g. 'now'\\, RFC3339\\, Unix ms)"`
 	Variables      map[string]string `json:"variables" jsonschema:"description=Override dashboard variables (e.g. {\"job\": \"api-server\"})"`
 	DatasourceUID  string            `json:"datasourceUid,omitempty" jsonschema:"description=Override datasource UID"`
-	DatasourceType string            `json:"datasourceType,omitempty" jsonschema:"description=Override datasource type (prometheus\\, loki\\, grafana-clickhouse-datasource\\, cloudwatch\\, influxdb)"`
+	DatasourceType string            `json:"datasourceType,omitempty" jsonschema:"description=Override datasource type (prometheus\\, loki\\, grafana-clickhouse-datasource\\, cloudwatch\\, influxdb\\, grafana-bigquery-datasource)"`
 }
 
 // QueryTimeRange represents the actual time range used for a panel query
@@ -222,6 +222,8 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 		results, err = executeCloudWatchPanelQuery(ctx, datasourceUID, panelData, params.Start, params.End, vars)
 	case "influxdb":
 		results, err = executeInfluxDBQuery(ctx, datasourceUID, panelData, query, params.Start, params.End)
+	case "bigquery":
+		results, err = executeBigQueryPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars)
 	default:
 		return nil, fmt.Errorf("datasource type '%s' is not supported by run_panel_query; use the native query tool (e.g. query_prometheus\\, query_loki_logs\\, query_clickhouse\\, query_cloudwatch\\, query_influxdb) directly", datasourceType)
 	}
@@ -535,6 +537,80 @@ func executeInfluxDBQuery(ctx context.Context, datasourceUID string, panelData *
 	})
 }
 
+// BigQueryDatasourceType is the type identifier for BigQuery datasources.
+const BigQueryDatasourceType = "grafana-bigquery-datasource"
+
+// BigQueryFormatTable is the format value for table/tabular query results.
+const BigQueryFormatTable = 1
+
+// BigQueryQueryResult represents the tabular result of a BigQuery panel query.
+type BigQueryQueryResult struct {
+	Columns        []string                 `json:"columns"`
+	Rows           []map[string]interface{} `json:"rows"`
+	RowCount       int                      `json:"rowCount"`
+	ProcessedQuery string                   `json:"processedQuery,omitempty"`
+}
+
+// executeBigQueryPanelQuery runs a BigQuery panel query via Grafana's /api/ds/query
+// endpoint. BigQuery is a SQL datasource (sqlds-based) whose backend plugin resolves
+// SQL macros such as $__timeFilter/$__timeFrom/$__timeGroup server-side, so we only
+// substitute the frontend-only macros ($__interval, $__range, etc.) here. The panel's
+// raw target is preserved so BigQuery-specific fields (location, project, dataset) reach
+// the backend; only rawSql, datasource, refId, and format are overridden.
+func executeBigQueryPanelQuery(ctx context.Context, datasourceUID string, panelData *panelInfo, query, start, end string, variables map[string]string) (*BigQueryQueryResult, error) {
+	if panelData == nil || panelData.RawTarget == nil {
+		return nil, fmt.Errorf("BigQuery panel target not available")
+	}
+
+	// Parse time range
+	startTime, err := parseTime(start)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
+	}
+	endTime, err := parseTime(end)
+	if err != nil {
+		return nil, fmt.Errorf("parsing end time: %w", err)
+	}
+
+	// Substitute Grafana frontend macros; leave SQL macros for the backend plugin.
+	processedQuery := substituteGrafanaMacros(query, startTime, endTime)
+
+	// Deep copy the raw target and substitute variables in its fields (e.g. location).
+	target := substituteTemplateVariablesInMap(panelData.RawTarget, variables)
+
+	// Override the SQL with the fully-processed query and ensure required fields are set.
+	target["rawSql"] = processedQuery
+	target["datasource"] = map[string]interface{}{"uid": datasourceUID, "type": BigQueryDatasourceType}
+	if safeString(target, "refId") == "" {
+		target["refId"] = "A"
+	}
+	if _, ok := target["format"]; !ok {
+		target["format"] = BigQueryFormatTable
+	}
+
+	client, baseURL, err := newDSQueryHTTPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := doDSQuery(ctx, client, baseURL, dsQueryPayload(startTime, endTime, target))
+	if err != nil {
+		return nil, err
+	}
+
+	columns, rows, err := framesToTabularRows(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BigQueryQueryResult{
+		Columns:        columns,
+		Rows:           rows,
+		RowCount:       len(rows),
+		ProcessedQuery: processedQuery,
+	}, nil
+}
+
 // executeGrafanaDSQuery executes a query through Grafana's /api/ds/query endpoint.
 func executeGrafanaDSQuery(ctx context.Context, payload map[string]interface{}) (interface{}, error) {
 	client, baseURL, err := newDSQueryHTTPClient(ctx)
@@ -662,6 +738,8 @@ func normalizeDatasourceType(dsType string) string {
 		return "influxdb"
 	case strings.Contains(lower, "clickhouse"):
 		return "clickhouse"
+	case strings.Contains(lower, "bigquery"):
+		return "bigquery"
 	default:
 		return lower
 	}
@@ -680,6 +758,8 @@ func isEmptyPanelResult(results interface{}) bool {
 	case *ClickHouseQueryResult:
 		return v == nil || len(v.Rows) == 0
 	case *InfluxDBQueryResult:
+		return v == nil || len(v.Rows) == 0
+	case *BigQueryQueryResult:
 		return v == nil || len(v.Rows) == 0
 	case model.Value:
 		switch m := v.(type) {
@@ -731,6 +811,13 @@ func generatePanelQueryHints(datasourceType, query string) []string {
 			"- Tag filters may be too restrictive - remove them to see if the measurement has any points",
 			"- InfluxDB retention policy may have expired the data - check the bucket's retention settings",
 		)
+	case "bigquery":
+		hints = append(hints,
+			"- Table or dataset may be empty for this time range - try a COUNT(*) without the time filter to verify",
+			"- Column names or WHERE clause may not match the schema - check the table definition in BigQuery",
+			"- The $__timeFilter(column) macro may reference a column whose type or timezone doesn't match the time range",
+			"- The datasource's processing location may not match the dataset's region",
+		)
 	}
 
 	if query != "" {
@@ -751,7 +838,7 @@ func truncateString(s string, maxLen int) string {
 // RunPanelQuery is the tool definition for running panel queries
 var RunPanelQuery = mcpgrafana.MustTool(
 	"run_panel_query",
-	"Executes one or more dashboard panel queries with optional time range and variable overrides. Accepts an array of panel IDs to query in a single call. Fetches the dashboard\\, extracts queries from the specified panels\\, substitutes template variables and Grafana macros ($__range\\, $__rate_interval\\, $__interval)\\, and routes to the appropriate datasource (Prometheus\\, Loki\\, ClickHouse\\, CloudWatch\\, or InfluxDB). Returns results keyed by panel ID - partial failures are allowed (some panels can succeed while others fail). Use get_dashboard_summary first to find panel IDs. If a panel uses a template variable datasource you cannot access\\, provide datasourceUid and datasourceType to override.",
+	"Executes one or more dashboard panel queries with optional time range and variable overrides. Accepts an array of panel IDs to query in a single call. Fetches the dashboard\\, extracts queries from the specified panels\\, substitutes template variables and Grafana macros ($__range\\, $__rate_interval\\, $__interval)\\, and routes to the appropriate datasource (Prometheus\\, Loki\\, ClickHouse\\, CloudWatch\\, InfluxDB\\, or BigQuery). Returns results keyed by panel ID - partial failures are allowed (some panels can succeed while others fail). Use get_dashboard_summary first to find panel IDs. If a panel uses a template variable datasource you cannot access\\, provide datasourceUid and datasourceType to override.",
 	runPanelQuery,
 	mcp.WithTitleAnnotation("Run panel query"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/run_panel_query_test.go
+++ b/tools/run_panel_query_test.go
@@ -830,6 +830,23 @@ func TestIsEmptyPanelResult(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name:     "nil BigQueryQueryResult",
+			results:  (*BigQueryQueryResult)(nil),
+			expected: true,
+		},
+		{
+			name:     "empty BigQueryQueryResult",
+			results:  &BigQueryQueryResult{Rows: []map[string]interface{}{}},
+			expected: true,
+		},
+		{
+			name: "non-empty BigQueryQueryResult",
+			results: &BigQueryQueryResult{
+				Rows: []map[string]interface{}{{"count": 42}},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -897,6 +914,17 @@ func TestGeneratePanelQueryHints(t *testing.T) {
 				"No data found",
 				"Bucket",
 				"Measurement",
+			},
+		},
+		{
+			name:           "bigquery hints",
+			datasourceType: "grafana-bigquery-datasource",
+			query:          "SELECT COUNT(*) FROM `proj.ds.tbl` WHERE $__timeFilter(ts)",
+			containsHints: []string{
+				"No data found",
+				"Time range",
+				"COUNT(*)",
+				"processing location",
 			},
 		},
 	}
@@ -973,6 +1001,9 @@ func TestNormalizeDatasourceType(t *testing.T) {
 		{"ClickHouse", "clickhouse"},
 		{"influxdb", "influxdb"},
 		{"InfluxDB", "influxdb"},
+		{"grafana-bigquery-datasource", "bigquery"},
+		{"bigquery", "bigquery"},
+		{"BigQuery", "bigquery"},
 		{"some-other-type", "some-other-type"},
 		{"", ""},
 	}
@@ -1087,6 +1118,41 @@ func TestExtractPanelInfo_CloudWatch(t *testing.T) {
 			assert.NotEmpty(t, info.RawTarget["namespace"], "RawTarget should contain CloudWatch fields")
 		})
 	}
+}
+
+func TestExtractPanelInfo_BigQuery(t *testing.T) {
+	panel := map[string]interface{}{
+		"id":    1,
+		"title": "BigQuery Failed Tests",
+		"datasource": map[string]interface{}{
+			"uid":  "bigquery-uid",
+			"type": "grafana-bigquery-datasource",
+		},
+		"targets": []interface{}{
+			map[string]interface{}{
+				"refId":    "A",
+				"rawSql":   "SELECT count(*) FROM `proj.ds.tbl` WHERE $__timeFilter(ts)",
+				"location": "US",
+				"format":   float64(1),
+			},
+		},
+	}
+
+	info, err := extractPanelInfo(panel, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "bigquery-uid", info.DatasourceUID)
+	assert.Equal(t, "grafana-bigquery-datasource", info.DatasourceType)
+	// BigQuery uses rawSql, which extractQueryExpression should pick up.
+	assert.Equal(t, "SELECT count(*) FROM `proj.ds.tbl` WHERE $__timeFilter(ts)", info.Query)
+	// The raw target is preserved so BigQuery-specific fields (e.g. location) survive.
+	assert.Equal(t, "US", info.RawTarget["location"])
+}
+
+func TestExecuteBigQueryPanelQuery_NilTarget(t *testing.T) {
+	// A missing raw target should produce a clear error rather than panicking.
+	_, err := executeBigQueryPanelQuery(t.Context(), "bigquery-uid", &panelInfo{}, "SELECT 1", "now-1h", "now", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BigQuery panel target not available")
 }
 
 func TestSubstituteTemplateVariablesInMap(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds support for BigQuery datasources (`grafana-bigquery-datasource`) to the `run_panel_query` tool. Previously, querying a BigQuery-backed panel failed with:

```
datasource type 'grafana-bigquery-datasource' is not supported by run_panel_query
```

forcing AI agents to route BigQuery-backed dashboards to a separate MCP server.

Fixes #922

## Changes

- Route `grafana-bigquery-datasource` panels through Grafana's `/api/ds/query` endpoint via a new `executeBigQueryPanelQuery` handler.
- `normalizeDatasourceType` now maps any `*bigquery*` type to the canonical `bigquery`.
- BigQuery is a SQL datasource (sqlds-based) whose backend resolves SQL macros (`$__timeFilter`, `$__timeFrom`, `$__timeGroup`, …) server-side, so we only substitute the frontend-only macros (`$__interval`, `$__range`, …) and template variables client-side.
- The panel's **raw target is preserved**, so BigQuery-specific fields (`location`, `project`, `dataset`) reach the backend; only `rawSql`, `datasource`, `refId`, and `format` are overridden.
- Results are returned as tabular rows (`BigQueryQueryResult`), mirroring the ClickHouse handler, with empty-result detection and BigQuery-specific hints.
- Updated tool/param descriptions to mention BigQuery.

## Testing

- `go test -tags unit ./tools/` — passes.
- `go vet ./...` and `golangci-lint run ./tools/` — clean (0 issues).
- New unit tests: `normalizeDatasourceType` BigQuery cases, `isEmptyPanelResult` for `BigQueryQueryResult`, BigQuery hints, BigQuery panel-info extraction (rawSql + preserved `location`), and the nil-target error path.

No live integration test was added, as it requires a real BigQuery datasource not available in CI.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (tool/param descriptions)
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only query routing in an existing tool pattern; no auth or schema changes, with unit tests and no live BigQuery integration in CI.
> 
> **Overview**
> **`run_panel_query`** now supports **`grafana-bigquery-datasource`** panels instead of failing with an unsupported-type error.
> 
> BigQuery panels are routed to a new **`executeBigQueryPanelQuery`** path that posts the panel target to Grafana’s **`/api/ds/query`**, applies frontend-only macro substitution and template variables on **`rawSql`**, keeps BigQuery-specific target fields (e.g. **`location`**), and returns tabular **`BigQueryQueryResult`** rows like ClickHouse. **`normalizeDatasourceType`**, empty-result handling, and empty-data hints were extended for BigQuery; tool/param descriptions mention BigQuery.
> 
> Unit tests cover type normalization, empty results, hints, panel extraction, and the nil-target error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9145bc6249293a883ddcea612b11512e3626db05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->