### PR TITLE
docs: distinguish the OSS Grafana MCP server from the Cloud one

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Open source Grafana MCP server
-menuTitle: Grafana MCP server
+menuTitle: Grafana OSS MCP server
 description: Connect AI assistants and LLM clients to Grafana using the Model Context Protocol.
 keywords:
   - MCP

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Grafana MCP server
+title: Open source Grafana MCP server
 menuTitle: Grafana MCP server
 description: Connect AI assistants and LLM clients to Grafana using the Model Context Protocol.
 keywords:
@@ -12,7 +12,7 @@ weight: 1
 aliases: []
 ---
 
-# Grafana MCP server
+# Open source Grafana MCP server
 
 This documentation helps you install and run the open source [Grafana MCP server](https://github.com/grafana/mcp-grafana), connect MCP-compatible clients, and configure authentication, transports, and tools.
 

--- a/docs/sources/clients/_index.md
+++ b/docs/sources/clients/_index.md
@@ -14,7 +14,7 @@ aliases: []
 
 # Set up by client
 
-Configure the Grafana MCP server for your MCP-compatible client. Each guide lists the config file location and a working server block.
+Configure the open source Grafana MCP server for your MCP-compatible client. Each guide lists the config file location and a working server block.
 
 Refer to [Client configuration examples](../set-up/client-configuration-examples/) and [Set up](../set-up/) when you need more JSON or install options.
 

--- a/docs/sources/configure/_index.md
+++ b/docs/sources/configure/_index.md
@@ -13,6 +13,6 @@ aliases: []
 
 # Configure the Grafana MCP server
 
-Configure how the server connects to Grafana, which tools are enabled, and how clients connect to the server.
+Configure the open source Grafana MCP server: how it connects to Grafana, which tools are enabled, and how clients connect to the server.
 
 {{< section withDescriptions="true" >}}

--- a/docs/sources/guides/_index.md
+++ b/docs/sources/guides/_index.md
@@ -15,6 +15,6 @@ aliases: []
 
 # Guides
 
-Step-by-step use cases for the Grafana MCP server: query metrics and logs, search and inspect dashboards, manage alert rules, generate deeplinks, run panel queries, and use Grafana Incident and Sift.
+Step-by-step use cases for the open source Grafana MCP server: query metrics and logs, search and inspect dashboards, manage alert rules, generate deeplinks, run panel queries, and use Grafana Incident and Sift.
 
 {{< section withDescriptions="true" >}}

--- a/docs/sources/reference/_index.md
+++ b/docs/sources/reference/_index.md
@@ -8,6 +8,6 @@ aliases: []
 
 # Reference
 
-Technical reference for the Grafana MCP server, including the MCP tools permission table.
+Technical reference for the open source Grafana MCP server, including the MCP tools permission table.
 
 {{< section withDescriptions="true" >}}

--- a/docs/sources/set-up/_index.md
+++ b/docs/sources/set-up/_index.md
@@ -14,6 +14,10 @@ aliases: []
 
 # Set up the Grafana MCP server
 
-Choose how you install and run the Grafana MCP server. Start with `uvx` for the least setup, or use Docker, a downloaded binary, or Helm when that fits your environment. Refer to [Clients](../clients/) for client-specific steps and [Client configuration examples](client-configuration-examples/) for copy-paste MCP JSON (debug, TLS, and more).
+Choose how you install and run the open source Grafana MCP server. Start with `uvx` for the least setup, or use Docker, a downloaded binary, or Helm when that fits your environment. Refer to [Clients](../clients/) for client-specific steps and [Client configuration examples](client-configuration-examples/) for copy-paste MCP JSON (debug, TLS, and more).
+
+{{< admonition type="note" >}}
+These instructions cover the open source server, which you install and run yourself. If you want to connect an external AI agent to Grafana Cloud without running your own server, refer to [Grafana Cloud MCP server](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/configure/cloud-mcp/) instead.
+{{< /admonition >}}
 
 {{< section withDescriptions="true" >}}

--- a/docs/sources/troubleshooting/_index.md
+++ b/docs/sources/troubleshooting/_index.md
@@ -8,6 +8,6 @@ aliases: []
 
 # Troubleshooting
 
-Diagnose common problems with the Grafana MCP server and Grafana compatibility.
+Diagnose common problems with the open source Grafana MCP server and Grafana compatibility.
 
 {{< section withDescriptions="true" >}}


### PR DESCRIPTION
## What

Clarifies throughout the docs that these pages describe the **open source** Grafana MCP server, not the Grafana Cloud hosted MCP server.

The top-level `_index.md` and `introduction.md` already distinguish the two (comparison table + Cloud pointer), but the landing page title and the per-section landing pages just said "Grafana MCP server" — so a reader who lands directly on a page via search or a deeplink couldn't tell which server it describes.

## Changes

- Retitle the landing page (`_index.md`): `title` and H1 → "Open source Grafana MCP server"; `menuTitle` (sidebar/nav) → "Grafana OSS MCP server".
- Qualify the first mention on each section landing page as the "open source Grafana MCP server" (`set-up`, `configure`, `clients`, `guides`, `reference`, `troubleshooting`).
- Add a `note` admonition on the set-up page pointing to the [Grafana Cloud MCP server](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/configure/cloud-mcp/) as the hosted alternative — set-up is where the OSS-vs-Cloud choice matters most.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)