### PR TITLE
feat(auth): support GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE for rotated tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,28 @@ This MCP server works with both local Grafana instances and Grafana Cloud. For G
 
    > **Note:** The environment variable `GRAFANA_API_KEY` is deprecated and will be removed in a future version. Please migrate to using `GRAFANA_SERVICE_ACCOUNT_TOKEN` instead. The old variable name will continue to work for backward compatibility but will show deprecation warnings.
 
+#### Reading the service account token from a file
+
+Instead of passing the token inline via `GRAFANA_SERVICE_ACCOUNT_TOKEN`, you can point `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` at a file path that contains the token. The file is read fresh on every request, so rotated tokens are picked up automatically without restarting the server.
+
+This is particularly useful in Kubernetes, where a Secret mounted as a volume is updated in place when the underlying Secret changes (typically within ~1 minute). Combined with the per-request client cache — which is keyed on the token value — a rotated token transparently produces a new client with no pod restart and no downtime:
+
+```yaml
+env:
+  - name: GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE
+    value: /var/run/secrets/grafana/token
+volumeMounts:
+  - name: grafana-token
+    mountPath: /var/run/secrets/grafana
+    readOnly: true
+volumes:
+  - name: grafana-token
+    secret:
+      secretName: grafana-mcp-token
+```
+
+Surrounding whitespace (including a trailing newline) is trimmed from the file contents. If both `GRAFANA_SERVICE_ACCOUNT_TOKEN` and `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` are set, the inline token takes precedence.
+
 ### Multi-Organization Support
  
 You can specify which organization to interact with using either:

--- a/docs/sources/configure/authentication.md
+++ b/docs/sources/configure/authentication.md
@@ -33,6 +33,28 @@ Set `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN` in the environment passed 
 
 The deprecated `GRAFANA_API_KEY` is still supported but will be removed in a future version; use `GRAFANA_SERVICE_ACCOUNT_TOKEN` instead.
 
+### Read the token from a file
+
+Set `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` to a file path that contains the token instead of passing the value inline. The file is read fresh on every request, so a rotated token is picked up automatically without restarting the server.
+
+This is useful in Kubernetes, where a Secret mounted as a volume is updated in place when the underlying Secret changes. Because the server's client cache is keyed on the token value, a rotated token transparently produces a new client with no pod restart:
+
+```yaml
+env:
+  - name: GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE
+    value: /var/run/secrets/grafana/token
+volumeMounts:
+  - name: grafana-token
+    mountPath: /var/run/secrets/grafana
+    readOnly: true
+volumes:
+  - name: grafana-token
+    secret:
+      secretName: grafana-mcp-token
+```
+
+Surrounding whitespace (including a trailing newline) is trimmed from the file contents. If both `GRAFANA_SERVICE_ACCOUNT_TOKEN` and `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` are set, the inline token takes precedence.
+
 ## Use username and password
 
 You can use basic auth by setting `GRAFANA_USERNAME` and `GRAFANA_PASSWORD` instead of a token. This is less suitable for automation; prefer a service account token when possible.

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -35,10 +35,11 @@ const (
 	defaultGrafanaHost = "localhost:3000"
 	defaultGrafanaURL  = "http://" + defaultGrafanaHost
 
-	grafanaURLEnvVar                 = "GRAFANA_URL"
-	grafanaServiceAccountTokenEnvVar = "GRAFANA_SERVICE_ACCOUNT_TOKEN"
-	grafanaAPIEnvVar                 = "GRAFANA_API_KEY" // Deprecated: use GRAFANA_SERVICE_ACCOUNT_TOKEN instead
-	grafanaOrgIDEnvVar               = "GRAFANA_ORG_ID"
+	grafanaURLEnvVar                     = "GRAFANA_URL"
+	grafanaServiceAccountTokenEnvVar     = "GRAFANA_SERVICE_ACCOUNT_TOKEN"
+	grafanaServiceAccountTokenFileEnvVar = "GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE"
+	grafanaAPIEnvVar                     = "GRAFANA_API_KEY" // Deprecated: use GRAFANA_SERVICE_ACCOUNT_TOKEN instead
+	grafanaOrgIDEnvVar                   = "GRAFANA_ORG_ID"
 
 	grafanaUsernameEnvVar = "GRAFANA_USERNAME"
 	grafanaPasswordEnvVar = "GRAFANA_PASSWORD"
@@ -54,10 +55,22 @@ const (
 func urlAndAPIKeyFromEnv(logger *slog.Logger) (string, string) {
 	u := strings.TrimRight(os.Getenv(grafanaURLEnvVar), "/")
 
-	// Check for the new service account token environment variable first
+	// Check for the new service account token environment variable first.
 	apiKey := os.Getenv(grafanaServiceAccountTokenEnvVar)
 	if apiKey != "" {
 		return u, apiKey
+	}
+
+	// Next, check for a file-based service account token. This is read fresh on
+	// every call so that rotated tokens (e.g. a Kubernetes Secret mounted as a
+	// volume) are picked up without restarting the server. See issue #800.
+	if tokenFile := os.Getenv(grafanaServiceAccountTokenFileEnvVar); tokenFile != "" {
+		token, err := os.ReadFile(tokenFile)
+		if err != nil {
+			logger.Warn("Failed to read GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE, ignoring", "path", tokenFile, "error", err)
+		} else if apiKey = strings.TrimSpace(string(token)); apiKey != "" {
+			return u, apiKey
+		}
 	}
 
 	// Fall back to the deprecated API key environment variable

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1209,6 +1211,85 @@ func TestExtractGrafanaInfoWithExtraHeaders(t *testing.T) {
 		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
 		config := GrafanaConfigFromContext(ctx)
 		assert.Equal(t, map[string]string{"X-Tenant-ID": "tenant-456"}, config.ExtraHeaders)
+	})
+}
+
+func TestServiceAccountTokenFromFile(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	writeToken := func(t *testing.T, contents string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+		return path
+	}
+
+	t.Run("reads token from file", func(t *testing.T) {
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+		t.Setenv("GRAFANA_API_KEY", "")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE", writeToken(t, "file-token"))
+
+		_, apiKey := urlAndAPIKeyFromEnv(logger)
+		assert.Equal(t, "file-token", apiKey)
+	})
+
+	t.Run("trims surrounding whitespace and newlines", func(t *testing.T) {
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+		t.Setenv("GRAFANA_API_KEY", "")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE", writeToken(t, "  file-token\n"))
+
+		_, apiKey := urlAndAPIKeyFromEnv(logger)
+		assert.Equal(t, "file-token", apiKey)
+	})
+
+	t.Run("direct token takes precedence over file", func(t *testing.T) {
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "direct-token")
+		t.Setenv("GRAFANA_API_KEY", "")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE", writeToken(t, "file-token"))
+
+		_, apiKey := urlAndAPIKeyFromEnv(logger)
+		assert.Equal(t, "direct-token", apiKey)
+	})
+
+	t.Run("file takes precedence over deprecated api key", func(t *testing.T) {
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+		t.Setenv("GRAFANA_API_KEY", "deprecated-key")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE", writeToken(t, "file-token"))
+
+		_, apiKey := urlAndAPIKeyFromEnv(logger)
+		assert.Equal(t, "file-token", apiKey)
+	})
+
+	t.Run("falls back to deprecated api key when file is missing", func(t *testing.T) {
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+		t.Setenv("GRAFANA_API_KEY", "deprecated-key")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE", filepath.Join(t.TempDir(), "does-not-exist"))
+
+		_, apiKey := urlAndAPIKeyFromEnv(logger)
+		assert.Equal(t, "deprecated-key", apiKey)
+	})
+
+	t.Run("empty file falls back to deprecated api key", func(t *testing.T) {
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+		t.Setenv("GRAFANA_API_KEY", "deprecated-key")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE", writeToken(t, "\n  \n"))
+
+		_, apiKey := urlAndAPIKeyFromEnv(logger)
+		assert.Equal(t, "deprecated-key", apiKey)
+	})
+
+	t.Run("rotated file is picked up on subsequent reads", func(t *testing.T) {
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
+		t.Setenv("GRAFANA_API_KEY", "")
+		path := writeToken(t, "old-token")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE", path)
+
+		_, apiKey := urlAndAPIKeyFromEnv(logger)
+		require.Equal(t, "old-token", apiKey)
+
+		require.NoError(t, os.WriteFile(path, []byte("new-token"), 0o600))
+		_, apiKey = urlAndAPIKeyFromEnv(logger)
+		assert.Equal(t, "new-token", apiKey)
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds support for a `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` environment variable holding a **file path** from which the service account token is read. This makes the server resilient to token rotation in Kubernetes (and similar environments) without requiring a pod restart.

Closes #800.

## Motivation

When `mcp-grafana` is deployed in Kubernetes and the service account token is injected from a Secret via `env[].valueFrom.secretKeyRef`, the value is resolved once at pod start. When the token is rotated (e.g. by the Grafana Operator writing a new value into the Secret), the running pod keeps the stale token and returns `401 Unauthorized` on every request until restarted — causing downtime and broken MCP sessions. The current workarounds (`kubectl rollout restart`, Stakater Reloader) all incur a restart.

A mounted Secret **volume**, by contrast, is updated in place by Kubernetes (~1 minute) when the Secret changes. Reading the token from that file per-request picks up rotations automatically. Because the HTTP client cache is keyed on the token value, a changed token transparently produces a fresh client — making rotation zero-downtime.

## Changes

- `urlAndAPIKeyFromEnv` now checks `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` and reads the token from the file path (read fresh on every call).
- Precedence: inline `GRAFANA_SERVICE_ACCOUNT_TOKEN` > `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` > deprecated `GRAFANA_API_KEY`.
- Surrounding whitespace / trailing newline is trimmed; unreadable or empty files are logged and fall through to the deprecated key.
- Documentation added to `README.md` and `docs/sources/configure/authentication.md`, including a Kubernetes Secret volume-mount example.

## Usage

```yaml
env:
  - name: GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE
    value: /var/run/secrets/grafana/token
volumeMounts:
  - name: grafana-token
    mountPath: /var/run/secrets/grafana
    readOnly: true
volumes:
  - name: grafana-token
    secret:
      secretName: grafana-mcp-token
```

## Testing

- New `TestServiceAccountTokenFromFile` covering: reading from file, whitespace trimming, precedence (inline > file > deprecated key), missing-file and empty-file fallback, and rotation (re-read picks up the new value).
- `make test-unit`, `golangci-lint run`, `make lint-jsonschema lint-openapi`, and `go vet ./...` all pass.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how credentials are resolved on every request in the auth path; behavior is well-tested with clear fallbacks, but misconfigured file paths could silently fall back to deprecated API keys.
> 
> **Overview**
> Adds **`GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE`** so the Grafana service account token can be loaded from a path instead of only inline env vars. **`urlAndAPIKeyFromEnv`** now reads that file on **every call** (after checking inline `GRAFANA_SERVICE_ACCOUNT_TOKEN`), trims whitespace, and falls through with a warning if the file is missing or empty. Precedence is **inline token → file → deprecated `GRAFANA_API_KEY`**.
> 
> This supports **Kubernetes Secret volume mounts** where the token updates in place after rotation, so new values are picked up **without restarting** the MCP server; docs note that the existing **client cache keyed on the token** should use a fresh client when the token changes.
> 
> **README** and **`docs/sources/configure/authentication.md`** document the env var, precedence, and a sample volume mount. **`TestServiceAccountTokenFromFile`** covers file read, trimming, precedence, fallbacks, and re-read after rotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 027a97e0fb4109f02e136912add796219e5c3dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->