### PR TITLE
feat(tools): support relative time syntax

### DIFF
--- a/tools/elasticsearch.go
+++ b/tools/elasticsearch.go
@@ -15,8 +15,8 @@ type QueryElasticsearchParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the Elasticsearch or OpenSearch datasource to query"`
 	Index         string `json:"index" jsonschema:"required,description=The index pattern to search (e.g.\\, 'logs-*'\\, 'filebeat-*'\\, or a specific index name)"`
 	Query         string `json:"query" jsonschema:"required,description=The search query. For Elasticsearch datasources\\, this can be either Lucene query syntax (e.g.\\, 'status:200 AND host:server1') or Elasticsearch Query DSL JSON (for advanced queries with aggregations). For OpenSearch datasources\\, only Lucene query syntax is supported."`
-	StartTime     string `json:"startTime,omitempty" jsonschema:"description=Optionally\\, the start time in RFC3339 format (e.g.\\, '2024-01-01T00:00:00Z'). Filters results to documents with @timestamp >= this value"`
-	EndTime       string `json:"endTime,omitempty" jsonschema:"description=Optionally\\, the end time in RFC3339 format (e.g.\\, '2024-01-01T23:59:59Z'). Filters results to documents with @timestamp <= this value"`
+	StartTime     string `json:"startTime,omitempty" jsonschema:"description=Optionally\\, the start time. Filters results to documents with the configured time field (default @timestamp) >= this value. Supports RFC3339 (e.g. '2024-01-01T00:00:00Z')\\, relative to now (e.g. 'now'\\, 'now-1h'\\, 'now-30m')\\, or Unix timestamps"`
+	EndTime       string `json:"endTime,omitempty" jsonschema:"description=Optionally\\, the end time. Filters results to documents with the configured time field (default @timestamp) <= this value. Supports RFC3339 (e.g. '2024-01-01T23:59:59Z')\\, relative to now (e.g. 'now'\\, 'now-1h')\\, or Unix timestamps"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"default=10,description=Optionally\\, the maximum number of documents to return (max: 100\\, default: 10)"`
 }
 
@@ -30,18 +30,22 @@ func queryElasticsearch(ctx context.Context, args QueryElasticsearchParams) ([]E
 	// Parse time range if provided
 	var startTime, endTime *time.Time
 	if args.StartTime != "" {
-		t, err := time.Parse(time.RFC3339, args.StartTime)
+		t, err := parseStartTime(args.StartTime)
 		if err != nil {
 			return nil, fmt.Errorf("parsing start time: %w", err)
 		}
-		startTime = &t
+		if !t.IsZero() {
+			startTime = &t
+		}
 	}
 	if args.EndTime != "" {
-		t, err := time.Parse(time.RFC3339, args.EndTime)
+		t, err := parseEndTime(args.EndTime)
 		if err != nil {
 			return nil, fmt.Errorf("parsing end time: %w", err)
 		}
-		endTime = &t
+		if !t.IsZero() {
+			endTime = &t
+		}
 	}
 
 	// Apply limit constraints

--- a/tools/elasticsearch.go
+++ b/tools/elasticsearch.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -27,25 +26,14 @@ func queryElasticsearch(ctx context.Context, args QueryElasticsearchParams) ([]E
 		return nil, fmt.Errorf("getting backend: %w", err)
 	}
 
-	// Parse time range if provided
-	var startTime, endTime *time.Time
-	if args.StartTime != "" {
-		t, err := parseStartTime(args.StartTime)
-		if err != nil {
-			return nil, fmt.Errorf("parsing start time: %w", err)
-		}
-		if !t.IsZero() {
-			startTime = &t
-		}
+	startTime, err := parseStartTime(args.StartTime)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	if args.EndTime != "" {
-		t, err := parseEndTime(args.EndTime)
-		if err != nil {
-			return nil, fmt.Errorf("parsing end time: %w", err)
-		}
-		if !t.IsZero() {
-			endTime = &t
-		}
+
+	endTime, err := parseEndTime(args.EndTime)
+	if err != nil {
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	// Apply limit constraints

--- a/tools/elasticsearch_test.go
+++ b/tools/elasticsearch_test.go
@@ -55,6 +55,21 @@ func TestElasticsearchTools(t *testing.T) {
 		assert.NotEmpty(t, result, "Should return documents within the time range")
 	})
 
+	t.Run("query elasticsearch with relative time range", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryElasticsearch(ctx, QueryElasticsearchParams{
+			DatasourceUID: "elasticsearch",
+			Index:         "test-logs-*",
+			Query:         "*",
+			StartTime:     "now-24h",
+			EndTime:       "now",
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result, "Should return a result")
+		assert.NotEmpty(t, result, "Should return documents within the relative time range")
+	})
+
 	t.Run("query elasticsearch with time range no results", func(t *testing.T) {
 		ctx := newTestContext()
 		// Use a time range far in the past that won't match any seeded data

--- a/tools/es_backend.go
+++ b/tools/es_backend.go
@@ -42,7 +42,7 @@ type ElasticsearchDocument struct {
 // datasource types, which both support Lucene query syntax.
 type esBackend interface {
 	// Search executes a search query and returns matching documents.
-	Search(ctx context.Context, index, query string, startTime, endTime *time.Time, limit int) ([]ElasticsearchDocument, error)
+	Search(ctx context.Context, index, query string, startTime, endTime time.Time, limit int) ([]ElasticsearchDocument, error)
 }
 
 // esBackendForDatasource looks up the datasource type and returns the appropriate backend.
@@ -130,7 +130,7 @@ type msearchResponse struct {
 
 // Search performs a search query against Elasticsearch using the _msearch API.
 // Grafana's datasource proxy only allows POST requests to /_msearch for Elasticsearch.
-func (b *elasticsearchBackend) Search(ctx context.Context, index, query string, startTime, endTime *time.Time, limit int) ([]ElasticsearchDocument, error) {
+func (b *elasticsearchBackend) Search(ctx context.Context, index, query string, startTime, endTime time.Time, limit int) ([]ElasticsearchDocument, error) {
 	url := buildURL(b.baseURL, "/_msearch")
 	searchQuery := esSearchQuery{
 		query:     query,
@@ -242,8 +242,8 @@ func executeMSearch(ctx context.Context, client *http.Client, url string, index 
 // esSearchQuery collects fields to build an Elasticsearch query DSL JSON
 type esSearchQuery struct {
 	query     string
-	startTime *time.Time
-	endTime   *time.Time
+	startTime time.Time
+	endTime   time.Time
 	size      int
 	timeField string
 	// sortFormat optionally sets the "format" on the time field sort clause,
@@ -277,7 +277,7 @@ func (q esSearchQuery) buildSortField() map[string]string {
 }
 
 func (q esSearchQuery) buildQueryClause() map[string]interface{} {
-	if q.startTime == nil && q.endTime == nil && q.query == "" {
+	if q.startTime.IsZero() && q.endTime.IsZero() && q.query == "" {
 		return map[string]interface{}{
 			"match_all": map[string]interface{}{},
 		}
@@ -315,14 +315,14 @@ func (q esSearchQuery) buildQueryClause() map[string]interface{} {
 }
 
 func (q esSearchQuery) buildRangeClause() map[string]interface{} {
-	if q.startTime == nil && q.endTime == nil {
+	if q.startTime.IsZero() && q.endTime.IsZero() {
 		return nil
 	}
 	rangeQuery := map[string]interface{}{}
-	if q.startTime != nil {
+	if !q.startTime.IsZero() {
 		rangeQuery["gte"] = q.startTime.Format(time.RFC3339)
 	}
-	if q.endTime != nil {
+	if !q.endTime.IsZero() {
 		rangeQuery["lte"] = q.endTime.Format(time.RFC3339)
 	}
 	return map[string]interface{}{

--- a/tools/es_backend_opensearch.go
+++ b/tools/es_backend_opensearch.go
@@ -79,7 +79,7 @@ func indexMatchesPattern(pattern, index string) bool {
 
 // Search executes a search query against an OpenSearch datasource using
 // the Grafana /api/ds/query endpoint with the OpenSearch plugin's query model.
-func (b *openSearchBackend) Search(ctx context.Context, index, query string, startTime, endTime *time.Time, limit int) ([]ElasticsearchDocument, error) {
+func (b *openSearchBackend) Search(ctx context.Context, index, query string, startTime, endTime time.Time, limit int) ([]ElasticsearchDocument, error) {
 	// Validate the requested index against the datasource's configured index pattern.
 	// The OpenSearch plugin always searches within the configured index, so requests
 	// for incompatible indices would silently return no results.
@@ -89,12 +89,12 @@ func (b *openSearchBackend) Search(ctx context.Context, index, query string, sta
 
 	// Determine time range
 	from := time.Now().Add(-10 * 365 * 24 * time.Hour) // Default: 10 years ago
-	if startTime != nil {
-		from = *startTime
+	if !startTime.IsZero() {
+		from = startTime
 	}
 	to := time.Now()
-	if endTime != nil {
-		to = *endTime
+	if !endTime.IsZero() {
+		to = endTime
 	}
 
 	// Use the user's query as-is. The OpenSearch plugin searches within the

--- a/tools/es_backend_test.go
+++ b/tools/es_backend_test.go
@@ -54,7 +54,7 @@ func TestBuildElasticsearchQueryTimeField(t *testing.T) {
 	end := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
 
 	t.Run("custom field in sort and range", func(t *testing.T) {
-		query := esSearchQuery{query: "*", startTime: &start, endTime: &end, size: 10, timeField: "timestamp"}.build()
+		query := esSearchQuery{query: "*", startTime: start, endTime: end, size: 10, timeField: "timestamp"}.build()
 
 		sort, ok := query["sort"].([]map[string]interface{})
 		require.True(t, ok)
@@ -80,7 +80,7 @@ func TestBuildElasticsearchQueryTimeField(t *testing.T) {
 	})
 
 	t.Run("default field unchanged", func(t *testing.T) {
-		query := esSearchQuery{startTime: &start, endTime: &end, size: 5, timeField: defaultTimeField}.build()
+		query := esSearchQuery{startTime: start, endTime: end, size: 5, timeField: defaultTimeField}.build()
 
 		sort, ok := query["sort"].([]map[string]interface{})
 		require.True(t, ok)

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -182,22 +182,8 @@ func (c *Client) fetchData(ctx context.Context, urlPath string, startRFC3339, en
 // ListLokiLabelNamesParams defines the parameters for listing Loki label names
 type ListLokiLabelNamesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
-}
-
-// parseRFC3339OrZero converts an RFC3339 string to a time.Time, returning a
-// zero time when the input is empty. Unparseable strings are surfaced as
-// errors so callers don't silently send garbage to the backend.
-func parseRFC3339OrZero(s string) (time.Time, error) {
-	if s == "" {
-		return time.Time{}, nil
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("parsing time %q: %w", s, err)
-	}
-	return t, nil
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 }
 
 // listLokiLabelNames lists all label names in a Loki (or VictoriaLogs) datasource
@@ -207,13 +193,13 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 		return nil, fmt.Errorf("creating Loki backend: %w", err)
 	}
 
-	start, err := parseRFC3339OrZero(args.StartRFC3339)
+	start, err := parseStartTime(args.StartRFC3339)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	end, err := parseRFC3339OrZero(args.EndRFC3339)
+	end, err := parseEndTime(args.EndRFC3339)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	result, err := backend.ListLabelNames(ctx, start, end)
@@ -242,8 +228,8 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 type ListLokiLabelValuesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LabelName     string `json:"labelName" jsonschema:"required,description=The name of the label to retrieve values for (e.g. 'app'\\, 'env'\\, 'pod')"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 }
 
 // listLokiLabelValues lists all values for a specific label in a Loki (or VictoriaLogs) datasource
@@ -253,13 +239,13 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 		return nil, fmt.Errorf("creating Loki backend: %w", err)
 	}
 
-	start, err := parseRFC3339OrZero(args.StartRFC3339)
+	start, err := parseStartTime(args.StartRFC3339)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	end, err := parseRFC3339OrZero(args.EndRFC3339)
+	end, err := parseEndTime(args.EndRFC3339)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	result, err := backend.ListLabelValues(ctx, args.LabelName, start, end)
@@ -460,8 +446,8 @@ func (c *Client) fetchQuery(ctx context.Context, p fetchQueryParams) (*lokiQuery
 type QueryLokiLogsParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL query to execute against Loki. This can be a simple label matcher or a complex query with filters\\, parsers\\, and expressions. Supports full LogQL syntax including label matchers\\, filter operators\\, pattern expressions\\, and pipeline operations."`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h')"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now')"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"default=10,description=Optionally\\, the maximum number of log lines to return (default max: 100\\, configurable by MCP server)."`
 	Direction     string `json:"direction,omitempty" jsonschema:"description=Optionally\\, the direction of the query: 'forward' (oldest first) or 'backward' (newest first\\, default)"`
 	QueryType     string `json:"queryType,omitempty" jsonschema:"description=Query type: 'range' (default) or 'instant'. Instant queries return a single value at one point in time. Range queries return values over a time window. Use 'instant' for metric queries when you want the current value."`
@@ -675,13 +661,13 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 		startTimeStr, endTimeStr = getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
 	}
 
-	startTime, err := parseRFC3339OrZero(startTimeStr)
+	startTime, err := parseStartTime(startTimeStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	endTime, err := parseRFC3339OrZero(endTimeStr)
+	endTime, err := parseEndTime(endTimeStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	limit := enforceLogLimit(ctx, args.Limit)
@@ -840,8 +826,8 @@ func (c *Client) fetchPatterns(ctx context.Context, query, startRFC3339, endRFC3
 type QueryLokiStatsParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LogQL         string `json:"logql" jsonschema:"required,description=The LogQL matcher expression to execute. This parameter only accepts label matcher expressions and does not support full LogQL queries. Line filters\\, pattern operations\\, and metric aggregations are not supported by the stats API endpoint. Only simple label selectors can be used here."`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h')"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now')"`
 }
 
 // queryLokiStats queries stats from a Loki-compatible datasource. On
@@ -853,13 +839,13 @@ func queryLokiStats(ctx context.Context, args QueryLokiStatsParams) (*Stats, err
 	}
 
 	startTimeStr, endTimeStr := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
-	startTime, err := parseRFC3339OrZero(startTimeStr)
+	startTime, err := parseStartTime(startTimeStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	endTime, err := parseRFC3339OrZero(endTimeStr)
+	endTime, err := parseEndTime(endTimeStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	return backend.QueryStats(ctx, args.LogQL, startTime, endTime)
@@ -879,8 +865,8 @@ var QueryLokiStats = mcpgrafana.MustTool(
 type QueryLokiPatternsParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LogQL         string `json:"logql" jsonschema:"required,description=A LogQL stream selector to identify the logs to analyze for patterns (e.g. {job=\"foo\"\\, namespace=\"bar\"})"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 	Step          string `json:"step,omitempty" jsonschema:"description=Optionally\\, the query resolution step (e.g. '5m')"`
 }
 
@@ -894,13 +880,13 @@ func queryLokiPatterns(ctx context.Context, args QueryLokiPatternsParams) ([]Pat
 	}
 
 	startTimeStr, endTimeStr := getDefaultTimeRange(args.StartRFC3339, args.EndRFC3339)
-	startTime, err := parseRFC3339OrZero(startTimeStr)
+	startTime, err := parseStartTime(startTimeStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	endTime, err := parseRFC3339OrZero(endTimeStr)
+	endTime, err := parseEndTime(endTimeStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	return backend.QueryPatterns(ctx, args.LogQL, args.Step, startTime, endTime)

--- a/tools/loki_label_analyzer.go
+++ b/tools/loki_label_analyzer.go
@@ -138,8 +138,8 @@ type GetLokiLabelCardinalityParams struct {
 	LabelNames      []string `json:"labelNames,omitempty" jsonschema:"description=Labels to measure. Omit to auto-discover."`
 	MaxLabels       int      `json:"maxLabels,omitempty" jsonschema:"description=Cap on auto-discovered labels (default 50)."`
 	MaxSampleValues int      `json:"maxSampleValues,omitempty" jsonschema:"description=Sample values per label (default 10\\, max 50)."`
-	StartRFC3339    string   `json:"startRfc3339,omitempty" jsonschema:"description=RFC3339 start (default: 1h ago)."`
-	EndRFC3339      string   `json:"endRfc3339,omitempty" jsonschema:"description=RFC3339 end (default: now)."`
+	StartRFC3339    string   `json:"startRfc3339,omitempty" jsonschema:"description=RFC3339 or relative (e.g. 'now-1h') start (default: 1h ago)."`
+	EndRFC3339      string   `json:"endRfc3339,omitempty" jsonschema:"description=RFC3339 or relative (e.g. 'now') end (default: now)."`
 }
 
 func getLokiLabelCardinality(ctx context.Context, args GetLokiLabelCardinalityParams) ([]LokiLabelCardinality, error) {
@@ -148,13 +148,13 @@ func getLokiLabelCardinality(ctx context.Context, args GetLokiLabelCardinalityPa
 		return nil, fmt.Errorf("creating Loki backend: %w", err)
 	}
 
-	start, err := parseRFC3339OrZero(args.StartRFC3339)
+	start, err := parseStartTime(args.StartRFC3339)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	end, err := parseRFC3339OrZero(args.EndRFC3339)
+	end, err := parseEndTime(args.EndRFC3339)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	labels := args.LabelNames
@@ -251,8 +251,8 @@ type AuditLokiLabelStrategyParams struct {
 	DatasourceUID      string            `json:"datasourceUid,omitempty" jsonschema:"description=Live mode: Loki/VictoriaLogs datasource UID. Either this or 'labels' is required."`
 	Selector           string            `json:"selector,omitempty" jsonschema:"description=Optional LogQL selector for live stats sample."`
 	MaxLabels          int               `json:"maxLabels,omitempty" jsonschema:"description=Live-mode label cap (default 50)."`
-	StartRFC3339       string            `json:"startRfc3339,omitempty" jsonschema:"description=RFC3339 start (default: 1h ago)."`
-	EndRFC3339         string            `json:"endRfc3339,omitempty" jsonschema:"description=RFC3339 end (default: now)."`
+	StartRFC3339       string            `json:"startRfc3339,omitempty" jsonschema:"description=RFC3339 or relative (e.g. 'now-1h') start (default: 1h ago)."`
+	EndRFC3339         string            `json:"endRfc3339,omitempty" jsonschema:"description=RFC3339 or relative (e.g. 'now') end (default: now)."`
 	Labels             []LabelDescriptor `json:"labels,omitempty" jsonschema:"description=Static mode: caller-supplied label set."`
 	ExpectedBaseLabels []string          `json:"expectedBaseLabels,omitempty" jsonschema:"description=Override the default recommended base labels."`
 }
@@ -361,8 +361,8 @@ func gatherLiveDescriptors(ctx context.Context, args AuditLokiLabelStrategyParam
 	if args.Selector != "" {
 		backend, err := lokiBackendForDatasource(ctx, args.DatasourceUID)
 		if err == nil {
-			start, _ := parseRFC3339OrZero(args.StartRFC3339)
-			end, _ := parseRFC3339OrZero(args.EndRFC3339)
+			start, _ := parseStartTime(args.StartRFC3339)
+			end, _ := parseEndTime(args.EndRFC3339)
 			if s, err := backend.QueryStats(ctx, args.Selector, start, end); err == nil {
 				stats = s
 			}
@@ -757,8 +757,8 @@ type DiagnoseLokiQueryPerformanceParams struct {
 	DatasourceUID string           `json:"datasourceUid,omitempty" jsonschema:"description=Datasource UID for live stats."`
 	LogQL         string           `json:"logql,omitempty" jsonschema:"description=Label-only selector for live stats."`
 	Metrics       QueryPerfMetrics `json:"metrics,omitempty" jsonschema:"description=Runtime metrics from metrics.go."`
-	StartRFC3339  string           `json:"startRfc3339,omitempty" jsonschema:"description=RFC3339 start."`
-	EndRFC3339    string           `json:"endRfc3339,omitempty" jsonschema:"description=RFC3339 end."`
+	StartRFC3339  string           `json:"startRfc3339,omitempty" jsonschema:"description=RFC3339 or relative (e.g. 'now-1h') start."`
+	EndRFC3339    string           `json:"endRfc3339,omitempty" jsonschema:"description=RFC3339 or relative (e.g. 'now') end."`
 }
 
 // QueryPerfDiagnosis is the structured output.
@@ -773,8 +773,8 @@ func diagnoseLokiQueryPerformance(ctx context.Context, args DiagnoseLokiQueryPer
 	if args.DatasourceUID != "" && args.LogQL != "" {
 		backend, err := lokiBackendForDatasource(ctx, args.DatasourceUID)
 		if err == nil {
-			start, _ := parseRFC3339OrZero(args.StartRFC3339)
-			end, _ := parseRFC3339OrZero(args.EndRFC3339)
+			start, _ := parseStartTime(args.StartRFC3339)
+			end, _ := parseEndTime(args.EndRFC3339)
 			s, statsErr := backend.QueryStats(ctx, args.LogQL, start, end)
 			if statsErr == nil {
 				stats = s

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -19,6 +19,17 @@ func TestLokiTools(t *testing.T) {
 		assert.NotEmpty(t, result, "Should have at least one label name")
 	})
 
+	t.Run("list loki label names with relative time range", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listLokiLabelNames(ctx, ListLokiLabelNamesParams{
+			DatasourceUID: "loki",
+			StartRFC3339:  "now-1h",
+			EndRFC3339:    "now",
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result, "Should have at least one label name")
+	})
+
 	t.Run("get loki label values", func(t *testing.T) {
 		ctx := newTestContext()
 		result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -180,8 +180,8 @@ type ListPrometheusMetricNamesParams struct {
 	Regex         string `json:"regex" jsonschema:"description=The regex to match against the metric names"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"default=10,description=The maximum number of results to return"`
 	Page          int    `json:"page,omitempty" jsonschema:"default=1,description=The page number to return"`
-	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the time range to filter the results by"`
-	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the time range to filter the results by"`
+	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now-1h')"`
+	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now')"`
 	ProjectName   string `json:"projectName,omitempty" jsonschema:"description=GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource."`
 }
 
@@ -201,16 +201,13 @@ func listPrometheusMetricNames(ctx context.Context, args ListPrometheusMetricNam
 		page = 1
 	}
 
-	var startTime, endTime time.Time
-	if args.StartRFC3339 != "" {
-		if startTime, err = time.Parse(time.RFC3339, args.StartRFC3339); err != nil {
-			return nil, fmt.Errorf("parsing start time: %w", err)
-		}
+	startTime, err := parseStartTime(args.StartRFC3339)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	if args.EndRFC3339 != "" {
-		if endTime, err = time.Parse(time.RFC3339, args.EndRFC3339); err != nil {
-			return nil, fmt.Errorf("parsing end time: %w", err)
-		}
+	endTime, err := parseEndTime(args.EndRFC3339)
+	if err != nil {
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	// Get all metric names via the backend
@@ -308,8 +305,8 @@ func (s Selector) Matches(lbls labels.Labels) (bool, error) {
 type ListPrometheusLabelNamesParams struct {
 	DatasourceUID string     `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally\\, a list of label matchers to filter the results by"`
-	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the time range to filter the results by"`
-	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the time range to filter the results by"`
+	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now-1h')"`
+	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the time range to filter the results by. Supports RFC3339 or relative time (e.g. 'now')"`
 	Limit         int        `json:"limit,omitempty" jsonschema:"default=100,description=Optionally\\, the maximum number of results to return"`
 	ProjectName   string     `json:"projectName,omitempty" jsonschema:"description=GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource."`
 }
@@ -325,16 +322,13 @@ func listPrometheusLabelNames(ctx context.Context, args ListPrometheusLabelNames
 		limit = 100
 	}
 
-	var startTime, endTime time.Time
-	if args.StartRFC3339 != "" {
-		if startTime, err = time.Parse(time.RFC3339, args.StartRFC3339); err != nil {
-			return nil, fmt.Errorf("parsing start time: %w", err)
-		}
+	startTime, err := parseStartTime(args.StartRFC3339)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	if args.EndRFC3339 != "" {
-		if endTime, err = time.Parse(time.RFC3339, args.EndRFC3339); err != nil {
-			return nil, fmt.Errorf("parsing end time: %w", err)
-		}
+	endTime, err := parseEndTime(args.EndRFC3339)
+	if err != nil {
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	var matchers []string
@@ -368,8 +362,8 @@ type ListPrometheusLabelValuesParams struct {
 	DatasourceUID string     `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LabelName     string     `json:"labelName" jsonschema:"required,description=The name of the label to query"`
 	Matches       []Selector `json:"matches,omitempty" jsonschema:"description=Optionally\\, a list of selectors to filter the results by"`
-	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query"`
-	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query"`
+	StartRFC3339  string     `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query. Supports RFC3339 or relative time (e.g. 'now-1h')"`
+	EndRFC3339    string     `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query. Supports RFC3339 or relative time (e.g. 'now')"`
 	Limit         int        `json:"limit,omitempty" jsonschema:"default=100,description=Optionally\\, the maximum number of results to return"`
 	ProjectName   string     `json:"projectName,omitempty" jsonschema:"description=GCP project name to query (Cloud Monitoring datasources only). Overrides or substitutes the defaultProject configured on the datasource."`
 }
@@ -385,16 +379,13 @@ func listPrometheusLabelValues(ctx context.Context, args ListPrometheusLabelValu
 		limit = 100
 	}
 
-	var startTime, endTime time.Time
-	if args.StartRFC3339 != "" {
-		if startTime, err = time.Parse(time.RFC3339, args.StartRFC3339); err != nil {
-			return nil, fmt.Errorf("parsing start time: %w", err)
-		}
+	startTime, err := parseStartTime(args.StartRFC3339)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	if args.EndRFC3339 != "" {
-		if endTime, err = time.Parse(time.RFC3339, args.EndRFC3339); err != nil {
-			return nil, fmt.Errorf("parsing end time: %w", err)
-		}
+	endTime, err := parseEndTime(args.EndRFC3339)
+	if err != nil {
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	var matchers []string

--- a/tools/pyroscope.go
+++ b/tools/pyroscope.go
@@ -47,19 +47,19 @@ var ListPyroscopeLabelNames = mcpgrafana.MustTool(
 type ListPyroscopeLabelNamesParams struct {
 	DataSourceUID string `json:"data_source_uid" jsonschema:"required,description=The UID of the datasource to query"`
 	Matchers      string `json:"matchers,omitempty" jsonschema:"Prometheus style matchers used t0 filter the result set (defaults to: {})"`
-	StartRFC3339  string `json:"start_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"end_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	StartRFC3339  string `json:"start_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"end_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 }
 
 func listPyroscopeLabelNames(ctx context.Context, args ListPyroscopeLabelNamesParams) ([]string, error) {
 	args.Matchers = stringOrDefault(args.Matchers, "{}")
 
-	start, err := rfc3339OrDefault(args.StartRFC3339, time.Time{})
+	start, err := parseStartTime(args.StartRFC3339)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse start timestamp %q: %w", args.StartRFC3339, err)
 	}
 
-	end, err := rfc3339OrDefault(args.EndRFC3339, time.Time{})
+	end, err := parseEndTime(args.EndRFC3339)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse end timestamp %q: %w", args.EndRFC3339, err)
 	}
@@ -107,8 +107,8 @@ type ListPyroscopeLabelValuesParams struct {
 	DataSourceUID string `json:"data_source_uid" jsonschema:"required,description=The UID of the datasource to query"`
 	Name          string `json:"name" jsonschema:"required,description=A label name"`
 	Matchers      string `json:"matchers,omitempty" jsonschema:"description=Optionally\\, Prometheus style matchers used to filter the result set (defaults to: {})"`
-	StartRFC3339  string `json:"start_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"end_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	StartRFC3339  string `json:"start_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"end_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 }
 
 func listPyroscopeLabelValues(ctx context.Context, args ListPyroscopeLabelValuesParams) ([]string, error) {
@@ -119,12 +119,12 @@ func listPyroscopeLabelValues(ctx context.Context, args ListPyroscopeLabelValues
 
 	args.Matchers = stringOrDefault(args.Matchers, "{}")
 
-	start, err := rfc3339OrDefault(args.StartRFC3339, time.Time{})
+	start, err := parseStartTime(args.StartRFC3339)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse start timestamp %q: %w", args.StartRFC3339, err)
 	}
 
-	end, err := rfc3339OrDefault(args.EndRFC3339, time.Time{})
+	end, err := parseEndTime(args.EndRFC3339)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse end timestamp %q: %w", args.EndRFC3339, err)
 	}
@@ -171,17 +171,17 @@ var ListPyroscopeProfileTypes = mcpgrafana.MustTool(
 
 type ListPyroscopeProfileTypesParams struct {
 	DataSourceUID string `json:"data_source_uid" jsonschema:"required,description=The UID of the datasource to query"`
-	StartRFC3339  string `json:"start_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format (defaults to 1 hour ago)"`
-	EndRFC3339    string `json:"end_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format (defaults to now)"`
+	StartRFC3339  string `json:"start_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
+	EndRFC3339    string `json:"end_rfc_3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 }
 
 func listPyroscopeProfileTypes(ctx context.Context, args ListPyroscopeProfileTypesParams) ([]string, error) {
-	start, err := rfc3339OrDefault(args.StartRFC3339, time.Time{})
+	start, err := parseStartTime(args.StartRFC3339)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse start timestamp %q: %w", args.StartRFC3339, err)
 	}
 
-	end, err := rfc3339OrDefault(args.EndRFC3339, time.Time{})
+	end, err := parseEndTime(args.EndRFC3339)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse end timestamp %q: %w", args.EndRFC3339, err)
 	}
@@ -340,20 +340,6 @@ func stringOrDefault(s string, def string) string {
 	return s
 }
 
-func rfc3339OrDefault(s string, def time.Time) (time.Time, error) {
-	s = strings.TrimSpace(s)
-
-	var err error
-	if s != "" {
-		def, err = time.Parse(time.RFC3339, s)
-		if err != nil {
-			return time.Time{}, err
-		}
-	}
-
-	return def, nil
-}
-
 func validateTimeRange(start time.Time, end time.Time) (time.Time, time.Time, error) {
 	if end.IsZero() {
 		end = time.Now()
@@ -458,8 +444,8 @@ type QueryPyroscopeParams struct {
 	GroupBy       []string `json:"group_by,omitempty" jsonschema:"description=Labels to group metrics series by"`
 	Step          float64  `json:"step,omitempty" jsonschema:"description=Seconds between metrics data points (default: auto)"`
 	MaxNodeDepth  int      `json:"max_node_depth,omitempty" jsonschema:"description=Max depth for profile call graph (default: 100)"`
-	StartRFC3339  string   `json:"start_rfc_3339,omitempty" jsonschema:"description=Start time in RFC3339 (defaults to 1 hour ago)"`
-	EndRFC3339    string   `json:"end_rfc_3339,omitempty" jsonschema:"description=End time in RFC3339 (defaults to now)"`
+	StartRFC3339  string   `json:"start_rfc_3339,omitempty" jsonschema:"description=Start time in RFC3339 or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
+	EndRFC3339    string   `json:"end_rfc_3339,omitempty" jsonschema:"description=End time in RFC3339 or relative time (e.g. 'now') (defaults to now)"`
 }
 
 func queryPyroscope(ctx context.Context, args QueryPyroscopeParams) (string, error) {
@@ -477,12 +463,12 @@ func queryPyroscope(ctx context.Context, args QueryPyroscopeParams) (string, err
 		matchers = fmt.Sprintf("{%s}", matchers)
 	}
 
-	start, err := rfc3339OrDefault(args.StartRFC3339, time.Time{})
+	start, err := parseStartTime(args.StartRFC3339)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse start timestamp %q: %w", args.StartRFC3339, err)
 	}
 
-	end, err := rfc3339OrDefault(args.EndRFC3339, time.Time{})
+	end, err := parseEndTime(args.EndRFC3339)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse end timestamp %q: %w", args.EndRFC3339, err)
 	}

--- a/tools/quickwit.go
+++ b/tools/quickwit.go
@@ -93,7 +93,7 @@ func (b *quickwitBackend) resolveIndex(index string) (string, error) {
 	return b.configuredIndex, nil
 }
 
-func (b *quickwitBackend) Search(ctx context.Context, index, query string, startTime, endTime *time.Time, limit int) ([]ElasticsearchDocument, error) {
+func (b *quickwitBackend) Search(ctx context.Context, index, query string, startTime, endTime time.Time, limit int) ([]ElasticsearchDocument, error) {
 	resolvedIndex, err := b.resolveIndex(index)
 	if err != nil {
 		return nil, err
@@ -233,24 +233,14 @@ func queryQuickwit(ctx context.Context, args QueryQuickwitParams) ([]Elasticsear
 		return nil, fmt.Errorf("getting backend: %w", err)
 	}
 
-	var startTime, endTime *time.Time
-	if args.StartTime != "" {
-		t, err := parseStartTime(args.StartTime)
-		if err != nil {
-			return nil, fmt.Errorf("parsing start time: %w", err)
-		}
-		if !t.IsZero() {
-			startTime = &t
-		}
+	startTime, err := parseStartTime(args.StartTime)
+	if err != nil {
+		return nil, fmt.Errorf("parsing start time: %w", err)
 	}
-	if args.EndTime != "" {
-		t, err := parseEndTime(args.EndTime)
-		if err != nil {
-			return nil, fmt.Errorf("parsing end time: %w", err)
-		}
-		if !t.IsZero() {
-			endTime = &t
-		}
+
+	endTime, err := parseEndTime(args.EndTime)
+	if err != nil {
+		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	limit := args.Limit

--- a/tools/quickwit_test.go
+++ b/tools/quickwit_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,7 +162,7 @@ func TestQuickwitBackendSearch(t *testing.T) {
 		configuredIndex: "test-logs",
 	}
 
-	docs, err := backend.Search(context.Background(), "test-logs", "severity_text:ERROR", nil, nil, 10)
+	docs, err := backend.Search(context.Background(), "test-logs", "severity_text:ERROR", time.Time{}, time.Time{}, 10)
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
 	assert.Equal(t, "test-logs", docs[0].Index)
@@ -230,7 +231,7 @@ func TestQuickwitBackendIndexValidation(t *testing.T) {
 	backend := &quickwitBackend{
 		configuredIndex: "test-logs",
 	}
-	_, err := backend.Search(context.Background(), "other-index", "*", nil, nil, 10)
+	_, err := backend.Search(context.Background(), "other-index", "*", time.Time{}, time.Time{}, 10)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not compatible")
 }


### PR DESCRIPTION
Use centralized gtime-backed helpers, so 'now', 'now-1h', ISO dates, and Unix timestamps work with all tools - to match Grafana UI behavior.

**Converted tools:**
- query_elasticsearch (ES/OpenSearch)
- query_loki_logs, query_loki_stats, query_loki_patterns,
  list_loki_label_names, list_loki_label_values
- Loki label analyzer tools (cardinality, audit, perf diagnosis)
- list_prometheus_metric_names, list_prometheus_label_names,
  list_prometheus_label_values
- Pyroscope tools (label names/values, profile types, query)

**Note:** The change is additive: every input accepted earlier parses identically; only previously-rejected inputs become valid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide change to how query time windows are interpreted across many tools; behavior is intended to stay compatible for previously valid RFC3339 inputs, but parsing mistakes could shift ranges for new syntax.
> 
> **Overview**
> MCP datasource tools now accept **Grafana-style time strings** (`now`, `now-1h`, RFC3339, ISO dates, Unix timestamps) via shared **`parseStartTime` / `parseEndTime`** (gtime-backed), replacing per-tool RFC3339-only parsing and removing helpers like **`parseRFC3339OrZero`** and **`rfc3339OrDefault`**.
> 
> **Elasticsearch / OpenSearch / Quickwit** search paths pass **`time.Time`** bounds (zero = no filter) instead of optional pointers; tool **jsonschema** text documents the new formats. **Loki**, **Prometheus** metadata/list tools, **Pyroscope**, and **Loki label analyzer** tools wire the same parsers and updated parameter descriptions. **Integration tests** cover relative ranges for Elasticsearch and Loki.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657c54b0dd19388a104ea17103ebbc4ee1608efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->