### PR TITLE
fix(observability): respect OTEL_LOGS_EXPORTER=none to disable OTLP log export

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ volumes:
 Surrounding whitespace (including a trailing newline) is trimmed from the file contents. If both `GRAFANA_SERVICE_ACCOUNT_TOKEN` and `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` are set, the inline token takes precedence.
 
 ### Multi-Organization Support
- 
+
 You can specify which organization to interact with using either:
 
 - **Environment variable:** Set `GRAFANA_ORG_ID` to the numeric organization ID
@@ -1118,6 +1118,14 @@ Tool call spans follow semconv naming (`tools/call <tool_name>`) and include att
 When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) is set, the server also exports structured logs via OTLP/gRPC in addition to the existing plain-text stderr output. The `otelslog` bridge automatically attaches `trace_id` and `span_id` from the active span, so log records correlate with the traces the server already emits.
 
 Traces and logs resolve their endpoints independently, so the two signals can be enabled separately: setting only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` enables tracing **without** log export, setting only `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` enables log export without tracing, and the generic `OTEL_EXPORTER_OTLP_ENDPOINT` enables both.
+
+If you use the generic `OTEL_EXPORTER_OTLP_ENDPOINT` but want to disable log export (e.g. your backend does not support the `LogsService`), set:
+
+```bash
+OTEL_LOGS_EXPORTER=none
+```
+
+This prevents the server from creating an OTLP logs exporter regardless of the endpoint configuration, avoiding errors like `unknown service opentelemetry.proto.collector.logs.v1.LogsService`.
 
 Stderr logging is unchanged when OTLP logging is enabled; you can continue to rely on container logs or pipe stderr to `/dev/null` if you prefer.
 

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -15,9 +16,13 @@ import (
 
 // OTLPLogsEndpoint returns the resolved OTLP logs endpoint, preferring the
 // signal-specific OTEL_EXPORTER_OTLP_LOGS_ENDPOINT over the generic
-// OTEL_EXPORTER_OTLP_ENDPOINT. Returns "" when neither is set, which is the
-// signal that OTLP log export is disabled.
+// OTEL_EXPORTER_OTLP_ENDPOINT. Returns "" when neither is set or when
+// OTEL_LOGS_EXPORTER is set to "none", which is the signal that OTLP log
+// export is disabled.
 func OTLPLogsEndpoint() string {
+	if strings.EqualFold(os.Getenv("OTEL_LOGS_EXPORTER"), "none") {
+		return ""
+	}
 	if v := os.Getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"); v != "" {
 		return v
 	}

--- a/observability/logs_test.go
+++ b/observability/logs_test.go
@@ -296,6 +296,23 @@ func TestOTLPLogsEndpoint_EmptyWhenNeitherSet(t *testing.T) {
 	assert.Empty(t, OTLPLogsEndpoint())
 }
 
+// TestOTLPLogsEndpoint_DisabledByExporterNone verifies that setting
+// OTEL_LOGS_EXPORTER=none disables OTLP log export even when an endpoint is
+// configured via the generic OTEL_EXPORTER_OTLP_ENDPOINT.
+func TestOTLPLogsEndpoint_DisabledByExporterNone(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic:4317")
+	t.Setenv("OTEL_LOGS_EXPORTER", "none")
+	assert.Empty(t, OTLPLogsEndpoint())
+}
+
+// TestOTLPLogsEndpoint_DisabledByExporterNoneCaseInsensitive verifies that
+// OTEL_LOGS_EXPORTER=None (mixed case) is also recognised.
+func TestOTLPLogsEndpoint_DisabledByExporterNoneCaseInsensitive(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://generic:4317")
+	t.Setenv("OTEL_LOGS_EXPORTER", "None")
+	assert.Empty(t, OTLPLogsEndpoint())
+}
+
 // TestOTLPTracesEndpoint_TracesEndpointTakesPrecedence verifies that when both
 // the signal-specific and generic OTEL endpoint env vars are set,
 // OTLPTracesEndpoint returns the signal-specific value.


### PR DESCRIPTION
When `OTEL_EXPORTER_OTLP_ENDPOINT` is set for traces, `OTLPLogsEndpoint()` was falling back to it and silently enabling OTLP log export — even when the backend does not support LogsService — causing:

```bash
  otel sdk error: rpc error: code = Unimplemented desc = unknown service
  opentelemetry.proto.collector.logs.v1.LogsService
```

`OTLPLogsEndpoint() `now short-circuits to "" when `OTEL_LOGS_EXPORTER=none` (case-insensitive), preventing the logs provider from being created regardless of endpoint configuration.

## Testing

Two new unit tests added:
- `TestOTLPLogsEndpoint_DisabledByExporterNone`
- `TestOTLPLogsEndpoint_DisabledByExporterNoneCaseInsensitive`

All existing tests continue to pass.

## Docs

README updated with the `OTEL_LOGS_EXPORTER=none` escape hatch and a note about the
error it prevents.