### PR TITLE
Add Gamut to MCP client examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This provides access to your Grafana instance and the surrounding ecosystem.
 
 ## Quick Start
 
-Requires [uv](https://docs.astral.sh/uv/getting-started/installation/). Add the following to your MCP client configuration (e.g. Claude Desktop, Cursor):
+Requires [uv](https://docs.astral.sh/uv/getting-started/installation/). Add the following to your MCP client configuration (e.g. Claude Desktop, Cursor, [Gamut](https://www.gamut.so/mcp/analytics-marketing/grafana)):
 
 ```json
 {


### PR DESCRIPTION
Adds [Gamut](https://www.gamut.so) as an example MCP client alongside Claude Desktop and Cursor.

Gamut is an AI agent platform with native MCP support that can connect to the Grafana MCP server.