### PR TITLE
[PoC] Feat: Add kiosk handling and drag-to-resize to MCP App iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,15 @@ wheels/
 *.egg-info
 .DS_Store
 .vscode/
+.idea/
 .env
 .cursor/
+
+# Local Go binary build output
+/mcp-grafana
+
+# Frontend dependencies
+node_modules/
 
 # Virtual environments
 .venv

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -86,8 +86,8 @@ type RenderLinkInMCPAppParams struct {
 	Kiosk *string `json:"kiosk,omitempty" jsonschema:"description=Grafana kiosk mode: 'true' (default for Grafana URLs)\\, 'tv'\\, or 'false' to disable"`
 }
 
-// addGrafanaKioskParam sets the Grafana kiosk query parameter on URLs that
-// point at the configured Grafana host. Other URLs are returned unchanged.
+// addGrafanaKioskParam sets the Grafana kiosk query parameter on URLs whose
+// host matches grafanaBaseURL. Other URLs are returned unchanged.
 func addGrafanaKioskParam(rawURL, grafanaBaseURL, override string) string {
 	if grafanaBaseURL == "" {
 		return rawURL
@@ -150,8 +150,7 @@ func renderLinkInMCPApp(ctx context.Context, args RenderLinkInMCPAppParams) (*mc
 		return nil, err
 	}
 
-	// Kiosk only affects the URL the iframe loads. Text content keeps the
-	// caller's original URL so it stays canonical when copied or shared.
+	// Apply kiosk only to the iframe URL; text content keeps the caller's original.
 	override := ""
 	if args.Kiosk != nil {
 		override = *args.Kiosk

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -82,7 +82,42 @@ type RenderTimeRange struct {
 }
 
 type RenderLinkInMCPAppParams struct {
-	URL string `json:"url" jsonschema:"required,description=HTTP(S) URL to render inside the MCP App iframe"`
+	URL   string  `json:"url" jsonschema:"required,description=HTTP(S) URL to render inside the MCP App iframe"`
+	Kiosk *string `json:"kiosk,omitempty" jsonschema:"description=Grafana kiosk mode: 'true' (default for Grafana URLs)\\, 'tv'\\, or 'false' to disable"`
+}
+
+// addGrafanaKioskParam sets the Grafana kiosk query parameter on URLs that
+// point at the configured Grafana host. Other URLs are returned unchanged.
+func addGrafanaKioskParam(rawURL, grafanaBaseURL, override string) string {
+	if grafanaBaseURL == "" {
+		return rawURL
+	}
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	base, err := url.Parse(grafanaBaseURL)
+	if err != nil {
+		return rawURL
+	}
+	if !strings.EqualFold(target.Host, base.Host) {
+		return rawURL
+	}
+
+	q := target.Query()
+	switch strings.ToLower(strings.TrimSpace(override)) {
+	case "false":
+		q.Del("kiosk")
+	case "":
+		if !q.Has("kiosk") {
+			q.Set("kiosk", "true")
+		}
+	default:
+		q.Set("kiosk", override)
+	}
+
+	target.RawQuery = q.Encode()
+	return target.String()
 }
 
 func normalizeEmbeddableURL(raw string) (string, error) {
@@ -109,11 +144,19 @@ func normalizeEmbeddableURL(raw string) (string, error) {
 	return parsed.String(), nil
 }
 
-func renderLinkInMCPApp(_ context.Context, args RenderLinkInMCPAppParams) (*mcp.CallToolResult, error) {
+func renderLinkInMCPApp(ctx context.Context, args RenderLinkInMCPAppParams) (*mcp.CallToolResult, error) {
 	safeURL, err := normalizeEmbeddableURL(args.URL)
 	if err != nil {
 		return nil, err
 	}
+
+	// Kiosk only affects the URL the iframe loads. Text content keeps the
+	// caller's original URL so it stays canonical when copied or shared.
+	override := ""
+	if args.Kiosk != nil {
+		override = *args.Kiosk
+	}
+	iframeURL := addGrafanaKioskParam(safeURL, mcpgrafana.GrafanaConfigFromContext(ctx).URL, override)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -123,7 +166,7 @@ func renderLinkInMCPApp(_ context.Context, args RenderLinkInMCPAppParams) (*mcp.
 			},
 		},
 		StructuredContent: map[string]any{
-			"url": safeURL,
+			"url": iframeURL,
 		},
 	}, nil
 }
@@ -284,7 +327,7 @@ var GetPanelImage = mcpgrafana.MustTool(
 
 var RenderLinkInMCPApp = mcpgrafana.MustTool(
 	"render_link_in_mcp_app",
-	"Render an arbitrary HTTP(S) URL inside an MCP App iframe. The URL is validated and returned as structured content for the app to display.",
+	"Render an HTTP(S) URL inside an MCP App iframe. Grafana URLs get kiosk=true by default; override with the kiosk parameter ('tv' to force TV mode\\, 'false' to disable). Non-Grafana URLs are unchanged.",
 	renderLinkInMCPApp,
 	mcp.WithTitleAnnotation("Render link in MCP App iframe"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -597,6 +598,175 @@ func TestRenderLinkInMCPApp(t *testing.T) {
 	structured, ok := result.StructuredContent.(map[string]any)
 	require.True(t, ok, "expected structured content map")
 	assert.Equal(t, "https://example.com/path?q=1", structured["url"])
+}
+
+func TestRenderLinkInMCPApp_AppliesKioskForGrafanaURLs(t *testing.T) {
+	grafanaCfg := mcpgrafana.GrafanaConfig{URL: "https://grafana.example.com"}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), grafanaCfg)
+
+	t.Run("Grafana host gets kiosk=true by default", func(t *testing.T) {
+		result, err := renderLinkInMCPApp(ctx, RenderLinkInMCPAppParams{
+			URL: "https://grafana.example.com/d/abc?from=now-1h&to=now",
+		})
+		require.NoError(t, err)
+
+		structured := result.StructuredContent.(map[string]any)
+		assert.Contains(t, structured["url"].(string), "kiosk=true")
+		assert.Contains(t, structured["url"].(string), "from=now-1h")
+
+		// Text content surfaces the caller's URL unchanged so kiosk=true
+		// doesn't leak when the URL is copied or shared.
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.NotContains(t, text, "kiosk=true")
+		assert.Contains(t, text, "https://grafana.example.com/d/abc?from=now-1h&to=now")
+	})
+
+	t.Run("Non-Grafana host is not modified", func(t *testing.T) {
+		result, err := renderLinkInMCPApp(ctx, RenderLinkInMCPAppParams{
+			URL: "https://example.com/path?q=1",
+		})
+		require.NoError(t, err)
+
+		structured := result.StructuredContent.(map[string]any)
+		assert.Equal(t, "https://example.com/path?q=1", structured["url"])
+	})
+
+	t.Run("Explicit kiosk=tv is preserved", func(t *testing.T) {
+		result, err := renderLinkInMCPApp(ctx, RenderLinkInMCPAppParams{
+			URL: "https://grafana.example.com/d/abc?kiosk=tv",
+		})
+		require.NoError(t, err)
+
+		structured := result.StructuredContent.(map[string]any)
+		assert.Contains(t, structured["url"].(string), "kiosk=tv")
+		assert.NotContains(t, structured["url"].(string), "kiosk=true")
+	})
+
+	t.Run("Override kiosk=tv forces TV mode", func(t *testing.T) {
+		tv := "tv"
+		result, err := renderLinkInMCPApp(ctx, RenderLinkInMCPAppParams{
+			URL:   "https://grafana.example.com/d/abc",
+			Kiosk: &tv,
+		})
+		require.NoError(t, err)
+
+		structured := result.StructuredContent.(map[string]any)
+		assert.Contains(t, structured["url"].(string), "kiosk=tv")
+
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.NotContains(t, text, "kiosk")
+	})
+
+	t.Run("Override kiosk=false strips kiosk", func(t *testing.T) {
+		off := "false"
+		result, err := renderLinkInMCPApp(ctx, RenderLinkInMCPAppParams{
+			URL:   "https://grafana.example.com/d/abc?kiosk=tv",
+			Kiosk: &off,
+		})
+		require.NoError(t, err)
+
+		structured := result.StructuredContent.(map[string]any)
+		assert.NotContains(t, structured["url"].(string), "kiosk")
+	})
+
+	t.Run("No Grafana URL configured leaves URL untouched", func(t *testing.T) {
+		emptyCtx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{})
+		result, err := renderLinkInMCPApp(emptyCtx, RenderLinkInMCPAppParams{
+			URL: "https://grafana.example.com/d/abc",
+		})
+		require.NoError(t, err)
+
+		structured := result.StructuredContent.(map[string]any)
+		assert.Equal(t, "https://grafana.example.com/d/abc", structured["url"])
+	})
+}
+
+func TestAddGrafanaKioskParam(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawURL    string
+		baseURL   string
+		override  string
+		expectKey string
+		mustEqual string
+	}{
+		{
+			name:      "auto adds kiosk=true on matching host",
+			rawURL:    "https://grafana.example.com/d/abc?from=now-1h",
+			baseURL:   "https://grafana.example.com",
+			expectKey: "true",
+		},
+		{
+			name:      "host mismatch returns URL unchanged",
+			rawURL:    "https://other.example.com/d/abc",
+			baseURL:   "https://grafana.example.com",
+			mustEqual: "https://other.example.com/d/abc",
+		},
+		{
+			name:      "empty base URL returns URL unchanged",
+			rawURL:    "https://grafana.example.com/d/abc",
+			baseURL:   "",
+			mustEqual: "https://grafana.example.com/d/abc",
+		},
+		{
+			name:      "existing kiosk=tv is preserved in auto mode",
+			rawURL:    "https://grafana.example.com/d/abc?kiosk=tv",
+			baseURL:   "https://grafana.example.com",
+			expectKey: "tv",
+		},
+		{
+			name:      "host comparison is case-insensitive",
+			rawURL:    "https://GRAFANA.example.com/d/abc",
+			baseURL:   "https://grafana.example.com",
+			expectKey: "true",
+		},
+		{
+			name:      "host with subpath base URL still matches",
+			rawURL:    "https://grafana.example.com/grafana/d/abc",
+			baseURL:   "https://grafana.example.com/grafana",
+			expectKey: "true",
+		},
+		{
+			name:      "override tv forces tv even without existing param",
+			rawURL:    "https://grafana.example.com/d/abc",
+			baseURL:   "https://grafana.example.com",
+			override:  "tv",
+			expectKey: "tv",
+		},
+		{
+			name:     "override false strips existing kiosk",
+			rawURL:   "https://grafana.example.com/d/abc?kiosk=true&from=now",
+			baseURL:  "https://grafana.example.com",
+			override: "false",
+		},
+		{
+			name:      "override true overrides existing kiosk=tv",
+			rawURL:    "https://grafana.example.com/d/abc?kiosk=tv",
+			baseURL:   "https://grafana.example.com",
+			override:  "true",
+			expectKey: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addGrafanaKioskParam(tt.rawURL, tt.baseURL, tt.override)
+			if tt.mustEqual != "" {
+				assert.Equal(t, tt.mustEqual, got)
+				return
+			}
+
+			parsed, err := url.Parse(got)
+			require.NoError(t, err)
+
+			if tt.override == "false" {
+				assert.False(t, parsed.Query().Has("kiosk"), "kiosk should be removed, got %q", got)
+				return
+			}
+
+			assert.Equal(t, tt.expectKey, parsed.Query().Get("kiosk"))
+		})
+	}
 }
 
 func TestRenderLinkInMCPApp_ToolDefinition(t *testing.T) {

--- a/ui/link/dist/mcp-app.html
+++ b/ui/link/dist/mcp-app.html
@@ -46,7 +46,7 @@
     iframe {
       display: block;
       width: 100%;
-      min-height: 500px;
+      min-height: 700px;
       border: 1px solid rgba(127, 127, 127, 0.35);
       border-radius: 8px 8px 0 0;
       background: white;
@@ -240,9 +240,9 @@
 
         function clampHeight(px) {
           if (!Number.isFinite(px)) {
-            return 100;
+            return 300;
           }
-          return Math.max(100, Math.min(4000, Math.round(px)));
+          return Math.max(300, Math.min(4000, Math.round(px)));
         }
 
         function endDrag() {

--- a/ui/link/dist/mcp-app.html
+++ b/ui/link/dist/mcp-app.html
@@ -39,12 +39,56 @@
       background: rgba(220, 50, 47, 0.12);
       font-size: 12px;
     }
+    .frame-wrapper {
+      position: relative;
+      width: 100%;
+    }
     iframe {
+      display: block;
       width: 100%;
       min-height: 500px;
       border: 1px solid rgba(127, 127, 127, 0.35);
-      border-radius: 8px;
+      border-radius: 8px 8px 0 0;
       background: white;
+      box-sizing: border-box;
+    }
+    .resize-handle {
+      height: 12px;
+      width: 100%;
+      border: 1px solid rgba(127, 127, 127, 0.35);
+      border-top: none;
+      border-radius: 0 0 8px 8px;
+      background: rgba(127, 127, 127, 0.08);
+      cursor: ns-resize;
+      touch-action: none;
+      user-select: none;
+      box-sizing: border-box;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 120ms ease;
+    }
+    .resize-handle::before {
+      content: "";
+      display: block;
+      width: 32px;
+      height: 4px;
+      background-image:
+        linear-gradient(currentColor, currentColor),
+        linear-gradient(currentColor, currentColor);
+      background-size: 100% 1px;
+      background-position: 0 0, 0 100%;
+      background-repeat: no-repeat;
+      color: rgba(127, 127, 127, 0.6);
+      transition: color 120ms ease;
+    }
+    .resize-handle:hover,
+    .resize-handle.dragging {
+      background: rgba(127, 127, 127, 0.16);
+    }
+    .resize-handle:hover::before,
+    .resize-handle.dragging::before {
+      color: rgba(127, 127, 127, 0.9);
     }
   </style>
 </head>
@@ -55,12 +99,22 @@
     <div class="subtle" id="current-url"></div>
   </div>
   <div id="error" class="error"></div>
-  <iframe
-    id="link-frame"
-    title="Embedded link content"
-    sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
-    referrerpolicy="no-referrer"
-  ></iframe>
+  <div class="frame-wrapper">
+    <iframe
+      id="link-frame"
+      title="Embedded link content"
+      sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+      referrerpolicy="no-referrer"
+    ></iframe>
+    <div
+      id="resize-handle"
+      class="resize-handle"
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label="Drag to resize embedded content"
+      title="Drag to resize"
+    ></div>
+  </div>
 
   <script>
     (function () {
@@ -69,6 +123,7 @@
       const currentUrlEl = document.getElementById("current-url");
       const errorEl = document.getElementById("error");
       const frameEl = document.getElementById("link-frame");
+      const resizeHandleEl = document.getElementById("resize-handle");
 
       let nextId = 1;
       const pending = new Map();
@@ -161,6 +216,76 @@
         currentUrlEl.textContent = url;
         setStatus("Rendering URL in iframe");
       }
+
+      // Set both so drag can shrink below the CSS min-height.
+      function setFrameHeight(px) {
+        if (typeof px === "number") {
+          frameEl.style.height = px + "px";
+          frameEl.style.minHeight = px + "px";
+        } else {
+          frameEl.style.height = "";
+          frameEl.style.minHeight = "";
+        }
+      }
+
+      // Cross-origin iframes capture pointer events, so we disable them on
+      // the iframe during a drag to keep the gesture alive.
+      function attachResizeHandle() {
+        if (!resizeHandleEl) {
+          return;
+        }
+        let pointerId = null;
+        let startY = 0;
+        let startHeight = 0;
+
+        function clampHeight(px) {
+          if (!Number.isFinite(px)) {
+            return 100;
+          }
+          return Math.max(100, Math.min(4000, Math.round(px)));
+        }
+
+        function endDrag() {
+          if (pointerId === null) {
+            return;
+          }
+          try {
+            resizeHandleEl.releasePointerCapture(pointerId);
+          } catch (_error) { /* already released */ }
+          pointerId = null;
+          frameEl.style.pointerEvents = "";
+          resizeHandleEl.classList.remove("dragging");
+          document.body.style.cursor = "";
+        }
+
+        resizeHandleEl.addEventListener("pointerdown", (event) => {
+          if (event.button !== 0 && event.pointerType === "mouse") {
+            return;
+          }
+          pointerId = event.pointerId;
+          startY = event.clientY;
+          startHeight = frameEl.getBoundingClientRect().height;
+          try {
+            resizeHandleEl.setPointerCapture(pointerId);
+          } catch (_error) { /* synthetic events can throw */ }
+          frameEl.style.pointerEvents = "none";
+          resizeHandleEl.classList.add("dragging");
+          document.body.style.cursor = "ns-resize";
+          event.preventDefault();
+        });
+
+        resizeHandleEl.addEventListener("pointermove", (event) => {
+          if (pointerId === null || event.pointerId !== pointerId) {
+            return;
+          }
+          setFrameHeight(clampHeight(startHeight + (event.clientY - startY)));
+        });
+
+        resizeHandleEl.addEventListener("pointerup", endDrag);
+        resizeHandleEl.addEventListener("pointercancel", endDrag);
+      }
+
+      attachResizeHandle();
 
       function handleMessage(event) {
         const message = event.data;


### PR DESCRIPTION
Follow-up to https://github.com/grafana/mcp-grafana/pull/879

Changes:
- Auto-apply `kiosk=true` to URLs whose host matches the configured Grafana. Override via new kiosk param. Only the iframe URL is transformed; text content stays canonical.
- Drag-to-resize handle below the iframe, bounded 300-4000px

https://github.com/user-attachments/assets/4da53e25-e84c-478d-af3b-193d3c1d0332

To do:

- [ ] Add deeplink
- [ ] Investigate support across tools

