### PR TITLE
tools: reject unknown tool arguments instead of silently dropping them

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/invopop/jsonschema"
@@ -191,89 +190,6 @@ func collectStringSliceFieldNames(structType reflect.Type) map[string]bool {
 	return fields
 }
 
-// knownJSONFieldNames returns the JSON property names that encoding/json accepts
-// for the given struct type, following the same field visibility and embedding
-// promotion rules (via reflect.VisibleFields).
-func knownJSONFieldNames(structType reflect.Type) []string {
-	var names []string
-	for _, f := range reflect.VisibleFields(structType) {
-		if !f.IsExported() {
-			continue
-		}
-		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
-		if name == "-" {
-			continue
-		}
-		if f.Anonymous && name == "" {
-			ft := f.Type
-			if ft.Kind() == reflect.Pointer {
-				ft = ft.Elem()
-			}
-			// An untagged embedded struct has its fields promoted; those fields
-			// appear as their own VisibleFields entries.
-			if ft.Kind() == reflect.Struct {
-				continue
-			}
-		}
-		if name == "" {
-			name = f.Name
-		}
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
-// unknownArguments returns the top-level keys in the JSON-encoded arguments that
-// do not match any field of argType. Matching is case-insensitive, mirroring
-// encoding/json's fallback behavior, so every key reported here would otherwise
-// be silently dropped by the decoder.
-func unknownArguments(argBytes []byte, argType reflect.Type) []string {
-	if argType.Kind() != reflect.Struct {
-		return nil
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(argBytes, &raw); err != nil {
-		// Not a JSON object; leave it to the decode path to report.
-		return nil
-	}
-	known := make(map[string]bool)
-	for _, name := range knownJSONFieldNames(argType) {
-		known[strings.ToLower(name)] = true
-	}
-	var unknown []string
-	for key := range raw {
-		if !known[strings.ToLower(key)] {
-			unknown = append(unknown, key)
-		}
-	}
-	sort.Strings(unknown)
-	return unknown
-}
-
-// unknownArgumentsError builds the error message for a call carrying unknown
-// arguments. Listing the valid argument names makes the error self-correcting
-// for LLM callers.
-func unknownArgumentsError(unknown, known []string) string {
-	var sb strings.Builder
-	sb.WriteString("unknown argument")
-	if len(unknown) > 1 {
-		sb.WriteString("s")
-	}
-	for i, key := range unknown {
-		if i > 0 {
-			sb.WriteString(",")
-		}
-		fmt.Fprintf(&sb, " %q", key)
-	}
-	if len(known) > 0 {
-		fmt.Fprintf(&sb, "; valid arguments: %s", strings.Join(known, ", "))
-	} else {
-		sb.WriteString("; this tool takes no arguments")
-	}
-	return sb.String()
-}
-
 // ConvertTool converts a toolHandler function to an MCP Tool and ToolHandlerFunc.
 // The toolHandler must accept a context.Context and a struct with jsonschema tags for parameter documentation.
 // The struct fields define the tool's input schema, while the return value can be a string, struct, or *mcp.CallToolResult.
@@ -302,6 +218,14 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 	argType := handlerType.In(1)
 	if argType.Kind() != reflect.Struct {
 		return zero, nil, errors.New("tool handler second argument must be a struct")
+	}
+
+	// Built before the handler closure so it can validate incoming argument
+	// keys against the same schema that is advertised to clients.
+	jsonSchema := createJSONSchemaFromHandler(toolHandler)
+	properties := make(map[string]any, jsonSchema.Properties.Len())
+	for pair := jsonSchema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		properties[pair.Key] = pair.Value
 	}
 
 	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -343,10 +267,9 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 		// otherwise leave the field zero-valued and the tool would answer a
 		// different question than the caller asked. The error is returned as a
 		// tool result (not a protocol error) so LLM callers can see it and retry.
-		if unknown := unknownArguments(argBytes, argType); len(unknown) > 0 {
-			msg := unknownArgumentsError(unknown, knownJSONFieldNames(argType))
+		if unknown := unknownArguments(request.Params.Arguments, properties); len(unknown) > 0 {
 			span.SetStatus(codes.Error, "unknown arguments")
-			return mcp.NewToolResultError(msg), nil
+			return mcp.NewToolResultError(unknownArgumentsError(unknown, properties)), nil
 		}
 
 		unmarshaledArgs := reflect.New(argType).Interface()
@@ -468,11 +391,6 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 		return mcp.NewToolResultText(string(returnBytes)), nil
 	}
 
-	jsonSchema := createJSONSchemaFromHandler(toolHandler)
-	properties := make(map[string]any, jsonSchema.Properties.Len())
-	for pair := jsonSchema.Properties.Oldest(); pair != nil; pair = pair.Next() {
-		properties[pair.Key] = pair.Value
-	}
 	// Use RawInputSchema with ToolArgumentsSchema to work around a Go limitation where type aliases
 	// don't inherit custom MarshalJSON methods. This ensures empty properties are included in the schema.
 	// additionalProperties: false advertises the strictness enforced above, so

--- a/tools.go
+++ b/tools.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/invopop/jsonschema"
@@ -190,6 +191,89 @@ func collectStringSliceFieldNames(structType reflect.Type) map[string]bool {
 	return fields
 }
 
+// knownJSONFieldNames returns the JSON property names that encoding/json accepts
+// for the given struct type, following the same field visibility and embedding
+// promotion rules (via reflect.VisibleFields).
+func knownJSONFieldNames(structType reflect.Type) []string {
+	var names []string
+	for _, f := range reflect.VisibleFields(structType) {
+		if !f.IsExported() {
+			continue
+		}
+		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+		if f.Anonymous && name == "" {
+			ft := f.Type
+			if ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			// An untagged embedded struct has its fields promoted; those fields
+			// appear as their own VisibleFields entries.
+			if ft.Kind() == reflect.Struct {
+				continue
+			}
+		}
+		if name == "" {
+			name = f.Name
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// unknownArguments returns the top-level keys in the JSON-encoded arguments that
+// do not match any field of argType. Matching is case-insensitive, mirroring
+// encoding/json's fallback behavior, so every key reported here would otherwise
+// be silently dropped by the decoder.
+func unknownArguments(argBytes []byte, argType reflect.Type) []string {
+	if argType.Kind() != reflect.Struct {
+		return nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(argBytes, &raw); err != nil {
+		// Not a JSON object; leave it to the decode path to report.
+		return nil
+	}
+	known := make(map[string]bool)
+	for _, name := range knownJSONFieldNames(argType) {
+		known[strings.ToLower(name)] = true
+	}
+	var unknown []string
+	for key := range raw {
+		if !known[strings.ToLower(key)] {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// unknownArgumentsError builds the error message for a call carrying unknown
+// arguments. Listing the valid argument names makes the error self-correcting
+// for LLM callers.
+func unknownArgumentsError(unknown, known []string) string {
+	var sb strings.Builder
+	sb.WriteString("unknown argument")
+	if len(unknown) > 1 {
+		sb.WriteString("s")
+	}
+	for i, key := range unknown {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, " %q", key)
+	}
+	if len(known) > 0 {
+		fmt.Fprintf(&sb, "; valid arguments: %s", strings.Join(known, ", "))
+	} else {
+		sb.WriteString("; this tool takes no arguments")
+	}
+	return sb.String()
+}
+
 // ConvertTool converts a toolHandler function to an MCP Tool and ToolHandlerFunc.
 // The toolHandler must accept a context.Context and a struct with jsonschema tags for parameter documentation.
 // The struct fields define the tool's input schema, while the return value can be a string, struct, or *mcp.CallToolResult.
@@ -252,6 +336,17 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 		// Add arguments as span attribute only if adding args to trace attributes is enabled
 		if config.IncludeArgumentsInSpans {
 			span.SetAttributes(attribute.String("gen_ai.tool.call.arguments", string(argBytes)))
+		}
+
+		// Reject unknown argument keys instead of silently dropping them: a typo'd
+		// optional argument (e.g. "start_rfc3339" for "start_rfc_3339") would
+		// otherwise leave the field zero-valued and the tool would answer a
+		// different question than the caller asked. The error is returned as a
+		// tool result (not a protocol error) so LLM callers can see it and retry.
+		if unknown := unknownArguments(argBytes, argType); len(unknown) > 0 {
+			msg := unknownArgumentsError(unknown, knownJSONFieldNames(argType))
+			span.SetStatus(codes.Error, "unknown arguments")
+			return mcp.NewToolResultError(msg), nil
 		}
 
 		unmarshaledArgs := reflect.New(argType).Interface()
@@ -380,10 +475,14 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 	}
 	// Use RawInputSchema with ToolArgumentsSchema to work around a Go limitation where type aliases
 	// don't inherit custom MarshalJSON methods. This ensures empty properties are included in the schema.
+	// additionalProperties: false advertises the strictness enforced above, so
+	// schema-validating clients (and providers with strict function calling)
+	// catch unknown arguments before the call reaches the server.
 	argumentsSchema := mcp.ToolArgumentsSchema{
-		Type:       jsonSchema.Type,
-		Properties: properties,
-		Required:   jsonSchema.Required,
+		Type:                 jsonSchema.Type,
+		Properties:           properties,
+		Required:             jsonSchema.Required,
+		AdditionalProperties: false,
 	}
 
 	// Marshal the schema to preserve empty properties
@@ -519,6 +618,13 @@ func checkSchemaNode(toolName string, v any, path string) error {
 	for _, key := range schemaValuedKeys {
 		if val, exists := obj[key]; exists {
 			if b, ok := val.(bool); ok {
+				// additionalProperties: false is valid, universally supported
+				// (OpenAI structured outputs even requires it), and emitted on
+				// purpose by ConvertTool. Only bare `true` — typically from
+				// interface{} fields — is known to break providers.
+				if key == "additionalProperties" && !b {
+					continue
+				}
 				return fmt.Errorf(
 					"tool %q has bare boolean schema (%v) at %s.%s; "+
 						"this is likely caused by an interface{}/any field — "+

--- a/tools_param_validation.go
+++ b/tools_param_validation.go
@@ -1,0 +1,69 @@
+package mcpgrafana
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// unknownArguments returns the top-level argument keys that do not match any
+// schema property, so that a typo'd argument is rejected instead of silently
+// dropped by the decoder. Matching is case-insensitive, mirroring
+// encoding/json's fallback field matching. Non-object argument shapes are left
+// to the decode path to report.
+func unknownArguments(args any, properties map[string]any) []string {
+	argMap, ok := args.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var unknown []string
+	for key := range argMap {
+		if _, ok := properties[key]; ok {
+			continue
+		}
+		if !hasKeyFold(properties, key) {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// hasKeyFold reports whether m contains a key equal to k under Unicode case
+// folding.
+func hasKeyFold(m map[string]any, k string) bool {
+	for name := range m {
+		if strings.EqualFold(name, k) {
+			return true
+		}
+	}
+	return false
+}
+
+// unknownArgumentsError builds the error message for a call carrying unknown
+// arguments. Listing the valid argument names makes the error self-correcting
+// for LLM callers.
+func unknownArgumentsError(unknown []string, properties map[string]any) string {
+	var sb strings.Builder
+	sb.WriteString("unknown argument")
+	if len(unknown) > 1 {
+		sb.WriteString("s")
+	}
+	for i, key := range unknown {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, " %q", key)
+	}
+	if len(properties) > 0 {
+		known := make([]string, 0, len(properties))
+		for name := range properties {
+			known = append(known, name)
+		}
+		sort.Strings(known)
+		fmt.Fprintf(&sb, "; valid arguments: %s", strings.Join(known, ", "))
+	} else {
+		sb.WriteString("; this tool takes no arguments")
+	}
+	return sb.String()
+}

--- a/tools_param_validation_test.go
+++ b/tools_param_validation_test.go
@@ -1,0 +1,159 @@
+//go:build unit
+// +build unit
+
+package mcpgrafana
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type embeddedTimeParams struct {
+	StartRFC3339 string `json:"start_rfc_3339,omitempty"`
+	EndRFC3339   string `json:"end_rfc_3339,omitempty"`
+}
+
+type unknownArgsParams struct {
+	embeddedTimeParams
+	DataSourceUID string `json:"data_source_uid" jsonschema:"required"`
+	Hidden        string `json:"-"`
+}
+
+func unknownArgsHandler(ctx context.Context, params unknownArgsParams) (string, error) {
+	return "ok", nil
+}
+
+func TestUnknownArguments(t *testing.T) {
+	properties := map[string]any{"data_source_uid": nil, "start_rfc_3339": nil}
+
+	t.Run("accepts exact and case-insensitive keys", func(t *testing.T) {
+		args := map[string]any{"data_source_uid": "x", "START_RFC_3339": "t"}
+		assert.Empty(t, unknownArguments(args, properties))
+	})
+
+	t.Run("reports typo'd and unknown keys sorted", func(t *testing.T) {
+		args := map[string]any{"data_source_uid": "x", "start_rfc3339": "t", "foo": 1}
+		assert.Equal(t, []string{"foo", "start_rfc3339"}, unknownArguments(args, properties))
+	})
+
+	t.Run("non-object arguments are left to the decode path", func(t *testing.T) {
+		assert.Empty(t, unknownArguments("not an object", properties))
+		assert.Empty(t, unknownArguments(nil, properties))
+	})
+
+	t.Run("error message names the keys and lists valid arguments", func(t *testing.T) {
+		msg := unknownArgumentsError([]string{"start_rfc3339"}, properties)
+		assert.Contains(t, msg, `unknown argument "start_rfc3339"`)
+		assert.Contains(t, msg, "valid arguments: data_source_uid, start_rfc_3339")
+	})
+}
+
+func TestConvertToolRejectsUnknownArguments(t *testing.T) {
+	_, handler, err := ConvertTool("test_tool", "A test tool", testToolHandler)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	t.Run("typo'd argument returns tool error listing valid arguments", func(t *testing.T) {
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "test_tool",
+				Arguments: map[string]any{
+					"name":    "test",
+					"value":   65,
+					"optionl": true,
+				},
+			},
+		}
+		result, err := handler(ctx, request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		text, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, `unknown argument "optionl"`)
+		assert.Contains(t, text.Text, "valid arguments: name, optional, value")
+	})
+
+	t.Run("valid arguments still succeed", func(t *testing.T) {
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "test_tool",
+				Arguments: map[string]any{"name": "test", "value": 65},
+			},
+		}
+		result, err := handler(ctx, request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+
+	t.Run("empty-params tool rejects any argument", func(t *testing.T) {
+		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "empty",
+				Arguments: map[string]any{"foo": "bar"},
+			},
+		}
+		result, err := emptyHandler(ctx, request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, "this tool takes no arguments")
+	})
+
+	t.Run("nil arguments succeed", func(t *testing.T) {
+		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{Name: "empty"},
+		}
+		result, err := emptyHandler(ctx, request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+}
+
+func TestConvertToolKnownArgumentsMatchSchema(t *testing.T) {
+	// The known-args check must accept exactly what the generated schema
+	// declares — including fields promoted from embedded structs — so that no
+	// call valid per the advertised schema starts failing.
+	tool, handler, err := ConvertTool("embedded", "description", unknownArgsHandler)
+	require.NoError(t, err)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(tool.RawInputSchema, &schema))
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, props, "start_rfc_3339")
+	assert.Contains(t, props, "end_rfc_3339")
+	assert.Contains(t, props, "data_source_uid")
+	assert.NotContains(t, props, "Hidden")
+
+	ctx := context.Background()
+	args := map[string]any{"data_source_uid": "x"}
+	for name := range props {
+		args[name] = "y"
+	}
+	result, err := handler(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "embedded", Arguments: args},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "every schema-declared property must pass the unknown-args check")
+
+	result, err = handler(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "embedded",
+			Arguments: map[string]any{"data_source_uid": "x", "start_rfc3339": "now"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}

--- a/tools_test.go
+++ b/tools_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -749,4 +750,125 @@ func TestConvertToolHandlesInterfaceFields(t *testing.T) {
 	modelObj, ok := model.(map[string]any)
 	require.True(t, ok, "model property should be an object schema, got %T", model)
 	t.Logf("model schema: %v", modelObj)
+}
+
+type embeddedTimeParams struct {
+	StartRFC3339 string `json:"start_rfc_3339,omitempty"`
+	EndRFC3339   string `json:"end_rfc_3339,omitempty"`
+}
+
+type unknownArgsParams struct {
+	embeddedTimeParams
+	DataSourceUID string `json:"data_source_uid" jsonschema:"required"`
+	Hidden        string `json:"-"`
+	Untagged      string
+}
+
+func TestUnknownArguments(t *testing.T) {
+	argType := reflect.TypeOf(unknownArgsParams{})
+
+	t.Run("known field names include promoted and untagged fields", func(t *testing.T) {
+		names := knownJSONFieldNames(argType)
+		assert.Equal(t, []string{"Untagged", "data_source_uid", "end_rfc_3339", "start_rfc_3339"}, names)
+	})
+
+	t.Run("accepts exact and case-insensitive keys", func(t *testing.T) {
+		args := []byte(`{"data_source_uid":"x","start_rfc_3339":"t","DATA_SOURCE_UID":"y","untagged":"z"}`)
+		assert.Empty(t, unknownArguments(args, argType))
+	})
+
+	t.Run("reports typo'd and unknown keys", func(t *testing.T) {
+		args := []byte(`{"data_source_uid":"x","start_rfc3339":"t","foo":1}`)
+		assert.Equal(t, []string{"foo", "start_rfc3339"}, unknownArguments(args, argType))
+	})
+
+	t.Run("error message names the keys and lists valid arguments", func(t *testing.T) {
+		msg := unknownArgumentsError([]string{"start_rfc3339"}, knownJSONFieldNames(argType))
+		assert.Contains(t, msg, `unknown argument "start_rfc3339"`)
+		assert.Contains(t, msg, "valid arguments: Untagged, data_source_uid, end_rfc_3339, start_rfc_3339")
+	})
+}
+
+func TestConvertToolRejectsUnknownArguments(t *testing.T) {
+	_, handler, err := ConvertTool("test_tool", "A test tool", testToolHandler)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	t.Run("typo'd argument returns tool error listing valid arguments", func(t *testing.T) {
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "test_tool",
+				Arguments: map[string]any{
+					"name":    "test",
+					"value":   65,
+					"optionl": true,
+				},
+			},
+		}
+		result, err := handler(ctx, request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		text, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, `unknown argument "optionl"`)
+		assert.Contains(t, text.Text, "valid arguments: name, optional, value")
+	})
+
+	t.Run("valid arguments still succeed", func(t *testing.T) {
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "test_tool",
+				Arguments: map[string]any{"name": "test", "value": 65},
+			},
+		}
+		result, err := handler(ctx, request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+
+	t.Run("empty-params tool rejects any argument", func(t *testing.T) {
+		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "empty",
+				Arguments: map[string]any{"foo": "bar"},
+			},
+		}
+		result, err := emptyHandler(ctx, request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, "this tool takes no arguments")
+	})
+
+	t.Run("nil arguments succeed", func(t *testing.T) {
+		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{Name: "empty"},
+		}
+		result, err := emptyHandler(ctx, request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+	})
+}
+
+func TestConvertToolSchemaDisallowsAdditionalProperties(t *testing.T) {
+	tool, _, err := ConvertTool("test_tool", "A test tool", testToolHandler)
+	require.NoError(t, err)
+
+	var schema map[string]any
+	err = json.Unmarshal(tool.RawInputSchema, &schema)
+	require.NoError(t, err)
+	require.Contains(t, schema, "additionalProperties")
+	assert.Equal(t, false, schema["additionalProperties"])
+}
+
+func TestValidateNoBooleanSchemasAllowsAdditionalPropertiesFalse(t *testing.T) {
+	input := `{"type":"object","properties":{"name":{"type":"string"}},"additionalProperties":false}`
+	err := validateNoBooleanSchemas("test_tool", []byte(input))
+	assert.NoError(t, err)
 }

--- a/tools_test.go
+++ b/tools_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"reflect"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -750,110 +749,6 @@ func TestConvertToolHandlesInterfaceFields(t *testing.T) {
 	modelObj, ok := model.(map[string]any)
 	require.True(t, ok, "model property should be an object schema, got %T", model)
 	t.Logf("model schema: %v", modelObj)
-}
-
-type embeddedTimeParams struct {
-	StartRFC3339 string `json:"start_rfc_3339,omitempty"`
-	EndRFC3339   string `json:"end_rfc_3339,omitempty"`
-}
-
-type unknownArgsParams struct {
-	embeddedTimeParams
-	DataSourceUID string `json:"data_source_uid" jsonschema:"required"`
-	Hidden        string `json:"-"`
-	Untagged      string
-}
-
-func TestUnknownArguments(t *testing.T) {
-	argType := reflect.TypeOf(unknownArgsParams{})
-
-	t.Run("known field names include promoted and untagged fields", func(t *testing.T) {
-		names := knownJSONFieldNames(argType)
-		assert.Equal(t, []string{"Untagged", "data_source_uid", "end_rfc_3339", "start_rfc_3339"}, names)
-	})
-
-	t.Run("accepts exact and case-insensitive keys", func(t *testing.T) {
-		args := []byte(`{"data_source_uid":"x","start_rfc_3339":"t","DATA_SOURCE_UID":"y","untagged":"z"}`)
-		assert.Empty(t, unknownArguments(args, argType))
-	})
-
-	t.Run("reports typo'd and unknown keys", func(t *testing.T) {
-		args := []byte(`{"data_source_uid":"x","start_rfc3339":"t","foo":1}`)
-		assert.Equal(t, []string{"foo", "start_rfc3339"}, unknownArguments(args, argType))
-	})
-
-	t.Run("error message names the keys and lists valid arguments", func(t *testing.T) {
-		msg := unknownArgumentsError([]string{"start_rfc3339"}, knownJSONFieldNames(argType))
-		assert.Contains(t, msg, `unknown argument "start_rfc3339"`)
-		assert.Contains(t, msg, "valid arguments: Untagged, data_source_uid, end_rfc_3339, start_rfc_3339")
-	})
-}
-
-func TestConvertToolRejectsUnknownArguments(t *testing.T) {
-	_, handler, err := ConvertTool("test_tool", "A test tool", testToolHandler)
-	require.NoError(t, err)
-	ctx := context.Background()
-
-	t.Run("typo'd argument returns tool error listing valid arguments", func(t *testing.T) {
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "test_tool",
-				Arguments: map[string]any{
-					"name":    "test",
-					"value":   65,
-					"optionl": true,
-				},
-			},
-		}
-		result, err := handler(ctx, request)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		assert.True(t, result.IsError)
-		text, ok := result.Content[0].(mcp.TextContent)
-		require.True(t, ok)
-		assert.Contains(t, text.Text, `unknown argument "optionl"`)
-		assert.Contains(t, text.Text, "valid arguments: name, optional, value")
-	})
-
-	t.Run("valid arguments still succeed", func(t *testing.T) {
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name:      "test_tool",
-				Arguments: map[string]any{"name": "test", "value": 65},
-			},
-		}
-		result, err := handler(ctx, request)
-		require.NoError(t, err)
-		assert.False(t, result.IsError)
-	})
-
-	t.Run("empty-params tool rejects any argument", func(t *testing.T) {
-		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
-		require.NoError(t, err)
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name:      "empty",
-				Arguments: map[string]any{"foo": "bar"},
-			},
-		}
-		result, err := emptyHandler(ctx, request)
-		require.NoError(t, err)
-		assert.True(t, result.IsError)
-		text, ok := result.Content[0].(mcp.TextContent)
-		require.True(t, ok)
-		assert.Contains(t, text.Text, "this tool takes no arguments")
-	})
-
-	t.Run("nil arguments succeed", func(t *testing.T) {
-		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
-		require.NoError(t, err)
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{Name: "empty"},
-		}
-		result, err := emptyHandler(ctx, request)
-		require.NoError(t, err)
-		assert.False(t, result.IsError)
-	})
 }
 
 func TestConvertToolSchemaDisallowsAdditionalProperties(t *testing.T) {


### PR DESCRIPTION
An MCP client that sends a misspelled or unknown argument name currently gets a successful response computed from defaults: the argument decode path (`json.Unmarshal`) silently drops unknown keys, and generated schemas don't declare `additionalProperties: false`, so nothing between the caller and the handler catches the mistake. For example, `query_pyroscope` with `start_rfc3339` (instead of `start_rfc_3339`) silently queries the default now-1h window instead of the requested one — the response looks healthy but answers a different question. LLM agents hit this frequently, plausibly because time-param names are inconsistent across the tool surface (`startRfc3339` in the Loki tools, `startTime` in the Prometheus tools, `start_rfc_3339` in the Pyroscope tools), so a blended spelling like `start_rfc3339` is a natural failure mode.

This change makes `ConvertTool` reject unknown top-level argument keys. The error is returned as a tool result (`IsError`) rather than a protocol error, so LLM callers see it and can self-correct:

```
unknown argument "start_rfc3339"; valid arguments: data_source_uid, end_rfc_3339, group_by, matchers, max_node_depth, profile_type, query_type, start_rfc_3339, step
```

Generated schemas now also declare `additionalProperties: false`, so schema-validating clients and providers with strict function calling catch the mistake before it reaches the server.

Notes:
- Key matching is case-insensitive, mirroring `encoding/json`, so calls that previously populated fields keep working; only keys that were being silently dropped now fail.
- Only top-level keys are checked — nested object schemas are unchanged.
- `validateNoBooleanSchemas` gets a carve-out for `additionalProperties: false`: it's valid JSON Schema and universally supported (OpenAI structured outputs requires it). The bare-boolean concern from #594 was `true` schemas coming from `interface{}` fields, and those are still rejected.
- Verified against a live Grafana with a Pyroscope datasource: correct calls are unchanged; typo'd/unknown args on `query_pyroscope`, `list_pyroscope_label_names`, `list_datasources`, and `query_prometheus` are all rejected with the message above.