### PR TITLE
fix(elasticsearch): refuse redirects that drop the request body

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -335,7 +335,7 @@ func normalizeGrafanaURL(raw string) string {
 	if u == "" {
 		return ""
 	}
-	if !strings.Contains(u, "://") {
+	if !hasScheme(u) {
 		if isLocalHostPort(u) {
 			u = "http://" + u
 		} else {
@@ -343,6 +343,20 @@ func normalizeGrafanaURL(raw string) string {
 		}
 	}
 	return u
+}
+
+// hasScheme reports whether u begins with a URL scheme (e.g. "https://"). It
+// looks for "://" in scheme position rather than anywhere in the string, so a
+// schemeless URL whose path or query happens to contain "://" (e.g. a query
+// parameter holding another URL) is still recognised as needing a scheme.
+func hasScheme(u string) bool {
+	i := strings.Index(u, "://")
+	if i <= 0 {
+		return false
+	}
+	// Anything path-, query-, or fragment-like before the "://" means it isn't
+	// a real scheme separator.
+	return !strings.ContainsAny(u[:i], "/?#")
 }
 
 // isLocalHostPort reports whether a schemeless URL points at a local address,

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -319,8 +319,46 @@ const (
 // WithGrafanaConfig adds Grafana configuration to the context.
 // This configuration includes API credentials, debug settings, and TLS options that will be used by all Grafana clients created from this context.
 func WithGrafanaConfig(ctx context.Context, config GrafanaConfig) context.Context {
-	config.URL = strings.TrimRight(config.URL, "/")
+	config.URL = normalizeGrafanaURL(config.URL)
 	return context.WithValue(ctx, grafanaConfigKey{}, config)
+}
+
+// normalizeGrafanaURL cleans up a configured Grafana URL so that requests built
+// from it are well-formed and don't trip avoidable redirects. It trims
+// surrounding whitespace and trailing slashes, and supplies a scheme when none
+// is provided — a schemeless value like "grafana.example.com" would otherwise
+// be parsed as a relative path and produce broken request URLs. Schemeless
+// local addresses default to http (local Grafana rarely serves TLS); everything
+// else defaults to https. An empty input is returned unchanged.
+func normalizeGrafanaURL(raw string) string {
+	u := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if u == "" {
+		return ""
+	}
+	if !strings.Contains(u, "://") {
+		if isLocalHostPort(u) {
+			u = "http://" + u
+		} else {
+			u = "https://" + u
+		}
+	}
+	return u
+}
+
+// isLocalHostPort reports whether a schemeless URL points at a local address,
+// e.g. "localhost:3000", "127.0.0.1", or "[::1]:3000".
+func isLocalHostPort(hostPort string) bool {
+	// Drop any path/query so only the host[:port] is inspected.
+	if i := strings.IndexAny(hostPort, "/?"); i >= 0 {
+		hostPort = hostPort[:i]
+	}
+	host := hostPort
+	if h, _, err := net.SplitHostPort(hostPort); err == nil {
+		host = h
+	}
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	return host == "localhost" || strings.HasSuffix(host, ".localhost") ||
+		host == "127.0.0.1" || host == "::1"
 }
 
 // GrafanaConfigFromContext extracts Grafana configuration from the context.

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -697,6 +697,7 @@ func TestWithGrafanaConfigNormalizesURL(t *testing.T) {
 		{"schemeless localhost with path defaults to http", "localhost:3000/grafana", "http://localhost:3000/grafana"},
 		{"schemeless loopback ip defaults to http", "127.0.0.1:3000", "http://127.0.0.1:3000"},
 		{"schemeless ipv6 loopback defaults to http", "[::1]:3000", "http://[::1]:3000"},
+		{"schemeless with :// in query still gets scheme", "example.grafana.net/p?next=http://x", "https://example.grafana.net/p?next=http://x"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -689,6 +689,14 @@ func TestWithGrafanaConfigNormalizesURL(t *testing.T) {
 		{"multiple trailing slashes stripped", "https://example.grafana.net///", "https://example.grafana.net"},
 		{"no trailing slash unchanged", "https://example.grafana.net", "https://example.grafana.net"},
 		{"empty string unchanged", "", ""},
+		{"surrounding whitespace trimmed", "  https://example.grafana.net/  ", "https://example.grafana.net"},
+		{"missing scheme defaults to https", "example.grafana.net", "https://example.grafana.net"},
+		{"missing scheme with path defaults to https", "example.grafana.net/grafana", "https://example.grafana.net/grafana"},
+		{"http scheme preserved", "http://localhost:3000", "http://localhost:3000"},
+		{"schemeless localhost defaults to http", "localhost:3000", "http://localhost:3000"},
+		{"schemeless localhost with path defaults to http", "localhost:3000/grafana", "http://localhost:3000/grafana"},
+		{"schemeless loopback ip defaults to http", "127.0.0.1:3000", "http://127.0.0.1:3000"},
+		{"schemeless ipv6 loopback defaults to http", "[::1]:3000", "http://[::1]:3000"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/ds_query.go
+++ b/tools/ds_query.go
@@ -85,7 +85,7 @@ func newDSQueryHTTPClient(ctx context.Context) (*http.Client, string, error) {
 		return nil, "", fmt.Errorf("failed to create transport: %w", err)
 	}
 
-	return &http.Client{Transport: transport, Timeout: 30 * time.Second}, baseURL, nil
+	return &http.Client{Transport: transport, Timeout: 30 * time.Second, CheckRedirect: refuseRedirect}, baseURL, nil
 }
 
 // framesToTabularRows converts SDK data frames into row-oriented maps — the

--- a/tools/es_backend.go
+++ b/tools/es_backend.go
@@ -94,7 +94,8 @@ func newElasticsearchBackend(ctx context.Context, ds *models.DataSource) (*elast
 	}
 
 	client := &http.Client{
-		Transport: transport,
+		Transport:     transport,
+		CheckRedirect: refuseRedirect,
 	}
 
 	return &elasticsearchBackend{

--- a/tools/es_backend_opensearch.go
+++ b/tools/es_backend_opensearch.go
@@ -36,8 +36,9 @@ func newOpenSearchBackend(ctx context.Context, ds *models.DataSource) (*openSear
 	}
 
 	client := &http.Client{
-		Transport: transport,
-		Timeout:   30 * time.Second,
+		Transport:     transport,
+		Timeout:       30 * time.Second,
+		CheckRedirect: refuseRedirect,
 	}
 
 	// The OpenSearch plugin stores the index pattern in jsonData.database,

--- a/tools/http_redirect.go
+++ b/tools/http_redirect.go
@@ -5,27 +5,43 @@ import (
 	"net/http"
 )
 
+// maxRedirects mirrors the cap Go's default CheckRedirect policy applies.
+const maxRedirects = 10
+
 // refuseRedirect is an http.Client.CheckRedirect callback for clients that POST
 // request bodies to Grafana (the datasource proxy and /api/ds/query endpoints).
 //
-// Per RFC 7231, Go's http.Client silently downgrades a redirected POST to a GET
-// and drops the request body when it follows a 301/302/303 response. A Grafana
-// URL that triggers a redirect — e.g. an http:// URL when root_url enforces
+// Per RFC 7231, Go's http.Client downgrades a redirected POST to a GET and
+// drops the request body when it follows a 301/302/303 response. A Grafana URL
+// that triggers such a redirect — e.g. an http:// URL when root_url enforces
 // https://, a missing/extra trailing path, or a host that 30x-es to a canonical
 // name — therefore causes the datasource to receive an empty-bodied GET. The
 // failure is opaque: Elasticsearch responds with a confusing 400 "request body
 // or source parameter is required" rather than anything pointing at the URL.
 //
-// Refusing to follow the redirect turns that silent corruption into an
-// actionable error naming both URLs.
+// 307 and 308 redirects, by contrast, preserve the method and body, so they are
+// safe to follow. Go signals the difference through req.Method: a body-dropping
+// redirect changes it (e.g. POST -> GET), while a method-preserving one leaves
+// it unchanged. We therefore refuse only the redirects that would silently
+// corrupt the request, turning that corruption into an actionable error.
 func refuseRedirect(req *http.Request, via []*http.Request) error {
-	orig := req.URL
-	if len(via) > 0 {
-		orig = via[0].URL
+	if len(via) == 0 {
+		return nil
 	}
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+
+	prev := via[len(via)-1]
+	if req.Method == prev.Method {
+		// Method preserved (307/308, or a redirected GET): no body is lost, so
+		// follow the redirect as normal.
+		return nil
+	}
+
 	return fmt.Errorf(
-		"refusing to follow HTTP redirect from %s to %s: following it would drop the request body and silently corrupt the query; "+
+		"refusing to follow HTTP redirect from %s to %s: it changes the request method from %s to %s and drops the request body, which would silently corrupt the query; "+
 			"check that your Grafana URL (GRAFANA_URL or X-Grafana-URL) uses the correct scheme and host and matches Grafana's configured root_url",
-		orig, req.URL,
+		prev.URL, req.URL, prev.Method, req.Method,
 	)
 }

--- a/tools/http_redirect.go
+++ b/tools/http_redirect.go
@@ -1,0 +1,31 @@
+package tools
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// refuseRedirect is an http.Client.CheckRedirect callback for clients that POST
+// request bodies to Grafana (the datasource proxy and /api/ds/query endpoints).
+//
+// Per RFC 7231, Go's http.Client silently downgrades a redirected POST to a GET
+// and drops the request body when it follows a 301/302/303 response. A Grafana
+// URL that triggers a redirect — e.g. an http:// URL when root_url enforces
+// https://, a missing/extra trailing path, or a host that 30x-es to a canonical
+// name — therefore causes the datasource to receive an empty-bodied GET. The
+// failure is opaque: Elasticsearch responds with a confusing 400 "request body
+// or source parameter is required" rather than anything pointing at the URL.
+//
+// Refusing to follow the redirect turns that silent corruption into an
+// actionable error naming both URLs.
+func refuseRedirect(req *http.Request, via []*http.Request) error {
+	orig := req.URL
+	if len(via) > 0 {
+		orig = via[0].URL
+	}
+	return fmt.Errorf(
+		"refusing to follow HTTP redirect from %s to %s: following it would drop the request body and silently corrupt the query; "+
+			"check that your Grafana URL (GRAFANA_URL or X-Grafana-URL) uses the correct scheme and host and matches Grafana's configured root_url",
+		orig, req.URL,
+	)
+}

--- a/tools/http_redirect_test.go
+++ b/tools/http_redirect_test.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRefuseRedirectMSearch verifies that a client configured with
+// refuseRedirect surfaces a clear error instead of silently following a
+// redirect that would downgrade the POST to a body-less GET (the failure mode
+// behind https://github.com/grafana/mcp-grafana/issues/938).
+func TestRefuseRedirectMSearch(t *testing.T) {
+	var gotMethods []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethods = append(gotMethods, r.Method)
+		// Redirect to a canonical path, the way a root_url / scheme mismatch
+		// would. A naive client follows this as a GET and drops the body.
+		http.Redirect(w, r, "/canonical/_msearch", http.StatusMovedPermanently)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: refuseRedirect}
+	searchQuery := esSearchQuery{query: "*", size: 10, timeField: defaultTimeField}.build()
+
+	_, err := executeMSearch(context.Background(), client, srv.URL+"/_msearch", "logs-*", searchQuery, defaultTimeField)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to follow HTTP redirect")
+	assert.Contains(t, err.Error(), "GRAFANA_URL")
+	// The redirect must not have been followed, so only the original request hit the server.
+	assert.Equal(t, []string{http.MethodPost}, gotMethods)
+}
+
+// TestRefuseRedirectAllowsNonRedirect confirms the CheckRedirect hook is inert
+// when the server responds without a redirect.
+func TestRefuseRedirectAllowsNonRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"took":1,"responses":[{"took":1,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}]}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: refuseRedirect, Timeout: 5 * time.Second}
+	searchQuery := esSearchQuery{query: "*", size: 10, timeField: defaultTimeField}.build()
+
+	docs, err := executeMSearch(context.Background(), client, srv.URL+"/_msearch", "logs-*", searchQuery, defaultTimeField)
+	require.NoError(t, err)
+	assert.Empty(t, docs)
+}

--- a/tools/http_redirect_test.go
+++ b/tools/http_redirect_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,6 +35,39 @@ func TestRefuseRedirectMSearch(t *testing.T) {
 	assert.Contains(t, err.Error(), "GRAFANA_URL")
 	// The redirect must not have been followed, so only the original request hit the server.
 	assert.Equal(t, []string{http.MethodPost}, gotMethods)
+}
+
+// TestRefuseRedirectFollows307 confirms that a 307 redirect — which preserves
+// the request method and body — is followed rather than refused, so deployments
+// behind proxies/load balancers that issue 307/308 keep working.
+func TestRefuseRedirectFollows307(t *testing.T) {
+	var (
+		gotMethods []string
+		gotBodyLen int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethods = append(gotMethods, r.Method)
+		if r.URL.Path == "/_msearch" {
+			http.Redirect(w, r, "/final/_msearch", http.StatusTemporaryRedirect)
+			return
+		}
+		// Final hop: the body must have survived the redirect.
+		body, _ := io.ReadAll(r.Body)
+		gotBodyLen = len(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"took":1,"responses":[{"took":1,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}]}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: refuseRedirect, Timeout: 5 * time.Second}
+	searchQuery := esSearchQuery{query: "*", size: 10, timeField: defaultTimeField}.build()
+
+	docs, err := executeMSearch(context.Background(), client, srv.URL+"/_msearch", "logs-*", searchQuery, defaultTimeField)
+	require.NoError(t, err)
+	assert.Empty(t, docs)
+	// Both hops used POST (method preserved) and the body reached the final hop.
+	assert.Equal(t, []string{http.MethodPost, http.MethodPost}, gotMethods)
+	assert.Positive(t, gotBodyLen, "request body should survive a 307 redirect")
 }
 
 // TestRefuseRedirectAllowsNonRedirect confirms the CheckRedirect hook is inert

--- a/tools/quickwit.go
+++ b/tools/quickwit.go
@@ -66,7 +66,7 @@ func newQuickwitBackend(ctx context.Context, ds *models.DataSource) (*quickwitBa
 	}
 
 	return &quickwitBackend{
-		httpClient:      &http.Client{Transport: transport},
+		httpClient:      &http.Client{Transport: transport, CheckRedirect: refuseRedirect},
 		baseURL:         proxyURL,
 		configuredIndex: indexFromQuickwitDataSource(ds),
 	}, nil


### PR DESCRIPTION
## Problem

`query_elasticsearch` returns an opaque `400 "request body or source parameter is required"` for **every** query, regardless of datasource, index, query, or time range (#938).

The clue is in the reporter's Grafana log:

```
msg="Proxying incoming request" ... uri=.../_msearch method=GET ... body=
```

Our code unambiguously sends a **POST** with an NDJSON body (`tools/es_backend.go`), but Grafana receives a **GET** with an empty body. The only thing that turns a POST into a GET *and drops the body* between client and server is an HTTP redirect: per RFC 7231, Go's `http.Client` silently downgrades a redirected POST to a body-less GET for 301/302/303 responses. So a Grafana URL that triggers a redirect — `http://` when `root_url` enforces `https://`, a host that 30x-es to a canonical name, etc. — causes Elasticsearch to receive an empty `_msearch` request and reject it. This also explains why query content / index / time range made no difference: the body never arrived.

## Fix

1. **Refuse redirects on body-carrying clients.** A shared `refuseRedirect` `CheckRedirect` callback is wired into every client that POSTs a body to Grafana — Elasticsearch, OpenSearch, Quickwit, and the shared `/api/ds/query` client. Instead of silently corrupting the request, they now fail with an actionable error:

   > refusing to follow HTTP redirect from `<orig>` to `<target>`: following it would drop the request body and silently corrupt the query; check that your Grafana URL (GRAFANA_URL or X-Grafana-URL) uses the correct scheme and host and matches Grafana's configured root_url

2. **Normalize the configured Grafana URL** in `WithGrafanaConfig`: trim surrounding whitespace and supply a scheme when none is given (`http` for local addresses like `localhost`/`127.0.0.1`/`::1`, `https` otherwise). Trailing-slash trimming is unchanged. This heads off a related class of broken-URL / redirect issues.

## Tests

- `tools/http_redirect_test.go` — redirect is refused with a clear error (and not followed); non-redirect responses pass through unchanged.
- Extended `TestWithGrafanaConfigNormalizesURL` with whitespace and scheme-defaulting cases (including localhost special-casing).

`go vet`, `gofmt`, `golangci-lint`, and the full `-tags unit` suite pass.

Fixes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP client redirect behavior and global Grafana URL normalization for all context-configured clients; misconfigured URLs may now fail fast with errors instead of silent bad queries, which is intended but affects operational troubleshooting.
> 
> **Overview**
> Fixes opaque Elasticsearch/OpenSearch query failures when Grafana responds with **301/302/303** redirects that cause Go’s client to turn POSTs into body-less GETs.
> 
> A shared **`refuseRedirect`** `CheckRedirect` hook is wired into HTTP clients that POST to Grafana (datasource proxy paths for Elasticsearch, OpenSearch, Quickwit, and **`/api/ds/query`**). Redirects that would change the method are rejected with an error pointing at **`GRAFANA_URL` / `X-Grafana-URL`** and **`root_url`**; **307/308** (method preserved) still follow.
> 
> **`WithGrafanaConfig`** now runs **`normalizeGrafanaURL`**: trim whitespace and trailing slashes, infer **`http`** for local hosts and **`https`** otherwise when the scheme is missing, with safer scheme detection when `://` appears in paths/queries.
> 
> Tests cover redirect refusal, 307 following, and expanded URL normalization cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad52bb5f47db115af104c5caa5f160f951c1aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->