### PR TITLE
pyroscope: default query_pyroscope profile output to a per-function table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `query_pyroscope` now returns a per-function table (`pprof -top` style: flat/cum per fully-qualified function name) by default instead of a line-level DOT call graph. The DOT call graph remains available via `format="dot"` and no longer deletes the `other` truncation node ([#1025](https://github.com/grafana/mcp-grafana/pull/1025))
+
 ## [1.0.0] - 2026-07-28
 
 ### Added

--- a/tools/pyroscope.go
+++ b/tools/pyroscope.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -356,7 +358,7 @@ func validateTimeRange(start time.Time, end time.Time) (time.Time, time.Time, er
 	return start, end, nil
 }
 
-var cleanupRegex = regexp.MustCompile(`(?m)(fontsize=\d+ )|(id="node\d+" )|(labeltooltip=".*?\)" )|(tooltip=".*?\)" )|(N\d+ -> N\d+).*|(N\d+ \[label="other.*\n)|(shape=box )|(fillcolor="#\w{6}")|(color="#\w{6}" )`)
+var cleanupRegex = regexp.MustCompile(`(?m)(fontsize=\d+ )|(id="node\d+" )|(labeltooltip=".*?\)" )|(tooltip=".*?\)" )|(N\d+ -> N\d+).*|(shape=box )|(fillcolor="#\w{6}")|(color="#\w{6}" )`)
 
 func cleanupDotProfile(profile string) string {
 	return cleanupRegex.ReplaceAllStringFunc(profile, func(match string) string {
@@ -414,6 +416,188 @@ func buildSeriesResponse(series []*typesv1.Series, start, end time.Time, step fl
 }
 
 // ---------------------------------------------------------------------------
+// per-function profile table
+// ---------------------------------------------------------------------------
+
+// Pyroscope truncates large profiles server-side by collapsing the tail of the
+// call tree into a synthetic frame with this name (truncatedNodeName in
+// pyroscope's pkg/model/tree.go).
+const truncatedFunctionName = "other"
+
+type functionStat struct {
+	name string
+	flat int64
+	cum  int64
+}
+
+func (c *pyroscopeClient) ProfileTable(ctx context.Context, profileType, matchers string, start, end time.Time, maxRows int) (string, error) {
+	res, err := c.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profileType,
+		LabelSelector: matchers,
+		Start:         start.UnixMilli(),
+		End:           end.UnixMilli(),
+	}))
+	if err != nil {
+		return "", err
+	}
+	return buildProfileTable(res.Msg.Flamegraph, sampleUnitFromProfileType(profileType), maxRows)
+}
+
+// The profile type ID has the form <name>:<sample type>:<sample unit>:<period type>:<period unit>.
+func sampleUnitFromProfileType(profileType string) string {
+	parts := strings.Split(profileType, ":")
+	if len(parts) < 3 {
+		return ""
+	}
+	return parts[2]
+}
+
+// buildProfileTable renders a merged flame graph as a per-function text table
+// in the style of `pprof -top`: flat (self) and cumulative values per
+// fully-qualified function name, ranked by flat.
+//
+// Flame graph levels encode nodes as [xOffset, total, self, nameIndex] quads
+// with delta-encoded offsets (see NewFlameGraph in pyroscope's pkg/model).
+// Level 0 is the synthetic root ("total"); sub-threshold subtrees are
+// collapsed server-side into explicit "other" nodes.
+func buildProfileTable(fg *querierv1.FlameGraph, unit string, maxRows int) (string, error) {
+	if fg == nil || fg.Total == 0 || len(fg.Levels) == 0 {
+		return "", fmt.Errorf("pyroscope API returned a empty profile")
+	}
+	total := fg.Total
+
+	type fgNode struct {
+		x      int64
+		total  int64
+		name   int64
+		parent int
+	}
+
+	flat := make([]int64, len(fg.Names))
+	cum := make([]int64, len(fg.Names))
+	var truncated int64
+
+	levels := make([][]fgNode, len(fg.Levels))
+	for li, level := range fg.Levels {
+		vals := level.Values
+		nodes := make([]fgNode, 0, len(vals)/4)
+		var offset int64
+		parentIdx := 0
+		for i := 0; i+3 < len(vals); i += 4 {
+			x := vals[i] + offset
+			offset = x + vals[i+1]
+			n := fgNode{x: x, total: vals[i+1], name: vals[i+3]}
+			self := vals[i+2]
+			if li > 0 && len(levels[li-1]) > 0 {
+				parents := levels[li-1]
+				for parentIdx < len(parents)-1 && parents[parentIdx].x+parents[parentIdx].total <= n.x {
+					parentIdx++
+				}
+				n.parent = parentIdx
+
+				if int(n.name) < len(fg.Names) && fg.Names[n.name] == truncatedFunctionName {
+					truncated += self
+				} else {
+					flat[n.name] += self
+					// Count total only at the outermost occurrence of the
+					// function so recursion isn't double-counted.
+					recursive := false
+					for pl, p := li-1, n.parent; pl > 0; pl-- {
+						if levels[pl][p].name == n.name {
+							recursive = true
+							break
+						}
+						p = levels[pl][p].parent
+					}
+					if !recursive {
+						cum[n.name] += n.total
+					}
+				}
+			}
+			nodes = append(nodes, n)
+		}
+		levels[li] = nodes
+	}
+
+	list := make([]*functionStat, 0, len(fg.Names))
+	for i, name := range fg.Names {
+		if i == 0 || (flat[i] == 0 && cum[i] == 0) {
+			continue
+		}
+		list = append(list, &functionStat{name: name, flat: flat[i], cum: cum[i]})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].flat != list[j].flat {
+			return list[i].flat > list[j].flat
+		}
+		if list[i].cum != list[j].cum {
+			return list[i].cum > list[j].cum
+		}
+		return list[i].name < list[j].name
+	})
+	shown := list
+	if len(shown) > maxRows {
+		shown = shown[:maxRows]
+	}
+	var shownFlat int64
+	for _, s := range shown {
+		shownFlat += s.flat
+	}
+
+	pct := func(v int64) float64 {
+		return float64(v) * 100 / float64(total)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Total: %s\n", formatSampleValue(total, unit))
+	fmt.Fprintf(&b, "Showing top %d out of %d functions by flat (self) value, accounting for %.2f%% of the total\n",
+		len(shown), len(list), pct(shownFlat))
+	if truncated > 0 {
+		fmt.Fprintf(&b, "Note: %.2f%% of the total was collapsed into an %q bucket by server-side tree truncation and cannot be attributed to functions; values below may be understated\n",
+			pct(truncated), truncatedFunctionName)
+	}
+	fmt.Fprintf(&b, "%12s %6s %6s %12s %6s  %s\n", "flat", "flat%", "sum%", "cum", "cum%", "function")
+	var sumFlat int64
+	for _, s := range shown {
+		sumFlat += s.flat
+		fmt.Fprintf(&b, "%12s %5.2f%% %5.2f%% %12s %5.2f%%  %s\n",
+			formatSampleValue(s.flat, unit), pct(s.flat), pct(sumFlat),
+			formatSampleValue(s.cum, unit), pct(s.cum), s.name)
+	}
+	return b.String(), nil
+}
+
+func formatSampleValue(v int64, unit string) string {
+	f := float64(v)
+	switch unit {
+	case "nanoseconds":
+		switch d := time.Duration(v); {
+		case d >= time.Second:
+			return fmt.Sprintf("%.2fs", d.Seconds())
+		case d >= time.Millisecond:
+			return fmt.Sprintf("%.2fms", f/1e6)
+		case d >= time.Microsecond:
+			return fmt.Sprintf("%.2fus", f/1e3)
+		default:
+			return fmt.Sprintf("%dns", v)
+		}
+	case "bytes":
+		switch {
+		case f >= 1<<30:
+			return fmt.Sprintf("%.2fGB", f/(1<<30))
+		case f >= 1<<20:
+			return fmt.Sprintf("%.2fMB", f/(1<<20))
+		case f >= 1<<10:
+			return fmt.Sprintf("%.2fkB", f/(1<<10))
+		default:
+			return fmt.Sprintf("%dB", v)
+		}
+	default:
+		return strconv.FormatInt(v, 10)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // query_pyroscope — unified tool: profile + metrics + both
 // ---------------------------------------------------------------------------
 
@@ -422,9 +606,13 @@ Unified Pyroscope query tool for fetching profiles or metrics from Pyroscope. Pr
 shows WHEN consumption spiked. Use query_type="both" for complete analysis in one call.
 
 query_type options (extends Grafana's PyroscopeQueryType):
-- "profile": returns DOT-format call graph
+- "profile": returns profile data (shape controlled by format)
 - "metrics": returns time-series data points
 - "both" (default): returns both profile and metrics in one response
+
+format options (shape of the profile data):
+- "table" (default): per-function table with flat (self) and cumulative values, ranked by flat
+- "dot": call graph in Graphviz DOT format; nodes are per source line, so one function may span several nodes
 `
 
 var QueryPyroscope = mcpgrafana.MustTool(
@@ -440,10 +628,11 @@ type QueryPyroscopeParams struct {
 	DataSourceUID string   `json:"data_source_uid" jsonschema:"required,description=The UID of the datasource to query"`
 	ProfileType   string   `json:"profile_type" jsonschema:"required,description=The profile type\\, use list_pyroscope_profile_types to discover available types"`
 	QueryType     string   `json:"query_type,omitempty" jsonschema:"description=Query type: \"profile\" (flamegraph)\\, \"metrics\" (time-series)\\, or \"both\" (default). Use \"both\" for complete analysis"`
+	Format        string   `json:"format,omitempty" jsonschema:"description=Profile output format: \"table\" (default) for a per-function flat/cum table\\, or \"dot\" for a call graph in Graphviz DOT format"`
 	Matchers      string   `json:"matchers,omitempty" jsonschema:"description=Prometheus style matchers (defaults to: {})"`
 	GroupBy       []string `json:"group_by,omitempty" jsonschema:"description=Labels to group metrics series by"`
 	Step          float64  `json:"step,omitempty" jsonschema:"description=Seconds between metrics data points (default: auto)"`
-	MaxNodeDepth  int      `json:"max_node_depth,omitempty" jsonschema:"description=Max depth for profile call graph (default: 100)"`
+	MaxNodeDepth  int      `json:"max_node_depth,omitempty" jsonschema:"description=Max functions in the profile table or nodes in the call graph; it is a count\\, not a depth (default: 100)"`
 	StartRFC3339  string   `json:"start_rfc_3339,omitempty" jsonschema:"description=Start time in RFC3339 or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
 	EndRFC3339    string   `json:"end_rfc_3339,omitempty" jsonschema:"description=End time in RFC3339 or relative time (e.g. 'now') (defaults to now)"`
 }
@@ -455,6 +644,14 @@ func queryPyroscope(ctx context.Context, args QueryPyroscopeParams) (string, err
 	}
 	if queryType != "profile" && queryType != "metrics" && queryType != "both" {
 		return "", fmt.Errorf("invalid query_type %q: must be \"profile\", \"metrics\", or \"both\"", args.QueryType)
+	}
+
+	format := strings.ToLower(strings.TrimSpace(args.Format))
+	if format == "" {
+		format = "table"
+	}
+	if format != "table" && format != "dot" {
+		return "", fmt.Errorf("invalid format %q: must be \"table\" or \"dot\"", args.Format)
 	}
 
 	// Common setup
@@ -491,14 +688,24 @@ func queryPyroscope(ctx context.Context, args QueryPyroscopeParams) (string, err
 
 	if wantProfile {
 		maxNodes := intOrDefault(args.MaxNodeDepth, 100)
-		res, profileErr := client.Render(ctx, &renderRequest{
-			ProfileType: args.ProfileType,
-			Matcher:     matchers,
-			Start:       start,
-			End:         end,
-			Format:      "dot",
-			MaxNodes:    maxNodes,
-		})
+		var profile string
+		var profileErr error
+		if format == "dot" {
+			var res string
+			res, profileErr = client.Render(ctx, &renderRequest{
+				ProfileType: args.ProfileType,
+				Matcher:     matchers,
+				Start:       start,
+				End:         end,
+				Format:      "dot",
+				MaxNodes:    maxNodes,
+			})
+			if profileErr == nil {
+				profile = cleanupDotProfile(res)
+			}
+		} else {
+			profile, profileErr = client.ProfileTable(ctx, args.ProfileType, matchers, start, end, maxNodes)
+		}
 		if profileErr != nil {
 			// Single-type query: propagate error so MCP framework sets IsError=true.
 			// "both" mode: embed error for partial results.
@@ -507,7 +714,7 @@ func queryPyroscope(ctx context.Context, args QueryPyroscopeParams) (string, err
 			}
 			result["profile"] = map[string]string{"error": profileErr.Error()}
 		} else {
-			result["profile"] = cleanupDotProfile(res)
+			result["profile"] = profile
 		}
 	}
 

--- a/tools/pyroscope_test.go
+++ b/tools/pyroscope_test.go
@@ -100,6 +100,30 @@ func TestPyroscopeTools(t *testing.T) {
 		assert.Equal(t, "profile", parsed["query_type"])
 		assert.NotNil(t, parsed["profile"])
 		assert.Nil(t, parsed["metrics"], "metrics should not be present for profile-only")
+
+		table, ok := parsed["profile"].(string)
+		require.True(t, ok, "profile should be a string")
+		assert.Contains(t, table, "Total:")
+		assert.Contains(t, table, "flat%")
+		assert.Contains(t, table, "functions by flat (self) value")
+	})
+
+	t.Run("query Pyroscope profile DOT format", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := queryPyroscope(ctx, QueryPyroscopeParams{
+			DataSourceUID: "pyroscope",
+			ProfileType:   "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			Matchers:      `{service_name="pyroscope"}`,
+			QueryType:     "profile",
+			Format:        "dot",
+		})
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+		dot, ok := parsed["profile"].(string)
+		require.True(t, ok, "profile should be a string")
+		assert.Contains(t, dot, "digraph")
 	})
 
 	t.Run("query Pyroscope metrics only", func(t *testing.T) {

--- a/tools/pyroscope_unit_test.go
+++ b/tools/pyroscope_unit_test.go
@@ -1,9 +1,11 @@
 package tools
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,4 +144,107 @@ func TestQueryPyroscope_QueryTypeValidation(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+func TestQueryPyroscope_FormatValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		wantErr string
+	}{
+		{name: "invalid rejected", format: "unknown", wantErr: `invalid format "unknown"`},
+		{name: "flamegraph rejected", format: "flamegraph", wantErr: `invalid format "flamegraph"`},
+		{name: "json rejected", format: "json", wantErr: `invalid format "json"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := queryPyroscope(t.Context(), QueryPyroscopeParams{
+				DataSourceUID: "fake",
+				ProfileType:   "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				Format:        tc.format,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// testFlameGraph builds the flame graph for the call tree (values are quads
+// of [xOffset, total, self, nameIndex] with delta-encoded offsets):
+//
+//	total (180)
+//	+- main.entry (150) -> main.mid (150, self 50) -> main.mid (100, recursion) -> main.leaf (100)
+//	+- other (30, server-side truncation bucket)
+func testFlameGraph() *querierv1.FlameGraph {
+	return &querierv1.FlameGraph{
+		Names: []string{"total", "main.entry", "main.mid", "main.leaf", "other"},
+		Total: 180,
+		Levels: []*querierv1.Level{
+			{Values: []int64{0, 180, 0, 0}},
+			{Values: []int64{0, 150, 0, 1, 0, 30, 30, 4}},
+			{Values: []int64{0, 150, 50, 2}},
+			{Values: []int64{50, 100, 0, 2}},
+			{Values: []int64{50, 100, 100, 3}},
+		},
+	}
+}
+
+func TestBuildProfileTable(t *testing.T) {
+	table, err := buildProfileTable(testFlameGraph(), "nanoseconds", 100)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(table, "\n"), "\n")
+	require.Len(t, lines, 7, table)
+
+	assert.Equal(t, "Total: 180ns", lines[0])
+	assert.Equal(t, "Showing top 3 out of 3 functions by flat (self) value, accounting for 83.33% of the total", lines[1])
+	assert.Contains(t, lines[2], `16.67% of the total was collapsed into an "other" bucket`)
+	assert.Contains(t, lines[3], "flat%")
+	assert.Contains(t, lines[3], "cum%")
+
+	// Ranked by flat; recursion counted once in cum; entry gets cum only.
+	assert.Regexp(t, `^\s+100ns\s+55.56%\s+55.56%\s+100ns\s+55.56%\s+main.leaf$`, lines[4])
+	assert.Regexp(t, `^\s+50ns\s+27.78%\s+83.33%\s+150ns\s+83.33%\s+main.mid$`, lines[5])
+	assert.Regexp(t, `^\s+0\S*\s+0.00%\s+83.33%\s+150ns\s+83.33%\s+main.entry$`, lines[6])
+
+	assert.NotContains(t, table, `  other`, "truncation bucket must not appear as a function row")
+	assert.NotContains(t, table, `  total`, "synthetic root must not appear as a function row")
+}
+
+func TestBuildProfileTable_MaxRows(t *testing.T) {
+	table, err := buildProfileTable(testFlameGraph(), "nanoseconds", 1)
+	require.NoError(t, err)
+
+	assert.Contains(t, table, "Showing top 1 out of 3 functions by flat (self) value, accounting for 55.56% of the total")
+	assert.Contains(t, table, "main.leaf")
+	assert.NotContains(t, table, "main.mid")
+}
+
+func TestBuildProfileTable_Empty(t *testing.T) {
+	_, err := buildProfileTable(&querierv1.FlameGraph{Names: []string{"total"}, Levels: []*querierv1.Level{{Values: []int64{0, 0, 0, 0}}}}, "nanoseconds", 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty profile")
+
+	_, err = buildProfileTable(nil, "nanoseconds", 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty profile")
+}
+
+func TestSampleUnitFromProfileType(t *testing.T) {
+	assert.Equal(t, "nanoseconds", sampleUnitFromProfileType("process_cpu:cpu:nanoseconds:cpu:nanoseconds"))
+	assert.Equal(t, "bytes", sampleUnitFromProfileType("memory:alloc_space:bytes:space:bytes"))
+	assert.Equal(t, "", sampleUnitFromProfileType("garbage"))
+}
+
+func TestFormatSampleValue(t *testing.T) {
+	assert.Equal(t, "615.26s", formatSampleValue(615_260_000_000, "nanoseconds"))
+	assert.Equal(t, "1.50ms", formatSampleValue(1_500_000, "nanoseconds"))
+	assert.Equal(t, "2.00us", formatSampleValue(2_000, "nanoseconds"))
+	assert.Equal(t, "999ns", formatSampleValue(999, "nanoseconds"))
+	assert.Equal(t, "1.42GB", formatSampleValue(1_525_000_000, "bytes"))
+	assert.Equal(t, "1.45MB", formatSampleValue(1_525_000, "bytes"))
+	assert.Equal(t, "1.49kB", formatSampleValue(1_525, "bytes"))
+	assert.Equal(t, "42B", formatSampleValue(42, "bytes"))
+	assert.Equal(t, "12345", formatSampleValue(12345, "count"))
 }


### PR DESCRIPTION
We benchmark LLM agents on profiling-analysis tasks against Pyroscope through different tool surfaces (profilecli, gcx, grafana-mcp). grafana-mcp scored lowest for every model we tested, and the dominant cause is the profile representation `query_pyroscope` returns, not model capability.

`query_pyroscope` returns the Pyroscope render API's DOT call graph (`format=dot`, `max-nodes=100`). That representation goes through two truncations and a name-mangling step before the model sees it.

## What this PR does

- `query_pyroscope` profile output defaults to a per-function table in `pprof -top` style — `flat, flat%, sum%, cum, cum%, function` — built from `SelectMergeStacktraces` and aggregated per fully-qualified function name. The header reports coverage, and when the server collapsed part of the tree into the synthetic `other` bucket, a note reports the unattributable share instead of hiding it.
- DOT stays available via `format="dot"` for call-graph-shaped questions; `cleanupDotProfile` no longer deletes the `other` node, so the header percentages are precise.
- `max_node_depth` description now says what it does (max table rows / graph nodes — a count, not a depth). Renaming it would break existing callers now that unknown arguments are rejected (#997), so the name stays.

Sample output:

```
Total: 2.26s
Showing top 15 out of 826 functions by flat (self) value, accounting for 41.15% of the total
        flat  flat%   sum%          cum   cum%  function
    320.00ms 14.16% 14.16%     320.00ms 14.16%  internal/runtime/syscall.Syscall6
    130.00ms  5.75% 19.91%     130.00ms  5.75%  runtime.futex
     30.00ms  1.33% 29.20%     170.00ms  7.52%  runtime.mallocgc
```

## Benchmark evidence

Full before/after benchmark of this exact change: 19 profiling-analysis tasks x 3 attempts x 2 models, grafana-mcp tool surface only, identical corpus and harness - only the mcp-grafana binary differs (upstream main `20648a1` vs this branch):

| grafana-mcp agent | baseline (DOT) | this PR (table) |
|---|---:|---:|
| claude-opus-5 mean reward | 70.8% | **90.4%** |
| claude-opus-5 pass^3 | 47.4% | **73.7%** |
| claude-opus-5 pass@3 | 89.5% | **100%** |
| claude-sonnet-5 mean reward | 52.7% | **68.9%** |
| claude-sonnet-5 pass^3 | 31.6% | **42.1%** |
| claude-sonnet-5 pass@3 | 57.9% | **84.2%** |

The table build was also cheaper and faster for the same work (opus-5 cell: 12.1M vs 14.8M tokens, $66 vs $82, 73m vs 99m).

Notes:
- The table intentionally ranks by flat; entry-point functions with negligible self time appear only via the `cum` column of listed rows. Call-graph questions are what `format="dot"` remains for.
- A function literally named `other` would be mistaken for the truncation bucket; Pyroscope reserves that name for truncation everywhere else, and the previous code deleted such nodes outright.