### PR TITLE
fix: proxied-tools memory scaling with session count and unbounded per-session tool-store growth

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -330,6 +330,11 @@ func newServer(transport string, dt disabledTools, obs *observability.Observabil
 	// unregister sessions from the SDK's internal session map.
 	sm.SetMCPServer(s)
 
+	// Give the SessionManager a reference to the ToolManager so tearing down a
+	// session releases its reference to the shared proxied tool set (closing the
+	// underlying clients only when the last session using them is gone).
+	sm.SetToolManager(stm)
+
 	dt.processTools(s)
 	mcpgrafana.RegisterAppResources(s)
 	return s, stm, sm
@@ -578,6 +583,15 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			server.WithEndpointPath(endpointPath),
 			server.WithStreamableHTTPServer(httpSrv),
 			server.WithStreamableHTTPCORS(server.WithCORSAllowedOrigins(hsc.corsOrigins()...)),
+			// Enable the SDK's idle-session sweeper so per-session transport state
+			// (the tool/resource maps populated by AddSessionTools, keyed by
+			// session ID in the server's shared stores) is freed when a client
+			// disconnects without sending a DELETE. Without it, UnregisterSession
+			// only drops the session handle and those stores grow without bound,
+			// leaking a fixed amount of memory per session that is ever created.
+			// Use the same idle timeout as our own SessionManager reaper so the
+			// two teardown paths stay aligned; a zero value disables both.
+			server.WithSessionIdleTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute),
 		}
 		if tls.certFile != "" || tls.keyFile != "" {
 			opts = append(opts, server.WithTLSCert(tls.certFile, tls.keyFile))

--- a/proxied_client.go
+++ b/proxied_client.go
@@ -27,6 +27,12 @@ type ProxiedClient struct {
 	Client         *mcp_client.Client
 	Tools          []mcp.Tool
 	mutex          sync.RWMutex
+
+	// closeHook, when set, runs inside Close (under the client mutex). It is a
+	// test seam so lifecycle tests can observe exactly how many times a client is
+	// Closed without standing up a real remote MCP transport. Always nil in
+	// production; do not use it for behavior.
+	closeHook func()
 }
 
 // contextCauseOrErr returns the context cause if the error is due to context
@@ -149,6 +155,10 @@ func (pc *ProxiedClient) ListTools() []mcp.Tool {
 func (pc *ProxiedClient) Close() error {
 	pc.mutex.Lock()
 	defer pc.mutex.Unlock()
+
+	if pc.closeHook != nil {
+		pc.closeHook()
+	}
 
 	if pc.Client != nil {
 		if err := pc.Client.Close(); err != nil {

--- a/proxied_handler.go
+++ b/proxied_handler.go
@@ -55,23 +55,32 @@ func (h *ProxiedToolHandler) Handle(ctx context.Context, request mcp.CallToolReq
 		return nil, fmt.Errorf("failed to parse tool name: %w", err)
 	}
 
-	// Get the proxied client for this datasource
+	// Get the proxied client for this datasource.
 	var client *ProxiedClient
+	// release, when non-nil, must be called once the forwarded call completes.
+	// For the session (HTTP/SSE) path it holds an in-flight reference on the
+	// shared set so the client cannot be Closed by a concurrent teardown while
+	// the call is running. The stdio path is single-tenant/process-level and
+	// needs no such guard, so its release is nil.
+	var release func()
 
 	if h.toolManager.serverMode {
 		// Server mode (stdio): clients stored at manager level
 		client, err = h.toolManager.GetServerClient(datasourceType, datasourceUID)
 	} else {
-		// Session mode (HTTP/SSE): clients stored per-session
-		client, err = h.sessionManager.GetProxiedClient(ctx, datasourceType, datasourceUID)
+		// Session mode (HTTP/SSE): clients live in the session's shared set.
+		client, release, err = h.sessionManager.GetProxiedClient(ctx, datasourceType, datasourceUID)
 		if err != nil {
-			// Fallback to server-level in case of mixed mode
+			// Fallback to server-level in case of mixed mode.
 			client, err = h.toolManager.GetServerClient(datasourceType, datasourceUID)
 		}
 	}
 
 	if err != nil {
 		return nil, fmt.Errorf("datasource '%s' not found or not accessible. Ensure the datasource exists and you have permission to access it", datasourceUID)
+	}
+	if release != nil {
+		defer release()
 	}
 
 	// Remove datasourceUid from args before forwarding to remote server

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -536,11 +536,22 @@ type builtProxiedTools struct {
 // built into a usable state (discovery failed or was cancelled). A successful
 // discovery that finds zero MCP datasources is not an error: it is a legitimate
 // "no proxied tools" result (an empty build, handled by the caller).
-func (tm *ToolManager) buildProxiedToolSet(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
-	built := builtProxiedTools{
+func (tm *ToolManager) buildProxiedToolSet(ctx context.Context, logger *slog.Logger) (built builtProxiedTools, err error) {
+	built = builtProxiedTools{
 		clients:           make(map[string]*ProxiedClient),
 		toolToDatasources: make(map[string][]string),
 	}
+
+	// Convert a panic into an error while KEEPING the clients connected so far in
+	// the named return, so the caller's non-publish path closes them instead of
+	// leaking their remote connections. (The caller also recovers, but only the
+	// caller's own frame; a panic here would otherwise discard `built` entirely.)
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic building proxied tool set: %v", r)
+			logger.ErrorContext(ctx, "panic building proxied tool set", "error", r)
+		}
+	}()
 
 	// Discover datasources with MCP support.
 	discovered, err := discoverMCPDatasources(ctx, logger)
@@ -646,6 +657,14 @@ func (tm *ToolManager) attachProxiedToolSet(state *SessionState, key proxiedTool
 func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedToolSet, logger *slog.Logger) {
 	buildCtx := context.WithoutCancel(ctx)
 
+	// buildSet is expected to convert its own panics into an error while
+	// returning any clients it already connected (buildProxiedToolSet does this
+	// via named returns), so a panic's partial clients are reaped by the
+	// non-publish path below. This outer recover is a last-resort guard that only
+	// fires if a builder panics past its own recovery: it keeps this goroutine and
+	// any ready-waiters alive by turning the panic into a failed build. In that
+	// escaped-panic case built is the zero value, so a builder that connects
+	// clients MUST recover internally to avoid leaking them.
 	var built builtProxiedTools
 	var buildErr error
 	func() {
@@ -692,19 +711,26 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 		set.built = true
 	}
 	abandoned := set.refs == 0
+	published := !abandoned && !failed
 	size := len(tm.proxiedSets)
 	tm.proxiedSetsMu.Unlock()
 
 	close(set.ready)
 
-	if abandoned {
-		// Close the freshly-built clients outside the lock (they were never
-		// published, so no other path can observe or close them).
+	// On any non-publish outcome the freshly-built clients were NOT stored on the
+	// set, so no teardown path can observe or close them: close them here (once,
+	// outside the lock) or their remote connections leak. This covers both the
+	// abandoned case (all sessions left mid-build) and the failed case where the
+	// builder connected some clients before erroring or panicking.
+	if !published {
 		tm.closeProxiedClients(built.clients)
+	}
+
+	switch {
+	case abandoned:
 		logger.InfoContext(ctx, "proxied tool set abandoned during build; closed clients without publishing", "key", set.key)
 		return
-	}
-	if failed {
+	case failed:
 		logger.InfoContext(ctx, "proxied tool set build failed; not caching", "key", set.key, "error", buildErr)
 		return
 	}

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -339,12 +339,16 @@ type proxiedToolSet struct {
 
 	// built reports that the build completed and published its results into the
 	// clients/tools maps. Until built is true the maps are empty placeholders and
-	// must not be treated as the set's contents.
+	// must not be treated as the set's contents. A build that discovers zero MCP
+	// datasources is still a successful build: built is true and the maps are
+	// legitimately empty (see failed for the transient case).
 	built bool
-	// failed reports that the build did not produce a usable set (discovery
-	// error, cancellation, panic, or zero clients). A failed set is removed from
-	// the cache so the next session rebuilds; waiters treat it as "no proxied
-	// tools this time" rather than a permanently cached empty set.
+	// failed reports that the build hit a TRANSIENT error (discovery error,
+	// context cancellation, or panic). A failed set is removed from the cache so
+	// the next session rebuilds and retries. It is NOT set for a successful build
+	// that simply found no MCP datasources: that empty result is stable, so the
+	// set is published (built=true, failed=false, empty maps) and cached, and
+	// sessions do not re-run discovery on every hook.
 	failed bool
 
 	// clients keyed by datasourceType_datasourceUID. Empty until built is true;
@@ -625,9 +629,16 @@ func (tm *ToolManager) attachProxiedToolSet(state *SessionState, key proxiedTool
 // for the other sessions waiting on the same set. ready is always closed, even
 // on panic, so concurrent waiters never block indefinitely.
 //
-// Failure handling: on discovery error, panic, or zero clients the set is marked
-// failed and removed from the cache so the next session rebuilds, rather than
-// leaving a poisoned empty entry cached forever.
+// Outcome handling, three cases:
+//   - TRANSIENT ERROR (buildErr != nil: discovery error, context cancel, panic):
+//     the set is marked failed and removed from the cache so the next session
+//     rebuilds and retries, rather than leaving a poisoned entry cached.
+//   - EMPTY SUCCESS (buildErr == nil, zero MCP datasources discovered): a stable
+//     "this instance has no proxied tools" result. The set is published with
+//     empty maps (built=true, failed=false) and KEPT in the cache, so sessions do
+//     not re-run full discovery on every hook. Only a real config change (a new
+//     datasource) surfaces after the cached set is torn down and rebuilt.
+//   - SUCCESS WITH CLIENTS: published and cached as usual.
 //
 // Teardown-during-build: if every session left while the build ran (refs==0 at
 // publish time), the freshly-built local clients are closed right here and never
@@ -647,9 +658,10 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 		built, buildErr = tm.buildSet(buildCtx, logger)
 	}()
 
-	// len(built.clients)==0 covers both a genuine "no MCP datasources" result and
-	// one where every client dial failed; a rebuild is cheap and correct for both.
-	failed := buildErr != nil || len(built.clients) == 0
+	// Only a real error is transient/failed. A successful build that found zero
+	// MCP datasources is a stable empty result and must be cached (built, empty),
+	// not de-cached, so sessions do not re-discover on every hook.
+	failed := buildErr != nil
 
 	tm.proxiedSetsMu.Lock()
 
@@ -671,8 +683,9 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 			delete(tm.proxiedSets, set.key)
 		}
 	default:
-		// Publish the build results. After this the maps are immutable and safe
-		// to read under the lock (teardown) or after <-ready (session use).
+		// Publish the build results (which may be legitimately empty). After this
+		// the maps are immutable and safe to read under the lock (teardown) or
+		// after <-ready (session use).
 		set.clients = built.clients
 		set.tools = built.tools
 		set.toolToDatasources = built.toolToDatasources
@@ -692,7 +705,7 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 		return
 	}
 	if failed {
-		logger.InfoContext(ctx, "proxied tool set build produced no usable tools; not caching", "key", set.key, "error", buildErr)
+		logger.InfoContext(ctx, "proxied tool set build failed; not caching", "key", set.key, "error", buildErr)
 		return
 	}
 	logger.InfoContext(ctx, "built proxied tool set", "key", set.key, "datasources", len(set.clients), "tools", len(set.tools), "cache_size", size)
@@ -860,17 +873,18 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 	tools := set.tools
 	tm.proxiedSetsMu.Unlock()
 
-	// A failed build (discovery error, cancellation, panic, or zero datasources
-	// discovered) is treated as transient and was de-cached. Do NOT mark this
-	// session registered: release its reference to the failed set, clear the
-	// binding, and return so the next hook invocation for this session retries a
-	// fresh attach (which triggers a fresh build). This keeps the failure
-	// transient for the session, matching the cache's behavior for later sessions.
+	// A failed build (transient: discovery error, cancellation, or panic) was
+	// de-cached. Do NOT mark this session registered: release its reference to
+	// the failed set, clear the binding, and return so the next hook invocation
+	// for this session retries a fresh attach (which triggers a fresh build).
+	// This keeps the failure transient for the session, matching the cache's
+	// behavior for later sessions.
 	//
-	// A usable build with zero tools is NOT a failure: the datasources were
-	// reachable but exposed no proxied tools. That is a valid, cached steady
-	// state, so the session keeps its reference and is marked registered (there
-	// is simply nothing to register); it must not retry forever.
+	// A usable build with zero tools is NOT a failure: either the instance has no
+	// MCP datasources, or its datasources exposed no tools. That is a stable,
+	// cached result, so the session keeps its reference and is marked registered
+	// (there is simply nothing to register); it must not retry, so repeated hooks
+	// do not re-run discovery.
 	if !usable {
 		tm.releaseSessionProxiedToolSet(state)
 		return

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -685,11 +685,9 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 	close(set.ready)
 
 	if abandoned {
-		for clientKey, client := range built.clients {
-			if err := client.Close(); err != nil {
-				tm.logger.Error("failed to close proxied client", "key", clientKey, "error", err)
-			}
-		}
+		// Close the freshly-built clients outside the lock (they were never
+		// published, so no other path can observe or close them).
+		tm.closeProxiedClients(built.clients)
 		logger.InfoContext(ctx, "proxied tool set abandoned during build; closed clients without publishing", "key", set.key)
 		return
 	}
@@ -709,18 +707,28 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 func (tm *ToolManager) releaseProxiedToolSet(set *proxiedToolSet) {
 	tm.proxiedSetsMu.Lock()
 	set.refs--
-	tm.maybeCloseProxiedToolSetLocked(set)
+	toClose := tm.takeClientsToCloseLocked(set)
 	tm.proxiedSetsMu.Unlock()
+
+	tm.closeProxiedClients(toClose)
 }
 
-// maybeCloseProxiedToolSetLocked closes a set's clients and removes it from the
-// cache when nothing references it and no call is in flight. Must be called with
-// proxiedSetsMu held. Closing is done under the lock; it is a local map/close
-// operation (no network I/O), and callers only reach it when inFlight==0 so no
-// live call can be blocked.
-func (tm *ToolManager) maybeCloseProxiedToolSetLocked(set *proxiedToolSet) {
+// takeClientsToCloseLocked decides whether a set can be torn down (refs==0,
+// inFlight==0, not already closed) and, if so, marks it closed, removes it from
+// the cache, and returns its clients for the caller to Close AFTER releasing the
+// lock. It returns nil when the set is still in use or already closed. Must be
+// called with proxiedSetsMu held.
+//
+// Closing is deliberately deferred to outside the lock: ProxiedClient.Close does
+// network I/O, and proxiedSetsMu serializes attach/release/acquire for ALL
+// credential keys, so closing under it would let a slow Close on one key stall
+// unrelated sessions. Setting closed=true under the lock keeps teardown
+// exactly-once (only the caller that flips closed collects the clients) and
+// keeps acquireProxiedClientForCall's closed check correct (an acquire either
+// runs before this selection and bumps inFlight, or sees closed afterwards).
+func (tm *ToolManager) takeClientsToCloseLocked(set *proxiedToolSet) map[string]*ProxiedClient {
 	if set.refs > 0 || set.inFlight > 0 || set.closed {
-		return
+		return nil
 	}
 	set.closed = true
 	// Remove from the cache if this set is still the entry for its key. A failed
@@ -728,7 +736,13 @@ func (tm *ToolManager) maybeCloseProxiedToolSetLocked(set *proxiedToolSet) {
 	if tm.proxiedSets[set.key] == set {
 		delete(tm.proxiedSets, set.key)
 	}
-	for clientKey, client := range set.clients {
+	return set.clients
+}
+
+// closeProxiedClients closes the given clients. It must be called WITHOUT
+// proxiedSetsMu held so a slow Close cannot stall unrelated sessions.
+func (tm *ToolManager) closeProxiedClients(clients map[string]*ProxiedClient) {
+	for clientKey, client := range clients {
 		if err := client.Close(); err != nil {
 			tm.logger.Error("failed to close proxied client", "key", clientKey, "error", err)
 		}
@@ -767,8 +781,10 @@ func (tm *ToolManager) acquireProxiedClientForCall(set *proxiedToolSet, datasour
 	release := func() {
 		tm.proxiedSetsMu.Lock()
 		set.inFlight--
-		tm.maybeCloseProxiedToolSetLocked(set)
+		toClose := tm.takeClientsToCloseLocked(set)
 		tm.proxiedSetsMu.Unlock()
+
+		tm.closeProxiedClients(toClose)
 	}
 	return client, release, nil
 }
@@ -801,46 +817,66 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 
 	key := proxiedToolSetKeyFromContext(ctx)
 
-	// Attach and register exactly once per session.
-	state.attachOnce.Do(func() {
-		// attachProxiedToolSet takes the reference AND binds the set to the
-		// session atomically (under proxiedSetsMu), so there is no window where a
-		// reference exists that teardown cannot find and release.
-		set, needsBuild := tm.attachProxiedToolSet(state, key)
+	// Serialize attach/build/register for this session and allow a later retry if
+	// this attempt does not end in a successful registration. proxiedInitMu is
+	// held for the whole attempt: concurrent hooks for the SAME session (e.g.
+	// OnBeforeListTools and OnBeforeCallTool) queue behind it, and the second one
+	// sees proxiedRegistered and returns, or retries if the first failed.
+	state.proxiedInitMu.Lock()
+	defer state.proxiedInitMu.Unlock()
 
-		// Reconcile against a teardown that raced this attach. A session may have
-		// been removed from the SessionManager (client DELETE / idle sweeper /
-		// reaper) between GetSession/CreateSession above and the bind inside
-		// attachProxiedToolSet. If so, that RemoveSession saw proxiedSet==nil and
-		// did not release, and no future teardown will fire for this (now
-		// untracked) session, so the ref we just took would leak. Detect it and
-		// release exactly once (releaseSessionProxiedToolSet is idempotent, so a
-		// RemoveSession that instead ran AFTER our bind is handled too, with no
-		// double release). We still run/await the build below so any live waiter
-		// for the same key is served.
-		if !tm.sm.sessionRegistered(sessionID, state) {
-			defer tm.releaseSessionProxiedToolSet(state)
-		}
+	if state.proxiedRegistered {
+		return
+	}
 
-		if needsBuild {
-			tm.runProxiedToolSetBuild(ctx, set, logger)
-		} else {
-			<-set.ready
-		}
+	// attachProxiedToolSet takes the reference AND binds the set to the session
+	// atomically (under proxiedSetsMu), so there is no window where a reference
+	// exists that teardown cannot find and release.
+	set, needsBuild := tm.attachProxiedToolSet(state, key)
 
-		// Read the published results under the lock: set.built/failed/tools are
-		// only stable once ready is closed, and are guarded by proxiedSetsMu.
-		tm.proxiedSetsMu.Lock()
-		usable := set.built && !set.failed
-		tools := set.tools
-		tm.proxiedSetsMu.Unlock()
+	// Reconcile against a teardown that raced this attach. A session may have been
+	// removed from the SessionManager (client DELETE / idle sweeper / reaper)
+	// between GetSession/CreateSession above and the bind inside
+	// attachProxiedToolSet. If so, that RemoveSession saw proxiedSet==nil and did
+	// not release, and no future teardown will fire for this (now untracked)
+	// session, so the ref we just took would leak. Detect it and release exactly
+	// once (releaseSessionProxiedToolSet is idempotent, so a RemoveSession that
+	// instead ran AFTER our bind is handled too, with no double release). We still
+	// run/await the build below so any live waiter for the same key is served.
+	if !tm.sm.sessionRegistered(sessionID, state) {
+		defer tm.releaseSessionProxiedToolSet(state)
+	}
 
-		// A failed or empty build produces no tools; nothing to register this
-		// time. The session keeps its reference and releases it on teardown.
-		if !usable || len(tools) == 0 {
-			return
-		}
+	if needsBuild {
+		tm.runProxiedToolSetBuild(ctx, set, logger)
+	} else {
+		<-set.ready
+	}
 
+	// Read the published results under the lock: set.built/failed/tools are only
+	// stable once ready is closed, and are guarded by proxiedSetsMu.
+	tm.proxiedSetsMu.Lock()
+	usable := set.built && !set.failed
+	tools := set.tools
+	tm.proxiedSetsMu.Unlock()
+
+	// A failed build (discovery error, cancellation, panic, or zero datasources
+	// discovered) is treated as transient and was de-cached. Do NOT mark this
+	// session registered: release its reference to the failed set, clear the
+	// binding, and return so the next hook invocation for this session retries a
+	// fresh attach (which triggers a fresh build). This keeps the failure
+	// transient for the session, matching the cache's behavior for later sessions.
+	//
+	// A usable build with zero tools is NOT a failure: the datasources were
+	// reachable but exposed no proxied tools. That is a valid, cached steady
+	// state, so the session keeps its reference and is marked registered (there
+	// is simply nothing to register); it must not retry forever.
+	if !usable {
+		tm.releaseSessionProxiedToolSet(state)
+		return
+	}
+
+	if len(tools) > 0 {
 		// Register the shared tools on this session. AddSessionTools is
 		// per-session SDK bookkeeping; it references the shared (now immutable)
 		// mcp.Tool values directly, with no per-session deep copy, JSON decode, or
@@ -859,7 +895,11 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 		} else {
 			logger.InfoContext(ctx, "registered proxied tools", "session", sessionID, "tools", len(tools))
 		}
-	})
+	}
+
+	// The attach succeeded (usable set, ref held). Mark the session registered so
+	// later hooks are no-ops; teardown will release the reference.
+	state.proxiedRegistered = true
 }
 
 // releaseSessionProxiedToolSet releases the session's reference to its shared

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -208,6 +210,163 @@ func parseProxiedToolName(toolName string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
+// proxiedToolSetKey uniquely identifies a set of proxied clients/tools by every
+// piece of GrafanaConfig that BuildTransport / NewProxiedClient consume to build
+// and authenticate the connection. Sessions that resolve to the same key share a
+// single proxiedToolSet, so the number of live sessions no longer multiplies
+// memory: proxied clients and rewritten tools are built and stored once per
+// distinct credential set rather than once per session.
+//
+// The key MUST include everything that changes the built client, otherwise two
+// sessions differing only in an omitted field would share a client built with
+// the first session's material (credential bleed across users/tenants):
+//   - AccessToken and IDToken: Grafana Cloud per-user / on-behalf-of auth.
+//   - TLS material (cert/key/CA/skip-verify): mutual-TLS client identity.
+//   - timeout: GrafanaConfig.Timeout is baked into the built transport.
+//   - extraHeaders: forwarded/extra headers land in GrafanaConfig.ExtraHeaders
+//     and are sent on every request; a serialized, unambiguous form is used
+//     because a map is neither comparable nor usable as a struct field of a map
+//     key.
+//
+// GrafanaConfig.BaseTransport is intentionally NOT part of the key: it is an
+// http.RoundTripper (an interface value that is not reliably comparable) and is
+// process-constant (set once at server construction, never per request/session),
+// so it cannot differ between two sessions and needs no differentiation.
+type proxiedToolSetKey struct {
+	url           string
+	apiKey        string
+	accessToken   string
+	idToken       string
+	orgID         int64
+	timeout       time.Duration
+	basicAuthUser string
+	basicAuthPass string
+	tlsCertFile   string
+	tlsKeyFile    string
+	tlsCAFile     string
+	tlsSkipVerify bool
+	extraHeaders  string // sorted, unambiguously-encoded ExtraHeaders
+}
+
+// proxiedToolSetKeyFromContext builds a proxiedToolSetKey from the GrafanaConfig
+// carried in the context.
+func proxiedToolSetKeyFromContext(ctx context.Context) proxiedToolSetKey {
+	config := GrafanaConfigFromContext(ctx)
+	key := proxiedToolSetKey{
+		url:          config.URL,
+		apiKey:       config.APIKey,
+		accessToken:  config.AccessToken,
+		idToken:      config.IDToken,
+		orgID:        config.OrgID,
+		timeout:      config.Timeout,
+		extraHeaders: serializeHeaders(config.ExtraHeaders),
+	}
+	if config.BasicAuth != nil {
+		key.basicAuthUser = config.BasicAuth.Username()
+		key.basicAuthPass, _ = config.BasicAuth.Password()
+	}
+	if tls := config.TLSConfig; tls != nil {
+		key.tlsCertFile = tls.CertFile
+		key.tlsKeyFile = tls.KeyFile
+		key.tlsCAFile = tls.CAFile
+		key.tlsSkipVerify = tls.SkipVerify
+	}
+	return key
+}
+
+// serializeHeaders renders a header map into a deterministic, injective string
+// so it can be part of a comparable cache key. Names and values are individually
+// percent-escaped before joining, so no combination of names/values can collide
+// with a different map: e.g. {"H":"a,b=c"} and {"H":"a","b":"c"} encode
+// distinctly. (client_cache.go's cacheKeyFromRequest uses a plainer, ambiguous
+// join; this key must not share that flaw.)
+func serializeHeaders(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(headers))
+	for k := range headers {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	var sb strings.Builder
+	for _, k := range names {
+		sb.WriteString(url.QueryEscape(k))
+		sb.WriteByte('=')
+		sb.WriteString(url.QueryEscape(headers[k]))
+		sb.WriteByte('&')
+	}
+	return sb.String()
+}
+
+// String returns a redacted string representation for logging.
+func (k proxiedToolSetKey) String() string {
+	return fmt.Sprintf("url=%s apiKey=%t accessToken=%t idToken=%t orgID=%d timeout=%s basicAuth=%t tlsCert=%t tlsCA=%t tlsSkipVerify=%t extraHeaders=%t",
+		k.url, k.apiKey != "", k.accessToken != "", k.idToken != "", k.orgID, k.timeout, k.basicAuthUser != "",
+		k.tlsCertFile != "", k.tlsCAFile != "", k.tlsSkipVerify, k.extraHeaders != "")
+}
+
+// proxiedToolSet is the shared, credential-keyed result of discovering and
+// connecting to proxied MCP datasources. It is reference counted: sessions
+// attach to it (incrementing refs) and detach on teardown (decrementing refs).
+// Its clients are closed and it is dropped from the cache only when the last
+// session detaches (refs reaches zero) AND no tool call is in flight against it.
+//
+// Lifecycle and memory model. A placeholder is inserted into the cache under
+// proxiedSetsMu (with refs already accounting for the first attaching session)
+// BEFORE the expensive discovery/connection runs, so a concurrent session for
+// the same key reuses it rather than building a second copy. The build itself
+// runs WITHOUT any lock and mutates only local variables; its results are
+// published into clients/tools/toolToDatasources in a single critical section
+// under proxiedSetsMu (see runProxiedToolSetBuild). This "build then publish"
+// ordering is essential: teardown (maybeCloseProxiedToolSetLocked) ranges over
+// clients while holding proxiedSetsMu, so clients must never be written outside
+// that lock while the set is reachable, otherwise a concurrent build write and
+// teardown read would be a "concurrent map iteration and map write" fatal error
+// that recover() cannot catch.
+//
+// All the fields below are guarded by ToolManager.proxiedSetsMu.
+type proxiedToolSet struct {
+	// key identifies this set in ToolManager.proxiedSets. Stored so teardown can
+	// remove the cache entry when releasing by set pointer, and so a rebuild
+	// after a failed build never removes a newer entry for the same key.
+	key proxiedToolSetKey
+
+	// ready is closed once the build has finished (whether it succeeded, failed,
+	// or was abandoned because all sessions left mid-build). Sessions that attach
+	// to an in-progress set wait on it before reading built/failed/tools.
+	ready chan struct{}
+
+	// built reports that the build completed and published its results into the
+	// clients/tools maps. Until built is true the maps are empty placeholders and
+	// must not be treated as the set's contents.
+	built bool
+	// failed reports that the build did not produce a usable set (discovery
+	// error, cancellation, panic, or zero clients). A failed set is removed from
+	// the cache so the next session rebuilds; waiters treat it as "no proxied
+	// tools this time" rather than a permanently cached empty set.
+	failed bool
+
+	// clients keyed by datasourceType_datasourceUID. Empty until built is true;
+	// published in one critical section and immutable afterwards.
+	clients map[string]*ProxiedClient
+	// tools is the deduplicated, schema-rewritten set of proxied tools. Empty
+	// until built is true; immutable afterwards.
+	tools []mcp.Tool
+	// toolToDatasources maps a proxied tool name to the datasource keys that
+	// support it. Empty until built is true; immutable afterwards.
+	toolToDatasources map[string][]string
+
+	// refs is the number of live sessions currently attached to this set.
+	refs int
+	// inFlight is the number of tool calls currently executing against this
+	// set's clients. Teardown must not Close clients while any call is in flight.
+	inFlight int
+	// closed reports that the set's clients have been Closed, so Close runs at
+	// most once.
+	closed bool
+}
+
 // ToolManager manages proxied tools (either per-session or server-wide)
 type ToolManager struct {
 	sm     *SessionManager
@@ -222,6 +381,22 @@ type ToolManager struct {
 	serverMode    bool // true if using server-wide tools (stdio), false for per-session (HTTP/SSE)
 	serverClients map[string]*ProxiedClient
 	clientsMutex  sync.RWMutex
+
+	// For HTTP/SSE transport: shared, credential-keyed proxied tool sets.
+	// Sessions with identical credentials share a single entry, so memory no
+	// longer scales with the number of live sessions. Entries are reference
+	// counted and their clients closed when the last session detaches. The
+	// entry for a key is inserted before the (slow) build runs, so concurrent
+	// sessions for the same key reuse it rather than each building a copy.
+	proxiedSets   map[proxiedToolSetKey]*proxiedToolSet
+	proxiedSetsMu sync.Mutex
+	// buildSet performs the discovery + connection + schema rewrite for a key and
+	// returns the results in LOCAL maps (it must mutate no shared state, so it can
+	// run without a lock while the placeholder set is already reachable). It
+	// returns an error when the set could not be built into a usable state. It
+	// defaults to buildProxiedToolSet and is a field only so tests can inject a
+	// fake builder that avoids real discovery/network I/O.
+	buildSet func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error)
 }
 
 // NewToolManager creates a new ToolManager
@@ -230,12 +405,19 @@ func NewToolManager(sm *SessionManager, mcpServer *server.MCPServer, opts ...too
 		sm:            sm,
 		server:        mcpServer,
 		serverClients: make(map[string]*ProxiedClient),
+		proxiedSets:   make(map[proxiedToolSetKey]*proxiedToolSet),
 	}
 	for _, opt := range opts {
 		opt(tm)
 	}
 	if tm.logger == nil {
 		tm.logger = slog.Default()
+	}
+	if tm.buildSet == nil {
+		tm.buildSet = tm.buildProxiedToolSet
+	}
+	if tm.proxiedSets == nil {
+		tm.proxiedSets = make(map[proxiedToolSetKey]*proxiedToolSet)
 	}
 	return tm
 }
@@ -334,8 +516,270 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 	return nil
 }
 
-// InitializeAndRegisterProxiedTools discovers datasources, creates clients, and registers tools per-session
-// This should be called in OnBeforeListTools and OnBeforeCallTool hooks for HTTP/SSE transports
+// builtProxiedTools is the result of a build, held in local variables while the
+// build runs so that nothing shared is mutated without the cache lock. It is
+// published into a proxiedToolSet in a single critical section.
+type builtProxiedTools struct {
+	clients           map[string]*ProxiedClient
+	tools             []mcp.Tool
+	toolToDatasources map[string][]string
+}
+
+// buildProxiedToolSet discovers datasources, connects to them, and returns the
+// built clients/tools/toolToDatasources in LOCAL maps. It mutates no shared
+// state, so it is safe to run without any lock while the placeholder set is
+// already reachable by teardown. It returns an error when the set could not be
+// built into a usable state (discovery failed or was cancelled). A successful
+// discovery that finds zero MCP datasources is not an error: it is a legitimate
+// "no proxied tools" result (an empty build, handled by the caller).
+func (tm *ToolManager) buildProxiedToolSet(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+	built := builtProxiedTools{
+		clients:           make(map[string]*ProxiedClient),
+		toolToDatasources: make(map[string][]string),
+	}
+
+	// Discover datasources with MCP support.
+	discovered, err := discoverMCPDatasources(ctx, logger)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to discover MCP datasources", "error", err)
+		return built, fmt.Errorf("failed to discover MCP datasources: %w", err)
+	}
+
+	// Connect to each discovered datasource.
+	for _, ds := range discovered {
+		client, err := NewProxiedClient(ctx, ds.UID, ds.Name, ds.Type, ds.MCPURL)
+		if err != nil {
+			logger.ErrorContext(ctx, "failed to create proxied client", "datasource", ds.UID, "error", err)
+			continue
+		}
+		key := ds.Type + "_" + ds.UID
+		built.clients[key] = client
+	}
+
+	// Collect unique tools and track which datasources support each one.
+	toolMap := make(map[string]mcp.Tool) // unique tools by name
+	for key, client := range built.clients {
+		for _, tool := range client.ListTools() {
+			// Tool name format: datasourceType_originalToolName (e.g., "tempo_traceql-search").
+			toolName := client.DatasourceType + "_" + tool.Name
+			if _, exists := toolMap[toolName]; !exists {
+				toolMap[toolName] = addDatasourceUidParameter(tool, client.DatasourceType)
+			}
+			built.toolToDatasources[toolName] = append(built.toolToDatasources[toolName], key)
+		}
+	}
+	for _, tool := range toolMap {
+		built.tools = append(built.tools, tool)
+	}
+	return built, nil
+}
+
+// attachProxiedToolSet find-or-inserts the shared proxiedToolSet for the given
+// key, takes one reference for the session, AND binds the set to the session,
+// all in a single critical section. Binding happens under state.mutex while
+// proxiedSetsMu is still held, so from the moment the reference exists the
+// session can already release it: there is no window in which a reference is
+// held but no teardown path can find it. (Teardown decrements under
+// proxiedSetsMu, which this holds, so it cannot run until attach returns.)
+// needsBuild reports whether this caller is the first for the key and must
+// therefore run the build; every other caller waits on set.ready.
+//
+// Lock order here is proxiedSetsMu then state.mutex. No other path takes
+// state.mutex and then proxiedSetsMu, so this nesting cannot deadlock.
+func (tm *ToolManager) attachProxiedToolSet(state *SessionState, key proxiedToolSetKey) (set *proxiedToolSet, needsBuild bool) {
+	tm.proxiedSetsMu.Lock()
+	defer tm.proxiedSetsMu.Unlock()
+
+	if existing, ok := tm.proxiedSets[key]; ok {
+		existing.refs++
+		set, needsBuild = existing, false
+	} else {
+		set = &proxiedToolSet{
+			key:               key,
+			ready:             make(chan struct{}),
+			clients:           make(map[string]*ProxiedClient),
+			toolToDatasources: make(map[string][]string),
+			refs:              1,
+		}
+		tm.proxiedSets[key] = set
+		needsBuild = true
+	}
+
+	state.mutex.Lock()
+	state.proxiedSet = set
+	state.proxiedSetReleased = false
+	state.mutex.Unlock()
+
+	return set, needsBuild
+}
+
+// runProxiedToolSetBuild builds the set (first caller only) and unblocks
+// waiters. The build runs with NO lock into local maps; its results are
+// published into the set in a single critical section under proxiedSetsMu,
+// together with close(ready). This build-then-publish ordering is what keeps
+// teardown (which ranges over set.clients under the same lock) from ever
+// observing a half-written map.
+//
+// The build runs under a context detached from cancellation (context.WithoutCancel)
+// so that a first client disconnecting mid-discovery does not cancel discovery
+// for the other sessions waiting on the same set. ready is always closed, even
+// on panic, so concurrent waiters never block indefinitely.
+//
+// Failure handling: on discovery error, panic, or zero clients the set is marked
+// failed and removed from the cache so the next session rebuilds, rather than
+// leaving a poisoned empty entry cached forever.
+//
+// Teardown-during-build: if every session left while the build ran (refs==0 at
+// publish time), the freshly-built local clients are closed right here and never
+// published, so nothing leaks and nothing is used after close.
+func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedToolSet, logger *slog.Logger) {
+	buildCtx := context.WithoutCancel(ctx)
+
+	var built builtProxiedTools
+	var buildErr error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				buildErr = fmt.Errorf("panic building proxied tool set: %v", r)
+				logger.ErrorContext(ctx, "panic building proxied tool set", "key", set.key, "panic", r)
+			}
+		}()
+		built, buildErr = tm.buildSet(buildCtx, logger)
+	}()
+
+	// len(built.clients)==0 covers both a genuine "no MCP datasources" result and
+	// one where every client dial failed; a rebuild is cheap and correct for both.
+	failed := buildErr != nil || len(built.clients) == 0
+
+	tm.proxiedSetsMu.Lock()
+
+	switch {
+	case set.refs == 0:
+		// Every session left while we built. Do not publish the live clients;
+		// close them here (once) and mark the set closed/failed so any late
+		// arrival treats it as unusable. The entry was already removed from the
+		// cache by the last release (delete-if-still-present is a no-op if a
+		// rebuild replaced it), but drop it defensively.
+		set.failed = true
+		set.closed = true
+		if tm.proxiedSets[set.key] == set {
+			delete(tm.proxiedSets, set.key)
+		}
+	case failed:
+		set.failed = true
+		if tm.proxiedSets[set.key] == set {
+			delete(tm.proxiedSets, set.key)
+		}
+	default:
+		// Publish the build results. After this the maps are immutable and safe
+		// to read under the lock (teardown) or after <-ready (session use).
+		set.clients = built.clients
+		set.tools = built.tools
+		set.toolToDatasources = built.toolToDatasources
+		set.built = true
+	}
+	abandoned := set.refs == 0
+	size := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+
+	close(set.ready)
+
+	if abandoned {
+		for clientKey, client := range built.clients {
+			if err := client.Close(); err != nil {
+				tm.logger.Error("failed to close proxied client", "key", clientKey, "error", err)
+			}
+		}
+		logger.InfoContext(ctx, "proxied tool set abandoned during build; closed clients without publishing", "key", set.key)
+		return
+	}
+	if failed {
+		logger.InfoContext(ctx, "proxied tool set build produced no usable tools; not caching", "key", set.key, "error", buildErr)
+		return
+	}
+	logger.InfoContext(ctx, "built proxied tool set", "key", set.key, "datasources", len(set.clients), "tools", len(set.tools), "cache_size", size)
+}
+
+// releaseProxiedToolSet decrements a set's reference count and, once no session
+// references it (refs==0) and no tool call is in flight against it, closes its
+// clients exactly once and drops it from the cache. It is called with the set
+// the session actually holds, not re-looked-up by key, so it works even for a
+// failed set that was already removed from the cache (teardown of a session that
+// attached mid-build still balances its reference).
+func (tm *ToolManager) releaseProxiedToolSet(set *proxiedToolSet) {
+	tm.proxiedSetsMu.Lock()
+	set.refs--
+	tm.maybeCloseProxiedToolSetLocked(set)
+	tm.proxiedSetsMu.Unlock()
+}
+
+// maybeCloseProxiedToolSetLocked closes a set's clients and removes it from the
+// cache when nothing references it and no call is in flight. Must be called with
+// proxiedSetsMu held. Closing is done under the lock; it is a local map/close
+// operation (no network I/O), and callers only reach it when inFlight==0 so no
+// live call can be blocked.
+func (tm *ToolManager) maybeCloseProxiedToolSetLocked(set *proxiedToolSet) {
+	if set.refs > 0 || set.inFlight > 0 || set.closed {
+		return
+	}
+	set.closed = true
+	// Remove from the cache if this set is still the entry for its key. A failed
+	// set was already removed; a rebuild may have replaced it.
+	if tm.proxiedSets[set.key] == set {
+		delete(tm.proxiedSets, set.key)
+	}
+	for clientKey, client := range set.clients {
+		if err := client.Close(); err != nil {
+			tm.logger.Error("failed to close proxied client", "key", clientKey, "error", err)
+		}
+	}
+}
+
+// acquireProxiedClientForCall looks up a proxied client on the given set and
+// registers an in-flight call against the set, so teardown cannot Close the
+// client while the call runs. The returned release func MUST be called (deferred)
+// once the call completes; it decrements the in-flight count and closes the set
+// if it was the last thing keeping it alive.
+func (tm *ToolManager) acquireProxiedClientForCall(set *proxiedToolSet, datasourceType, datasourceUID string) (*ProxiedClient, func(), error) {
+	tm.proxiedSetsMu.Lock()
+	defer tm.proxiedSetsMu.Unlock()
+
+	if set.closed {
+		return nil, nil, fmt.Errorf("datasource '%s' is no longer available", datasourceUID)
+	}
+
+	key := datasourceType + "_" + datasourceUID
+	client, ok := set.clients[key]
+	if !ok {
+		var availableUIDs []string
+		for _, c := range set.clients {
+			if c.DatasourceType == datasourceType {
+				availableUIDs = append(availableUIDs, c.DatasourceUID)
+			}
+		}
+		if len(availableUIDs) > 0 {
+			return nil, nil, fmt.Errorf("datasource '%s' not found. Available %s datasources: %v", datasourceUID, datasourceType, availableUIDs)
+		}
+		return nil, nil, fmt.Errorf("datasource '%s' not found. No %s datasources with MCP support are configured", datasourceUID, datasourceType)
+	}
+
+	set.inFlight++
+	release := func() {
+		tm.proxiedSetsMu.Lock()
+		set.inFlight--
+		tm.maybeCloseProxiedToolSetLocked(set)
+		tm.proxiedSetsMu.Unlock()
+	}
+	return client, release, nil
+}
+
+// InitializeAndRegisterProxiedTools attaches the calling session to a shared,
+// credential-keyed proxied tool set and registers that set's tools on the
+// session. The shared set is discovered/connected/rewritten at most once per
+// distinct credential set, so multiple concurrent sessions with identical
+// credentials reuse a single set instead of each building their own. This is
+// called from OnBeforeListTools and OnBeforeCallTool hooks for HTTP/SSE
+// transports and is idempotent per session.
 func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, session server.ClientSession) {
 	if !tm.enableProxiedTools {
 		return
@@ -346,7 +790,7 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 	sessionID := session.SessionID()
 	state, exists := tm.sm.GetSession(sessionID)
 	if !exists {
-		// Session exists in server context but not in our SessionManager yet
+		// Session exists in server context but not in our SessionManager yet.
 		tm.sm.CreateSession(ctx, session)
 		state, exists = tm.sm.GetSession(sessionID)
 		if !exists {
@@ -355,89 +799,86 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 		}
 	}
 
-	// Step 1: Discover and connect (guaranteed to run exactly once per session)
-	state.initOnce.Do(func() {
-		// Discover datasources with MCP support
-		discovered, err := discoverMCPDatasources(ctx, logger)
-		if err != nil {
-			logger.ErrorContext(ctx, "failed to discover MCP datasources", "error", err)
-			state.mutex.Lock()
-			state.proxiedToolsInitialized = true
-			state.mutex.Unlock()
+	key := proxiedToolSetKeyFromContext(ctx)
+
+	// Attach and register exactly once per session.
+	state.attachOnce.Do(func() {
+		// attachProxiedToolSet takes the reference AND binds the set to the
+		// session atomically (under proxiedSetsMu), so there is no window where a
+		// reference exists that teardown cannot find and release.
+		set, needsBuild := tm.attachProxiedToolSet(state, key)
+
+		// Reconcile against a teardown that raced this attach. A session may have
+		// been removed from the SessionManager (client DELETE / idle sweeper /
+		// reaper) between GetSession/CreateSession above and the bind inside
+		// attachProxiedToolSet. If so, that RemoveSession saw proxiedSet==nil and
+		// did not release, and no future teardown will fire for this (now
+		// untracked) session, so the ref we just took would leak. Detect it and
+		// release exactly once (releaseSessionProxiedToolSet is idempotent, so a
+		// RemoveSession that instead ran AFTER our bind is handled too, with no
+		// double release). We still run/await the build below so any live waiter
+		// for the same key is served.
+		if !tm.sm.sessionRegistered(sessionID, state) {
+			defer tm.releaseSessionProxiedToolSet(state)
+		}
+
+		if needsBuild {
+			tm.runProxiedToolSetBuild(ctx, set, logger)
+		} else {
+			<-set.ready
+		}
+
+		// Read the published results under the lock: set.built/failed/tools are
+		// only stable once ready is closed, and are guarded by proxiedSetsMu.
+		tm.proxiedSetsMu.Lock()
+		usable := set.built && !set.failed
+		tools := set.tools
+		tm.proxiedSetsMu.Unlock()
+
+		// A failed or empty build produces no tools; nothing to register this
+		// time. The session keeps its reference and releases it on teardown.
+		if !usable || len(tools) == 0 {
 			return
 		}
 
-		state.mutex.Lock()
-		// For each discovered datasource, create a proxied client
-		for _, ds := range discovered {
-			client, err := NewProxiedClient(ctx, ds.UID, ds.Name, ds.Type, ds.MCPURL)
-			if err != nil {
-				logger.ErrorContext(ctx, "failed to create proxied client", "datasource", ds.UID, "error", err)
-				continue
-			}
-
-			// Store the client
-			key := ds.Type + "_" + ds.UID
-			state.proxiedClients[key] = client
+		// Register the shared tools on this session. AddSessionTools is
+		// per-session SDK bookkeeping; it references the shared (now immutable)
+		// mcp.Tool values directly, with no per-session deep copy, JSON decode, or
+		// client dial.
+		serverTools := make([]server.ServerTool, 0, len(tools))
+		for _, tool := range tools {
+			handler := NewProxiedToolHandler(tm.sm, tm, tool.Name)
+			serverTools = append(serverTools, server.ServerTool{
+				Tool:    tool,
+				Handler: handler.Handle,
+			})
 		}
-		state.proxiedToolsInitialized = true
-		state.mutex.Unlock()
 
-		logger.InfoContext(ctx, "connected to proxied MCP servers", "session", sessionID, "datasources", len(state.proxiedClients))
+		if err := tm.server.AddSessionTools(sessionID, serverTools...); err != nil {
+			logger.WarnContext(ctx, "failed to add session tools", "session", sessionID, "error", err)
+		} else {
+			logger.InfoContext(ctx, "registered proxied tools", "session", sessionID, "tools", len(tools))
+		}
 	})
+}
 
-	// Step 2: Register tools with the MCP server
+// releaseSessionProxiedToolSet releases the session's reference to its shared
+// proxied tool set, if any. It is safe to call on sessions that never attached
+// (no-op) and is guarded so a session releases its reference at most once. It
+// releases by the set pointer the session holds, so it balances the reference
+// even when the set was a failed build already removed from the cache.
+func (tm *ToolManager) releaseSessionProxiedToolSet(state *SessionState) {
 	state.mutex.Lock()
-	defer state.mutex.Unlock()
-
-	// Check if tools already registered
-	if len(state.proxiedTools) > 0 {
+	set := state.proxiedSet
+	if set == nil || state.proxiedSetReleased {
+		state.mutex.Unlock()
 		return
 	}
+	state.proxiedSetReleased = true
+	state.proxiedSet = nil
+	state.mutex.Unlock()
 
-	// Check if we have any clients (discovery should have happened above)
-	if len(state.proxiedClients) == 0 {
-		return
-	}
-
-	// First pass: collect all unique tools and track which datasources support them
-	toolMap := make(map[string]mcp.Tool) // unique tools by name
-
-	for key, client := range state.proxiedClients {
-		remoteTools := client.ListTools()
-
-		for _, tool := range remoteTools {
-			// Tool name format: datasourceType_originalToolName (e.g., "tempo_traceql-search")
-			toolName := client.DatasourceType + "_" + tool.Name
-
-			// Store the tool if we haven't seen it yet
-			if _, exists := toolMap[toolName]; !exists {
-				// Add datasourceUid parameter to the tool
-				modifiedTool := addDatasourceUidParameter(tool, client.DatasourceType)
-				toolMap[toolName] = modifiedTool
-			}
-
-			// Track which datasources support this tool
-			state.toolToDatasources[toolName] = append(state.toolToDatasources[toolName], key)
-		}
-	}
-
-	// Second pass: register all unique tools at once (reduces listChanged notifications)
-	var serverTools []server.ServerTool
-	for toolName, tool := range toolMap {
-		handler := NewProxiedToolHandler(tm.sm, tm, toolName)
-		serverTools = append(serverTools, server.ServerTool{
-			Tool:    tool,
-			Handler: handler.Handle,
-		})
-		state.proxiedTools = append(state.proxiedTools, tool)
-	}
-
-	if err := tm.server.AddSessionTools(sessionID, serverTools...); err != nil {
-		logger.WarnContext(ctx, "failed to add session tools", "session", sessionID, "error", err)
-	} else {
-		logger.InfoContext(ctx, "registered proxied tools", "session", sessionID, "tools", len(state.proxiedTools))
-	}
+	tm.releaseProxiedToolSet(set)
 }
 
 // GetServerClient retrieves a proxied client from server-level storage (for stdio transport)

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -299,11 +299,22 @@ func serializeHeaders(headers map[string]string) string {
 	return sb.String()
 }
 
-// String returns a redacted string representation for logging.
+// String returns a redacted string representation for logging: secret-bearing
+// fields (apiKey, accessToken, idToken, basicAuthPass) are reduced to a present/
+// absent bool, never their value.
 func (k proxiedToolSetKey) String() string {
 	return fmt.Sprintf("url=%s apiKey=%t accessToken=%t idToken=%t orgID=%d timeout=%s basicAuth=%t tlsCert=%t tlsCA=%t tlsSkipVerify=%t extraHeaders=%t",
 		k.url, k.apiKey != "", k.accessToken != "", k.idToken != "", k.orgID, k.timeout, k.basicAuthUser != "",
 		k.tlsCertFile != "", k.tlsCAFile != "", k.tlsSkipVerify, k.extraHeaders != "")
+}
+
+// LogValue makes proxiedToolSetKey a slog.LogValuer so that logging it (e.g.
+// slog "key", set.key) emits the redacted String() form. slog does NOT honor
+// fmt.Stringer for Any values, so without this the raw struct fields (including
+// the secret apiKey/accessToken/idToken/basicAuthPass) would be reflected into
+// logs.
+func (k proxiedToolSetKey) LogValue() slog.Value {
+	return slog.StringValue(k.String())
 }
 
 // proxiedToolSet is the shared, credential-keyed result of discovering and

--- a/proxied_tools_lifecycle_test.go
+++ b/proxied_tools_lifecycle_test.go
@@ -390,6 +390,33 @@ func TestInFlightCallBlocksClose(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&closes), "the client must be Closed exactly once after the call returns")
 }
 
+// TestFailedBuildClosesClients guards that when a build errors AFTER connecting
+// some clients, those freshly-built clients are closed rather than leaked. The
+// failed set is de-cached and not published, so nothing else can close them.
+func TestFailedBuildClosesClients(t *testing.T) {
+	var closes int32
+	tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		// A builder that connected a client, then hit an error.
+		return builtProxiedTools{
+			clients: map[string]*ProxiedClient{
+				"tempo_uid": newCloseCountingClient("tempo", "uid", &closes),
+			},
+			toolToDatasources: map[string][]string{},
+		}, errors.New("failed after connecting a client")
+	})
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+	sess := &mockClientSession{id: "failclose"}
+	sm.CreateSession(ctx, sess)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess)
+
+	tm.proxiedSetsMu.Lock()
+	size := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, 0, size, "a failed build must not be cached")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&closes), "clients connected before the error must be Closed, not leaked")
+}
+
 // newCloseCountingClient returns a ProxiedClient whose Close increments closes.
 // Its underlying Client is nil, so Close only runs the counter (all these tests
 // need to observe). The counter lets us assert "closed exactly once".

--- a/proxied_tools_lifecycle_test.go
+++ b/proxied_tools_lifecycle_test.go
@@ -190,39 +190,89 @@ func TestFailedBuildNotCached(t *testing.T) {
 	assert.Equal(t, 1, refs, "only the second session references the rebuilt set")
 }
 
-// TestEmptyBuildNotCached verifies that a successful build that finds no MCP
-// datasources is treated as a transient "no proxied tools" result: it is not
-// left cached, so a later session (when a datasource has appeared) rebuilds.
-func TestEmptyBuildNotCached(t *testing.T) {
-	var attempt int32
+// TestEmptyBuildCachedAndReused verifies that a SUCCESSFUL build that finds no
+// MCP datasources is a stable "this instance has no proxied tools" result: the
+// empty set is cached (not de-cached), the session is registered so it does not
+// retry, and a second session for the same key reuses the cached empty set
+// WITHOUT re-running discovery. This is the regression guard for empty builds
+// re-running full discovery on every hook on no-MCP-datasource instances.
+func TestEmptyBuildCachedAndReused(t *testing.T) {
+	var discoveries int32
 	tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
-		if atomic.AddInt32(&attempt, 1) == 1 {
-			// No error, but zero clients discovered.
-			return builtProxiedTools{clients: map[string]*ProxiedClient{}, toolToDatasources: map[string][]string{}}, nil
-		}
-		return builtWith("tempo", "uid"), nil
+		atomic.AddInt32(&discoveries, 1)
+		// Successful discovery, but this instance exposes no MCP datasources.
+		return builtProxiedTools{clients: map[string]*ProxiedClient{}, toolToDatasources: map[string][]string{}}, nil
 	})
 
 	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
 
+	// First session: builds once, gets an empty set, registers, keeps its ref.
 	sess1 := &mockClientSession{id: "empty-1"}
 	sm.CreateSession(ctx, sess1)
 	tm.InitializeAndRegisterProxiedTools(ctx, sess1)
 
 	tm.proxiedSetsMu.Lock()
 	sizeAfterEmpty := len(tm.proxiedSets)
+	var refsAfter1 int
+	for _, s := range tm.proxiedSets {
+		refsAfter1 = s.refs
+	}
 	tm.proxiedSetsMu.Unlock()
-	assert.Equal(t, 0, sizeAfterEmpty, "an empty build must not be left cached")
+	assert.Equal(t, 1, sizeAfterEmpty, "a successful empty build must be cached")
+	assert.Equal(t, 1, refsAfter1, "the first session must keep a reference to the empty set")
 
+	state1, ok := sm.GetSession("empty-1")
+	require.True(t, ok)
+	state1.proxiedInitMu.Lock()
+	registered1 := state1.proxiedRegistered
+	state1.proxiedInitMu.Unlock()
+	assert.True(t, registered1, "the session must be registered on an empty-but-successful build")
+
+	// Repeated hooks for the SAME session must not re-run discovery.
+	tm.InitializeAndRegisterProxiedTools(ctx, sess1)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess1)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&discoveries), "repeated hooks for one session must not re-run discovery")
+
+	// A second session with the SAME credentials must reuse the cached empty set,
+	// not trigger a fresh discovery.
 	sess2 := &mockClientSession{id: "empty-2"}
 	sm.CreateSession(ctx, sess2)
 	tm.InitializeAndRegisterProxiedTools(ctx, sess2)
 
 	tm.proxiedSetsMu.Lock()
-	sizeAfterRetry := len(tm.proxiedSets)
+	sizeAfterReuse := len(tm.proxiedSets)
+	var refsAfter2 int
+	for _, s := range tm.proxiedSets {
+		refsAfter2 = s.refs
+	}
 	tm.proxiedSetsMu.Unlock()
-	assert.Equal(t, int32(2), atomic.LoadInt32(&attempt), "the next session must rebuild after an empty result")
-	assert.Equal(t, 1, sizeAfterRetry, "the non-empty rebuild must be cached")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&discoveries), "a second same-key session must reuse the cached empty set (no re-discovery)")
+	assert.Equal(t, 1, sizeAfterReuse, "the cached empty set must still be the only entry")
+	assert.Equal(t, 2, refsAfter2, "both sessions must reference the shared empty set")
+
+	// Both sessions must reference the very same underlying set pointer.
+	s1set := sessionSet(t, sm, "empty-1")
+	s2set := sessionSet(t, sm, "empty-2")
+	assert.Same(t, s1set, s2set, "same-credential sessions must share one empty set")
+
+	// Teardown must balance both references and remove the entry.
+	sm.RemoveSession(ctx, sess1)
+	sm.RemoveSession(ctx, sess2)
+	tm.proxiedSetsMu.Lock()
+	sizeAfterTeardown := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, 0, sizeAfterTeardown, "teardown must release both references to the empty set")
+}
+
+// sessionSet returns the shared proxiedToolSet bound to a session, for identity
+// assertions.
+func sessionSet(t *testing.T, sm *SessionManager, id string) *proxiedToolSet {
+	t.Helper()
+	state, ok := sm.GetSession(id)
+	require.True(t, ok)
+	state.mutex.RLock()
+	defer state.mutex.RUnlock()
+	return state.proxiedSet
 }
 
 // TestBuildPanicUnblocksWaitersAndDeCaches guards that a panic in the builder

--- a/proxied_tools_lifecycle_test.go
+++ b/proxied_tools_lifecycle_test.go
@@ -1,10 +1,12 @@
 package mcpgrafana
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,6 +15,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestProxiedToolSetKeyNotLoggedInClear guards that logging a proxiedToolSetKey
+// emits the redacted form and never the raw secret values. slog does not honor
+// fmt.Stringer for Any values, so the key implements slog.LogValuer.
+func TestProxiedToolSetKeyNotLoggedInClear(t *testing.T) {
+	// JSONHandler reflects an Any value's struct fields (unlike TextHandler,
+	// which formats via fmt and would honor String()), so it is the handler that
+	// actually leaks without a slog.LogValuer. Use it so this test truly guards.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	key := proxiedToolSetKeyFromContext(WithGrafanaConfig(context.Background(), GrafanaConfig{
+		URL:         "http://grafana",
+		APIKey:      "super-secret-api-key",
+		AccessToken: "super-secret-access-token",
+		IDToken:     "super-secret-id-token",
+	}))
+
+	logger.Info("built proxied tool set", "key", key)
+
+	out := buf.String()
+	for _, secret := range []string{"super-secret-api-key", "super-secret-access-token", "super-secret-id-token"} {
+		assert.False(t, strings.Contains(out, secret), "secret %q must not appear in logs; got: %s", secret, out)
+	}
+	assert.True(t, strings.Contains(out, "apiKey=true"), "redacted form should report presence, not value")
+}
 
 // TestTeardownReleaseToZeroDuringBuild is the real-overlap regression guard for
 // the "build then publish" fix. It forces the dangerous interleaving the naive

--- a/proxied_tools_lifecycle_test.go
+++ b/proxied_tools_lifecycle_test.go
@@ -1,0 +1,352 @@
+package mcpgrafana
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTeardownReleaseToZeroDuringBuild is the real-overlap regression guard for
+// the "build then publish" fix. It forces the dangerous interleaving the naive
+// publish-then-build had: the builder signals it has STARTED and blocks; the
+// last (only) session is torn down to refs==0 while the build is still running;
+// then the builder finishes and returns its freshly-built clients.
+//
+// Two things must hold:
+//   - No `fatal error: concurrent map iteration and map write`. Because the
+//     build mutates only local maps and publishes them under proxiedSetsMu only
+//     if refs>0, teardown (which iterates set.clients under the same lock) can
+//     never observe a half-written map. Run under -race to shake this out.
+//   - The freshly-built clients are closed (abandoned path) and the set ends at
+//     refs==0, closed, unpublished (built==false), and removed from the cache.
+//     Nothing leaks and nothing is used after close.
+func TestTeardownReleaseToZeroDuringBuild(t *testing.T) {
+	buildStarted := make(chan struct{})
+	releaseBuild := make(chan struct{})
+	var closes int32
+
+	tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		close(buildStarted)
+		<-releaseBuild // block here while the test tears the session down
+		return builtProxiedTools{
+			clients: map[string]*ProxiedClient{
+				"tempo_uid": newCloseCountingClient("tempo", "uid", &closes),
+			},
+			toolToDatasources: map[string][]string{},
+		}, nil
+	})
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+	sess := &mockClientSession{id: "midbuild"}
+	sm.CreateSession(ctx, sess)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tm.InitializeAndRegisterProxiedTools(ctx, sess)
+	}()
+
+	<-buildStarted // build is in flight; the session is already bound to the set
+
+	// Grab the set the session is bound to so we can assert on it afterward.
+	state, ok := sm.GetSession("midbuild")
+	require.True(t, ok)
+	state.mutex.RLock()
+	set := state.proxiedSet
+	state.mutex.RUnlock()
+	require.NotNil(t, set, "attach must bind the set before the build runs")
+
+	// Tear the session down to refs==0 WHILE the build is still blocked. This is
+	// the concurrent teardown-vs-build window; releaseProxiedToolSet iterates
+	// set.clients (empty placeholder) under proxiedSetsMu here.
+	sm.RemoveSession(ctx, sess)
+
+	// Now let the build finish. Its results must NOT be published (refs==0); the
+	// abandoned path must close the freshly-built clients instead.
+	close(releaseBuild)
+	wg.Wait()
+
+	tm.proxiedSetsMu.Lock()
+	built := set.built
+	closed := set.closed
+	refs := set.refs
+	cacheSize := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+
+	assert.False(t, built, "live clients must NOT be published after teardown to zero")
+	assert.True(t, closed, "the abandoned set must be marked closed")
+	assert.Equal(t, 0, refs, "the reference taken before the build must be released")
+	assert.Equal(t, 0, cacheSize, "the abandoned entry must be removed from the cache")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&closes), "the freshly-built client must be Closed exactly once")
+}
+
+// TestTeardownBetweenAttachAndBind guards the pre-bind ref-leak window. The old
+// code took refs++ under proxiedSetsMu, then bound state.proxiedSet under
+// state.mutex in a SEPARATE critical section; a teardown in that gap saw
+// state.proxiedSet==nil and no-oped, leaking the ref forever.
+//
+// attachProxiedToolSet now binds the set under state.mutex while still holding
+// proxiedSetsMu, and teardown must take proxiedSetsMu to decrement, so teardown
+// cannot run until attach has fully bound. This test hammers attach and teardown
+// concurrently for many sessions; every ref taken must be releasable, so the
+// cache must drain to empty (no orphaned entry whose ref no teardown can find).
+func TestTeardownBetweenAttachAndBind(t *testing.T) {
+	// A build that yields so its execution overlaps concurrent teardown. Under
+	// -race this also shakes out any lock-free write of shared set fields during
+	// the build (the previous round's crash): the builder here returns local maps
+	// only, so there must be no data race between build and teardown-iterate.
+	build := func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		runtime.Gosched()
+		return builtWith("tempo", "uid"), nil
+	}
+	tm, sm := newTestToolManager(t, time.Hour, build)
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		id := "race-" + string(rune('a'+i%26)) + "-" + string(rune('0'+i/26))
+		sess := &mockClientSession{id: id}
+		sm.CreateSession(ctx, sess)
+
+		wg.Add(2)
+		// Attach.
+		go func() {
+			defer wg.Done()
+			tm.InitializeAndRegisterProxiedTools(ctx, sess)
+		}()
+		// Teardown, racing the attach: it may land before, during, or after the
+		// attach/bind. Whenever it lands, the session's ref must be releasable.
+		go func() {
+			defer wg.Done()
+			sm.RemoveSession(ctx, sess)
+		}()
+	}
+	wg.Wait()
+
+	// Any session that attached after its teardown ran keeps a live set; drain
+	// those by removing again (idempotent for already-removed sessions).
+	for i := 0; i < n; i++ {
+		id := "race-" + string(rune('a'+i%26)) + "-" + string(rune('0'+i/26))
+		sm.RemoveSession(ctx, &mockClientSession{id: id})
+	}
+
+	require.Eventually(t, func() bool {
+		tm.proxiedSetsMu.Lock()
+		defer tm.proxiedSetsMu.Unlock()
+		return len(tm.proxiedSets) == 0
+	}, 2*time.Second, 10*time.Millisecond, "every attached reference must be releasable; no entry may be orphaned")
+}
+
+// TestFailedBuildNotCached guards against a poisoned cache: a build that fails
+// (discovery error / cancellation) must not leave an entry cached, so the next
+// session for the same key rebuilds and can succeed.
+func TestFailedBuildNotCached(t *testing.T) {
+	var attempt int32
+	tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		if atomic.AddInt32(&attempt, 1) == 1 {
+			return builtProxiedTools{}, errors.New("transient discovery failure")
+		}
+		return builtWith("tempo", "uid"), nil
+	})
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+
+	// First session: build fails. The entry must not remain cached.
+	sess1 := &mockClientSession{id: "fail-1"}
+	sm.CreateSession(ctx, sess1)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess1)
+
+	tm.proxiedSetsMu.Lock()
+	sizeAfterFailure := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, 0, sizeAfterFailure, "a failed build must not be left cached")
+
+	// Second session, same credentials: must rebuild (attempt 2) and succeed.
+	sess2 := &mockClientSession{id: "fail-2"}
+	sm.CreateSession(ctx, sess2)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess2)
+
+	tm.proxiedSetsMu.Lock()
+	sizeAfterRetry := len(tm.proxiedSets)
+	var refs int
+	for _, s := range tm.proxiedSets {
+		refs = s.refs
+	}
+	tm.proxiedSetsMu.Unlock()
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempt), "the next session must retry the build")
+	assert.Equal(t, 1, sizeAfterRetry, "the successful rebuild must be cached")
+	assert.Equal(t, 1, refs, "only the second session references the rebuilt set")
+}
+
+// TestEmptyBuildNotCached verifies that a successful build that finds no MCP
+// datasources is treated as a transient "no proxied tools" result: it is not
+// left cached, so a later session (when a datasource has appeared) rebuilds.
+func TestEmptyBuildNotCached(t *testing.T) {
+	var attempt int32
+	tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		if atomic.AddInt32(&attempt, 1) == 1 {
+			// No error, but zero clients discovered.
+			return builtProxiedTools{clients: map[string]*ProxiedClient{}, toolToDatasources: map[string][]string{}}, nil
+		}
+		return builtWith("tempo", "uid"), nil
+	})
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+
+	sess1 := &mockClientSession{id: "empty-1"}
+	sm.CreateSession(ctx, sess1)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess1)
+
+	tm.proxiedSetsMu.Lock()
+	sizeAfterEmpty := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, 0, sizeAfterEmpty, "an empty build must not be left cached")
+
+	sess2 := &mockClientSession{id: "empty-2"}
+	sm.CreateSession(ctx, sess2)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess2)
+
+	tm.proxiedSetsMu.Lock()
+	sizeAfterRetry := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempt), "the next session must rebuild after an empty result")
+	assert.Equal(t, 1, sizeAfterRetry, "the non-empty rebuild must be cached")
+}
+
+// TestBuildPanicUnblocksWaitersAndDeCaches guards that a panic in the builder
+// still closes ready (so concurrent waiters do not block forever) and removes
+// the entry from the cache (so a later session can rebuild).
+func TestBuildPanicUnblocksWaitersAndDeCaches(t *testing.T) {
+	var attempt int32
+	tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		if atomic.AddInt32(&attempt, 1) == 1 {
+			panic("boom during build")
+		}
+		return builtWith("tempo", "uid"), nil
+	})
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+
+	// The first attach triggers the panicking build. runProxiedToolSetBuild
+	// recovers it, so InitializeAndRegisterProxiedTools must return (not panic)
+	// and must not leave the session's goroutine blocked on <-ready.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sess := &mockClientSession{id: "panic-1"}
+		sm.CreateSession(ctx, sess)
+		tm.InitializeAndRegisterProxiedTools(ctx, sess)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("attach blocked after a build panic: ready was not closed")
+	}
+
+	tm.proxiedSetsMu.Lock()
+	sizeAfterPanic := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, 0, sizeAfterPanic, "a panicked build must be de-cached so a later session rebuilds")
+
+	// A later session with the same key must rebuild successfully.
+	sess2 := &mockClientSession{id: "panic-2"}
+	sm.CreateSession(ctx, sess2)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess2)
+
+	tm.proxiedSetsMu.Lock()
+	sizeAfterRetry := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempt), "the next session must retry after a build panic")
+	assert.Equal(t, 1, sizeAfterRetry, "the rebuilt set must be cached")
+}
+
+// TestInFlightCallBlocksClose guards that a proxied client is not Closed while a
+// tool call is in flight against it, even if the last session is torn down
+// concurrently. The set is closed only once the in-flight call releases.
+func TestInFlightCallBlocksClose(t *testing.T) {
+	var closes int32
+	tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		return builtProxiedTools{
+			clients: map[string]*ProxiedClient{
+				"tempo_uid": newCloseCountingClient("tempo", "uid", &closes),
+			},
+			toolToDatasources: map[string][]string{},
+		}, nil
+	})
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+	sess := &mockClientSession{id: "inflight"}
+	sm.CreateSession(ctx, sess)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess)
+
+	state, ok := sm.GetSession("inflight")
+	require.True(t, ok)
+	state.mutex.RLock()
+	set := state.proxiedSet
+	state.mutex.RUnlock()
+	require.NotNil(t, set)
+
+	// Acquire a client for a call, then start last-session teardown concurrently.
+	client, release, err := tm.acquireProxiedClientForCall(set, "tempo", "uid")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	teardownDone := make(chan struct{})
+	go func() {
+		defer close(teardownDone)
+		sm.RemoveSession(ctx, sess) // drops the last ref while the call is in flight
+	}()
+
+	// Wait for teardown to drop the session ref. The client must NOT be Closed
+	// yet, because a call is in flight.
+	require.Eventually(t, func() bool {
+		tm.proxiedSetsMu.Lock()
+		defer tm.proxiedSetsMu.Unlock()
+		return set.refs == 0
+	}, 2*time.Second, 10*time.Millisecond, "teardown should have dropped the session reference")
+
+	tm.proxiedSetsMu.Lock()
+	closedWhileInFlight := set.closed
+	inFlight := set.inFlight
+	tm.proxiedSetsMu.Unlock()
+	assert.False(t, closedWhileInFlight, "the set must not be closed while a call is in flight")
+	assert.Equal(t, 1, inFlight, "the in-flight call must still be counted")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&closes), "no client may be Closed during an in-flight call")
+
+	// The acquired client is the live one and stays usable while held.
+	assert.NotNil(t, client)
+
+	// The in-flight call completes and releases; only now may the set close.
+	release()
+	<-teardownDone
+
+	tm.proxiedSetsMu.Lock()
+	closedAfter := set.closed
+	tm.proxiedSetsMu.Unlock()
+	assert.True(t, closedAfter, "the set must close once the in-flight call releases and no session references it")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&closes), "the client must be Closed exactly once after the call returns")
+}
+
+// newCloseCountingClient returns a ProxiedClient whose Close increments closes.
+// Its underlying Client is nil, so Close only runs the counter (all these tests
+// need to observe). The counter lets us assert "closed exactly once".
+func newCloseCountingClient(dsType, dsUID string, closes *int32) *ProxiedClient {
+	return &ProxiedClient{
+		DatasourceType: dsType,
+		DatasourceUID:  dsUID,
+		closeHook:      func() { atomic.AddInt32(closes, 1) },
+	}
+}

--- a/proxied_tools_test.go
+++ b/proxied_tools_test.go
@@ -2,6 +2,7 @@ package mcpgrafana
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/url"
 	"sync"
@@ -84,32 +85,117 @@ func TestSessionManagerConcurrency(t *testing.T) {
 	})
 }
 
-func TestAttachOncePattern(t *testing.T) {
-	t.Run("verify sync.Once guarantees single execution", func(t *testing.T) {
-		var once sync.Once
-		var counter int32
+// TestProxiedToolsRegistrationGuard covers the per-session registration guard
+// that replaced the one-shot attachOnce: it must serialize concurrent hooks for
+// one session into a single successful registration, and it must NOT let a
+// failed/empty build consume the session's attempt (so a later hook retries).
+func TestProxiedToolsRegistrationGuard(t *testing.T) {
+	t.Run("concurrent hooks for one session build and register once", func(t *testing.T) {
+		var builds int32
+		tm, sm, srv := newToolManagerWithServer(t, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+			atomic.AddInt32(&builds, 1)
+			time.Sleep(20 * time.Millisecond) // widen the window for concurrent hooks
+			return builtWithTool("tempo", "uid", "tempo_example"), nil
+		})
+
+		ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+		sess := newToolsCapableSession("guard-1")
+		sm.CreateSession(ctx, sess)
+		require.NoError(t, srv.RegisterSession(ctx, sess))
+
+		// Fire many concurrent hook invocations for the SAME session.
+		const hooks = 20
 		var wg sync.WaitGroup
-
-		// Simulate the attachOnce guard used in InitializeAndRegisterProxiedTools.
-		attach := func() {
-			atomic.AddInt32(&counter, 1)
-			// Simulate expensive attach work
-			time.Sleep(50 * time.Millisecond)
-		}
-
-		// Launch many concurrent calls
-		for i := 0; i < 1000; i++ {
-			wg.Add(1)
+		wg.Add(hooks)
+		for i := 0; i < hooks; i++ {
 			go func() {
 				defer wg.Done()
-				once.Do(attach)
+				tm.InitializeAndRegisterProxiedTools(ctx, sess)
 			}()
 		}
-
 		wg.Wait()
 
-		assert.Equal(t, int32(1), atomic.LoadInt32(&counter),
-			"sync.Once should guarantee the attach runs exactly once")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&builds), "the set must be built exactly once")
+		assert.Len(t, sess.GetSessionTools(), 1, "the session must be registered with its tool exactly once")
+
+		state, ok := sm.GetSession("guard-1")
+		require.True(t, ok)
+		state.proxiedInitMu.Lock()
+		registered := state.proxiedRegistered
+		state.proxiedInitMu.Unlock()
+		assert.True(t, registered, "the session must be marked registered after success")
+
+		tm.proxiedSetsMu.Lock()
+		refs := 0
+		for _, s := range tm.proxiedSets {
+			refs = s.refs
+		}
+		size := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+		assert.Equal(t, 1, size, "exactly one shared set is cached")
+		assert.Equal(t, 1, refs, "the session holds exactly one reference (no per-hook double-count)")
+	})
+
+	t.Run("failed build does not stick the session; a later hook retries and registers", func(t *testing.T) {
+		var attempt int32
+		tm, sm, srv := newToolManagerWithServer(t, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+			if atomic.AddInt32(&attempt, 1) == 1 {
+				return builtProxiedTools{}, errors.New("transient discovery failure")
+			}
+			return builtWithTool("tempo", "uid", "tempo_example"), nil
+		})
+
+		ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+		sess := newToolsCapableSession("retry-1")
+		sm.CreateSession(ctx, sess)
+		require.NoError(t, srv.RegisterSession(ctx, sess))
+
+		// First hook: the build fails. The session must NOT be registered, must
+		// hold no reference, and the failed set must not be cached.
+		tm.InitializeAndRegisterProxiedTools(ctx, sess)
+
+		state, ok := sm.GetSession("retry-1")
+		require.True(t, ok)
+		state.proxiedInitMu.Lock()
+		registeredAfterFail := state.proxiedRegistered
+		state.proxiedInitMu.Unlock()
+		assert.False(t, registeredAfterFail, "a failed build must not mark the session registered")
+		assert.Empty(t, sess.GetSessionTools(), "no tools registered after a failed build")
+
+		tm.proxiedSetsMu.Lock()
+		sizeAfterFail := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+		assert.Equal(t, 0, sizeAfterFail, "the failed set must not be left cached and its ref must be released")
+
+		// Second hook for the SAME session: the builder now succeeds. The session
+		// must retry, build afresh, and end up registered with its tool.
+		tm.InitializeAndRegisterProxiedTools(ctx, sess)
+
+		assert.Equal(t, int32(2), atomic.LoadInt32(&attempt), "the second hook must retry the build")
+		assert.Len(t, sess.GetSessionTools(), 1, "the session must be registered with its tool after retry")
+
+		state.proxiedInitMu.Lock()
+		registeredAfterRetry := state.proxiedRegistered
+		state.proxiedInitMu.Unlock()
+		assert.True(t, registeredAfterRetry, "the session must be marked registered after the successful retry")
+
+		tm.proxiedSetsMu.Lock()
+		sizeAfterRetry := len(tm.proxiedSets)
+		var refs int
+		for _, s := range tm.proxiedSets {
+			refs = s.refs
+		}
+		tm.proxiedSetsMu.Unlock()
+		assert.Equal(t, 1, sizeAfterRetry, "exactly one live set after the successful retry")
+		assert.Equal(t, 1, refs, "no ref leak across the failed->success transition")
+
+		// Teardown must balance the single reference: the set is released and its
+		// clients closed.
+		sm.RemoveSession(ctx, sess)
+		tm.proxiedSetsMu.Lock()
+		sizeAfterTeardown := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+		assert.Equal(t, 0, sizeAfterTeardown, "teardown must release the session's reference")
 	})
 }
 
@@ -162,7 +248,10 @@ func TestSessionStateLifecycle(t *testing.T) {
 // and its reference counting without real discovery or network I/O.
 type testBuildFunc func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error)
 
-// newTestToolManager builds a ToolManager with an injected set builder.
+// newTestToolManager builds a ToolManager with an injected set builder and a nil
+// MCP server. Suitable for tests that never reach per-session tool registration
+// (they use no-tool builds); reaching AddSessionTools would panic on the nil
+// server, so use newToolManagerWithServer for registration-path tests.
 func newTestToolManager(t *testing.T, ttl time.Duration, build testBuildFunc) (*ToolManager, *SessionManager) {
 	t.Helper()
 	sm := NewSessionManager(WithSessionTTL(ttl))
@@ -173,7 +262,22 @@ func newTestToolManager(t *testing.T, ttl time.Duration, build testBuildFunc) (*
 	return tm, sm
 }
 
-// builtWith returns a build result holding a single proxied client.
+// newToolManagerWithServer is like newTestToolManager but wires a real
+// server.MCPServer, so builds that produce tools can exercise the per-session
+// AddSessionTools registration path. Sessions must be RegisterSession'd on the
+// returned server and must implement server.SessionWithTools.
+func newToolManagerWithServer(t *testing.T, build testBuildFunc) (*ToolManager, *SessionManager, *server.MCPServer) {
+	t.Helper()
+	sm := NewSessionManager(WithSessionTTL(time.Hour))
+	t.Cleanup(sm.Close)
+	srv := server.NewMCPServer("test", "1.0")
+	tm := NewToolManager(sm, srv, WithProxiedTools(true))
+	tm.buildSet = build
+	sm.SetToolManager(tm)
+	return tm, sm, srv
+}
+
+// builtWith returns a build result holding a single proxied client and no tools.
 func builtWith(clientType, clientUID string) builtProxiedTools {
 	return builtProxiedTools{
 		clients: map[string]*ProxiedClient{
@@ -181,6 +285,14 @@ func builtWith(clientType, clientUID string) builtProxiedTools {
 		},
 		toolToDatasources: map[string][]string{},
 	}
+}
+
+// builtWithTool returns a build result holding a single proxied client and one
+// tool, so it reaches the per-session registration path (AddSessionTools).
+func builtWithTool(clientType, clientUID, toolName string) builtProxiedTools {
+	b := builtWith(clientType, clientUID)
+	b.tools = []mcp.Tool{mcp.NewTool(toolName)}
+	return b
 }
 
 // setWith returns a builder that produces a single proxied client.
@@ -526,4 +638,40 @@ func (m *mockClientSession) Initialize() {
 
 func (m *mockClientSession) Initialized() bool {
 	return m.isInitialized
+}
+
+// toolsCapableSession implements server.SessionWithTools so AddSessionTools can
+// register per-session tools on it. Its tool map is guarded for the concurrent
+// hook test.
+type toolsCapableSession struct {
+	id    string
+	mu    sync.RWMutex
+	tools map[string]server.ServerTool
+}
+
+func newToolsCapableSession(id string) *toolsCapableSession {
+	return &toolsCapableSession{id: id, tools: map[string]server.ServerTool{}}
+}
+
+var _ server.SessionWithTools = (*toolsCapableSession)(nil)
+
+func (s *toolsCapableSession) SessionID() string                                   { return s.id }
+func (s *toolsCapableSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return nil }
+func (s *toolsCapableSession) Initialize()                                         {}
+func (s *toolsCapableSession) Initialized() bool                                   { return true }
+
+func (s *toolsCapableSession) GetSessionTools() map[string]server.ServerTool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]server.ServerTool, len(s.tools))
+	for k, v := range s.tools {
+		out[k] = v
+	}
+	return out
+}
+
+func (s *toolsCapableSession) SetSessionTools(tools map[string]server.ServerTool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tools = tools
 }

--- a/proxied_tools_test.go
+++ b/proxied_tools_test.go
@@ -2,125 +2,23 @@ package mcpgrafana
 
 import (
 	"context"
+	"log/slog"
+	"net/url"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func TestSessionStateRaceConditions(t *testing.T) {
-	t.Run("concurrent initialization with sync.Once is safe", func(t *testing.T) {
-		state := newSessionState()
-
-		var initCounter int32
-		var wg sync.WaitGroup
-
-		// Launch 100 goroutines that all try to initialize at once
-		const numGoroutines = 100
-		wg.Add(numGoroutines)
-
-		for i := 0; i < numGoroutines; i++ {
-			go func() {
-				defer wg.Done()
-				state.initOnce.Do(func() {
-					// Simulate initialization work
-					atomic.AddInt32(&initCounter, 1)
-					time.Sleep(10 * time.Millisecond) // Simulate some work
-					state.mutex.Lock()
-					state.proxiedToolsInitialized = true
-					state.mutex.Unlock()
-				})
-			}()
-		}
-
-		wg.Wait()
-
-		// Verify initialization happened exactly once
-		assert.Equal(t, int32(1), atomic.LoadInt32(&initCounter),
-			"Initialization should run exactly once despite 100 concurrent calls")
-		assert.True(t, state.proxiedToolsInitialized)
-	})
-
-	t.Run("concurrent reads and writes with mutex protection", func(t *testing.T) {
-		state := newSessionState()
-		var wg sync.WaitGroup
-
-		// Writer goroutines
-		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func(id int) {
-				defer wg.Done()
-				state.mutex.Lock()
-				key := "tempo_" + string(rune('a'+id))
-				state.proxiedClients[key] = &ProxiedClient{
-					DatasourceUID:  key,
-					DatasourceName: "Test " + key,
-					DatasourceType: "tempo",
-				}
-				state.mutex.Unlock()
-			}(i)
-		}
-
-		// Reader goroutines
-		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				state.mutex.RLock()
-				_ = len(state.proxiedClients)
-				state.mutex.RUnlock()
-			}()
-		}
-
-		wg.Wait()
-
-		// Verify all writes succeeded
-		state.mutex.RLock()
-		count := len(state.proxiedClients)
-		state.mutex.RUnlock()
-
-		assert.Equal(t, 10, count, "All 10 clients should be stored")
-	})
-
-	t.Run("concurrent tool registration is safe", func(t *testing.T) {
-		state := newSessionState()
-		var wg sync.WaitGroup
-
-		// Multiple goroutines trying to register tools
-		const numGoroutines = 50
-		wg.Add(numGoroutines)
-
-		for i := 0; i < numGoroutines; i++ {
-			go func(id int) {
-				defer wg.Done()
-				state.mutex.Lock()
-				toolName := "tempo_tool-" + string(rune('a'+id%26))
-				if state.toolToDatasources[toolName] == nil {
-					state.toolToDatasources[toolName] = []string{}
-				}
-				state.toolToDatasources[toolName] = append(
-					state.toolToDatasources[toolName],
-					"datasource_"+string(rune('a'+id%26)),
-				)
-				state.mutex.Unlock()
-			}(i)
-		}
-
-		wg.Wait()
-
-		// Verify the tool mappings exist
-		state.mutex.RLock()
-		defer state.mutex.RUnlock()
-		assert.Greater(t, len(state.toolToDatasources), 0, "Should have tool mappings")
-	})
-}
 
 func TestSessionManagerConcurrency(t *testing.T) {
 	t.Run("concurrent session creation is safe", func(t *testing.T) {
 		sm := NewSessionManager()
+		defer sm.Close()
 		var wg sync.WaitGroup
 
 		// Create many sessions concurrently
@@ -148,6 +46,7 @@ func TestSessionManagerConcurrency(t *testing.T) {
 
 	t.Run("concurrent get and remove is safe", func(t *testing.T) {
 		sm := NewSessionManager()
+		defer sm.Close()
 
 		// Pre-populate sessions
 		for i := 0; i < 50; i++ {
@@ -185,16 +84,16 @@ func TestSessionManagerConcurrency(t *testing.T) {
 	})
 }
 
-func TestInitOncePattern(t *testing.T) {
+func TestAttachOncePattern(t *testing.T) {
 	t.Run("verify sync.Once guarantees single execution", func(t *testing.T) {
 		var once sync.Once
 		var counter int32
 		var wg sync.WaitGroup
 
-		// Simulate what happens in InitializeAndRegisterProxiedTools
-		initFunc := func() {
+		// Simulate the attachOnce guard used in InitializeAndRegisterProxiedTools.
+		attach := func() {
 			atomic.AddInt32(&counter, 1)
-			// Simulate expensive initialization
+			// Simulate expensive attach work
 			time.Sleep(50 * time.Millisecond)
 		}
 
@@ -203,76 +102,35 @@ func TestInitOncePattern(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				once.Do(initFunc)
+				once.Do(attach)
 			}()
 		}
 
 		wg.Wait()
 
 		assert.Equal(t, int32(1), atomic.LoadInt32(&counter),
-			"sync.Once should guarantee function runs exactly once")
-	})
-
-	t.Run("sync.Once with different functions only runs first", func(t *testing.T) {
-		var once sync.Once
-		var result string
-		var mu sync.Mutex
-
-		once.Do(func() {
-			mu.Lock()
-			result = "first"
-			mu.Unlock()
-		})
-
-		once.Do(func() {
-			mu.Lock()
-			result = "second"
-			mu.Unlock()
-		})
-
-		mu.Lock()
-		finalResult := result
-		mu.Unlock()
-
-		assert.Equal(t, "first", finalResult, "Only first function should execute")
+			"sync.Once should guarantee the attach runs exactly once")
 	})
 }
 
-func TestProxiedToolsInitializationFlow(t *testing.T) {
-	t.Run("initialization state transitions are correct", func(t *testing.T) {
-		state := newSessionState()
+func TestSessionStateLifecycle(t *testing.T) {
+	t.Run("create and get session", func(t *testing.T) {
+		sm := NewSessionManager()
+		defer sm.Close()
 
-		// Initial state
-		assert.False(t, state.proxiedToolsInitialized)
-		assert.Empty(t, state.proxiedClients)
-		assert.Empty(t, state.proxiedTools)
+		mockSession := &mockClientSession{id: "test-session-123"}
+		sm.CreateSession(context.Background(), mockSession)
 
-		// Simulate initialization
-		state.initOnce.Do(func() {
-			state.mutex.Lock()
-			state.proxiedToolsInitialized = true
-			state.proxiedClients["tempo_test"] = &ProxiedClient{
-				DatasourceUID:  "test",
-				DatasourceName: "Test",
-				DatasourceType: "tempo",
-			}
-			state.mutex.Unlock()
-		})
-
-		// Verify state after initialization
-		state.mutex.RLock()
-		initialized := state.proxiedToolsInitialized
-		clientCount := len(state.proxiedClients)
-		state.mutex.RUnlock()
-
-		assert.True(t, initialized)
-		assert.Equal(t, 1, clientCount)
+		state, exists := sm.GetSession("test-session-123")
+		assert.True(t, exists)
+		require.NotNil(t, state)
+		assert.Nil(t, state.proxiedSet)
 	})
 
 	t.Run("multiple sessions maintain separate state", func(t *testing.T) {
 		sm := NewSessionManager()
+		defer sm.Close()
 
-		// Create two sessions
 		session1 := &mockClientSession{id: "session-1"}
 		session2 := &mockClientSession{id: "session-2"}
 
@@ -282,160 +140,364 @@ func TestProxiedToolsInitializationFlow(t *testing.T) {
 		state1, _ := sm.GetSession("session-1")
 		state2, _ := sm.GetSession("session-2")
 
-		// Initialize only session1
-		state1.initOnce.Do(func() {
-			state1.mutex.Lock()
-			state1.proxiedToolsInitialized = true
-			state1.mutex.Unlock()
-		})
+		state1.mutex.Lock()
+		state1.proxiedSet = &proxiedToolSet{}
+		state1.mutex.Unlock()
 
-		// Verify states are independent
-		assert.True(t, state1.proxiedToolsInitialized)
-		assert.False(t, state2.proxiedToolsInitialized)
+		state1.mutex.RLock()
+		set1 := state1.proxiedSet
+		state1.mutex.RUnlock()
+		state2.mutex.RLock()
+		set2 := state2.proxiedSet
+		state2.mutex.RUnlock()
+
+		assert.NotNil(t, set1)
+		assert.Nil(t, set2)
 		assert.NotSame(t, state1, state2)
 	})
 }
 
-func TestRaceConditionDemonstration(t *testing.T) {
-	t.Run("old pattern WITHOUT sync.Once would have race condition", func(t *testing.T) {
-		// This test demonstrates what WOULD happen with the old mutex-check pattern
-		state := newSessionState()
+// testBuildFunc matches ToolManager.buildSet: it returns the built results in
+// local maps (never mutating shared state), so tests exercise the shared cache
+// and its reference counting without real discovery or network I/O.
+type testBuildFunc func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error)
 
-		var discoveryCallCount int32
-		var wg sync.WaitGroup
+// newTestToolManager builds a ToolManager with an injected set builder.
+func newTestToolManager(t *testing.T, ttl time.Duration, build testBuildFunc) (*ToolManager, *SessionManager) {
+	t.Helper()
+	sm := NewSessionManager(WithSessionTTL(ttl))
+	t.Cleanup(sm.Close)
+	tm := NewToolManager(sm, nil, WithProxiedTools(true))
+	tm.buildSet = build
+	sm.SetToolManager(tm)
+	return tm, sm
+}
 
-		// Simulate the OLD pattern (mutex check, unlock, then do work)
-		oldPatternInitialize := func() {
-			state.mutex.Lock()
-			// Check if already initialized
-			if state.proxiedToolsInitialized {
-				state.mutex.Unlock()
-				return
-			}
-			alreadyDiscovered := state.proxiedToolsInitialized
-			state.mutex.Unlock() // ❌ OLD PATTERN: Unlock before expensive work
+// builtWith returns a build result holding a single proxied client.
+func builtWith(clientType, clientUID string) builtProxiedTools {
+	return builtProxiedTools{
+		clients: map[string]*ProxiedClient{
+			clientType + "_" + clientUID: {DatasourceType: clientType, DatasourceUID: clientUID},
+		},
+		toolToDatasources: map[string][]string{},
+	}
+}
 
-			if !alreadyDiscovered {
-				// Simulate discovery work that should only happen once
-				atomic.AddInt32(&discoveryCallCount, 1)
-				time.Sleep(10 * time.Millisecond) // Simulate expensive operation
+// setWith returns a builder that produces a single proxied client.
+func setWith(clientType, clientUID string) testBuildFunc {
+	return func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		return builtWith(clientType, clientUID), nil
+	}
+}
 
-				state.mutex.Lock()
-				state.proxiedToolsInitialized = true
-				state.mutex.Unlock()
-			}
-		}
-
-		// Launch concurrent initializations
-		const numGoroutines = 10
-		wg.Add(numGoroutines)
-		for i := 0; i < numGoroutines; i++ {
-			go func() {
-				defer wg.Done()
-				oldPatternInitialize()
-			}()
-		}
-		wg.Wait()
-
-		// With the old pattern, multiple goroutines can get past the check
-		// and call discovery multiple times
-		count := atomic.LoadInt32(&discoveryCallCount)
-		if count > 1 {
-			t.Logf("OLD PATTERN: Discovery called %d times (race condition!)", count)
-		}
-		// We can't assert > 1 reliably because timing matters, but this demonstrates the problem
-	})
-
-	t.Run("new pattern WITH sync.Once prevents race condition", func(t *testing.T) {
-		// This test demonstrates the NEW pattern with sync.Once
-		state := newSessionState()
-
-		var discoveryCallCount int32
-		var wg sync.WaitGroup
-
-		// NEW pattern: sync.Once guarantees single execution
-		newPatternInitialize := func() {
-			state.initOnce.Do(func() {
-				// Simulate discovery work that should only happen once
-				atomic.AddInt32(&discoveryCallCount, 1)
-				time.Sleep(10 * time.Millisecond) // Simulate expensive operation
-
-				state.mutex.Lock()
-				state.proxiedToolsInitialized = true
-				state.mutex.Unlock()
-			})
-		}
-
-		// Launch concurrent initializations
-		const numGoroutines = 10
-		wg.Add(numGoroutines)
-		for i := 0; i < numGoroutines; i++ {
-			go func() {
-				defer wg.Done()
-				newPatternInitialize()
-			}()
-		}
-		wg.Wait()
-
-		// With sync.Once, discovery is guaranteed to run exactly once
-		count := atomic.LoadInt32(&discoveryCallCount)
-		assert.Equal(t, int32(1), count, "NEW PATTERN: Discovery must be called exactly once")
+// ctxWithCreds returns a context carrying the given credential-bearing config.
+func ctxWithCreds(grafanaURL, apiKey string, basicAuth *url.Userinfo, orgID int64) context.Context {
+	return WithGrafanaConfig(context.Background(), GrafanaConfig{
+		URL:       grafanaURL,
+		APIKey:    apiKey,
+		BasicAuth: basicAuth,
+		OrgID:     orgID,
 	})
 }
 
-func TestRaceDetector(t *testing.T) {
-	// This test is primarily valuable when run with -race flag
-	t.Run("stress test with race detector", func(t *testing.T) {
+// withExtraHeaders returns a copy of cfg with the given ExtraHeaders set.
+func withExtraHeaders(cfg GrafanaConfig, headers map[string]string) GrafanaConfig {
+	cfg.ExtraHeaders = headers
+	return cfg
+}
 
-		sm := NewSessionManager()
+// TestProxiedToolSetSharing is the regression guard for the per-session
+// duplication that caused proxied clients and tools to scale with the number of
+// live sessions (linear memory growth, OOM under session churn). It verifies:
+//   - multiple sessions with identical credentials share exactly ONE
+//     proxiedToolSet (cache size stays 1);
+//   - distinct credentials produce distinct entries;
+//   - reaping/closing the last session for a key closes its clients exactly
+//     once and removes the entry, while earlier detaches leave them open.
+func TestProxiedToolSetSharing(t *testing.T) {
+	t.Run("identical credentials share exactly one set", func(t *testing.T) {
+		var builds int32
+		tm, sm := newTestToolManager(t, time.Hour, func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+			atomic.AddInt32(&builds, 1)
+			return builtWith("tempo", "uid"), nil
+		})
+
+		ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+
+		// Many concurrent sessions with identical credentials must all resolve to
+		// the same shared set: before the fix each of these built and stored its
+		// own copy of the clients and tools, so heap grew linearly with this count.
+		const numSessions = 25
 		var wg sync.WaitGroup
-
-		// Create a mix of operations happening concurrently
-		for i := 0; i < 20; i++ {
-			sessionID := "stress-session-" + string(rune('a'+i%10))
-
-			// Create session
-			wg.Add(1)
-			go func(sid string) {
+		wg.Add(numSessions)
+		for i := 0; i < numSessions; i++ {
+			go func(id int) {
 				defer wg.Done()
-				mockSession := &mockClientSession{id: sid}
-				sm.CreateSession(context.Background(), mockSession)
-			}(sessionID)
-
-			// Initialize session state
-			wg.Add(1)
-			go func(sid string) {
-				defer wg.Done()
-				time.Sleep(time.Millisecond) // Let creation happen first
-				state, exists := sm.GetSession(sid)
-				if exists {
-					state.initOnce.Do(func() {
-						state.mutex.Lock()
-						state.proxiedToolsInitialized = true
-						state.mutex.Unlock()
-					})
-				}
-			}(sessionID)
-
-			// Read session state
-			wg.Add(1)
-			go func(sid string) {
-				defer wg.Done()
-				time.Sleep(2 * time.Millisecond)
-				state, exists := sm.GetSession(sid)
-				if exists {
-					state.mutex.RLock()
-					_ = state.proxiedToolsInitialized
-					state.mutex.RUnlock()
-				}
-			}(sessionID)
+				sess := &mockClientSession{id: "shared-" + string(rune('a'+id%26)) + "-" + string(rune('0'+id/26))}
+				sm.CreateSession(ctx, sess)
+				tm.InitializeAndRegisterProxiedTools(ctx, sess)
+			}(i)
 		}
-
 		wg.Wait()
 
-		// If we get here without race detector warnings, we're good
-		t.Log("Stress test completed without race conditions")
+		tm.proxiedSetsMu.Lock()
+		cacheSize := len(tm.proxiedSets)
+		var refs int
+		for _, s := range tm.proxiedSets {
+			refs = s.refs
+		}
+		tm.proxiedSetsMu.Unlock()
+
+		assert.Equal(t, 1, cacheSize, "identical credentials must produce exactly one shared set")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&builds), "the set must be built at most once per key")
+		assert.Equal(t, numSessions, refs, "every session must hold a reference to the shared set")
+
+		// All sessions must reference the very same underlying set pointer.
+		s1, _ := sm.GetSession("shared-a-0")
+		s2, _ := sm.GetSession("shared-b-0")
+		require.NotNil(t, s1)
+		require.NotNil(t, s2)
+		s1.mutex.RLock()
+		set1 := s1.proxiedSet
+		s1.mutex.RUnlock()
+		s2.mutex.RLock()
+		set2 := s2.proxiedSet
+		s2.mutex.RUnlock()
+		assert.Same(t, set1, set2, "sessions with identical credentials must share the same set")
 	})
+
+	t.Run("distinct credentials produce distinct sets", func(t *testing.T) {
+		tm, sm := newTestToolManager(t, time.Hour, setWith("tempo", "uid"))
+
+		// Different URL, apiKey, orgID, basic-auth user, and basic-auth password
+		// must each key to a distinct set. Also verify that identical credentials
+		// (the repeated first entry) do not add a second entry.
+		ctxs := []context.Context{
+			ctxWithCreds("http://a", "k1", nil, 1),
+			ctxWithCreds("http://a", "k1", nil, 1), // duplicate of the first
+			ctxWithCreds("http://b", "k1", nil, 1),
+			ctxWithCreds("http://a", "k2", nil, 1),
+			ctxWithCreds("http://a", "k1", nil, 2),
+			ctxWithCreds("http://a", "", url.UserPassword("u1", "p1"), 1),
+			ctxWithCreds("http://a", "", url.UserPassword("u2", "p1"), 1),
+			ctxWithCreds("http://a", "", url.UserPassword("u1", "p2"), 1),
+		}
+
+		for i, ctx := range ctxs {
+			sess := &mockClientSession{id: "distinct-" + string(rune('a'+i))}
+			sm.CreateSession(ctx, sess)
+			tm.InitializeAndRegisterProxiedTools(ctx, sess)
+		}
+
+		tm.proxiedSetsMu.Lock()
+		cacheSize := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+
+		// 8 contexts, one is a duplicate, so 7 distinct keys.
+		assert.Equal(t, 7, cacheSize, "each distinct credential set must produce its own entry")
+	})
+
+	t.Run("access and id tokens are part of the key", func(t *testing.T) {
+		tm, sm := newTestToolManager(t, time.Hour, setWith("tempo", "uid"))
+
+		base := GrafanaConfig{URL: "http://grafana", APIKey: "shared", OrgID: 1}
+
+		cfgA := base
+		cfgA.AccessToken = "userA-access"
+		cfgA.IDToken = "userA-id"
+
+		cfgB := base
+		cfgB.AccessToken = "userB-access"
+		cfgB.IDToken = "userB-id"
+
+		for i, cfg := range []GrafanaConfig{cfgA, cfgB} {
+			ctx := WithGrafanaConfig(context.Background(), cfg)
+			sess := &mockClientSession{id: "token-" + string(rune('a'+i))}
+			sm.CreateSession(ctx, sess)
+			tm.InitializeAndRegisterProxiedTools(ctx, sess)
+		}
+
+		tm.proxiedSetsMu.Lock()
+		cacheSize := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+
+		assert.Equal(t, 2, cacheSize, "per-user access/id tokens must not collide on a shared instance")
+	})
+
+	t.Run("TLS material and extra headers are part of the key", func(t *testing.T) {
+		tm, sm := newTestToolManager(t, time.Hour, setWith("tempo", "uid"))
+
+		base := GrafanaConfig{URL: "http://grafana", APIKey: "shared", OrgID: 1}
+
+		// Each of these differs from base only in a field that changes the built
+		// client (TLS client identity, CA, skip-verify, or forwarded/extra
+		// headers). Sharing one client across them would bleed one session's TLS
+		// cert or headers into another's requests, so each must key distinctly.
+		mkTLS := func(mutate func(*TLSConfig)) GrafanaConfig {
+			cfg := base
+			cfg.TLSConfig = &TLSConfig{}
+			mutate(cfg.TLSConfig)
+			return cfg
+		}
+
+		cfgs := []GrafanaConfig{
+			base, // no TLS, no extra headers
+			mkTLS(func(t *TLSConfig) { t.CertFile = "/a/client-a.pem"; t.KeyFile = "/a/client-a.key" }),
+			mkTLS(func(t *TLSConfig) { t.CertFile = "/b/client-b.pem"; t.KeyFile = "/b/client-b.key" }),
+			mkTLS(func(t *TLSConfig) { t.CAFile = "/ca/roots-a.pem" }),
+			mkTLS(func(t *TLSConfig) { t.CAFile = "/ca/roots-b.pem" }),
+			mkTLS(func(t *TLSConfig) { t.SkipVerify = true }),
+			withExtraHeaders(base, map[string]string{"X-Webauth-User": "alice"}),
+			withExtraHeaders(base, map[string]string{"X-Webauth-User": "bob"}),
+		}
+		// Append a duplicate of the alice-headers config to prove identical
+		// header sets collapse to one entry.
+		cfgs = append(cfgs, withExtraHeaders(base, map[string]string{"X-Webauth-User": "alice"}))
+
+		for i, cfg := range cfgs {
+			ctx := WithGrafanaConfig(context.Background(), cfg)
+			sess := &mockClientSession{id: "tlskey-" + string(rune('a'+i))}
+			sm.CreateSession(ctx, sess)
+			tm.InitializeAndRegisterProxiedTools(ctx, sess)
+		}
+
+		tm.proxiedSetsMu.Lock()
+		cacheSize := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+
+		// 9 configs, one duplicate (alice headers), so 8 distinct keys.
+		assert.Equal(t, 8, cacheSize, "TLS material and extra headers must each key distinctly (no client bleed)")
+	})
+
+	t.Run("ambiguous header maps do not collide", func(t *testing.T) {
+		tm, sm := newTestToolManager(t, time.Hour, setWith("tempo", "uid"))
+
+		base := GrafanaConfig{URL: "http://grafana", APIKey: "shared", OrgID: 1}
+
+		// These two header maps serialize to the same string under a naive
+		// name=value,name=value join, but are genuinely different and must key
+		// distinctly. A collision would share one built client (header bleed).
+		a := withExtraHeaders(base, map[string]string{"H": "a,b=c"})
+		b := withExtraHeaders(base, map[string]string{"H": "a", "b": "c"})
+
+		for i, cfg := range []GrafanaConfig{a, b} {
+			ctx := WithGrafanaConfig(context.Background(), cfg)
+			sess := &mockClientSession{id: "ambig-" + string(rune('a'+i))}
+			sm.CreateSession(ctx, sess)
+			tm.InitializeAndRegisterProxiedTools(ctx, sess)
+		}
+
+		tm.proxiedSetsMu.Lock()
+		cacheSize := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+		assert.Equal(t, 2, cacheSize, "distinct header maps must not collide under key serialization")
+	})
+
+	t.Run("timeout is part of the key", func(t *testing.T) {
+		tm, sm := newTestToolManager(t, time.Hour, setWith("tempo", "uid"))
+
+		base := GrafanaConfig{URL: "http://grafana", APIKey: "shared", OrgID: 1}
+		a := base
+		a.Timeout = 5 * time.Second
+		b := base
+		b.Timeout = 30 * time.Second
+
+		for i, cfg := range []GrafanaConfig{a, b} {
+			ctx := WithGrafanaConfig(context.Background(), cfg)
+			sess := &mockClientSession{id: "timeout-" + string(rune('a'+i))}
+			sm.CreateSession(ctx, sess)
+			tm.InitializeAndRegisterProxiedTools(ctx, sess)
+		}
+
+		tm.proxiedSetsMu.Lock()
+		cacheSize := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+		assert.Equal(t, 2, cacheSize, "different Timeout values bake different transports, so must key distinctly")
+	})
+
+	t.Run("entry is removed only when the last session detaches", func(t *testing.T) {
+		tm, sm := newTestToolManager(t, time.Hour, setWith("tempo", "uid"))
+
+		ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+
+		sessA := &mockClientSession{id: "life-a"}
+		sessB := &mockClientSession{id: "life-b"}
+		sm.CreateSession(ctx, sessA)
+		sm.CreateSession(ctx, sessB)
+		tm.InitializeAndRegisterProxiedTools(ctx, sessA)
+		tm.InitializeAndRegisterProxiedTools(ctx, sessB)
+
+		tm.proxiedSetsMu.Lock()
+		require.Len(t, tm.proxiedSets, 1)
+		var key proxiedToolSetKey
+		for k, s := range tm.proxiedSets {
+			key = k
+			assert.Equal(t, 2, s.refs, "both sessions must reference the set")
+		}
+		tm.proxiedSetsMu.Unlock()
+
+		// First session goes away: the shared set must survive because the other
+		// session still uses it (closing here would break the live session).
+		sm.RemoveSession(ctx, sessA)
+		tm.proxiedSetsMu.Lock()
+		s, ok := tm.proxiedSets[key]
+		require.True(t, ok, "entry must survive while other sessions reference it")
+		assert.Equal(t, 1, s.refs)
+		tm.proxiedSetsMu.Unlock()
+
+		// Last session goes away: the entry (and its clients) is torn down. The
+		// entry is deleted in a single branch reached exactly once per key, so
+		// its clients are closed exactly once.
+		sm.RemoveSession(ctx, sessB)
+		tm.proxiedSetsMu.Lock()
+		_, ok = tm.proxiedSets[key]
+		tm.proxiedSetsMu.Unlock()
+		assert.False(t, ok, "entry must be removed once the last session detaches")
+	})
+
+	t.Run("release is idempotent per session", func(t *testing.T) {
+		tm, sm := newTestToolManager(t, time.Hour, setWith("tempo", "uid"))
+
+		ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+		sess := &mockClientSession{id: "idem"}
+		sm.CreateSession(ctx, sess)
+		tm.InitializeAndRegisterProxiedTools(ctx, sess)
+
+		state, ok := sm.GetSession("idem")
+		require.True(t, ok)
+
+		// Two releases of the same session must decrement refs exactly once, so
+		// the entry is removed and stays removed. A second decrement would drive
+		// refs below zero and could close another key's clients.
+		tm.releaseSessionProxiedToolSet(state)
+		tm.releaseSessionProxiedToolSet(state)
+
+		tm.proxiedSetsMu.Lock()
+		cacheSize := len(tm.proxiedSets)
+		tm.proxiedSetsMu.Unlock()
+		assert.Equal(t, 0, cacheSize, "the entry must be removed after the single owning session releases it")
+	})
+}
+
+func TestReaperReleasesSharedSet(t *testing.T) {
+	tm, sm := newTestToolManager(t, 100*time.Millisecond, setWith("tempo", "uid"))
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+	sess := &mockClientSession{id: "reaped"}
+	sm.CreateSession(ctx, sess)
+	tm.InitializeAndRegisterProxiedTools(ctx, sess)
+
+	tm.proxiedSetsMu.Lock()
+	require.Len(t, tm.proxiedSets, 1)
+	tm.proxiedSetsMu.Unlock()
+
+	// Reaping the idle session must release the shared set (dropping refs to zero
+	// and removing the entry), so idle-session churn cannot leak sets.
+	require.Eventually(t, func() bool {
+		tm.proxiedSetsMu.Lock()
+		defer tm.proxiedSetsMu.Unlock()
+		return len(tm.proxiedSets) == 0
+	}, 2*time.Second, 25*time.Millisecond, "reaping the last session must release the shared set")
 }
 
 // mockClientSession implements server.ClientSession for testing
@@ -444,6 +506,8 @@ type mockClientSession struct {
 	notifChannel  chan mcp.JSONRPCNotification
 	isInitialized bool
 }
+
+var _ server.ClientSession = (*mockClientSession)(nil)
 
 func (m *mockClientSession) SessionID() string {
 	return m.id

--- a/session.go
+++ b/session.go
@@ -59,7 +59,16 @@ type SessionState struct {
 	// shared set; teardown releases the reference by that pointer (not by key),
 	// so the reference is balanced even for a set already dropped from the cache.
 	// proxiedSetReleased makes that release idempotent per session.
-	attachOnce         sync.Once
+	//
+	// proxiedInitMu serializes attach/build/register for this one session and
+	// proxiedRegistered records that it succeeded. A one-shot sync.Once is
+	// deliberately NOT used: a failed or empty build must NOT consume the
+	// session's attempt, or that session would be stuck without proxied tools
+	// forever even though the cache treats the failure as transient and lets
+	// other sessions rebuild. Leaving proxiedRegistered false on failure lets the
+	// next OnBeforeListTools/OnBeforeCallTool hook for this session retry.
+	proxiedInitMu      sync.Mutex
+	proxiedRegistered  bool
 	proxiedSet         *proxiedToolSet
 	proxiedSetReleased bool
 	mutex              sync.RWMutex

--- a/session.go
+++ b/session.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -51,20 +50,24 @@ type SessionState struct {
 	// Updated on every GetSession call.
 	lastActivity time.Time
 
-	// Proxied tools state
-	initOnce                sync.Once
-	proxiedToolsInitialized bool
-	proxiedTools            []mcp.Tool
-	proxiedClients          map[string]*ProxiedClient // key: datasourceType_datasourceUID
-	toolToDatasources       map[string][]string       // key: toolName, value: list of datasource keys that support it
-	mutex                   sync.RWMutex
+	// Proxied tools state.
+	//
+	// Rather than discovering, connecting, and rewriting proxied tools per
+	// session (which made proxied clients and tools scale with the number of
+	// live sessions), a session attaches to a shared, credential-keyed
+	// proxiedToolSet owned by the ToolManager. proxiedSet is a reference to that
+	// shared set; teardown releases the reference by that pointer (not by key),
+	// so the reference is balanced even for a set already dropped from the cache.
+	// proxiedSetReleased makes that release idempotent per session.
+	attachOnce         sync.Once
+	proxiedSet         *proxiedToolSet
+	proxiedSetReleased bool
+	mutex              sync.RWMutex
 }
 
 func newSessionState() *SessionState {
 	return &SessionState{
-		lastActivity:      time.Now(),
-		proxiedClients:    make(map[string]*ProxiedClient),
-		toolToDatasources: make(map[string][]string),
+		lastActivity: time.Now(),
 	}
 }
 
@@ -105,6 +108,11 @@ type SessionManager struct {
 	// in horizontal scaling scenarios (where ephemeral sessions are registered
 	// so that AddSessionTools can find them).
 	mcpServer *server.MCPServer
+
+	// toolManager is an optional reference to the ToolManager, used on session
+	// teardown to release the session's reference to its shared proxied tool
+	// set (closing the underlying clients only when the last session detaches).
+	toolManager *ToolManager
 }
 
 // SetMCPServer sets the MCP server reference for session cleanup. When set,
@@ -114,6 +122,15 @@ func (sm *SessionManager) SetMCPServer(s *server.MCPServer) {
 	sm.mutex.Lock()
 	defer sm.mutex.Unlock()
 	sm.mcpServer = s
+}
+
+// SetToolManager sets the ToolManager reference for session cleanup. When set,
+// tearing down a session releases its reference to the shared proxied tool set,
+// so the set's clients are closed once the last session using them is gone.
+func (sm *SessionManager) SetToolManager(tm *ToolManager) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	sm.toolManager = tm
 }
 
 func NewSessionManager(opts ...SessionManagerOption) *SessionManager {
@@ -164,6 +181,18 @@ func (sm *SessionManager) GetSession(sessionID string) (*SessionState, bool) {
 	return session, exists
 }
 
+// sessionRegistered reports whether sessionID is still tracked and maps to the
+// exact state pointer given. It is used to detect a teardown that raced an
+// attach: if the session was removed (or replaced by a newer state) since the
+// state was obtained, the caller must release the reference it took, because no
+// future RemoveSession will fire for this untracked state.
+func (sm *SessionManager) sessionRegistered(sessionID string, state *SessionState) bool {
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
+	current, exists := sm.sessions[sessionID]
+	return exists && current == state
+}
+
 func (sm *SessionManager) RemoveSession(ctx context.Context, session server.ClientSession) {
 	sm.mutex.Lock()
 	sessionID := session.SessionID()
@@ -179,15 +208,17 @@ func (sm *SessionManager) RemoveSession(ctx context.Context, session server.Clie
 	sm.cleanupSessionState(state)
 }
 
-// cleanupSessionState closes all proxied clients in a session state.
+// cleanupSessionState releases the session's reference to its shared proxied
+// tool set. The set's clients are closed only when the last referencing session
+// is torn down; other live sessions sharing the same credentials keep them
+// open.
 func (sm *SessionManager) cleanupSessionState(state *SessionState) {
-	state.mutex.Lock()
-	defer state.mutex.Unlock()
+	sm.mutex.RLock()
+	tm := sm.toolManager
+	sm.mutex.RUnlock()
 
-	for key, client := range state.proxiedClients {
-		if err := client.Close(); err != nil {
-			sm.logger.Error("failed to close proxied client", "key", key, "error", err)
-		}
+	if tm != nil {
+		tm.releaseSessionProxiedToolSet(state)
 	}
 }
 
@@ -273,36 +304,36 @@ func (sm *SessionManager) reapStaleSessions() {
 	}
 }
 
-// GetProxiedClient retrieves a proxied client for the given datasource
-func (sm *SessionManager) GetProxiedClient(ctx context.Context, datasourceType, datasourceUID string) (*ProxiedClient, error) {
+// GetProxiedClient retrieves a proxied client for the given datasource and
+// registers an in-flight call against its shared set, so the client cannot be
+// Closed by a concurrent teardown (RemoveSession / reaper) while the returned
+// client is still in use. The caller MUST invoke the returned release func
+// (deferred) once the call completes; only then may the set be torn down. On
+// error the release func is nil and must not be called.
+func (sm *SessionManager) GetProxiedClient(ctx context.Context, datasourceType, datasourceUID string) (*ProxiedClient, func(), error) {
 	session := server.ClientSessionFromContext(ctx)
 	if session == nil {
-		return nil, fmt.Errorf("session not found in context")
+		return nil, nil, fmt.Errorf("session not found in context")
 	}
 
 	state, exists := sm.GetSession(session.SessionID())
 	if !exists {
-		return nil, fmt.Errorf("session not found")
+		return nil, nil, fmt.Errorf("session not found")
 	}
 
 	state.mutex.RLock()
-	defer state.mutex.RUnlock()
+	set := state.proxiedSet
+	state.mutex.RUnlock()
 
-	key := datasourceType + "_" + datasourceUID
-	client, exists := state.proxiedClients[key]
-	if !exists {
-		// List available datasources to help with debugging
-		var availableUIDs []string
-		for _, c := range state.proxiedClients {
-			if c.DatasourceType == datasourceType {
-				availableUIDs = append(availableUIDs, c.DatasourceUID)
-			}
-		}
-		if len(availableUIDs) > 0 {
-			return nil, fmt.Errorf("datasource '%s' not found. Available %s datasources: %v", datasourceUID, datasourceType, availableUIDs)
-		}
-		return nil, fmt.Errorf("datasource '%s' not found. No %s datasources with MCP support are configured", datasourceUID, datasourceType)
+	sm.mutex.RLock()
+	tm := sm.toolManager
+	sm.mutex.RUnlock()
+
+	if set == nil || tm == nil {
+		return nil, nil, fmt.Errorf("datasource '%s' not found. No %s datasources with MCP support are configured", datasourceUID, datasourceType)
 	}
 
-	return client, nil
+	// acquireProxiedClientForCall looks up the client and takes the in-flight
+	// count under the set lock, so it cannot race a last-ref release/Close.
+	return tm.acquireProxiedClientForCall(set, datasourceType, datasourceUID)
 }

--- a/session_reaper_test.go
+++ b/session_reaper_test.go
@@ -3,6 +3,7 @@ package mcpgrafana
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -66,18 +67,28 @@ func TestSessionManager_ReaperCleansUpProxiedClients(t *testing.T) {
 	sm := NewSessionManager(WithSessionTTL(100 * time.Millisecond))
 	defer sm.Close()
 
-	session := &testClientSession{id: "cleanup-session"}
-	sm.CreateSession(context.Background(), session)
-
-	// Access the state directly to add a proxied client without updating lastActivity
-	sm.mutex.RLock()
-	state := sm.sessions["cleanup-session"]
-	sm.mutex.RUnlock()
-	state.proxiedClients["tempo_test-uid"] = &ProxiedClient{
-		DatasourceUID:  "test-uid",
-		DatasourceName: "Test",
-		DatasourceType: "tempo",
+	// Wire a ToolManager with an injected set builder so the session attaches to
+	// a shared proxied tool set without any real discovery or network I/O. When
+	// the reaper removes the idle session, it must release that shared set.
+	tm := NewToolManager(sm, nil, WithProxiedTools(true))
+	tm.buildSet = func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error) {
+		return builtProxiedTools{
+			clients: map[string]*ProxiedClient{
+				"tempo_test-uid": {DatasourceUID: "test-uid", DatasourceName: "Test", DatasourceType: "tempo"},
+			},
+			toolToDatasources: map[string][]string{},
+		}, nil
 	}
+	sm.SetToolManager(tm)
+
+	session := &testClientSession{id: "cleanup-session"}
+	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: "http://grafana", APIKey: "secret"})
+	sm.CreateSession(ctx, session)
+	tm.InitializeAndRegisterProxiedTools(ctx, session)
+
+	tm.proxiedSetsMu.Lock()
+	require.Len(t, tm.proxiedSets, 1)
+	tm.proxiedSetsMu.Unlock()
 
 	// Wait for reaper
 	time.Sleep(500 * time.Millisecond)
@@ -86,6 +97,12 @@ func TestSessionManager_ReaperCleansUpProxiedClients(t *testing.T) {
 	_, exists := sm.sessions["cleanup-session"]
 	sm.mutex.RUnlock()
 	assert.False(t, exists, "Session should have been reaped")
+
+	// Reaping the last session for the key must release its shared set.
+	tm.proxiedSetsMu.Lock()
+	setCount := len(tm.proxiedSets)
+	tm.proxiedSetsMu.Unlock()
+	assert.Equal(t, 0, setCount, "Reaper should release the session's shared proxied tool set")
 }
 
 func TestSessionManager_Close(t *testing.T) {

--- a/session_test.go
+++ b/session_test.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -182,136 +181,6 @@ func TestToolNamespacing(t *testing.T) {
 	})
 }
 
-func TestSessionStateLifecycle(t *testing.T) {
-	t.Run("create and get session", func(t *testing.T) {
-		sm := NewSessionManager()
-
-		// Create mock session
-		mockSession := &mockClientSession{id: "test-session-123"}
-
-		sm.CreateSession(context.Background(), mockSession)
-
-		state, exists := sm.GetSession("test-session-123")
-		assert.True(t, exists)
-		assert.NotNil(t, state)
-		assert.NotNil(t, state.proxiedClients)
-		assert.False(t, state.proxiedToolsInitialized)
-	})
-
-	t.Run("remove session cleans up clients", func(t *testing.T) {
-		sm := NewSessionManager()
-
-		mockSession := &mockClientSession{id: "test-session-456"}
-		sm.CreateSession(context.Background(), mockSession)
-
-		state, _ := sm.GetSession("test-session-456")
-
-		// Add a mock proxied client
-		mockClient := &ProxiedClient{
-			DatasourceUID:  "test-uid",
-			DatasourceName: "Test Datasource",
-			DatasourceType: "tempo",
-		}
-		state.proxiedClients["tempo_test-uid"] = mockClient
-
-		// Remove session
-		sm.RemoveSession(context.Background(), mockSession)
-
-		// Session should be gone
-		_, exists := sm.GetSession("test-session-456")
-		assert.False(t, exists)
-	})
-
-	t.Run("get non-existent session", func(t *testing.T) {
-		sm := NewSessionManager()
-
-		state, exists := sm.GetSession("non-existent")
-		assert.False(t, exists)
-		assert.Nil(t, state)
-	})
-}
-
-func TestConcurrentInitializationRaceCondition(t *testing.T) {
-	t.Run("concurrent initialization calls should be safe", func(t *testing.T) {
-		sm := NewSessionManager()
-		mockSession := &mockClientSession{id: "race-test-session"}
-		sm.CreateSession(context.Background(), mockSession)
-
-		state, exists := sm.GetSession("race-test-session")
-		require.True(t, exists)
-
-		// Track how many times the initialization logic runs
-		var initCount int
-		var initCountMutex sync.Mutex
-
-		// Create a custom initOnce to track calls
-		state.initOnce = sync.Once{}
-
-		// Simulate the initialization work that should run exactly once
-		initWork := func() {
-			initCountMutex.Lock()
-			initCount++
-			initCountMutex.Unlock()
-			// Simulate some work
-			state.mutex.Lock()
-			state.proxiedToolsInitialized = true
-			state.proxiedClients["tempo_test"] = &ProxiedClient{
-				DatasourceUID:  "test",
-				DatasourceName: "Test",
-				DatasourceType: "tempo",
-			}
-			state.mutex.Unlock()
-		}
-
-		// Launch multiple goroutines that all try to initialize concurrently
-		const numGoroutines = 10
-		var wg sync.WaitGroup
-		wg.Add(numGoroutines)
-
-		for i := 0; i < numGoroutines; i++ {
-			go func() {
-				defer wg.Done()
-				// This should be the pattern used in InitializeAndRegisterProxiedTools
-				state.initOnce.Do(initWork)
-			}()
-		}
-
-		wg.Wait()
-
-		// Verify initialization ran exactly once
-		assert.Equal(t, 1, initCount, "Initialization should run exactly once despite concurrent calls")
-		assert.True(t, state.proxiedToolsInitialized, "State should be initialized")
-		assert.Len(t, state.proxiedClients, 1, "Should have exactly one client")
-	})
-
-	t.Run("sync.Once prevents double initialization", func(t *testing.T) {
-		sm := NewSessionManager()
-		mockSession := &mockClientSession{id: "double-init-test"}
-		sm.CreateSession(context.Background(), mockSession)
-
-		state, _ := sm.GetSession("double-init-test")
-
-		callCount := 0
-
-		// First call
-		state.initOnce.Do(func() {
-			callCount++
-		})
-
-		// Second call should not execute
-		state.initOnce.Do(func() {
-			callCount++
-		})
-
-		// Third call should also not execute
-		state.initOnce.Do(func() {
-			callCount++
-		})
-
-		assert.Equal(t, 1, callCount, "sync.Once should ensure function runs exactly once")
-	})
-}
-
 func TestProxiedClientLifecycle(t *testing.T) {
 	ctx := newProxiedToolsTestContext(t)
 
@@ -397,20 +266,27 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 
 		// Step 5: Test session integration
 		sm := NewSessionManager()
+		defer sm.Close()
 		mockSession := &mockClientSession{id: "e2e-test-session"}
 		sm.CreateSession(ctx, mockSession)
 
 		state, exists := sm.GetSession("e2e-test-session")
 		require.True(t, exists)
 
-		// Store the proxied client in session state
+		// Attach a shared proxied tool set holding the client to the session.
 		key := ds.Type + "_" + ds.UID
-		state.proxiedClients[key] = client
+		set := &proxiedToolSet{
+			clients:           map[string]*ProxiedClient{key: client},
+			toolToDatasources: map[string][]string{},
+		}
+		state.mutex.Lock()
+		state.proxiedSet = set
+		state.mutex.Unlock()
 
-		// Step 6: Verify client is stored correctly in session
-		retrievedClient, exists := state.proxiedClients[key]
-		require.True(t, exists, "Client should be stored in session state")
-		assert.Equal(t, client, retrievedClient, "Should retrieve the same client from session")
+		// Step 6: Verify client is stored correctly in the shared set
+		retrievedClient, exists := set.clients[key]
+		require.True(t, exists, "Client should be stored in the shared proxied tool set")
+		assert.Equal(t, client, retrievedClient, "Should retrieve the same client from the set")
 
 		// Step 7: Test ProxiedToolHandler flow
 		handler := NewProxiedToolHandler(sm, nil, modifiedTool.Name)
@@ -430,10 +306,17 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 		}
 
 		sm := NewSessionManager()
+		defer sm.Close()
 		mockSession := &mockClientSession{id: "multi-ds-test-session"}
 		sm.CreateSession(ctx, mockSession)
 
 		state, _ := sm.GetSession("multi-ds-test-session")
+
+		// A single shared set holds all the datasource clients for this session.
+		set := &proxiedToolSet{
+			clients:           map[string]*ProxiedClient{},
+			toolToDatasources: map[string][]string{},
+		}
 
 		// Try to connect to multiple datasources
 		connectedCount := 0
@@ -452,7 +335,7 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 			}()
 
 			key := ds.Type + "_" + ds.UID
-			state.proxiedClients[key] = client
+			set.clients[key] = client
 			connectedCount++
 
 			t.Logf("Connected to datasource %s with %d tools", ds.UID, len(client.Tools))
@@ -462,8 +345,12 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 			t.Skip("Could not connect to any Tempo datasources")
 		}
 
+		state.mutex.Lock()
+		state.proxiedSet = set
+		state.mutex.Unlock()
+
 		// Verify each client is stored correctly
-		for key, client := range state.proxiedClients {
+		for key, client := range set.clients {
 			parts := strings.Split(key, "_")
 			require.Len(t, parts, 2, "Key should have format type_uid")
 			assert.NotNil(t, client, "Client should not be nil")

--- a/session_tool_store_leak_test.go
+++ b/session_tool_store_leak_test.go
@@ -1,0 +1,111 @@
+package mcpgrafana
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamableHTTPSessionToolStoreReclaimed is the regression guard for the
+// per-session tool-registration leak.
+//
+// The streamable-http transport stores each session's registered tools (added
+// via MCPServer.AddSessionTools) in a server-shared store keyed by session ID.
+// UnregisterSession only drops the session handle; it does NOT delete that
+// store entry. So a client that disconnects without sending a DELETE leaves a
+// fixed amount of memory (its rewritten tool set) retained for every session
+// ever created: memory that grows monotonically and is never reclaimed.
+//
+// The SDK's idle-session sweeper (WithSessionIdleTTL) is the fix: it runs the
+// transport's full teardown, which unregisters the session AND deletes its
+// per-session stores. This test enables the sweeper (as the server wiring does)
+// and asserts that, after many sessions go idle, each one's tool-store entry is
+// reclaimed rather than retained forever.
+func TestStreamableHTTPSessionToolStoreReclaimed(t *testing.T) {
+	mcpServer := server.NewMCPServer("test", "1.0")
+
+	// Short idle TTL so the sweeper reclaims idle sessions quickly.
+	const idleTTL = 200 * time.Millisecond
+	streamable := server.NewStreamableHTTPServer(mcpServer,
+		server.WithStateLess(false),
+		server.WithSessionIdleTTL(idleTTL),
+	)
+
+	httpServer := httptest.NewServer(streamable)
+	defer httpServer.Close()
+
+	// Create several sessions and register a tool on each, exactly as the
+	// per-session proxied-tools path does. Each session is then abandoned (no
+	// DELETE), which is what leaks without the sweeper.
+	const numSessions = 20
+	sessionIDs := make([]string, 0, numSessions)
+	for i := 0; i < numSessions; i++ {
+		sessionID := initializeStreamableSession(t, httpServer.URL)
+		require.NotEmpty(t, sessionID)
+		sessionIDs = append(sessionIDs, sessionID)
+
+		err := mcpServer.AddSessionTools(sessionID, server.ServerTool{
+			Tool: mcp.NewTool("tempo_example"),
+			Handler: func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return nil, nil
+			},
+		})
+		require.NoError(t, err, "tools should register while the session is live")
+	}
+
+	// While sessions are live, adding tools must succeed (the entries exist).
+	require.NoError(t, mcpServer.AddSessionTools(sessionIDs[0],
+		server.ServerTool{Tool: mcp.NewTool("tempo_example2")}))
+
+	// Let all sessions go idle past the TTL so the sweeper reclaims them.
+	require.Eventually(t, func() bool {
+		for _, id := range sessionIDs {
+			// Once the sweeper has run its full teardown for a session, the
+			// session handle is gone and AddSessionTools reports it as not found.
+			// That teardown is the same path that deletes the per-session tool
+			// store, so ErrSessionNotFound here means the store entry was freed.
+			if err := mcpServer.AddSessionTools(id, server.ServerTool{Tool: mcp.NewTool("probe")}); !errors.Is(err, server.ErrSessionNotFound) {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, idleTTL/2, "all idle sessions must be swept, freeing their per-session tool stores")
+}
+
+// initializeStreamableSession performs the MCP initialize handshake against a
+// streamable-http server and returns the assigned session ID.
+func initializeStreamableSession(t *testing.T, url string) string {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+			"clientInfo":      map[string]any{"name": "test-client", "version": "1.0.0"},
+		},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	return resp.Header.Get("Mcp-Session-Id")
+}


### PR DESCRIPTION
## Problem

Two independent memory leaks in the HTTP/streamable-http proxied-tools path.

1. **Per-session build duplication (scales with live sessions).** Proxied MCP tools are discovered, connected, and schema-rewritten per session and stored in `SessionState`. For N concurrent sessions with the same credentials that is N identical copies of the clients and tools. Memory grew linearly with live session count and OOMed under session churn.

2. **Per-session tool registration never freed (monotonic).** The streamable-http transport stores each session's tools (registered via `AddSessionTools`) in a server-shared map keyed by session ID. `UnregisterSession` only drops the session handle, not that map entry, so a client disconnecting without a DELETE leaves a fixed amount of memory retained for every session ever created.

## Heap evidence

Profiled with a pprof-enabled build of the streamable-http server, driven under session churn (short-lived sessions that each list/call proxied tools, then disconnect without a clean DELETE).

**Leak 1 scales with live sessions.** In-use heap (`heap_inuse`) tracked live-session count roughly linearly:

| live sessions | heap_inuse |
|--------------:|-----------:|
| 100  | 23.9 MB  |
| 300  | 43.4 MB  |
| 595  | 103.3 MB |
| 800  | 135.2 MB |
| 1930 | 307.9 MB |

A heap profile (`inuse_space`) at ~1930 sessions attributed **84.4%** of sampled live heap to a single call path:

```
(*ToolManager).InitializeAndRegisterProxiedTools   125.1 MB  84.4% (cumulated)
  encoding/json (*decodeState).objectInterface      39.0 MB   decoding proxied tool schemas
  reflect.growslice                                  29.1 MB   tool-schema slices
  server.newStreamableHttpSession                    13.5 MB
  reflect.mapassign_faststr0                         13.5 MB
  encoding/json (*decodeState).literalStore          12.5 MB
```

consistent with each session retaining its own copy of the discovered clients and rewritten tools.

**Leak 2 is a fixed residual per session, not reclaimed on teardown.** After driving ~2000 sessions, letting the idle reaper unregister all of them, and forcing a GC, **57.1 MB** of live heap remained above the pre-traffic baseline, all in the same proxied-tools shapes (`newStreamableHttpSession`, the `AddSessionTools` server-side store, decoded schemas). This residual grows monotonically with the total number of sessions ever created.

## Fix

1. Introduce a credential-keyed, reference-counted shared tool set on `ToolManager`. Sessions with identical credentials attach to one set, built at most once per key; its clients are closed only when the last session detaches. This mirrors the process-level client cache added for #682, which solved the analogous per-request client duplication but did not cover the proxied-tools path. The key includes the Grafana Cloud access token and ID token so per-user / on-behalf-of auth cannot collide across users of a shared instance, and the TLS material, forwarded headers, and timeout so sessions that build a different client do not share one.

2. Enable the SDK's idle-session sweeper (`WithSessionIdleTTL`) on the streamable-http server, reusing the existing session idle-timeout. The sweeper runs the transport's full teardown, which deletes the per-session tool store on top of unregistering the session. SSE is unaffected (it holds tools on the session object, reclaimed on unregister).

## Tests

- Shared-cache regression tests: multiple sessions with identical credentials produce exactly one set; distinct credentials (including access/ID tokens, basic-auth, TLS material, forwarded headers, and timeout) produce distinct entries; the entry and its clients are released exactly once when the last referencing session ends or is reaped.
- Concurrency regression tests: a session torn down mid-build still balances its reference; an in-flight tool call keeps its client alive against a concurrent last-session teardown; a failed or cancelled build is not cached (the next session rebuilds); a panicking build unblocks waiters and de-caches. Run under `-race`.
- Tool-store regression test: many sessions register tools, are abandoned, and after going idle each session's per-session tool store is reclaimed. Verified to fail without the sweeper enabled.

All unit tests pass with `-race`; lint is clean.

## Note

`GetProxiedClient`'s signature changes to `(*ProxiedClient, func(), error)`: the returned release func must be deferred by the caller so an in-flight call keeps the shared client alive. The only in-repo caller (the proxied tool handler) is updated.
