### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Grafana MCP server
 
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.grafana%2Fmcp-grafana.svg)](https://mcptoplist.com/server/io.github.grafana%2Fmcp-grafana)
+
 [![Unit Tests](https://github.com/grafana/mcp-grafana/actions/workflows/unit.yml/badge.svg)](https://github.com/grafana/mcp-grafana/actions/workflows/unit.yml)
 [![Integration Tests](https://github.com/grafana/mcp-grafana/actions/workflows/integration.yml/badge.svg)](https://github.com/grafana/mcp-grafana/actions/workflows/integration.yml)
 [![E2E Tests](https://github.com/grafana/mcp-grafana/actions/workflows/e2e.yml/badge.svg)](https://github.com/grafana/mcp-grafana/actions/workflows/e2e.yml)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 77,308 MCP servers across the major
registries, and **MCP Grafana** is currently ranked **#46**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/io.github.grafana%2Fmcp-grafana.svg)](https://mcptoplist.com/server/io.github.grafana%2Fmcp-grafana)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building MCP Grafana!
