### PR TITLE
ci: add read-only permissions to test-install-scripts workflow

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/test-install-scripts.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-nodejs-script:
     name: Test Node.js Script


### PR DESCRIPTION
## Summary

The `Test Install Scripts` workflow declared no `permissions:` block, so it inherited the default `GITHUB_TOKEN` permissions. `zizmor` flags this as `excessive-permissions` (one warning per job) because:

- it breaks when the org restricts default `GITHUB_TOKEN` permissions to read-only, and
- it grants more scope than the jobs actually need.

## Change

Added a top-level `permissions: contents: read` block. GitHub Actions jobs inherit workflow-level permissions, so this single block covers all four jobs (`test-nodejs-script`, `test-checksum-verification`, `test-version-update`). `contents: read` is sufficient — these jobs only check out the repo and download release assets via the GitHub API; none write to the repo or need other scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission tightening with no application or runtime behavior changes.
> 
> **Overview**
> Adds a workflow-level **`permissions: contents: read`** block to **Test Install Scripts**, aligning it with other read-only CI workflows and addressing **zizmor** `excessive-permissions` warnings.
> 
> Jobs only check out the repo and use `GITHUB_TOKEN` to fetch release assets for install-script tests; they do not push or mutate repository contents, so read scope is sufficient for all matrix jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8763afea227ea09011b87c65eb8b185365946eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->