### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-15
+
 ### Added
 
-- Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window
+- Relative time syntax (e.g. `now-1h`) for tool time range parameters ([#942](https://github.com/grafana/mcp-grafana/pull/942))
+- Support for the native Grafana dashboard schema v2 in dashboard tools ([#937](https://github.com/grafana/mcp-grafana/pull/937))
+- Support for querying Quickwit datasources ([#941](https://github.com/grafana/mcp-grafana/pull/941))
+- Elasticsearch and OpenSearch queries now honor the datasource-configured time field ([#909](https://github.com/grafana/mcp-grafana/pull/909))
+- `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` environment variable to load the service account token from a file, supporting rotated tokens ([#935](https://github.com/grafana/mcp-grafana/pull/935))
+- BigQuery datasource support in `run_panel_query` ([#930](https://github.com/grafana/mcp-grafana/pull/930))
+- Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window ([#927](https://github.com/grafana/mcp-grafana/pull/927))
+
+### Fixed
+
+- Headers are now propagated to downstream Loki calls by passing the configured HTTP transport ([#945](https://github.com/grafana/mcp-grafana/pull/945))
 
 ## [0.15.2] - 2026-06-04
 
@@ -274,6 +286,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.16.0]: https://github.com/grafana/mcp-grafana/compare/v0.15.2...v0.16.0
 [0.15.2]: https://github.com/grafana/mcp-grafana/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/grafana/mcp-grafana/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/grafana/mcp-grafana/compare/v0.14.0...v0.15.0


### PR DESCRIPTION
## Summary

- Bump version to v0.16.0
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.16.0` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update for a release; no runtime or code behavior changes in this diff.
> 
> **Overview**
> Prepares the **v0.16.0** release by moving notes out of `[Unreleased]` into a dated **0.16.0** section and adding the compare link at the bottom of `CHANGELOG.md`.
> 
> The new release notes cover relative time ranges on tools, dashboard schema v2, Quickwit and BigQuery query support, ES/OpenSearch time-field behavior, token loading via `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE`, optional Prometheus metric listing windows, and a fix for propagating headers on downstream Loki calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42236c2847735135faaddbf1400d6e8a40e7246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->