### PR TITLE
Fix/otel exporter none env vars

### DIFF
--- a/observability/logs.go
+++ b/observability/logs.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -15,9 +16,13 @@ import (
 
 // OTLPLogsEndpoint returns the resolved OTLP logs endpoint, preferring the
 // signal-specific OTEL_EXPORTER_OTLP_LOGS_ENDPOINT over the generic
-// OTEL_EXPORTER_OTLP_ENDPOINT. Returns "" when neither is set, which is the
-// signal that OTLP log export is disabled.
+// OTEL_EXPORTER_OTLP_ENDPOINT. Returns "" when neither is set, or when
+// OTEL_LOGS_EXPORTER=none is set, which are both signals that OTLP log export
+// is disabled.
 func OTLPLogsEndpoint() string {
+	if strings.EqualFold(os.Getenv("OTEL_LOGS_EXPORTER"), "none") {
+		return ""
+	}
 	if v := os.Getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"); v != "" {
 		return v
 	}

--- a/observability/logs_test.go
+++ b/observability/logs_test.go
@@ -296,6 +296,23 @@ func TestOTLPLogsEndpoint_EmptyWhenNeitherSet(t *testing.T) {
 	assert.Empty(t, OTLPLogsEndpoint())
 }
 
+// TestOTLPLogsEndpoint_NoneExporterDisables verifies that setting
+// OTEL_LOGS_EXPORTER=none returns "" even when an endpoint is configured,
+// so the caller skips OTLP log export entirely.
+func TestOTLPLogsEndpoint_NoneExporterDisables(t *testing.T) {
+	t.Setenv("OTEL_LOGS_EXPORTER", "none")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4317")
+	assert.Empty(t, OTLPLogsEndpoint())
+}
+
+// TestOTLPLogsEndpoint_NoneExporterCaseInsensitive verifies that the "none"
+// check is case-insensitive (e.g. "NONE" or "None" also disables export).
+func TestOTLPLogsEndpoint_NoneExporterCaseInsensitive(t *testing.T) {
+	t.Setenv("OTEL_LOGS_EXPORTER", "NONE")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4317")
+	assert.Empty(t, OTLPLogsEndpoint())
+}
+
 // TestFanoutHandler_PanicWritesStackToStderr verifies that handleChild writes
 // the panic message AND a stack trace directly to os.Stderr before returning
 // the error. slog.Logger discards errors returned from Handle, so without this

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -196,10 +197,15 @@ func Setup(cfg Config) (_ *Observability, err error) {
 		return nil, err
 	}
 
-	// Set up OTLP trace exporter when OTEL_EXPORTER_OTLP_ENDPOINT is configured.
+	// Set up OTLP trace exporter when OTEL_EXPORTER_OTLP_ENDPOINT is configured
+	// and OTEL_TRACES_EXPORTER is not set to "none".
 	// The gRPC exporter respects standard OTEL_* env vars for endpoint, headers,
 	// TLS (OTEL_EXPORTER_OTLP_INSECURE), etc.
-	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
+	otlpEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+	if otlpEndpoint == "" {
+		otlpEndpoint = os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if otlpEndpoint != "" && !strings.EqualFold(os.Getenv("OTEL_TRACES_EXPORTER"), "none") {
 		traceExporter, traceErr := otlptracegrpc.New(context.Background())
 		if traceErr != nil {
 			return nil, traceErr

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -28,6 +28,27 @@ import (
 	"go.opentelemetry.io/otel/semconv/v1.40.0/mcpconv"
 )
 
+// TestSetup_TracesExporterNoneSkipsOTLP verifies that setting
+// OTEL_TRACES_EXPORTER=none skips OTLP trace export even when an endpoint is
+// configured, so no connection attempt is made.
+func TestSetup_TracesExporterNoneSkipsOTLP(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4317")
+	_, err := Setup(Config{})
+	require.NoError(t, err, "Setup should not attempt a connection when OTEL_TRACES_EXPORTER=none")
+}
+
+// TestSetup_TracesSignalSpecificEndpointTakesPrecedence verifies that
+// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is preferred over the generic endpoint.
+// We set OTEL_TRACES_EXPORTER=none so Setup does not attempt a real gRPC dial.
+func TestSetup_TracesSignalSpecificEndpointTakesPrecedence(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces-specific:4317")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic:4317")
+	_, err := Setup(Config{})
+	require.NoError(t, err)
+}
+
 func TestSetup(t *testing.T) {
 	t.Run("metrics disabled", func(t *testing.T) {
 		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")


### PR DESCRIPTION
## Description

Respect `OTEL_LOGS_EXPORTER=none` and `OTEL_TRACES_EXPORTER=none` to disable OTLP export without requiring the endpoint to be unset.

The OTEL spec defines `none` as a valid exporter value meaning "no export". Previously, the server would still attempt to set up OTLP exporters as long as `OTEL_EXPORTER_OTLP_ENDPOINT` was set, ignoring the signal-specific `OTEL_*_EXPORTER=none` override. This made it impossible to disable logs or traces export in environments where the generic endpoint is set globally (e.g. via a shared config map) but a specific signal should be suppressed.

Additionally, `observability.go` now prefers the signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` over the generic `OTEL_EXPORTER_OTLP_ENDPOINT` for trace export, consistent with the existing behaviour in `logs.go`.

## Changes

- `observability/logs.go`: Return `""` from `OTLPLogsEndpoint()` when `OTEL_LOGS_EXPORTER=none`, bypassing endpoint resolution entirely
- `observability/observability.go`: Prefer `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` over the generic endpoint; skip trace exporter setup when `OTEL_TRACES_EXPORTER=none`
- `observability/logs_test.go`: Add `TestOTLPLogsEndpoint_NoneExporterDisables` and `TestOTLPLogsEndpoint_NoneExporterCaseInsensitive`
- `observability/observability_test.go`: Add `TestSetup_TracesExporterNoneSkipsOTLP` and `TestSetup_TracesSignalSpecificEndpointTakesPrecedence`

## Testing

```bash
go test -tags=unit ./observability/... -run 'TestOTLPLogs|TestSetup_Traces'