### PR TITLE
docs: correct --endpoint-path default in README to /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 - `-t, --transport`: Transport type (`stdio`, `sse`, or `streamable-http`) - default: `stdio`
 - `--address`: The host and port for SSE/streamable-http server - default: `localhost:8000`
 - `--base-path`: Base path for the SSE/streamable-http server
-- `--endpoint-path`: Endpoint path for the streamable-http server - default: `/`
+- `--endpoint-path`: Endpoint path for the streamable-http server - default: `/mcp`
 
 **HTTP Transport Security (SSE / streamable-http only):**
 


### PR DESCRIPTION
The README lists the `--endpoint-path` default as `/`, but the actual default is `/mcp` (`cmd/mcp-grafana/main.go:619`), which also matches the released `0.17.0` binary's `--help` output. This corrects the docs.
