### PR TITLE
fix(observability): allow enabling OTLP tracing without log export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,7 +1097,7 @@ Slow-request logging works on all transports (including stdio) and does not requ
 
 #### Tracing
 
-Distributed tracing is configured via standard `OTEL_*` environment variables and works independently of the `--metrics` flag. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the server exports traces via OTLP/gRPC:
+Distributed tracing is configured via standard `OTEL_*` environment variables and works independently of the `--metrics` flag. When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is set, the server exports traces via OTLP/gRPC:
 
 ```bash
 # Send traces to a local Tempo instance
@@ -1115,7 +1115,9 @@ Tool call spans follow semconv naming (`tools/call <tool_name>`) and include att
 
 #### Logs
 
-When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) is set — the same trigger that enables tracing — the server also exports structured logs via OTLP/gRPC in addition to the existing plain-text stderr output. The `otelslog` bridge automatically attaches `trace_id` and `span_id` from the active span, so log records correlate with the traces the server already emits.
+When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) is set, the server also exports structured logs via OTLP/gRPC in addition to the existing plain-text stderr output. The `otelslog` bridge automatically attaches `trace_id` and `span_id` from the active span, so log records correlate with the traces the server already emits.
+
+Traces and logs resolve their endpoints independently, so the two signals can be enabled separately: setting only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` enables tracing **without** log export, setting only `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` enables log export without tracing, and the generic `OTEL_EXPORTER_OTLP_ENDPOINT` enables both.
 
 Stderr logging is unchanged when OTLP logging is enabled; you can continue to rely on container logs or pipe stderr to `/dev/null` if you prefer.
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -486,6 +486,12 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		slog.Info("OTLP log export configured", "endpoint", observability.OTLPLogsEndpoint())
 	}
 
+	// Announced after the log fanout so this line is itself exported when both
+	// signals are on.
+	if o.TracerProvider() != nil {
+		slog.Info("OTLP trace export configured", "endpoint", observability.OTLPTracesEndpoint())
+	}
+
 	// Create a client cache for HTTP-based transports to avoid per-request
 	// transport allocation (see https://github.com/grafana/mcp-grafana/issues/682).
 	var clientCache *mcpgrafana.ClientCache

--- a/docs/sources/developer/observability-metrics-and-tracing.md
+++ b/docs/sources/developer/observability-metrics-and-tracing.md
@@ -54,7 +54,7 @@ When using SSE or streamable HTTP transports, enable Prometheus metrics with `--
 
 ## Enable OpenTelemetry tracing
 
-When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the server exports traces via OTLP/gRPC.
+When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is set, the server exports traces via OTLP/gRPC.
 
 Local example:
 ```bash
@@ -77,7 +77,13 @@ Tool call spans follow naming like `tools/call <tool_name>` and include attribut
 
 ## Enable OpenTelemetry logs
 
-When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) is set — the same trigger as tracing — the server also exports structured logs via OTLP/gRPC in addition to the existing plain-text stderr output. Logs carry `trace_id` and `span_id` from the active span so they correlate with exported traces.
+When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) is set, the server also exports structured logs via OTLP/gRPC in addition to the existing plain-text stderr output. Logs carry `trace_id` and `span_id` from the active span so they correlate with exported traces.
+
+Traces and logs resolve their endpoints independently, so the two signals can be enabled separately:
+
+- Setting only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` enables tracing **without** log export.
+- Setting only `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` enables log export without tracing.
+- Setting the generic `OTEL_EXPORTER_OTLP_ENDPOINT` enables both.
 
 ```bash
 # Send logs and traces to a local OTel collector

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -24,6 +24,17 @@ func OTLPLogsEndpoint() string {
 	return os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 }
 
+// OTLPTracesEndpoint returns the resolved OTLP traces endpoint, preferring the
+// signal-specific OTEL_EXPORTER_OTLP_TRACES_ENDPOINT over the generic
+// OTEL_EXPORTER_OTLP_ENDPOINT. Returns "" when neither is set, which is the
+// signal that OTLP trace export is disabled.
+func OTLPTracesEndpoint() string {
+	if v := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"); v != "" {
+		return v
+	}
+	return os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+}
+
 type fanoutHandler struct {
 	children []slog.Handler
 }

--- a/observability/logs_test.go
+++ b/observability/logs_test.go
@@ -296,6 +296,44 @@ func TestOTLPLogsEndpoint_EmptyWhenNeitherSet(t *testing.T) {
 	assert.Empty(t, OTLPLogsEndpoint())
 }
 
+// TestOTLPTracesEndpoint_TracesEndpointTakesPrecedence verifies that when both
+// the signal-specific and generic OTEL endpoint env vars are set,
+// OTLPTracesEndpoint returns the signal-specific value.
+func TestOTLPTracesEndpoint_TracesEndpointTakesPrecedence(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic:4317")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces-specific:4317")
+	assert.Equal(t, "http://traces-specific:4317", OTLPTracesEndpoint())
+}
+
+// TestOTLPTracesEndpoint_FallsBackToGeneric verifies the fallback path: when the
+// signal-specific env var is empty, the generic endpoint is used.
+func TestOTLPTracesEndpoint_FallsBackToGeneric(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic:4317")
+	assert.Equal(t, "http://generic:4317", OTLPTracesEndpoint())
+}
+
+// TestOTLPTracesEndpoint_EmptyWhenNeitherSet verifies the "disabled" signal:
+// when neither env var is set, OTLPTracesEndpoint returns "" so Setup skips
+// creating a tracer provider.
+func TestOTLPTracesEndpoint_EmptyWhenNeitherSet(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	assert.Empty(t, OTLPTracesEndpoint())
+}
+
+// TestOTLPEndpoints_TracesOnlyDoesNotEnableLogs is the regression guard for the
+// signal-decoupling fix: setting only the traces-specific endpoint must resolve
+// a traces endpoint while leaving the logs endpoint empty, so enabling tracing
+// does not silently turn on OTLP log export.
+func TestOTLPEndpoints_TracesOnlyDoesNotEnableLogs(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces-specific:4317")
+	assert.Equal(t, "http://traces-specific:4317", OTLPTracesEndpoint())
+	assert.Empty(t, OTLPLogsEndpoint())
+}
+
 // TestFanoutHandler_PanicWritesStackToStderr verifies that handleChild writes
 // the panic message AND a stack trace directly to os.Stderr before returning
 // the error. slog.Logger discards errors returned from Handle, so without this

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -134,12 +134,11 @@ func newSlowRequestLogger(level slog.Level) *slog.Logger {
 // a global MeterProvider. The otelhttp instrumentation will automatically
 // use this provider for HTTP metrics.
 //
-// Tracing configuration is handled via standard OTEL_* environment variables
-// (e.g., OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_TRACES_SAMPLER).
-//
-// Log export is enabled when OTEL_EXPORTER_OTLP_ENDPOINT or
-// OTEL_EXPORTER_OTLP_LOGS_ENDPOINT is set; use LoggerProvider() to retrieve
-// the provider for wiring into an slog.Handler (e.g., via the otelslog bridge).
+// Trace export is gated on OTLPTracesEndpoint and log export on
+// OTLPLogsEndpoint; use LoggerProvider() to retrieve the log provider for
+// wiring into an slog.Handler (e.g., via the otelslog bridge). Other tracing
+// behaviour is configured via standard OTEL_* environment variables
+// (e.g., OTEL_TRACES_SAMPLER).
 func Setup(cfg Config) (_ *Observability, err error) {
 	// Ensure OTel SDK internal errors (async export failures, queue drops, etc.)
 	// surface through slog instead of the stdlib log package where operators
@@ -196,10 +195,10 @@ func Setup(cfg Config) (_ *Observability, err error) {
 		return nil, err
 	}
 
-	// Set up OTLP trace exporter when OTEL_EXPORTER_OTLP_ENDPOINT is configured.
+	// Set up OTLP trace exporter when a traces endpoint is configured.
 	// The gRPC exporter respects standard OTEL_* env vars for endpoint, headers,
 	// TLS (OTEL_EXPORTER_OTLP_INSECURE), etc.
-	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
+	if OTLPTracesEndpoint() != "" {
 		traceExporter, traceErr := otlptracegrpc.New(context.Background())
 		if traceErr != nil {
 			return nil, traceErr
@@ -562,4 +561,11 @@ func MergeHooks(hooks ...*server.Hooks) *server.Hooks {
 // not set).
 func (o *Observability) LoggerProvider() *sdklog.LoggerProvider {
 	return o.loggerProvider
+}
+
+// TracerProvider returns the OTLP tracer provider, or nil if OTLP tracing is
+// not configured (OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+// not set).
+func (o *Observability) TracerProvider() *sdktrace.TracerProvider {
+	return o.tracerProvider
 }

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -51,8 +51,45 @@ func TestSetup(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("logger provider populated when OTLP logs endpoint set", func(t *testing.T) {
+	t.Run("traces endpoint enables tracing but not log export", func(t *testing.T) {
 		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4317")
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true")
+		cfg := Config{MetricsEnabled: false}
+
+		obs, err := Setup(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, obs)
+		assert.NotNil(t, obs.tracerProvider, "tracer provider should be set when traces endpoint is configured")
+		assert.Nil(t, obs.LoggerProvider(), "log export must stay off when only the traces endpoint is set")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		assert.NoError(t, obs.Shutdown(shutdownCtx))
+	})
+
+	t.Run("generic endpoint enables both tracing and log export", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+		t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+		cfg := Config{MetricsEnabled: false}
+
+		obs, err := Setup(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, obs)
+		assert.NotNil(t, obs.tracerProvider, "generic endpoint should enable trace export")
+		assert.NotNil(t, obs.LoggerProvider(), "generic endpoint should enable log export")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		assert.NoError(t, obs.Shutdown(shutdownCtx))
+	})
+
+	t.Run("logs endpoint enables log export but not tracing", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
 		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://localhost:4317")
 		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_INSECURE", "true")
 		cfg := Config{MetricsEnabled: false}
@@ -61,6 +98,7 @@ func TestSetup(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, obs)
 		require.NotNil(t, obs.LoggerProvider())
+		assert.Nil(t, obs.tracerProvider, "trace export must stay off when only the logs endpoint is set")
 
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()


### PR DESCRIPTION
## Summary

Enabling OpenTelemetry **tracing** currently forces OTLP **log export** on as well. Trace export is gated solely on the generic `OTEL_EXPORTER_OTLP_ENDPOINT`, and when log export is on the server routes *all* of its `slog` output through the otelslog bridge to the collector. An operator who just wants traces in their collector unavoidably ships every application log line there too — with no way to get one signal without the other.

## What changes

Trace export now honors the signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (falling back to the generic endpoint), via a new `OTLPTracesEndpoint()` helper that mirrors the existing `OTLPLogsEndpoint()`. Setting only the traces-specific variable enables tracing **without** log export.

**Log export behaviour is unchanged** — it was already independently controllable via `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`. The only new capability here is on the tracing side.

Resulting behaviour by environment:

- `OTEL_EXPORTER_OTLP_ENDPOINT` (generic) — traces **on**, logs **on** (unchanged)
- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` only — traces **on**, logs **off** (new; previously enabled nothing)
- `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` only — traces **off**, logs **on** (unchanged; already worked)

This also fixes a latent gap: before, setting only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` enabled nothing, because the gate checked only the generic variable even though the exporter itself honors the traces-specific one.

Also adds a `TracerProvider()` accessor and a symmetric `"OTLP trace export configured"` startup log line, matching the existing log-export announcement.

## Testing

- Unit tests for `OTLPTracesEndpoint()` (precedence, fallback, empty) plus a regression guard asserting a traces-only endpoint brings up the tracer provider while `LoggerProvider()` stays nil.
- Verified end-to-end against all four env configurations (traces-only, generic, logs-only, none) — each announces the correct signal(s) on startup.
- `go build`, `go vet`, and the observability unit tests pass.

README and the observability docs page are updated to describe the per-signal endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)