### PR TITLE
fix(navigation): send relative path when shortening URLs

### DIFF
--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -222,6 +222,10 @@ func shortenURL(ctx context.Context, longURL string) (string, error) {
 	if !strings.HasPrefix(path, "/") {
 		return "", fmt.Errorf("url must include an absolute path")
 	}
+	// Grafana's /api/short-urls endpoint rejects absolute paths
+	// (messageId "shorturl.absolute-path") and requires the path to be
+	// relative, so strip the leading slash before submitting.
+	path = strings.TrimPrefix(path, "/")
 
 	payload, err := json.Marshal(map[string]string{"path": path})
 	if err != nil {

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -424,7 +424,7 @@ func TestShortenURL(t *testing.T) {
 		result, err := shortenURL(ctx, "https://grafana.example.com/explore?left=%7B%22datasource%22%3A%22abc%22%7D")
 		require.NoError(t, err)
 		assert.Equal(t, "https://grafana.example.com/goto/abc123", result)
-		assert.Equal(t, "/explore?left=%7B%22datasource%22%3A%22abc%22%7D", capturedPath)
+		assert.Equal(t, "explore?left=%7B%22datasource%22%3A%22abc%22%7D", capturedPath)
 	})
 
 	t.Run("Includes auth headers", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `generate_deeplink` with `shorten=true` was posting an **absolute** path (e.g. `/explore?...`) to Grafana's `/api/short-urls` endpoint.
- Newer Grafana rejects this with `400 shorturl.absolute-path / "Path should be relative"`, so shortening silently failed and the tool returned the full URL instead of a `/goto/<uid>` link.
- Fix: strip the leading slash so the submitted path is relative. The absolute-path guard is retained so a path-less URL is still rejected.

This was causing the `Python E2E Tests` `test_generate_and_shorten_explore_deeplink` cases to fail (they assert the response contains a `/goto/` URL).

## Test plan

- [x] `go test ./tools/ -run 'TestShortenURL|TestGenerateDeeplink'` passes
- [x] Updated `TestShortenURL/Success` to assert the path is submitted relative (no leading slash)
- [ ] Python E2E `test_generate_and_shorten_explore_deeplink` passes in CI (requires live Grafana + model keys)