### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.0] - 2026-06-16
 
 ### Added
 
-- Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window
-- `query_prometheus` now surfaces datasource `warnings` (e.g. partial responses from Thanos) in its result
+- Snapshot tools (`list_snapshots`, `get_snapshot`, `create_snapshot`, `delete_snapshot`) for managing Grafana dashboard snapshots ([#949](https://github.com/grafana/mcp-grafana/pull/949))
+- Native dashboard schema v2 support in the dashboard tools ([#937](https://github.com/grafana/mcp-grafana/pull/937))
+- Quickwit datasource support ([#941](https://github.com/grafana/mcp-grafana/pull/941))
+- BigQuery datasource support in `run_panel_query` ([#930](https://github.com/grafana/mcp-grafana/pull/930))
+- Elasticsearch and OpenSearch tools now honor the datasource-configured `timeField` ([#909](https://github.com/grafana/mcp-grafana/pull/909))
+- Relative time syntax (e.g. `now-1h`) for time range parameters across tools ([#942](https://github.com/grafana/mcp-grafana/pull/942))
+- `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` environment variable to read the service account token from a file, supporting rotated tokens ([#935](https://github.com/grafana/mcp-grafana/pull/935))
+- Optional `startRfc3339`/`endRfc3339` time range parameters for `list_prometheus_metric_names` to restrict results to metrics active within a window ([#927](https://github.com/grafana/mcp-grafana/pull/927))
+- `query_prometheus` now surfaces datasource `warnings` (e.g. partial responses from Thanos) in its result ([#946](https://github.com/grafana/mcp-grafana/pull/946))
+
+### Fixed
+
+- Elasticsearch client now refuses HTTP redirects that would drop the request body, preventing malformed queries against redirecting endpoints ([#951](https://github.com/grafana/mcp-grafana/pull/951))
+- Propagate forwarded headers to downstream Loki calls by using the configured HTTP transport ([#945](https://github.com/grafana/mcp-grafana/pull/945))
 
 ## [0.15.2] - 2026-06-04
 
@@ -275,6 +287,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Docker base image packages to resolve critical OpenSSL CVE-2025-15467 (CVSS 9.8) ([#551](https://github.com/grafana/mcp-grafana/pull/551))
 
+[0.16.0]: https://github.com/grafana/mcp-grafana/compare/v0.15.2...v0.16.0
 [0.15.2]: https://github.com/grafana/mcp-grafana/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/grafana/mcp-grafana/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/grafana/mcp-grafana/compare/v0.14.0...v0.15.0


### PR DESCRIPTION
## Summary

- Bump version to v0.16.0
- Add CHANGELOG.md entries for this release

## Checklist

- [x] CHANGELOG entries are accurate and complete
- [x] Version number is correct
- [x] All significant changes are documented

> [!NOTE]
> Merging this PR will automatically create the `v0.16.0` tag,
> which triggers goreleaser (GitHub Release + binaries) and Docker image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release prep; no application code changes in this diff.
> 
> **Overview**
> **Release v0.16.0** — updates `CHANGELOG.md` from `[Unreleased]` to a dated **0.16.0** section and adds the **v0.15.2…v0.16.0** compare link.
> 
> The new notes cover capabilities already merged in prior PRs: **dashboard snapshot** MCP tools, **dashboard schema v2**, **Quickwit** and **BigQuery** (`run_panel_query`) support, **relative time** ranges, **`GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE`**, Prometheus **metric-name time windows** and **query warnings**, plus fixes for **Elasticsearch redirect/body** handling and **Loki forwarded headers**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86daa9383baa18eeb60370bf13e074bc827fda29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->