### PR TITLE
docs: clarify Grafana MCP server options

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,9 +14,20 @@ aliases: []
 
 # Grafana MCP server
 
-This documentation helps you install the [Grafana MCP server](https://github.com/grafana/mcp-grafana), connect MCP-compatible clients, and configure authentication, transports, and tools.
+This documentation helps you install and run the open source [Grafana MCP server](https://github.com/grafana/mcp-grafana), connect MCP-compatible clients, and configure authentication, transports, and tools.
 
 The Grafana MCP server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server that gives AI assistants and LLM clients access to your Grafana instance. You can query metrics and logs, search and manage dashboards, manage alert rules, work with Grafana Incident and Sift, and generate deeplinks to Grafana resources.
+
+## Choose the right Grafana MCP option
+
+Grafana offers two MCP server options:
+
+| Option | Best for | Authentication |
+| --- | --- | --- |
+| Open source Grafana MCP server | Running and managing the MCP server yourself for Grafana Cloud or self-managed Grafana | Service account token |
+| [Grafana Cloud MCP server](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/configure/cloud-mcp/) | Connecting external AI agents to Grafana Cloud without installing a local server | OAuth 2.1 browser authorization, scoped to the signed-in Grafana user |
+
+Use this documentation for the open source server. For Grafana Cloud's hosted MCP server, refer to [Grafana Cloud MCP server](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/configure/cloud-mcp/).
 
 ## Overview
 
@@ -41,7 +52,7 @@ This quick start requires [uv](https://docs.astral.sh/uv/getting-started/install
 }
 ```
 
-For Grafana Cloud, set `GRAFANA_URL` to your instance URL (for example `https://myinstance.grafana.net`). Refer to [Clients](clients/) and [Set up](set-up/) for next steps.
+When using this open source server with Grafana Cloud, set `GRAFANA_URL` to your instance URL (for example `https://myinstance.grafana.net`). Refer to [Clients](clients/) and [Set up](set-up/) for next steps.
 
 Grafana **9.0 or later** is required for full functionality. Some features, particularly datasource-related operations, may not work correctly with earlier versions due to missing API endpoints.
 

--- a/docs/sources/introduction.md
+++ b/docs/sources/introduction.md
@@ -14,7 +14,9 @@ aliases: []
 
 # Introduction to the Grafana MCP server
 
-This article outlines what the [Grafana MCP serve](https://github.com/grafana/mcp-grafana) is, what it can do, and how authentication and permissions work.
+This article outlines what the open source [Grafana MCP server](https://github.com/grafana/mcp-grafana) is, what it can do, and how authentication and permissions work.
+
+For Grafana Cloud's hosted MCP server, refer to [Grafana Cloud MCP server](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/configure/cloud-mcp/).
 
 ## What you'll achieve
 


### PR DESCRIPTION
## Summary
- Clarify that these docs cover the open source Grafana MCP server.
- Add a top-level comparison with the hosted Grafana Cloud MCP server and link to the Cloud MCP docs.
- Reword the Grafana Cloud quick-start note so it is clear it refers to running the open source server against a Grafana Cloud instance.

## Test plan
- Ran `make test` in `docs/`; Hugo build passed with relref errors treated as errors.


Made with [Cursor](https://cursor.com)