### PR TITLE
fix(security): block DNS rebinding on HTTP transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,13 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 - `--base-path`: Base path for the SSE/streamable-http server
 - `--endpoint-path`: Endpoint path for the streamable-http server - default: `/`
 
+**HTTP Transport Security (SSE / streamable-http only):**
+
+`Host`/`Origin` validation is enforced on *every* route on the listener — `/sse`, `/mcp`, `/healthz`, and `/metrics` — so a DNS-rebinding browser cannot reach any of them. Stdio transport is unaffected.
+
+- `--allowed-hosts`: Comma-separated allowlist of `Host` header values. Defaults to loopback variants of `--address` (e.g. `localhost:8000,127.0.0.1:8000,[::1]:8000`). A value that parses to empty (unset, `,`, ` , `, etc.) also falls back to the defaults so a typo cannot silently disable the check. Requests with a `Host` header outside the allowlist are rejected with `403`. Pass `*` to disable the check — only safe when running behind a trusted reverse proxy that rewrites `Host`, or in an isolated network. K8s `httpGet` probes and external `/metrics` scrapes will need either an explicit hostname in this list, `*`, or a `tcpSocket` probe / a separate metrics port (`--metrics-address`).
+- `--allowed-origins`: Comma-separated allowlist of `Origin` header values. Empty by default — any request that carries an `Origin` header is rejected (browsers always send one for cross-origin requests, and no browser should be calling this server directly). Set to an explicit list to permit browser-based clients, or `*` to disable the check.
+
 **Debug and Logging:**
 - `--debug`: Enable debug mode for detailed HTTP request/response logging
 - `--log-level`: Log level (`debug`, `info`, `warn`, `error`) - default: `info`

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -343,6 +343,58 @@ func (tc *tlsConfig) addFlags() {
 	flag.StringVar(&tc.keyFile, "server.tls-key-file", "", "Path to TLS private key file for server HTTPS (required for TLS)")
 }
 
+// httpSecurityConfig holds the Host/Origin allowlists enforced on HTTP-based
+// transports. See DNSRebindingProtectionMiddleware for semantics.
+type httpSecurityConfig struct {
+	allowedHosts   string
+	allowedOrigins string
+}
+
+func (hsc *httpSecurityConfig) addFlags() {
+	flag.StringVar(&hsc.allowedHosts, "allowed-hosts", "", "Comma-separated allowlist of Host header values for the HTTP/SSE transports. Defaults to loopback variants of --address. Use \"*\" to disable validation (only safe behind a trusted reverse proxy that rewrites Host).")
+	flag.StringVar(&hsc.allowedOrigins, "allowed-origins", "", "Comma-separated allowlist of Origin header values for the HTTP/SSE transports. Empty (the default) rejects any request that carries an Origin header — appropriate for non-browser MCP clients. Use \"*\" to disable validation.")
+}
+
+// policy resolves the configured flags into a HostOriginPolicy. An
+// --allowed-hosts whose parsed form is empty (unset, "," " , ", etc.) falls
+// back to DefaultAllowedHosts so a malformed value cannot silently disable
+// the Host check.
+func (hsc httpSecurityConfig) policy(address string) mcpgrafana.HostOriginPolicy {
+	hosts := splitAndTrim(hsc.allowedHosts)
+	if len(hosts) == 0 {
+		hosts = mcpgrafana.DefaultAllowedHosts(address)
+	}
+	return mcpgrafana.HostOriginPolicy{
+		AllowedHosts:   hosts,
+		AllowedOrigins: splitAndTrim(hsc.allowedOrigins),
+	}
+}
+
+func (hsc httpSecurityConfig) corsOrigins() []string {
+	if origins := splitAndTrim(hsc.allowedOrigins); len(origins) > 0 {
+		for i, o := range origins {
+			origins[i] = strings.ToLower(o)
+		}
+		return origins
+	}
+	// Sentinel keeps mcp-go's corsConfig.enabled() true so its SSE default
+	// of Access-Control-Allow-Origin: * is suppressed.
+	return []string{"https://mcp-grafana.invalid"}
+}
+
+func splitAndTrim(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // httpServer represents a server with Start and Shutdown methods
 type httpServer interface {
 	Start(addr string) error
@@ -406,7 +458,7 @@ func runMetricsServer(addr string, o *observability.Observability) {
 	}
 }
 
-func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, obs observability.Config, sessionIdleTimeoutMinutes int) error {
+func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, hsc httpSecurityConfig, obs observability.Config, sessionIdleTimeoutMinutes int) error {
 	stderrHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
 	slog.SetDefault(slog.New(stderrHandler))
 
@@ -494,6 +546,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			server.WithSSEContextFunc(mcpgrafana.ComposedSSEContextFunc(gc, clientCache)),
 			server.WithStaticBasePath(basePath),
 			server.WithHTTPServer(httpSrv),
+			server.WithSSECORS(server.WithCORSAllowedOrigins(hsc.corsOrigins()...)),
 		)
 		mux := http.NewServeMux()
 		if basePath == "" {
@@ -511,7 +564,8 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 				go runMetricsServer(obs.MetricsAddress, o)
 			}
 		}
-		httpSrv.Handler = mux
+		// Wrap the full mux so /healthz and /metrics are validated too.
+		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
 		slog.Info("Starting Grafana MCP server using SSE transport",
 			"version", mcpgrafana.Version(), "address", addr, "basePath", basePath, "metrics", obs.MetricsEnabled)
 		return runHTTPServer(ctx, srv, addr, "SSE")
@@ -522,6 +576,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			server.WithStateLess(dt.proxied), // Stateful when proxied tools enabled (requires sessions)
 			server.WithEndpointPath(endpointPath),
 			server.WithStreamableHTTPServer(httpSrv),
+			server.WithStreamableHTTPCORS(server.WithCORSAllowedOrigins(hsc.corsOrigins()...)),
 		}
 		if tls.certFile != "" || tls.keyFile != "" {
 			opts = append(opts, server.WithTLSCert(tls.certFile, tls.keyFile))
@@ -540,7 +595,8 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 				go runMetricsServer(obs.MetricsAddress, o)
 			}
 		}
-		httpSrv.Handler = mux
+		// Wrap the full mux so /healthz and /metrics are validated too.
+		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
 		slog.Info("Starting Grafana MCP server using StreamableHTTP transport",
 			"version", mcpgrafana.Version(), "address", addr, "endpointPath", endpointPath, "metrics", obs.MetricsEnabled)
 		return runHTTPServer(ctx, srv, addr, "StreamableHTTP")
@@ -570,6 +626,8 @@ func main() {
 	gc.addFlags()
 	var tls tlsConfig
 	tls.addFlags()
+	var hsc httpSecurityConfig
+	hsc.addFlags()
 	var obs observability.Config
 	flag.BoolVar(&obs.MetricsEnabled, "metrics", false, "Enable Prometheus metrics endpoint")
 	flag.StringVar(&obs.MetricsAddress, "metrics-address", "", "Separate address for metrics server (e.g., :9090). If empty, metrics are served on the main server at /metrics")
@@ -625,7 +683,7 @@ func main() {
 		level = slog.LevelDebug
 	}
 
-	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, obs, *sessionIdleTimeoutMinutes); err != nil {
+	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, hsc, obs, *sessionIdleTimeoutMinutes); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"strings"
 	"testing"
@@ -10,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -304,6 +308,150 @@ func TestHandleFlagsPostParse(t *testing.T) {
 			} else {
 				assert.NoError(t, err, "expected no error")
 			}
+		})
+	}
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty string", "", nil},
+		{"single value", "a", []string{"a"}},
+		{"comma separated", "a,b,c", []string{"a", "b", "c"}},
+		{"whitespace trimmed", " a , b , c ", []string{"a", "b", "c"}},
+		{"empty entries skipped", "a,,b, ,c", []string{"a", "b", "c"}},
+		{"only commas yields nil", ",,, , ,", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitAndTrim(tc.in))
+		})
+	}
+}
+
+func TestHTTPSecurityConfigPolicy(t *testing.T) {
+	cases := []struct {
+		name           string
+		allowedHosts   string
+		allowedOrigins string
+		address        string
+		wantHosts      []string
+		wantOrigins    []string
+	}{
+		{
+			name:        "unset --allowed-hosts falls back to defaults",
+			address:     "localhost:8000",
+			wantHosts:   []string{"localhost:8000", "127.0.0.1:8000", "[::1]:8000"},
+			wantOrigins: nil,
+		},
+		{
+			// Regression guard: a malformed value that splits to empty must
+			// NOT silently disable Host validation.
+			name:         "comma-only --allowed-hosts falls back to defaults",
+			allowedHosts: ",,, ,",
+			address:      "localhost:8000",
+			wantHosts:    []string{"localhost:8000", "127.0.0.1:8000", "[::1]:8000"},
+			wantOrigins:  nil,
+		},
+		{
+			name:         "explicit --allowed-hosts overrides defaults",
+			allowedHosts: "mcp.example:8000, other.example:8000",
+			address:      "localhost:8000",
+			wantHosts:    []string{"mcp.example:8000", "other.example:8000"},
+		},
+		{
+			name:           "origins pass through",
+			allowedOrigins: "https://app.example",
+			address:        "localhost:8000",
+			wantHosts:      []string{"localhost:8000", "127.0.0.1:8000", "[::1]:8000"},
+			wantOrigins:    []string{"https://app.example"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hsc := httpSecurityConfig{allowedHosts: tc.allowedHosts, allowedOrigins: tc.allowedOrigins}
+			got := hsc.policy(tc.address)
+			assert.Equal(t, tc.wantHosts, got.AllowedHosts)
+			assert.Equal(t, tc.wantOrigins, got.AllowedOrigins)
+		})
+	}
+}
+
+// TestSSEServerSuppressesWildcardCORS pins the load-bearing assumption behind
+// corsOrigins(): that passing any non-empty AllowedOrigins through
+// WithSSECORS makes mcp-go's corsConfig.enabled() return true, suppressing
+// the historical Access-Control-Allow-Origin: * default on /sse.
+//
+// The control sub-test boots an SSE server without our opt-in and asserts the
+// wildcard IS emitted, documenting the regression scenario. If a future
+// mcp-go bump removes the historical default, the control fails and we know
+// the sentinel workaround can be removed.
+func TestSSEServerSuppressesWildcardCORS(t *testing.T) {
+	hitSSE := func(t *testing.T, opts ...server.SSEOption) http.Header {
+		t.Helper()
+		mcpServer := server.NewMCPServer("test", "0")
+		sse := server.NewSSEServer(mcpServer, opts...)
+		ts := httptest.NewServer(sse)
+		t.Cleanup(ts.Close)
+
+		// Abort as soon as we have headers — SSE keeps the stream open.
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/sse", nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			require.NoError(t, err)
+		}
+		require.NotNil(t, resp)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		return resp.Header
+	}
+
+	t.Run("control: mcp-go emits the wildcard by default", func(t *testing.T) {
+		h := hitSSE(t)
+		assert.Equal(t, "*", h.Get("Access-Control-Allow-Origin"),
+			"mcp-go's historical default changed — sentinel workaround in corsOrigins() may be removable")
+	})
+
+	t.Run("opt-in via corsOrigins sentinel suppresses the wildcard", func(t *testing.T) {
+		hsc := httpSecurityConfig{}
+		h := hitSSE(t, server.WithSSECORS(server.WithCORSAllowedOrigins(hsc.corsOrigins()...)))
+		assert.Empty(t, h.Get("Access-Control-Allow-Origin"),
+			"sentinel did not suppress wildcard — mcp-go CORS contract may have changed")
+	})
+}
+
+func TestHTTPSecurityConfigCORSOrigins(t *testing.T) {
+	cases := []struct {
+		name           string
+		allowedOrigins string
+		want           []string
+	}{
+		{
+			// The sentinel keeps mcp-go's corsConfig.enabled() true so its
+			// SSE default of Access-Control-Allow-Origin: * is suppressed.
+			name: "unset returns the .invalid sentinel",
+			want: []string{"https://mcp-grafana.invalid"},
+		},
+		{
+			name:           "comma-only returns the sentinel",
+			allowedOrigins: ", ,",
+			want:           []string{"https://mcp-grafana.invalid"},
+		},
+		{
+			name:           "explicit origins pass through lowercased",
+			allowedOrigins: "HTTPS://App.Example, https://other.example",
+			want:           []string{"https://app.example", "https://other.example"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hsc := httpSecurityConfig{allowedOrigins: tc.allowedOrigins}
+			assert.Equal(t, tc.want, hsc.corsOrigins())
 		})
 	}
 }

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -31,6 +31,15 @@ You can look up defaults, choose `--disable-*` flags, or configure TLS without r
 - `--endpoint-path`: HTTP path for the streamable-http MCP endpoint. Default: `/mcp`.
 - `--session-idle-timeout-minutes`: Idle timeout for streamable-http sessions, in minutes. Sessions with no activity for this duration are automatically reaped. Set to `0` to disable. Default: `30`.
 
+## Configure HTTP transport security
+
+The SSE and streamable-http transports validate `Host` and `Origin` headers on every route (`/sse`, `/mcp`, `/healthz`, `/metrics`) to block DNS-rebinding attacks. Stdio transport is unaffected.
+
+- `--allowed-hosts`: Comma-separated allowlist of `Host` header values. When unset (or when the parsed value is empty — for example, `,,,`), it falls back to loopback variants of `--address` (for example, `localhost:8000`, `127.0.0.1:8000`, `[::1]:8000`). Pass `*` to disable the check — only safe behind a trusted reverse proxy that rewrites `Host`.
+- `--allowed-origins`: Comma-separated allowlist of `Origin` header values. Empty by default — any request that carries an `Origin` header is rejected (browsers always send `Origin` for cross-origin requests, and no browser should be calling this server directly). Pass an explicit list to permit browser clients, or `*` to disable the check.
+
+When deploying behind an ingress or reverse proxy that forwards the original `Host`, set `--allowed-hosts` to the expected hostname (or `*` if the proxy is fully trusted). Kubernetes `httpGet` liveness/readiness probes send `Host: <pod-ip>:<port>` by default — either set `--allowed-hosts '*'`, override the probe's `host:` field, or use a `tcpSocket` probe. External `/metrics` scrapes must add the scrape source's `Host` to the allowlist (or use `--metrics-address` to bind metrics on a separate port, which is unaffected).
+
 ## Configure debug and logging
 
 - `--debug`: Enable debug mode for detailed HTTP request and response logging to and from the Grafana API.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grafana/pyroscope/api v1.3.2
 	github.com/invopop/jsonschema v0.13.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/mark3labs/mcp-go v0.46.0
+	github.com/mark3labs/mcp-go v0.55.0
 	github.com/prometheus/alertmanager v0.31.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
@@ -141,6 +141,7 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/prometheus/sigv4 v0.4.1 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
@@ -248,8 +250,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/mark3labs/mcp-go v0.46.0 h1:8KRibF4wcKejbLsHxCA/QBVUr5fQ9nwz/n8lGqmaALo=
-github.com/mark3labs/mcp-go v0.46.0/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
+github.com/mark3labs/mcp-go v0.55.0 h1:lJfz2aoctiwK+sI991+uIYwmKNIBciI+O7zsyDsa4U8=
+github.com/mark3labs/mcp-go v0.55.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
 github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mattetti/filebuffer v1.0.1 h1:gG7pyfnSIZCxdoKq+cPa8T0hhYtD9NxCdI4D7PTjRLM=
@@ -322,6 +324,8 @@ github.com/prometheus/sigv4 v0.4.1 h1:EIc3j+8NBea9u1iV6O5ZAN8uvPq2xOIUPcqCTivHuX
 github.com/prometheus/sigv4 v0.4.1/go.mod h1:eu+ZbRvsc5TPiHwqh77OWuCnWK73IdkETYY46P4dXOU=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=

--- a/http_security.go
+++ b/http_security.go
@@ -1,0 +1,83 @@
+package mcpgrafana
+
+import (
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+type HostOriginPolicy struct {
+	AllowedHosts   []string
+	AllowedOrigins []string
+}
+
+// DNSRebindingProtectionMiddleware rejects requests whose Host (or Origin,
+// when present) is not in the configured allowlists, defending HTTP/SSE
+// transports against DNS-rebinding attacks. An empty AllowedOrigins rejects
+// any request carrying an Origin header; a literal "*" disables either check.
+func DNSRebindingProtectionMiddleware(policy HostOriginPolicy) func(http.Handler) http.Handler {
+	hosts := normalizeAllowlist(policy.AllowedHosts)
+	origins := normalizeAllowlist(policy.AllowedOrigins)
+	skipHosts := slices.Contains(hosts, "*")
+	skipOrigins := slices.Contains(origins, "*")
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !skipHosts && len(hosts) > 0 {
+				if !slices.Contains(hosts, strings.ToLower(r.Host)) {
+					http.Error(w, "forbidden: host not allowed", http.StatusForbidden)
+					return
+				}
+			}
+			if !skipOrigins {
+				if origin := r.Header.Get("Origin"); origin != "" {
+					if !slices.Contains(origins, strings.ToLower(origin)) {
+						http.Error(w, "forbidden: origin not allowed", http.StatusForbidden)
+						return
+					}
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func normalizeAllowlist(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(strings.ToLower(v))
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// DefaultAllowedHosts derives a Host allowlist from a bind address. Wildcard
+// binds (0.0.0.0, ::, empty host) return all loopback variants; "localhost"
+// adds 127.0.0.1 and [::1]; specific hostnames return only themselves.
+func DefaultAllowedHosts(address string) []string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return []string{strings.ToLower(address)}
+	}
+	host = strings.ToLower(host)
+
+	switch host {
+	case "", "0.0.0.0", "::":
+		return []string{
+			net.JoinHostPort("localhost", port),
+			net.JoinHostPort("127.0.0.1", port),
+			net.JoinHostPort("::1", port),
+		}
+	case "localhost":
+		return []string{
+			net.JoinHostPort("localhost", port),
+			net.JoinHostPort("127.0.0.1", port),
+			net.JoinHostPort("::1", port),
+		}
+	default:
+		return []string{net.JoinHostPort(host, port)}
+	}
+}

--- a/http_security_test.go
+++ b/http_security_test.go
@@ -1,0 +1,150 @@
+package mcpgrafana
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// okHandler is the inner handler the middleware wraps. We assert that the
+// middleware either calls it (allow) or short-circuits before it (deny).
+func okHandler(t *testing.T) (http.Handler, *bool) {
+	t.Helper()
+	called := false
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}), &called
+}
+
+func TestDNSRebindingProtectionMiddleware_Host(t *testing.T) {
+	cases := []struct {
+		name       string
+		allowed    []string
+		host       string
+		wantStatus int
+		wantCalled bool
+	}{
+		{"matching host passes", []string{"localhost:8000"}, "localhost:8000", http.StatusOK, true},
+		{"case-insensitive host match passes", []string{"localhost:8000"}, "LOCALHOST:8000", http.StatusOK, true},
+		{"mismatched host blocked", []string{"localhost:8000"}, "evil.example:8000", http.StatusForbidden, false},
+		{"loopback IP variant blocked when not allowlisted", []string{"localhost:8000"}, "127.0.0.1:8000", http.StatusForbidden, false},
+		{"empty allowlist permits everything (Host check disabled)", nil, "anything.example", http.StatusOK, true},
+		{"wildcard disables host validation", []string{"*"}, "rebinding.attacker.example", http.StatusOK, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inner, called := okHandler(t)
+			mw := DNSRebindingProtectionMiddleware(HostOriginPolicy{AllowedHosts: tc.allowed})
+
+			req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+			req.Host = tc.host
+			rr := httptest.NewRecorder()
+			mw(inner).ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.wantStatus, rr.Code)
+			assert.Equal(t, tc.wantCalled, *called)
+		})
+	}
+}
+
+func TestDNSRebindingProtectionMiddleware_Origin(t *testing.T) {
+	cases := []struct {
+		name       string
+		allowed    []string
+		origin     string
+		wantStatus int
+		wantCalled bool
+	}{
+		{"no Origin header passes (CLI client)", nil, "", http.StatusOK, true},
+		{"empty allowlist rejects any Origin", nil, "http://evil.example", http.StatusForbidden, false},
+		{"matching Origin passes", []string{"http://localhost:3000"}, "http://localhost:3000", http.StatusOK, true},
+		{"case-insensitive Origin match passes", []string{"http://localhost:3000"}, "HTTP://LOCALHOST:3000", http.StatusOK, true},
+		{"non-matching Origin blocked", []string{"http://localhost:3000"}, "http://evil.example", http.StatusForbidden, false},
+		{"wildcard disables Origin validation even with Origin present", []string{"*"}, "http://evil.example", http.StatusOK, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inner, called := okHandler(t)
+			// AllowedHosts is left empty so only Origin is exercised here.
+			mw := DNSRebindingProtectionMiddleware(HostOriginPolicy{AllowedOrigins: tc.allowed})
+
+			req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			rr := httptest.NewRecorder()
+			mw(inner).ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.wantStatus, rr.Code)
+			assert.Equal(t, tc.wantCalled, *called)
+		})
+	}
+}
+
+// TestDNSRebindingProtectionMiddleware_RebindingScenario simulates the exact
+// DNS-rebinding case from the customer report: a browser hits 127.0.0.1:8000
+// but the URL bar (and therefore the Host header) is the attacker's domain.
+// With the default Host allowlist derived from the bind address, the request
+// must be rejected before reaching the SSE handler.
+func TestDNSRebindingProtectionMiddleware_RebindingScenario(t *testing.T) {
+	inner, called := okHandler(t)
+	policy := HostOriginPolicy{AllowedHosts: DefaultAllowedHosts("localhost:8000")}
+	mw := DNSRebindingProtectionMiddleware(policy)
+
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Host = "rebinding.attacker.example:8000"
+	req.Header.Set("Origin", "http://rebinding.attacker.example:8000")
+
+	rr := httptest.NewRecorder()
+	mw(inner).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.False(t, *called, "inner handler must not be reached for a rebinding Host")
+}
+
+func TestDefaultAllowedHosts(t *testing.T) {
+	cases := []struct {
+		name    string
+		address string
+		want    []string
+	}{
+		{
+			name:    "localhost bind allows IPv4 and IPv6 loopback too",
+			address: "localhost:8000",
+			want:    []string{"localhost:8000", "127.0.0.1:8000", "[::1]:8000"},
+		},
+		{
+			name:    "wildcard IPv4 bind allows all loopback variants",
+			address: "0.0.0.0:8000",
+			want:    []string{"localhost:8000", "127.0.0.1:8000", "[::1]:8000"},
+		},
+		{
+			name:    "empty host bind allows all loopback variants",
+			address: ":8000",
+			want:    []string{"localhost:8000", "127.0.0.1:8000", "[::1]:8000"},
+		},
+		{
+			name:    "explicit hostname binds only that hostname",
+			address: "mcp.internal:8000",
+			want:    []string{"mcp.internal:8000"},
+		},
+		{
+			name:    "explicit IPv4 binds only that IPv4",
+			address: "10.0.0.5:8000",
+			want:    []string{"10.0.0.5:8000"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DefaultAllowedHosts(tc.address)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Related to [this](https://github.com/grafana/support-escalations/issues/22881)

 When run with `-t sse` or `-t streamable-http`, mcp-grafana accepted any `Host`/`Origin` and emitted `Access-Control-Allow-Origin: *` on `/sse`. A malicious page that DNS-rebinds to `127.0.0.1` could drive the local MCP server as the configured Grafana service account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive HTTP listener behavior changes defaults (403 on bad Host/Origin) and may break health checks, metrics scrapes, or ingress deployments until `--allowed-hosts`/`--allowed-origins` are set correctly.
> 
> **Overview**
> Adds **DNS-rebinding protection** for SSE and streamable-http by validating **`Host`** and **`Origin`** on every route (MCP endpoints, **`/healthz`**, **`/metrics`**) via new **`DNSRebindingProtectionMiddleware`**.
> 
> New flags **`--allowed-hosts`** and **`--allowed-origins`** control allowlists; unset or comma-only **`--allowed-hosts`** falls back to loopback variants of **`--address`** so Host checks cannot be accidentally disabled. Default **`Origin`** policy rejects any request that sends an **`Origin`** header. CORS is wired through mcp-go so the prior **`Access-Control-Allow-Origin: *`** default on SSE is suppressed unless origins are explicitly allowed (including a sentinel when origins are unset).
> 
> **`mcp-go`** is bumped **0.46.0 → 0.55.0**. README and command-line docs describe probe/scrape implications (K8s **`httpGet`**, Prometheus on the main listener).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f3afa95d8358da1ce3aa6acd01854a46c27174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->