### PR TITLE
feat(prometheus): surface query warnings to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window
+- `query_prometheus` now surfaces datasource `warnings` (e.g. partial responses from Thanos) in its result
 
 ## [0.15.2] - 2026-06-04
 

--- a/tools/prom_backend.go
+++ b/tools/prom_backend.go
@@ -19,8 +19,10 @@ import (
 // promBackend abstracts the differences between datasource types that support
 // PromQL-compatible queries (native Prometheus, Cloud Monitoring, etc.).
 type promBackend interface {
-	// Query executes a PromQL query (instant or range) and returns the result.
-	Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, error)
+	// Query executes a PromQL query (instant or range) and returns the result
+	// along with any warnings the datasource reported (e.g. partial responses
+	// from a Thanos store).
+	Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, promv1.Warnings, error)
 
 	// LabelNames returns label names, optionally filtered by matchers and time range.
 	LabelNames(ctx context.Context, matchers []string, start, end time.Time) ([]string, error)
@@ -101,27 +103,27 @@ func newPrometheusBackend(ctx context.Context, uid string, ds *models.DataSource
 	return &prometheusBackend{api: promv1.NewAPI(c)}, nil
 }
 
-func (b *prometheusBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, error) {
+func (b *prometheusBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, promv1.Warnings, error) {
 	switch queryType {
 	case "range":
 		step := time.Duration(stepSeconds) * time.Second
-		result, _, err := b.api.QueryRange(ctx, expr, promv1.Range{
+		result, warnings, err := b.api.QueryRange(ctx, expr, promv1.Range{
 			Start: start,
 			End:   end,
 			Step:  step,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("querying Prometheus range: %w", err)
+			return nil, nil, fmt.Errorf("querying Prometheus range: %w", err)
 		}
-		return result, nil
+		return result, warnings, nil
 	case "instant":
-		result, _, err := b.api.Query(ctx, expr, end)
+		result, warnings, err := b.api.Query(ctx, expr, end)
 		if err != nil {
-			return nil, fmt.Errorf("querying Prometheus instant: %w", err)
+			return nil, nil, fmt.Errorf("querying Prometheus instant: %w", err)
 		}
-		return result, nil
+		return result, warnings, nil
 	default:
-		return nil, fmt.Errorf("invalid query type: %s", queryType)
+		return nil, nil, fmt.Errorf("invalid query type: %s", queryType)
 	}
 }
 

--- a/tools/prom_backend_cloudmonitoring.go
+++ b/tools/prom_backend_cloudmonitoring.go
@@ -77,10 +77,10 @@ func (b *cloudMonitoringBackend) project() (string, error) {
 }
 
 // Query executes a PromQL query via Grafana's /api/ds/query endpoint.
-func (b *cloudMonitoringBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, error) {
+func (b *cloudMonitoringBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, promv1.Warnings, error) {
 	project, err := b.project()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	step := fmt.Sprintf("%ds", stepSeconds)
 	if stepSeconds == 0 {
@@ -119,10 +119,11 @@ func (b *cloudMonitoringBackend) Query(ctx context.Context, expr string, queryTy
 
 	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, dsQueryPayload(start, end, query))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return framesToPrometheusValue(resp, queryType)
+	v, err := framesToPrometheusValue(resp, queryType)
+	return v, nil, err
 }
 
 // LabelNames returns label names by issuing a TIME_SERIES_LIST HEADERS query

--- a/tools/prom_backend_test.go
+++ b/tools/prom_backend_test.go
@@ -1,0 +1,62 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestPrometheusBackend builds a prometheusBackend talking to the given test
+// server, bypassing the Grafana datasource proxy plumbing.
+func newTestPrometheusBackend(t *testing.T, server *httptest.Server) *prometheusBackend {
+	t.Helper()
+	c, err := api.NewClient(api.Config{Address: server.URL})
+	require.NoError(t, err)
+	return &prometheusBackend{api: promv1.NewAPI(c)}
+}
+
+func TestPrometheusBackendQuery_SurfacesWarnings(t *testing.T) {
+	const body = `{
+		"status": "success",
+		"data": {"resultType": "vector", "result": []},
+		"warnings": ["source cluster-b is unavailable, returning partial data"]
+	}`
+
+	for _, queryType := range []string{"instant", "range"} {
+		t.Run(queryType, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			t.Cleanup(server.Close)
+
+			b := newTestPrometheusBackend(t, server)
+			end := time.Unix(1700000000, 0)
+			_, warnings, err := b.Query(context.Background(), "up", queryType, end.Add(-time.Hour), end, 60)
+			require.NoError(t, err)
+			assert.Equal(t, promv1.Warnings{"source cluster-b is unavailable, returning partial data"}, warnings)
+		})
+	}
+}
+
+func TestPrometheusBackendQuery_NoWarnings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	b := newTestPrometheusBackend(t, server)
+	_, warnings, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+}

--- a/tools/prom_backend_victoriametrics.go
+++ b/tools/prom_backend_victoriametrics.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
@@ -53,9 +54,9 @@ func newVictoriaMetricsBackend(ctx context.Context, uid string, ds *models.DataS
 
 // Query executes a PromQL/MetricsQL query via Grafana's /api/ds/query endpoint.
 // The VM plugin signals instant vs range with two boolean fields on the payload.
-func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, error) {
+func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryType string, start, end time.Time, stepSeconds int) (model.Value, promv1.Warnings, error) {
 	if queryType != "instant" && queryType != "range" {
-		return nil, fmt.Errorf("invalid query type: %s", queryType)
+		return nil, nil, fmt.Errorf("invalid query type: %s", queryType)
 	}
 
 	if start.IsZero() && end.IsZero() {
@@ -88,8 +89,9 @@ func (b *victoriaMetricsBackend) Query(ctx context.Context, expr string, queryTy
 
 	resp, err := doDSQuery(ctx, b.httpClient, b.baseURL, dsQueryPayload(start, end, query))
 	if err != nil {
-		return nil, fmt.Errorf("querying VictoriaMetrics %s: %w", queryType, err)
+		return nil, nil, fmt.Errorf("querying VictoriaMetrics %s: %w", queryType, err)
 	}
 
-	return framesToPrometheusValue(resp, queryType)
+	v, err := framesToPrometheusValue(resp, queryType)
+	return v, nil, err
 }

--- a/tools/prom_backend_victoriametrics_test.go
+++ b/tools/prom_backend_victoriametrics_test.go
@@ -101,7 +101,7 @@ func TestVictoriaMetricsBackendQuery_PayloadShape(t *testing.T) {
 
 			start := time.Unix(1700000000, 0)
 			end := time.Unix(1700003600, 0)
-			_, err := b.Query(context.Background(), `up{job="prometheus"}`, tc.queryType, start, end, tc.stepSeconds)
+			_, _, err := b.Query(context.Background(), `up{job="prometheus"}`, tc.queryType, start, end, tc.stepSeconds)
 			require.NoError(t, err)
 
 			require.NotNil(t, fake.lastPayload)
@@ -138,7 +138,7 @@ func TestVictoriaMetricsBackendQuery_DecodesInstantResponse(t *testing.T) {
 	}})
 	b := newTestVMBackend(t, fake.server)
 
-	v, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
+	v, _, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
 	require.NoError(t, err)
 
 	vec, ok := v.(model.Vector)
@@ -163,7 +163,7 @@ func TestVictoriaMetricsBackendQuery_DecodesRangeResponseAsMatrix(t *testing.T) 
 	}})
 	b := newTestVMBackend(t, fake.server)
 
-	v, err := b.Query(
+	v, _, err := b.Query(
 		context.Background(),
 		"up",
 		"range",
@@ -189,7 +189,7 @@ func TestVictoriaMetricsBackendQuery_PropagatesUpstreamError(t *testing.T) {
 	}})
 	b := newTestVMBackend(t, fake.server)
 
-	_, err := b.Query(context.Background(), "rate(", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
+	_, _, err := b.Query(context.Background(), "rate(", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rate: bad expression")
 }
@@ -198,7 +198,7 @@ func TestVictoriaMetricsBackendQuery_RejectsInvalidQueryType(t *testing.T) {
 	fake := newFakeVMServer(t, backend.QueryDataResponse{})
 	b := newTestVMBackend(t, fake.server)
 
-	_, err := b.Query(context.Background(), "up", "bogus", time.Time{}, time.Unix(1700000000, 0), 0)
+	_, _, err := b.Query(context.Background(), "up", "bogus", time.Time{}, time.Unix(1700000000, 0), 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid query type")
 	assert.Nil(t, fake.lastPayload, "should not hit the server with an invalid query type")
@@ -211,7 +211,7 @@ func TestVictoriaMetricsBackendQuery_DefaultsToNowWhenBothTimesZero(t *testing.T
 	b := newTestVMBackend(t, fake.server)
 
 	before := time.Now().UnixMilli()
-	_, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Time{}, 0)
+	_, _, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Time{}, 0)
 	require.NoError(t, err)
 	after := time.Now().UnixMilli()
 
@@ -234,7 +234,7 @@ func TestVictoriaMetricsBackendQuery_HTTPError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	b := newTestVMBackend(t, server)
-	_, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
+	_, _, err := b.Query(context.Background(), "up", "instant", time.Time{}, time.Unix(1700000000, 0), 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "querying VictoriaMetrics instant")
 	assert.Contains(t, err.Error(), "status 500")

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -74,8 +74,9 @@ type QueryPrometheusParams struct {
 
 // QueryPrometheusResult wraps the Prometheus query result with optional hints
 type QueryPrometheusResult struct {
-	Data  model.Value       `json:"data"`
-	Hints *EmptyResultHints `json:"hints,omitempty"`
+	Data     model.Value       `json:"data"`
+	Hints    *EmptyResultHints `json:"hints,omitempty"`
+	Warnings []string          `json:"warnings,omitempty"`
 }
 
 func parseTime(timeStr string) (time.Time, error) {
@@ -108,9 +109,16 @@ func isPrometheusResultEmpty(result model.Value) bool {
 // queryPrometheus executes a PromQL query and returns raw results.
 // This is the internal function - use queryPrometheusWithHints for MCP tools.
 func queryPrometheus(ctx context.Context, args QueryPrometheusParams) (model.Value, error) {
+	result, _, err := queryPrometheusWithWarnings(ctx, args)
+	return result, err
+}
+
+// queryPrometheusWithWarnings is like queryPrometheus but also returns any
+// warnings the datasource reported, such as partial responses from Thanos.
+func queryPrometheusWithWarnings(ctx context.Context, args QueryPrometheusParams) (model.Value, promv1.Warnings, error) {
 	backend, err := backendForDatasource(ctx, args.DatasourceUID, args.ProjectName)
 	if err != nil {
-		return nil, fmt.Errorf("getting backend: %w", err)
+		return nil, nil, fmt.Errorf("getting backend: %w", err)
 	}
 
 	queryType := args.QueryType
@@ -121,18 +129,18 @@ func queryPrometheus(ctx context.Context, args QueryPrometheusParams) (model.Val
 	var endTime time.Time
 	endTime, err = parseTime(args.EndTime)
 	if err != nil {
-		return nil, fmt.Errorf("parsing end time: %w", err)
+		return nil, nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
 	var startTime time.Time
 
 	if queryType == "range" {
 		if args.StepSeconds == 0 {
-			return nil, fmt.Errorf("stepSeconds must be provided when queryType is 'range'")
+			return nil, nil, fmt.Errorf("stepSeconds must be provided when queryType is 'range'")
 		}
 		startTime, err = parseTime(args.StartTime)
 		if err != nil {
-			return nil, fmt.Errorf("parsing start time: %w", err)
+			return nil, nil, fmt.Errorf("parsing start time: %w", err)
 		}
 	}
 
@@ -142,13 +150,14 @@ func queryPrometheus(ctx context.Context, args QueryPrometheusParams) (model.Val
 // queryPrometheusWithHints wraps queryPrometheus and adds hints for empty results.
 // This is the MCP tool handler - hints are added at this layer, not in the internal function.
 func queryPrometheusWithHints(ctx context.Context, args QueryPrometheusParams) (*QueryPrometheusResult, error) {
-	result, err := queryPrometheus(ctx, args)
+	result, warnings, err := queryPrometheusWithWarnings(ctx, args)
 	if err != nil {
 		return nil, err
 	}
 
 	response := &QueryPrometheusResult{
-		Data: result,
+		Data:     result,
+		Warnings: warnings,
 	}
 
 	// Add hints if the result is empty


### PR DESCRIPTION
**Problem**

The Prometheus query path discards the client's `v1.Warnings` return value (`result, _, err := b.api.Query(...)`). On a Thanos datasource with partial-response enabled, a cross-cluster blip returns HTTP 200 with partial data and a non-empty `warnings` array.  Today that's dropped, so a partial aggregate reads as complete and callers silently trust it.

**Fix**
`promBackend.Query` now returns `v1.Warnings`; the native Prometheus backend threads through what the client already returns; `query_prometheus` exposes a new `Warnings []string` field on `QueryPrometheusResult` (`json:"warnings,omitempty"`).

**Compatibility**

Additive on the tool output (field omitted when empty). The only signature change is the internal `promBackend.Query` method; all implementers (native Prometheus, Cloud Monitoring, VictoriaMetrics) are updated.

**Tests**

Added `tools/prom_backend_test.go` covering instant and range queries with and without a `warnings` payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive MCP response field and internal interface change with all backends updated; no change to query semantics when warnings are absent.
> 
> **Overview**
> **`query_prometheus`** now includes an optional **`warnings`** array on its result so callers can see datasource-reported issues (e.g. Thanos partial responses) instead of treating HTTP 200 + partial data as fully complete.
> 
> The internal **`promBackend.Query`** contract returns **`promv1.Warnings`** alongside the series data. The native Prometheus/Thanos path forwards warnings from instant and range API calls; Cloud Monitoring and VictoriaMetrics keep returning empty warnings. **`queryPrometheusWithWarnings`** carries warnings through the stack while **`queryPrometheus`** (used by histogram and other callers) still returns data only.
> 
> Unit tests in **`prom_backend_test.go`** cover instant/range responses with and without a **`warnings`** payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2eecc687fe20aa2c0fc2b456b6658383390f264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->