### PR TITLE
feat: add CLI flags for IncludeArgumentsInSpans and Grafana timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 - `--debug`: Enable debug mode for detailed HTTP request/response logging
 - `--log-level`: Log level (`debug`, `info`, `warn`, `error`) - default: `info`
 
+**Grafana Client Options:**
+- `--grafana-timeout`: Time limit for requests made by the Grafana client. Accepts Go duration strings (e.g., `10s`, `500ms`) - default: `10s`
+- `--include-args-in-spans`: Include tool call arguments in OpenTelemetry spans. Only enable in non-production environments or when arguments are known not to contain PII - default: `false`
+
 **Observability:**
 - `--metrics`: Enable Prometheus metrics endpoint at `/metrics`
 - `--metrics-address`: Separate address for metrics server (e.g., `:9090`). If empty, metrics are served on the main server

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -105,6 +105,12 @@ type grafanaConfig struct {
 
 	// Loki configuration
 	maxLokiLogLimit int
+
+	// includeArgsInSpans enables logging of tool arguments in OpenTelemetry spans.
+	includeArgsInSpans bool
+
+	// timeout is the time limit for requests made by the Grafana client.
+	timeout time.Duration
 }
 
 func (dt *disabledTools) addFlags() {
@@ -156,6 +162,9 @@ func (gc *grafanaConfig) addFlags() {
 
 	// Loki configuration flags
 	flag.IntVar(&gc.maxLokiLogLimit, "max-loki-log-limit", tools.MaxLokiLogLimit, "Maximum number of log lines returned per query_loki_logs call")
+
+	flag.BoolVar(&gc.includeArgsInSpans, "include-args-in-spans", false, "Include tool call arguments in OpenTelemetry spans. Only enable in non-production environments or when arguments are known not to contain PII.")
+	flag.DurationVar(&gc.timeout, "grafana-timeout", mcpgrafana.DefaultGrafanaClientTimeout, "Time limit for requests made by the Grafana client. Accepts Go duration strings, e.g. 10s, 500ms.")
 }
 
 // toolEntry pairs a tool registration function with its category and disable flag.
@@ -665,8 +674,10 @@ func main() {
 
 	// Convert local grafanaConfig to mcpgrafana.GrafanaConfig
 	grafanaConfig := mcpgrafana.GrafanaConfig{
-		Debug:           gc.debug,
-		MaxLokiLogLimit: gc.maxLokiLogLimit,
+		Debug:                   gc.debug,
+		MaxLokiLogLimit:         gc.maxLokiLogLimit,
+		IncludeArgumentsInSpans: gc.includeArgsInSpans,
+		Timeout:                 gc.timeout,
 	}
 	if gc.tlsCertFile != "" || gc.tlsKeyFile != "" || gc.tlsCAFile != "" || gc.tlsSkipVerify {
 		grafanaConfig.TLSConfig = &mcpgrafana.TLSConfig{

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -45,6 +45,11 @@ When deploying behind an ingress or reverse proxy that forwards the original `Ho
 - `--debug`: Enable debug mode for detailed HTTP request and response logging to and from the Grafana API.
 - `--log-level`: Log level (`debug`, `info`, `warn`, `error`). Default: `info`.
 
+## Configure the Grafana client
+
+- `--grafana-timeout`: Time limit for requests made by the Grafana client. Accepts Go duration strings, e.g. `10s`, `500ms`. Default: `10s`.
+- `--include-args-in-spans`: Include tool call arguments in OpenTelemetry spans. Only enable in non-production environments or when arguments are known not to contain PII. Default: `false`.
+
 ## Configure observability endpoints
 
 - `--metrics`: Expose a Prometheus metrics endpoint at `/metrics` (SSE and streamable-http only).

--- a/docs/sources/developer/observability-metrics-and-tracing.md
+++ b/docs/sources/developer/observability-metrics-and-tracing.md
@@ -75,6 +75,8 @@ OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ..." \
 
 Tool call spans follow naming like `tools/call <tool_name>` and include attributes such as `gen_ai.tool.name`, `mcp.method.name`, and `mcp.session.id`. The server supports W3C trace context propagation from the `_meta` field of tool call requests.
 
+Tool call arguments are excluded from spans by default. Pass `--include-args-in-spans` to add them as the `gen_ai.tool.call.arguments` attribute — only enable this in non-production environments or when you're certain the arguments don't contain PII.
+
 ## Enable OpenTelemetry logs
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`) is set, the server also exports structured logs via OTLP/gRPC in addition to the existing plain-text stderr output. Logs carry `trace_id` and `span_id` from the active span so they correlate with exported traces.


### PR DESCRIPTION
## Summary

This PR adds support for configuring two existing `GrafanaConfig` fields from the official [mcp-grafana](cci:9://file:///home/wpkq73/oss/mcp-grafana:0:0-0:0) CLI:

- `--include-args-in-spans` → `GrafanaConfig.IncludeArgumentsInSpans`
- `--grafana-timeout` → `GrafanaConfig.Timeout`

The goal is to expose existing behavior in the binary with minimal code changes and keep current semantics unchanged by default.

## Why

The OpenTelemetry MCP semantic conventions note that `gen_ai.tool.call.arguments` is optional / opt-in:  
https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/mcp.md

Today, [mcp-grafana](cci:9://file:///home/wpkq73/oss/mcp-grafana:0:0-0:0) already supports this behavior internally (`IncludeArgumentsInSpans`), but the official binary has no CLI way to enable it.  
This PR adds that operator-facing toggle via `--include-args-in-spans`.

## Changes

- Added CLI flags in [cmd/mcp-grafana/main.go](cci:7://file:///home/wpkq73/oss/mcp-grafana/cmd/mcp-grafana/main.go:0:0-0:0):
  - `--include-args-in-spans` (default: `false`)
  - `--grafana-timeout` (default: `10s`)
- Wired both flags into the `mcpgrafana.GrafanaConfig` passed to server startup.
- Updated docs:
  - [README.md](cci:7://file:///home/wpkq73/oss/mcp-grafana/README.md:0:0-0:0)
  - [docs/sources/configure/command-line-flags.md](cci:7://file:///home/wpkq73/oss/mcp-grafana/docs/sources/configure/command-line-flags.md:0:0-0:0)
  - [docs/sources/developer/observability-metrics-and-tracing.md](cci:7://file:///home/wpkq73/oss/mcp-grafana/docs/sources/developer/observability-metrics-and-tracing.md:0:0-0:0)

## Semantics / compatibility

- No behavior change unless flags are explicitly set.
- Default timeout remains `10s` (same as existing `DefaultGrafanaClientTimeout` behavior).
- Tool arguments remain excluded from spans by default (`false`) for safety.

## Test plan

- `go build ./...`
- `go test ./cmd/...`
- Verified new flags are present in help output:
  - `--include-args-in-spans`
  - `--grafana-timeout`

## Notes

- This change is intentionally minimal and focused on CLI exposure of existing config fields.
- No additional unit tests were added since this is straightforward flag-to-config wiring, consistent with nearby flag patterns.