### PR TITLE
fix(security): bind environment credentials to the configured Grafana URL

### DIFF
--- a/client_cache.go
+++ b/client_cache.go
@@ -334,7 +334,7 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 			logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 		}
 
-		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
+		u, apiKey, basicAuth, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		grafanaClient := cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {
@@ -352,7 +352,7 @@ func extractIncidentClientCached(cache *ClientCache) httpContextFunc {
 		config := GrafanaConfigFromContext(ctx)
 		logger := config.LoggerOrDefault()
 
-		grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req, logger)
+		grafanaURL, apiKey, _, orgID, _ := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID, req)
 
 		incidentClient := cache.GetOrCreateIncidentClient(key, func() *incident.Client {
@@ -381,7 +381,7 @@ func extractKubernetesClientCached(cache *ClientCache) httpContextFunc {
 		config := GrafanaConfigFromContext(ctx)
 		logger := config.LoggerOrDefault()
 
-		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
+		u, apiKey, basicAuth, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		k8sClient := cache.GetOrCreateK8sClient(key, func() *KubernetesClient {

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -778,35 +778,62 @@ func extractKeyGrafanaInfoFromEnv(logger *slog.Logger) (url, apiKey string, auth
 }
 
 // Tries to get grafana info from a request.
-// Gets info from environment if it can't get it from request
-func extractKeyGrafanaInfoFromReq(req *http.Request, logger *slog.Logger) (grafanaUrl, apiKey string, auth *url.Userinfo, orgId int64) {
+// Gets info from environment if it can't get it from request.
+//
+// envCredsAllowed reports whether environment-configured credentials were
+// eligible to be used for this request. Environment credentials are bound to the
+// environment-configured Grafana URL: if a request supplies an X-Grafana-URL
+// header pointing at a different instance, environment credentials are withheld
+// so that a caller-controlled URL cannot receive them.
+func extractKeyGrafanaInfoFromReq(req *http.Request, logger *slog.Logger) (grafanaUrl, apiKey string, auth *url.Userinfo, orgId int64, envCredsAllowed bool) {
 	eUrl, eApiKey, eAuth, eOrgId := extractKeyGrafanaInfoFromEnv(logger)
 	username, password, _ := req.BasicAuth()
 
 	grafanaUrl, apiKey = urlAndAPIKeyFromHeaders(req)
-	// If anything is missing, check if we can get it from the environment
+	envCredsAllowed = requestTargetsEnvURL(grafanaUrl, eUrl)
+
+	// If no URL was supplied in the request, use the environment URL.
 	if grafanaUrl == "" {
 		grafanaUrl = eUrl
 	}
 
-	if apiKey == "" {
+	// Fall back to the environment token only when it is bound to the target URL.
+	if apiKey == "" && envCredsAllowed {
 		apiKey = eApiKey
 	}
 
-	// Use environment configured auth if nothing was passed in request
+	// Use request basic auth if supplied; otherwise fall back to the environment
+	// credentials only when they are bound to the target URL.
 	if username == "" && password == "" {
-		auth = eAuth
+		if envCredsAllowed {
+			auth = eAuth
+		}
 	} else {
 		auth = url.UserPassword(username, password)
 	}
 
-	// extract org ID from header, fall back to environment
+	// extract org ID from header, fall back to environment.
+	// The org ID is not a secret, so it is not gated on the target URL.
 	orgId = orgIdFromHeaders(req, logger)
 	if orgId == 0 {
 		orgId = eOrgId
 	}
 
 	return
+}
+
+// requestTargetsEnvURL reports whether a request's X-Grafana-URL points at the
+// same Grafana instance as the environment configuration, meaning it is safe to
+// attach environment-configured credentials. An empty requestURL means the
+// caller did not override the URL, so the environment URL (and its credentials)
+// apply. A non-empty requestURL only matches when it normalizes to the same
+// value as the environment URL; anything else is treated as a foreign target and
+// environment credentials are withheld.
+func requestTargetsEnvURL(requestURL, envURL string) bool {
+	if requestURL == "" {
+		return true
+	}
+	return normalizeGrafanaURL(requestURL) == normalizeGrafanaURL(envURL)
 }
 
 // ExtractGrafanaInfoFromEnv is a StdioContextFunc that extracts Grafana configuration from environment variables.
@@ -848,13 +875,22 @@ var ExtractGrafanaInfoFromHeaders httpContextFunc = func(ctx context.Context, re
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
 
-	u, apiKey, basicAuth, orgID := extractKeyGrafanaInfoFromReq(req, logger)
+	u, apiKey, basicAuth, orgID, envCredsAllowed := extractKeyGrafanaInfoFromReq(req, logger)
 
 	config.URL = u
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
 	config.OrgID = orgID
-	config.ExtraHeaders = mergeHeaders(extraHeadersFromEnv(logger), forwardedHeadersFromRequest(req))
+
+	// Environment extra headers may carry credentials (e.g. an Authorization
+	// header), so they are bound to the environment-configured URL just like the
+	// service-account token. When a request targets a foreign URL, only headers
+	// the operator explicitly opted to forward (GRAFANA_FORWARD_HEADERS) are sent.
+	var envHeaders map[string]string
+	if envCredsAllowed {
+		envHeaders = extraHeadersFromEnv(logger)
+	}
+	config.ExtraHeaders = mergeHeaders(envHeaders, forwardedHeadersFromRequest(req))
 	return WithGrafanaConfig(ctx, config)
 }
 
@@ -1272,7 +1308,7 @@ var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, 
 	}
 
 	// Extract transport config from request headers, and set it on the context.
-	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
+	u, apiKey, basicAuth, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
 	logger.Debug("Creating Grafana client", "url", u, "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil)
 
 	grafanaClient := NewGrafanaClient(ctx, u, apiKey, basicAuth)
@@ -1374,7 +1410,7 @@ var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Cont
 var ExtractIncidentClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
-	grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req, logger)
+	grafanaURL, apiKey, _, orgID, _ := extractKeyGrafanaInfoFromReq(req, logger)
 	incidentURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/v1/", grafanaURL)
 	client := incident.NewClient(incidentURL, apiKey)
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -280,6 +280,94 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 	})
 }
 
+// TestExtractGrafanaInfoFromHeadersCredentialBinding verifies that
+// environment-configured credentials are bound to the environment-configured
+// Grafana URL. A request that supplies an X-Grafana-URL pointing at a different
+// instance must not receive the environment service-account token, basic auth,
+// or extra headers.
+func TestExtractGrafanaInfoFromHeadersCredentialBinding(t *testing.T) {
+	const envURL = "http://my-grafana.internal:3000"
+	const envToken = "env-service-account-token"
+
+	t.Run("foreign URL header does not receive env service account token", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", envURL)
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Equal(t, "http://attacker.example.com", config.URL)
+		assert.Empty(t, config.APIKey, "env token must not be sent to a caller-specified URL")
+	})
+
+	t.Run("foreign URL header does not receive env deprecated api key", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", envURL)
+		t.Setenv("GRAFANA_API_KEY", "env-deprecated-key")
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Empty(t, config.APIKey, "env api key must not be sent to a caller-specified URL")
+	})
+
+	t.Run("foreign URL header does not receive env basic auth", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", envURL)
+		t.Setenv("GRAFANA_USERNAME", "env-user")
+		t.Setenv("GRAFANA_PASSWORD", "env-pass")
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Nil(t, config.BasicAuth, "env basic auth must not be sent to a caller-specified URL")
+	})
+
+	t.Run("foreign URL header does not receive env extra headers", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", envURL)
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+		t.Setenv("GRAFANA_EXTRA_HEADERS", `{"Authorization": "Bearer smuggled-secret"}`)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Empty(t, config.ExtraHeaders, "env extra headers must not be sent to a caller-specified URL")
+	})
+
+	t.Run("URL header matching env URL still receives env token", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", envURL)
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		// Same instance, only differing by a trailing slash — must still match.
+		req.Header.Set(grafanaURLHeader, envURL+"/")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Equal(t, envToken, config.APIKey, "env token should still be used for the env-configured instance")
+	})
+
+	t.Run("foreign URL with its own token uses the request token", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", envURL)
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "http://tenant.example.com")
+		req.Header.Set(grafanaServiceAccountTokenHeader, "tenant-token")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Equal(t, "http://tenant.example.com", config.URL)
+		assert.Equal(t, "tenant-token", config.APIKey, "caller-supplied token must be used, not the env token")
+	})
+}
+
 func TestExtractGrafanaClientPath(t *testing.T) {
 	t.Run("no custom path", func(t *testing.T) {
 		t.Setenv("GRAFANA_URL", "http://my-test-url.grafana.com/")


### PR DESCRIPTION
On HTTP/SSE transports, the Grafana URL and credentials were resolved from the request independently, each with a fallback. A request that supplied an `X-Grafana-URL` header but no credential header would be pointed at the caller-specified URL while still being given the environment-configured service-account token — allowing an unauthenticated caller to have the server send its token to an arbitrary host.

This change binds environment-configured credentials to the environment-configured Grafana URL. When a request's `X-Grafana-URL` targets a different instance, the environment service-account token, deprecated API key, basic auth, and extra headers are no longer attached; the caller must supply its own credentials for that URL. Requests with no `X-Grafana-URL`, or one matching the configured `GRAFANA_URL`, are unchanged.