### PR TITLE
feat(datasources): support name filter on list_datasources

### DIFF
--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -25,6 +25,7 @@ const (
 
 type ListDatasourcesParams struct {
 	Type   string `json:"type,omitempty" jsonschema:"description=The type of datasources to search for. For example\\, 'prometheus'\\, 'loki'\\, 'tempo'\\, etc..."`
+	Name   string `json:"name,omitempty" jsonschema:"description=Case-insensitive substring match on the datasource name. For example\\, 'prod' matches datasources named 'prometheus-prod-eu' and 'loki-prod-us'. Useful on instances with many datasources where filtering by type alone returns too many results."`
 	Limit  int    `json:"limit,omitempty" jsonschema:"default=50,description=Maximum number of datasources to return (max 100)"`
 	Offset int    `json:"offset,omitempty" jsonschema:"default=0,description=Number of datasources to skip for pagination"`
 }
@@ -52,8 +53,8 @@ func listDatasources(ctx context.Context, args ListDatasourcesParams) (*ListData
 		return nil, fmt.Errorf("list datasources: %w", err)
 	}
 
-	// Filter by type if specified
-	datasources := filterDatasources(resp.Payload, args.Type)
+	// Filter by type and/or name if specified
+	datasources := filterDatasources(resp.Payload, args.Type, args.Name)
 	total := len(datasources)
 
 	// Apply default limit if not specified
@@ -296,18 +297,24 @@ func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.Ca
 	return mcp.NewToolResultText(string(b)), nil
 }
 
-// filterDatasources returns only datasources of the specified type `t`. If `t`
-// is an empty string no filtering is done.
-func filterDatasources(datasources models.DataSourceList, t string) models.DataSourceList {
-	if t == "" {
+// filterDatasources returns only datasources whose type contains `t` and
+// whose name contains `name`, both as case-insensitive substring matches.
+// Empty arguments are treated as wildcards (no filtering on that field).
+func filterDatasources(datasources models.DataSourceList, t, name string) models.DataSourceList {
+	if t == "" && name == "" {
 		return datasources
 	}
-	filtered := models.DataSourceList{}
 	t = strings.ToLower(t)
+	name = strings.ToLower(name)
+	filtered := models.DataSourceList{}
 	for _, ds := range datasources {
-		if strings.Contains(strings.ToLower(ds.Type), t) {
-			filtered = append(filtered, ds)
+		if t != "" && !strings.Contains(strings.ToLower(ds.Type), t) {
+			continue
 		}
+		if name != "" && !strings.Contains(strings.ToLower(ds.Name), name) {
+			continue
+		}
+		filtered = append(filtered, ds)
 	}
 	return filtered
 }
@@ -328,7 +335,7 @@ func summarizeDatasources(dataSources models.DataSourceList) []dataSourceSummary
 
 var ListDatasources = mcpgrafana.MustTool(
 	"list_datasources",
-	"List all configured datasources in Grafana. Use this to discover available datasources and their UIDs. Supports filtering by type and pagination.",
+	"List all configured datasources in Grafana. Use this to discover available datasources and their UIDs. Supports filtering by type and/or name (case-insensitive substring match) and pagination.",
 	listDatasources,
 	mcp.WithTitleAnnotation("List datasources"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -612,7 +619,7 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 			}
 		}
 	} else {
-		all = filterDatasources(resp.Payload, args.Type)
+		all = filterDatasources(resp.Payload, args.Type, "")
 	}
 
 	limit := 10

--- a/tools/datasources_test.go
+++ b/tools/datasources_test.go
@@ -45,6 +45,35 @@ func TestDatasourcesTools(t *testing.T) {
 		assert.Len(t, result.Datasources, 2)
 	})
 
+	t.Run("list datasources by name", func(t *testing.T) {
+		ctx := newTestContext()
+
+		// Case-insensitive substring match on the datasource Name field.
+		// The provisioned names are "InfluxDB Flux" and "InfluxDB InfluxQL";
+		// the lowercase query proves case-insensitivity.
+		result, err := listDatasources(ctx, ListDatasourcesParams{Name: "influxdb"})
+		require.NoError(t, err)
+		uids := make([]string, len(result.Datasources))
+		for i, ds := range result.Datasources {
+			uids[i] = ds.UID
+		}
+		assert.ElementsMatch(t, []string{"influxdb-flux", "influxdb-influxql"}, uids)
+
+		// Name composes with the type filter (AND). "Custom Time" is provisioned
+		// for both an elasticsearch and an opensearch datasource, so the name
+		// substring alone is ambiguous across types; adding the type narrows the
+		// match to just the elasticsearch one.
+		result, err = listDatasources(ctx, ListDatasourcesParams{Type: "elasticsearch", Name: "custom"})
+		require.NoError(t, err)
+		require.Len(t, result.Datasources, 1)
+		assert.Equal(t, "elasticsearch-custom-time", result.Datasources[0].UID)
+
+		// No match returns an empty list.
+		result, err = listDatasources(ctx, ListDatasourcesParams{Name: "does-not-exist"})
+		require.NoError(t, err)
+		assert.Empty(t, result.Datasources)
+	})
+
 	t.Run("get datasource by uid", func(t *testing.T) {
 		ctx := newTestContext()
 		result, err := getDatasource(ctx, GetDatasourceParams{

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -149,6 +149,73 @@ func TestListDatasources_TypeFilter(t *testing.T) {
 	})
 }
 
+func TestListDatasources_NameFilter(t *testing.T) {
+	mockDS := []*models.DataSource{
+		{ID: 1, UID: "prom-prod-eu", Name: "prometheus-prod-eu", Type: "prometheus"},
+		{ID: 2, UID: "prom-prod-us", Name: "prometheus-prod-us", Type: "prometheus"},
+		{ID: 3, UID: "prom-dev", Name: "prometheus-dev", Type: "prometheus"},
+		{ID: 4, UID: "loki-prod-eu", Name: "loki-prod-eu", Type: "loki"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(mockDS)
+	}))
+	defer server.Close()
+
+	ctx := mockDatasourcesCtx(server)
+
+	t.Run("empty name does not filter", func(t *testing.T) {
+		result, err := listDatasources(ctx, ListDatasourcesParams{Name: ""})
+		require.NoError(t, err)
+		assert.Equal(t, 4, result.Total)
+	})
+
+	t.Run("substring match across types", func(t *testing.T) {
+		result, err := listDatasources(ctx, ListDatasourcesParams{Name: "prod"})
+		require.NoError(t, err)
+		assert.Equal(t, 3, result.Total)
+		uids := make([]string, len(result.Datasources))
+		for i, ds := range result.Datasources {
+			uids[i] = ds.UID
+		}
+		assert.ElementsMatch(t, []string{"prom-prod-eu", "prom-prod-us", "loki-prod-eu"}, uids)
+	})
+
+	t.Run("case-insensitive match", func(t *testing.T) {
+		result, err := listDatasources(ctx, ListDatasourcesParams{Name: "PROD-EU"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Total)
+	})
+
+	t.Run("composes with type filter (AND)", func(t *testing.T) {
+		result, err := listDatasources(ctx, ListDatasourcesParams{Type: "prometheus", Name: "prod"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Total)
+		for _, ds := range result.Datasources {
+			assert.Equal(t, "prometheus", ds.Type)
+			assert.Contains(t, ds.Name, "prod")
+		}
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		result, err := listDatasources(ctx, ListDatasourcesParams{Name: "does-not-exist"})
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.Total)
+		assert.Empty(t, result.Datasources)
+	})
+
+	t.Run("name filter respects pagination", func(t *testing.T) {
+		// 3 datasources match "prod"; ask for page 2 with limit 2.
+		result, err := listDatasources(ctx, ListDatasourcesParams{Name: "prod", Limit: 2, Offset: 2})
+		require.NoError(t, err)
+		assert.Equal(t, 3, result.Total)
+		assert.Len(t, result.Datasources, 1)
+		assert.False(t, result.HasMore)
+	})
+}
+
 func TestGetDatasource_RoutesToUID(t *testing.T) {
 	mockDS := &models.DataSource{
 		ID:   1,


### PR DESCRIPTION
## Summary

- Adds a `name` parameter to the `list_datasources` tool for case-insensitive substring matching on the datasource name, composable with the existing `type` filter (both must match).
- Motivated by Grafana instances with thousands of datasources (6k+ is realistic in large multi-tenant deployments): the `type` filter alone often returns too many entries for an LLM context window. With this change the model can express the partial name it already knows (e.g. `prometheus-prod-eu`) and skip pagination noise.

## Implementation

- Extends `filterDatasources` in `tools/datasources.go` to apply name and type filters together; both are case-insensitive substring matches, and an empty value is treated as a wildcard for that field (matching the existing `type` semantics).
- The Grafana API (`GET /api/datasources`) does not support server-side name filtering, so this is done inline before pagination — mirroring the precedent set in #52 when the `type` filter was added.
- The bulk health caller (`checkDatasourcesHealth`) continues to filter by type only; the signature update is a no-op there.
- Tool description updated to surface the new parameter.

## Tests

New `TestListDatasources_NameFilter` (unit, build-tag `unit`) covering:

- empty name = no filter
- substring match across types
- case-insensitive match
- composition with the `type` filter (AND semantics)
- no-match returns empty
- name filter respects pagination

Existing `TestListDatasources_TypeFilter`, `TestListDatasources_Pagination`, and `TestCheckDatasourcesHealth_*` all still pass.

## Test plan

- [x] `go build ./...`
- [x] `go test -tags=unit ./tools/`
- [x] `gofmt -l` clean on touched files
- [x] `make lint` — JSON schema and OpenAPI linters clean for the new field; only pre-existing govet failures on `mcpgrafana.go` / `tools.go` (unrelated to this change) remain

Fixes #972

---

_This PR was generated with the help of AI, and reviewed by a Human_
