### PR TITLE
fix(dashboard): recognize Athena plugin's rawSQL query field

### DIFF
--- a/tools/dashboard_helpers.go
+++ b/tools/dashboard_helpers.go
@@ -255,6 +255,7 @@ func extractQueryExpression(target map[string]interface{}) string {
 		"query",      // Loki, ClickHouse, generic
 		"expression", // CloudWatch
 		"rawSql",     // SQL databases
+		"rawSQL",     // Athena (grafana-athena-datasource)
 		"rawQuery",   // Some datasources
 	}
 

--- a/tools/dashboard_helpers_test.go
+++ b/tools/dashboard_helpers_test.go
@@ -248,6 +248,13 @@ func TestExtractQueryExpression(t *testing.T) {
 			expected: "SELECT * FROM metrics WHERE time > $__from",
 		},
 		{
+			name: "athena rawSQL",
+			target: map[string]interface{}{
+				"rawSQL": "SELECT * FROM logs WHERE time > $__timeFilter",
+			},
+			expected: "SELECT * FROM logs WHERE time > $__timeFilter",
+		},
+		{
 			name:     "empty target",
 			target:   map[string]interface{}{},
 			expected: "",

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -354,7 +354,7 @@ func extractPanelInfo(panel map[string]interface{}, queryIndex int) (*panelInfo,
 
 	// CloudWatch panels use structured targets rather than string expressions
 	if query == "" && normalizeDatasourceType(info.DatasourceType) != "cloudwatch" {
-		return nil, fmt.Errorf("could not extract query from panel target (checked: expr, query, expression, rawSql, rawQuery)")
+		return nil, fmt.Errorf("could not extract query from panel target (checked: expr, query, expression, rawSql, rawSQL, rawQuery)")
 	}
 	info.Query = query
 


### PR DESCRIPTION
## Summary

`get_dashboard_panel_queries` and `run_panel_query` failed to extract queries from panels using the Grafana Athena datasource (`grafana-athena-datasource`), returning:

> extracting panel info: could not extract query from panel target (checked: expr, query, expression, rawSql, rawQuery)

The Athena plugin stores its query in a `rawSQL` field (capital `S`), which was not in the list of recognized query field names in `extractQueryExpression`.

## Changes

- Add `"rawSQL"` to the `queryFields` slice in `extractQueryExpression` (`tools/dashboard_helpers.go`)
- Update the corresponding error message in `tools/run_panel_query.go` to reflect the new field
- Add a test case covering the Athena `rawSQL` field in `TestExtractQueryExpression`

## Testing

- `go test -tags unit ./tools/` passes
- `golangci-lint run ./tools/` reports 0 issues

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (n/a — internal field list)
- [x] Linting passes

Fixes #955

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to query-field detection with a matching unit test; no auth, data, or execution-path refactors.
> 
> **Overview**
> Dashboard panel query extraction now treats the Grafana Athena datasource’s **`rawSQL`** target field (capital `S`) the same as other SQL-style fields, so **`get_dashboard_panel_queries`** and **`run_panel_query`** can read Athena panel SQL instead of failing with “could not extract query from panel target.”
> 
> **`extractQueryExpression`** gains **`rawSQL`** in its field scan list; the **`run_panel_query`** extraction error text lists the updated fields. A unit test covers Athena **`rawSQL`** extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe3d016a93ae26a87ff1a86f62df227fb692a9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->