### PR TITLE
feat(tools):add get_dashboard_version and list_dashboard_versions tools

### DIFF
--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -1214,4 +1214,6 @@ func AddDashboardTools(mcp *server.MCPServer, enableWriteTools bool) {
 	GetDashboardPanelQueries.Register(mcp)
 	GetDashboardProperty.Register(mcp)
 	GetDashboardSummary.Register(mcp)
+	ListDashboardVersions.Register(mcp)
+	GetDashboardVersion.Register(mcp)
 }

--- a/tools/dashboard_versions.go
+++ b/tools/dashboard_versions.go
@@ -1,0 +1,154 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+)
+
+// DashboardVersionSummary is a compact representation of a dashboard version
+// returned by list_dashboard_versions. The full dashboard JSON (data) is
+// intentionally omitted to keep response sizes manageable; use
+// get_dashboard_version to retrieve a specific version with its content.
+type DashboardVersionSummary struct {
+	Version       int64  `json:"version"`
+	CreatedBy     string `json:"createdBy,omitempty"`
+	Created       string `json:"created,omitempty"`
+	Message       string `json:"message,omitempty"`
+	ParentVersion int64  `json:"parentVersion,omitempty"`
+	RestoredFrom  int64  `json:"restoredFrom,omitempty"`
+}
+
+type ListDashboardVersionsParams struct {
+	UID   string `json:"uid" jsonschema:"required,description=The UID of the dashboard"`
+	Limit int64  `json:"limit,omitempty" jsonschema:"description=Maximum number of versions to return. Defaults to all versions when omitted"`
+	Start int64  `json:"start,omitempty" jsonschema:"description=Dashboard version number to start from. Only versions with a version number less than or equal to this value are returned. Omit to start from the latest version."`
+}
+
+func listDashboardVersions(ctx context.Context, args ListDashboardVersionsParams) ([]DashboardVersionSummary, error) {
+	if args.UID == "" {
+		return nil, fmt.Errorf("uid is required")
+	}
+
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	params := dashboards.NewGetDashboardVersionsByUIDParamsWithContext(ctx).
+		WithUID(args.UID)
+
+	if args.Limit > 0 {
+		params.SetLimit(&args.Limit)
+	}
+	if args.Start > 0 {
+		params.SetStart(&args.Start)
+	}
+
+	resp, err := c.Dashboards.GetDashboardVersionsByUID(params)
+	if err != nil {
+		return nil, fmt.Errorf("list dashboard versions for %q: %w", args.UID, err)
+	}
+
+	if resp.Payload == nil {
+		return nil, fmt.Errorf("list dashboard versions for %q: empty response from Grafana", args.UID)
+	}
+	versions := resp.Payload.Versions
+	summaries := make([]DashboardVersionSummary, 0, len(versions))
+	for _, v := range versions {
+		summaries = append(summaries, DashboardVersionSummary{
+			Version:       v.Version,
+			CreatedBy:     v.CreatedBy,
+			Created:       v.Created.String(),
+			Message:       v.Message,
+			ParentVersion: v.ParentVersion,
+			RestoredFrom:  v.RestoredFrom,
+		})
+	}
+	return summaries, nil
+}
+
+var ListDashboardVersions = mcpgrafana.MustTool(
+	"list_dashboard_versions",
+	"List the saved versions of a Grafana dashboard. Returns version metadata such as version number, author, timestamp, and save message. Use get_dashboard_version to retrieve the full content of a specific version.",
+	listDashboardVersions,
+	mcp.WithTitleAnnotation("List dashboard versions"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+type GetDashboardVersionParams struct {
+	UID     string `json:"uid" jsonschema:"required,description=The UID of the dashboard"`
+	Version int64  `json:"version" jsonschema:"required,description=The version number to retrieve"`
+}
+
+// DashboardVersionDetail is the full representation of a single dashboard
+// version, including the complete dashboard JSON stored in that version.
+type DashboardVersionDetail struct {
+	Version       int64          `json:"version"`
+	CreatedBy     string         `json:"createdBy,omitempty"`
+	Created       string         `json:"created,omitempty"`
+	Message       string         `json:"message,omitempty"`
+	ParentVersion int64          `json:"parentVersion,omitempty"`
+	RestoredFrom  int64          `json:"restoredFrom,omitempty"`
+	Data          map[string]any `json:"data,omitempty"`
+}
+
+func getDashboardVersion(ctx context.Context, args GetDashboardVersionParams) (*DashboardVersionDetail, error) {
+	if args.UID == "" {
+		return nil, fmt.Errorf("uid is required")
+	}
+	if args.Version <= 0 {
+		return nil, fmt.Errorf("version must be a positive integer")
+	}
+
+	c := mcpgrafana.GrafanaClientFromContext(ctx)
+	params := dashboards.NewGetDashboardVersionByUIDParamsWithContext(ctx).
+		WithUID(args.UID).
+		WithDashboardVersionID(args.Version)
+	resp, err := c.Dashboards.GetDashboardVersionByUIDWithParams(params)
+	if err != nil {
+		return nil, fmt.Errorf("get dashboard version %d for %q: %w", args.Version, args.UID, err)
+	}
+
+	if resp.Payload == nil {
+		return nil, fmt.Errorf("get dashboard version %d for %q: empty response from Grafana", args.Version, args.UID)
+	}
+
+	v := resp.Payload
+	detail := &DashboardVersionDetail{
+		Version:       v.Version,
+		CreatedBy:     v.CreatedBy,
+		Created:       v.Created.String(),
+		Message:       v.Message,
+		ParentVersion: v.ParentVersion,
+		RestoredFrom:  v.RestoredFrom,
+	}
+
+	// v.Data is models.JSON (interface{}). Re-encode then decode into
+	// map[string]any so the response is always a structured JSON object
+	// regardless of how the openapi library decoded the raw value.
+	if v.Data != nil {
+		b, err := json.Marshal(v.Data)
+		if err != nil {
+			return nil, fmt.Errorf("marshal dashboard data for version %d of %q: %w", args.Version, args.UID, err)
+		}
+		var data map[string]any
+		if err := json.Unmarshal(b, &data); err != nil {
+			return nil, fmt.Errorf("unmarshal dashboard data for version %d of %q: %w", args.Version, args.UID, err)
+		}
+		detail.Data = data
+	}
+
+	return detail, nil
+}
+
+var GetDashboardVersion = mcpgrafana.MustTool(
+	"get_dashboard_version",
+	"Retrieve a specific saved version of a Grafana dashboard by its version number, including the full dashboard JSON stored in that version.",
+	getDashboardVersion,
+	mcp.WithTitleAnnotation("Get dashboard version"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+)

--- a/tools/dashboard_versions_unit_test.go
+++ b/tools/dashboard_versions_unit_test.go
@@ -1,0 +1,216 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/client"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mockDashboardVersionsCtx(server *httptest.Server) context.Context {
+	u, _ := url.Parse(server.URL)
+	cfg := client.DefaultTransportConfig()
+	cfg.Host = u.Host
+	cfg.Schemes = []string{"http"}
+	cfg.APIKey = "test"
+
+	c := client.NewHTTPClientWithConfig(nil, cfg)
+	return mcpgrafana.WithGrafanaClient(context.Background(), &mcpgrafana.GrafanaClient{GrafanaHTTPAPI: c})
+}
+
+func TestListDashboardVersions(t *testing.T) {
+	emptyVersionsPayload := map[string]any{"versions": []any{}}
+
+	t.Run("sends uid as path parameter", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/dashboards/uid/my-uid/versions", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(emptyVersionsPayload)
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		result, err := listDashboardVersions(ctx, ListDashboardVersionsParams{UID: "my-uid"})
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns version summaries without data field", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			payload := map[string]any{
+				"versions": []map[string]any{
+					{
+						"version":       3,
+						"createdBy":     "alice",
+						"created":       "0001-01-01T00:00:00.000Z",
+						"message":       "add new panel",
+						"parentVersion": 2,
+						"restoredFrom":  0,
+						"data":          map[string]any{"title": "My Dashboard"},
+					},
+					{
+						"version":       2,
+						"createdBy":     "bob",
+						"created":       "0001-01-01T00:00:00.000Z",
+						"message":       "",
+						"parentVersion": 1,
+						"restoredFrom":  0,
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(payload)
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		result, err := listDashboardVersions(ctx, ListDashboardVersionsParams{UID: "my-uid"})
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+
+		assert.Equal(t, int64(3), result[0].Version)
+		assert.Equal(t, "alice", result[0].CreatedBy)
+		assert.Equal(t, "add new panel", result[0].Message)
+		assert.Equal(t, int64(2), result[0].ParentVersion)
+
+		assert.Equal(t, int64(2), result[1].Version)
+		assert.Equal(t, "bob", result[1].CreatedBy)
+	})
+
+	t.Run("forwards limit query parameter", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(emptyVersionsPayload)
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		_, err := listDashboardVersions(ctx, ListDashboardVersionsParams{UID: "my-uid", Limit: 10})
+		require.NoError(t, err)
+	})
+
+	t.Run("forwards start query parameter", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "5", r.URL.Query().Get("start"))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(emptyVersionsPayload)
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		_, err := listDashboardVersions(ctx, ListDashboardVersionsParams{UID: "my-uid", Start: 5})
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error when uid is empty", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("unexpected HTTP call when uid is empty")
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		_, err := listDashboardVersions(ctx, ListDashboardVersionsParams{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uid is required")
+	})
+
+	t.Run("omits limit and start when zero", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.URL.Query().Get("limit"))
+			assert.Empty(t, r.URL.Query().Get("start"))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(emptyVersionsPayload)
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		_, err := listDashboardVersions(ctx, ListDashboardVersionsParams{UID: "my-uid", Limit: 0, Start: 0})
+		require.NoError(t, err)
+	})
+}
+
+func TestGetDashboardVersion(t *testing.T) {
+	t.Run("sends uid and version as path parameters", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/dashboards/uid/my-uid/versions/3", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"version":   3,
+				"createdBy": "alice",
+				"message":   "fix typo",
+				"data":      map[string]any{"title": "My Dashboard"},
+			})
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		result, err := getDashboardVersion(ctx, GetDashboardVersionParams{UID: "my-uid", Version: 3})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), result.Version)
+		assert.Equal(t, "alice", result.CreatedBy)
+		assert.Equal(t, "fix typo", result.Message)
+	})
+
+	t.Run("includes dashboard data in response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"version": 1,
+				"data":    map[string]any{"title": "Test Dashboard", "panels": []any{}},
+			})
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		result, err := getDashboardVersion(ctx, GetDashboardVersionParams{UID: "my-uid", Version: 1})
+		require.NoError(t, err)
+		assert.NotNil(t, result.Data)
+		assert.Equal(t, "Test Dashboard", result.Data["title"])
+	})
+
+	t.Run("returns error when uid is empty", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("unexpected HTTP call when uid is empty")
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		_, err := getDashboardVersion(ctx, GetDashboardVersionParams{Version: 1})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uid is required")
+	})
+
+	t.Run("returns error when version is zero", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("unexpected HTTP call when version is zero")
+		}))
+		defer server.Close()
+
+		ctx := mockDashboardVersionsCtx(server)
+		_, err := getDashboardVersion(ctx, GetDashboardVersionParams{UID: "my-uid", Version: 0})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "version must be a positive integer")
+	})
+}


### PR DESCRIPTION
## What

Adds two new read-only MCP tools for inspecting Grafana dashboard version history:

- **`list_dashboard_versions`** – Returns a compact list of saved versions for a dashboard (version number, author, timestamp, save message, parent version). The full dashboard JSON is intentionally omitted to keep response sizes manageable.
- **`get_dashboard_version`** – Retrieves a specific version by number, including the full dashboard JSON stored in that version.

Both tools are registered in `AddDashboardTools`.

## Why

Dashboard version history is useful in agentic workflows, for example:
- Auditing what changed and who changed it
- Comparing the current dashboard against a previous version
- Restoring context when diagnosing a regression

## Changes

- `tools/dashboard_versions.go` – implementation of both tools
- `tools/dashboard_versions_unit_test.go` – unit tests covering path params, pagination, response structure, and input validation
- `tools/dashboard.go` – register the two new tools in `AddDashboardTools`

## Testing

Unit tests run with the `unit` build tag:
```bash
go test -tags unit ./tools/... -run TestListDashboardVersions
go test -tags unit ./tools/... -run TestGetDashboardVersion