### PR TITLE
fix: pass cfg.HTTPTransport() to propagate headers to loki downstream calls

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -662,7 +662,7 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 	}
 
 	if base == nil {
-		base = http.DefaultTransport
+		base = cfg.HTTPTransport()
 	}
 	transport := base
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -1071,6 +1071,31 @@ func TestBuildTransport(t *testing.T) {
 		require.NotNil(t, transport)
 	})
 
+	t.Run("nil base preserves configured BaseTransport", func(t *testing.T) {
+		var capturedReq *http.Request
+		usedBase := false
+		base := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			usedBase = true
+			capturedReq = req
+			return &http.Response{StatusCode: 200}, nil
+		}}
+
+		cfg := &GrafanaConfig{
+			APIKey:        "test-key",
+			BaseTransport: base,
+		}
+		transport, err := BuildTransport(cfg, nil, WithoutOtel())
+		require.NoError(t, err)
+
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		_, err = transport.RoundTrip(req)
+		require.NoError(t, err)
+
+		require.True(t, usedBase)
+		require.NotNil(t, capturedReq)
+		assert.Equal(t, "Bearer test-key", capturedReq.Header.Get("Authorization"))
+	})
+
 	t.Run("zero-value config produces working transport", func(t *testing.T) {
 		var capturedReq *http.Request
 		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small behavioral fix in shared HTTP middleware with a focused regression test; low blast radius unless callers depended on ignoring BaseTransport when base was nil.
> 
> **Overview**
> When **`BuildTransport`** is called with a **nil** base round tripper, it now uses **`cfg.HTTPTransport()`** instead of always **`http.DefaultTransport`**. That means a configured **`BaseTransport`** (and the same default fallback as elsewhere) is used as the innermost layer, so auth, extra headers, org ID, and other middleware still wrap the transport the host actually configured.
> 
> This aligns nil-base call sites—such as **frontend settings**, **incident**, and **Loki downstream** HTTP clients—with **`NewGrafanaClient`**, which already relied on **`BaseTransport`** for custom pooling, tracing, or forwarded headers.
> 
> A test confirms that with **`BaseTransport`** set, **`BuildTransport(cfg, nil)`** routes requests through that base and still applies middleware (e.g. **`Authorization`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f120056804642982de4fd970716e95ab8e57d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->