### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.0] - 2026-06-16
 
 ### Added
 
-- Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window
-- `query_prometheus` now surfaces datasource `warnings` (e.g. partial responses from Thanos) in its result
+- `query_prometheus` now surfaces datasource `warnings` (e.g. partial responses from Thanos) in its result ([#946](https://github.com/grafana/mcp-grafana/pull/946))
+- Relative time syntax (e.g. `now-1h`, `now-7d`) is now accepted wherever tools take time range parameters ([#942](https://github.com/grafana/mcp-grafana/pull/942))
+- Native support for dashboard schema v2 in dashboard tools ([#937](https://github.com/grafana/mcp-grafana/pull/937))
+- Quickwit datasources are now supported by the search/query tools ([#941](https://github.com/grafana/mcp-grafana/pull/941))
+- Elasticsearch and OpenSearch queries now honor the datasource's configured `timeField` ([#909](https://github.com/grafana/mcp-grafana/pull/909))
+- `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` environment variable for reading a service account token from a file, enabling support for rotated tokens ([#935](https://github.com/grafana/mcp-grafana/pull/935))
+- BigQuery datasource support in `run_panel_query` ([#930](https://github.com/grafana/mcp-grafana/pull/930))
+- Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window ([#927](https://github.com/grafana/mcp-grafana/pull/927))
+
+### Fixed
+
+- Elasticsearch requests now refuse to follow redirects that would silently drop the request body, preventing malformed downstream queries ([#951](https://github.com/grafana/mcp-grafana/pull/951))
+- Loki downstream calls now propagate configured HTTP headers via the shared transport ([#945](https://github.com/grafana/mcp-grafana/pull/945))
 
 ## [0.15.2] - 2026-06-04
 
@@ -275,6 +286,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.16.0]: https://github.com/grafana/mcp-grafana/compare/v0.15.2...v0.16.0
 [0.15.2]: https://github.com/grafana/mcp-grafana/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/grafana/mcp-grafana/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/grafana/mcp-grafana/compare/v0.14.0...v0.15.0


### PR DESCRIPTION
## Summary

- Bump version to v0.16.0
- Add CHANGELOG.md entries for this release

## Checklist

- [ ] CHANGELOG entries are accurate and complete
- [ ] Version number is correct
- [ ] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.16.0` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CHANGELOG documentation changes; no runtime code in this diff, though merging is intended to cut the v0.16.0 tag and run release automation.
> 
> **Overview**
> Prepares **v0.16.0** by replacing the `[Unreleased]` section with a dated **0.16.0** release block and adding the standard `[0.16.0]` compare URL at the bottom of `CHANGELOG.md`.
> 
> The new release notes consolidate **Added** items (Prometheus warnings, relative time ranges, dashboard schema v2, Quickwit, ES/OpenSearch `timeField`, token file env var, BigQuery in `run_panel_query`, Prometheus metric list time window) and **Fixed** items (Elasticsearch redirect/body handling, Loki header propagation), each with PR links. Some previously unreleased bullets are rewritten or deduplicated with explicit issue/PR references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c16a0217146c5def44f4870d192a2f437e575caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->