### PR TITLE
Normalize GRAFANA_URL where it enters the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A `GRAFANA_URL` without a scheme is normalized where it enters the process, so the API client and the client cache resolve the same instance as the rest of the server. `GRAFANA_URL=127.0.0.1:3000` used to panic at startup, and a schemeless hostname produced requests with no host while tools built from `GrafanaConfig.URL` kept working ([#1032](https://github.com/grafana/mcp-grafana/issues/1032))
+- A `GRAFANA_URL` without a scheme is normalized where it enters the process, so the API client and the client cache resolve the same instance as the rest of the server. `GRAFANA_URL=127.0.0.1:3000` used to panic at startup, and a schemeless hostname produced requests with no host while tools built from `GrafanaConfig.URL` kept working ([#1034](https://github.com/grafana/mcp-grafana/pull/1034))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agent Observability tool `agento11y_manage_eval_collections`, in the opt-in `agento11y` category. Reads cover saved conversations, the collections that group them, and the membership in both directions. The write operations (bookmark and delete a saved conversation; create, update, and delete a collection; add and remove collection members) need `grafana-agento11y-app.eval:write` and are registered only when write tools are enabled
 - Agent Observability eval control-plane tools `agento11y_manage_evaluators` and `agento11y_manage_eval_rules`, in the opt-in `agento11y` category. Reads cover evaluators, evaluator templates, template versions, the judge provider and model catalog, eval rules, and guards. The write operations (evaluator upsert, fork, test, and delete; rule and guard create, update, preview, and delete) need `grafana-agento11y-app.eval:write` and are registered only when write tools are enabled ([#1028](https://github.com/grafana/mcp-grafana/pull/1028))
 
+### Fixed
+
+- A `GRAFANA_URL` without a scheme is normalized where it enters the process, so the API client and the client cache resolve the same instance as the rest of the server. `GRAFANA_URL=127.0.0.1:3000` used to panic at startup, and a schemeless hostname produced requests with no host while tools built from `GrafanaConfig.URL` kept working ([#1032](https://github.com/grafana/mcp-grafana/issues/1032))
+
 ### Changed
 
 - `query_pyroscope` now returns a per-function table (`pprof -top` style: flat/cum per fully-qualified function name) by default instead of a line-level DOT call graph. The DOT call graph remains available via `format="dot"` and no longer deletes the `other` truncation node ([#1025](https://github.com/grafana/mcp-grafana/pull/1025))

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -53,10 +53,6 @@ const (
 )
 
 func urlAndAPIKeyFromEnv(logger *slog.Logger) (string, string) {
-	// Normalized here, at the point the value enters the process, so that every
-	// consumer — the config in the context, the API client, and the client cache
-	// key — derives from the same URL. Normalizing only in WithGrafanaConfig left
-	// the earlier consumers reading the raw string.
 	u := normalizeGrafanaURL(os.Getenv(grafanaURLEnvVar))
 
 	// Check for the new service account token environment variable first.

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -53,7 +53,11 @@ const (
 )
 
 func urlAndAPIKeyFromEnv(logger *slog.Logger) (string, string) {
-	u := strings.TrimRight(os.Getenv(grafanaURLEnvVar), "/")
+	// Normalized here, at the point the value enters the process, so that every
+	// consumer — the config in the context, the API client, and the client cache
+	// key — derives from the same URL. Normalizing only in WithGrafanaConfig left
+	// the earlier consumers reading the raw string.
+	u := normalizeGrafanaURL(os.Getenv(grafanaURLEnvVar))
 
 	// Check for the new service account token environment variable first.
 	apiKey := os.Getenv(grafanaServiceAccountTokenEnvVar)

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -9,12 +9,14 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/go-openapi/runtime/client"
 	grafana_client "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2284,4 +2286,149 @@ func TestBuildTransportContextOverrides(t *testing.T) {
 		assert.Equal(t, "10", capturedReq.Header.Get(grafana_client.OrgIDHeader))
 		assert.Equal(t, "val", capturedReq.Header.Get("X-Custom"))
 	})
+}
+
+// normalizeGrafanaURL accepts a schemeless GRAFANA_URL and TestNormalizeGrafanaURL
+// pins that behavior, but it used to run only at the end of the chain, in
+// WithGrafanaConfig. Consumers reading the environment value earlier saw the raw
+// string and disagreed with GrafanaConfig.URL about the target instance — see
+// https://github.com/grafana/mcp-grafana/issues/1032.
+
+// The normalizer runs at the environment boundary and again in
+// WithGrafanaConfig, so it has to be idempotent: a second pass must not move the
+// value.
+func TestNormalizeGrafanaURLIsIdempotent(t *testing.T) {
+	for _, raw := range []string{
+		"",
+		"   ",
+		"https://grafana.example.com",
+		"https://grafana.example.com/",
+		"https://grafana.example.com///",
+		"  https://grafana.example.com/  ",
+		"grafana.example.com",
+		"grafana.example.com/grafana/",
+		"localhost:3000",
+		"127.0.0.1:3000",
+		"[::1]:3000",
+		"http://grafana.example.com/grafana",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			once := normalizeGrafanaURL(raw)
+			assert.Equal(t, once, normalizeGrafanaURL(once), "second pass changed the value")
+		})
+	}
+}
+
+// Whatever spelling of GRAFANA_URL the operator uses, GrafanaConfig.URL and the
+// API client must resolve to the same place — including the path, which subpath
+// deployments depend on.
+func TestEnvURLSpellingsAgreeAcrossConsumers(t *testing.T) {
+	cases := []struct {
+		name string
+		// %s is replaced with the test server's host:port
+		envTemplate string
+		wantConfig  string
+		wantPath    string
+	}{
+		{"canonical", "http://%s", "http://%s", "/api/datasources"},
+		{"trailing slash", "http://%s/", "http://%s", "/api/datasources"},
+		{"surrounding whitespace", "  http://%s  ", "http://%s", "/api/datasources"},
+		{"schemeless loopback defaults to http", "%s", "http://%s", "/api/datasources"},
+		{"subpath preserved", "http://%s/grafana", "http://%s/grafana", "/grafana/api/datasources"},
+		{"schemeless subpath", "%s/grafana/", "http://%s/grafana", "/grafana/api/datasources"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPaths []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPaths = append(gotPaths, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer srv.Close()
+			hostPort := strings.TrimPrefix(srv.URL, "http://")
+
+			t.Setenv("GRAFANA_URL", strings.ReplaceAll(tc.envTemplate, "%s", hostPort))
+
+			var ctx context.Context
+			require.NotPanics(t, func() {
+				ctx = ExtractGrafanaInfoFromEnv(context.Background())
+			})
+			assert.Equal(t, strings.ReplaceAll(tc.wantConfig, "%s", hostPort), GrafanaConfigFromContext(ctx).URL)
+
+			ctx = ExtractGrafanaClientFromEnv(ctx)
+			_, err := GrafanaClientFromContext(ctx).Datasources.GetDataSourcesWithParams(
+				datasources.NewGetDataSourcesParamsWithContext(ctx),
+			)
+			require.NoError(t, err)
+			assert.Contains(t, gotPaths, tc.wantPath,
+				"the API client did not reach the configured host and path; saw %v", gotPaths)
+		})
+	}
+}
+
+// An unset or blank GRAFANA_URL must still fall back to the documented default
+// rather than producing a client with no host.
+func TestBlankEnvURLFallsBackToDefault(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		t.Run(strconv.Quote(raw), func(t *testing.T) {
+			t.Setenv("GRAFANA_URL", raw)
+			config := GrafanaConfigFromContext(ExtractGrafanaInfoFromEnv(context.Background()))
+			assert.Equal(t, defaultGrafanaURL, config.URL)
+		})
+	}
+}
+
+// Normalizing the environment URL must not move the boundary that binds
+// environment credentials to the environment instance.
+func TestSchemelessEnvURLKeepsCredentialBinding(t *testing.T) {
+	const envToken = "env-service-account-token"
+
+	t.Run("same instance spelled with a scheme still receives env credentials", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "grafana.example.com")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "https://grafana.example.com")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Equal(t, envToken, config.APIKey)
+	})
+
+	t.Run("foreign URL still has env credentials withheld", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "grafana.example.com")
+		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set(grafanaURLHeader, "https://attacker.example.com")
+
+		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+		assert.Empty(t, config.APIKey, "env token must not be sent to a caller-specified URL")
+	})
+}
+
+// The cached client extractors derive their cache key from the URL the request
+// resolves to, so spellings of GRAFANA_URL that name one instance must collapse
+// to one value before they reach the key — otherwise a single instance occupies
+// an extra cache entry per spelling.
+func TestEnvURLSpellingsResolveToOneValue(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+
+	const canonical = "https://grafana.example.com"
+	for _, spelling := range []string{
+		canonical,
+		canonical + "/",
+		"  " + canonical + "  ",
+		"grafana.example.com",
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			t.Setenv("GRAFANA_URL", spelling)
+			resolvedURL, _, _, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
+			assert.Equal(t, canonical, resolvedURL)
+		})
+	}
 }

--- a/validate_url_test.go
+++ b/validate_url_test.go
@@ -38,6 +38,12 @@ func TestValidateGrafanaURL(t *testing.T) {
 		// Invalid inputs.
 		{"empty string", "", true},
 		{"slash-only trims to empty", "/", true},
+		// A schemeless value is accepted from GRAFANA_URL, where
+		// normalizeGrafanaURL supplies the scheme, but not from a caller-supplied
+		// header: guessing a scheme for a caller-controlled host would widen what
+		// the header is allowed to name.
+		{"schemeless host rejected", "grafana.example.com", true},
+		{"schemeless host and port rejected", "grafana.example.com:3000", true},
 		{"plain text", "not a url", true},
 		{"invalid percent encoding", "http://%gg", true},
 		{"javascript scheme", "javascript:alert(1)", true},
@@ -84,6 +90,7 @@ func TestValidateGrafanaURLMiddleware(t *testing.T) {
 		{"malformed percent encoding rejected", true, "http://%gg", http.StatusBadRequest, false},
 		{"javascript scheme rejected", true, "javascript:alert(1)", http.StatusBadRequest, false},
 		{"relative path rejected", true, "/relative", http.StatusBadRequest, false},
+		{"schemeless header rejected", true, "grafana.example.com", http.StatusBadRequest, false},
 		{"trim-to-empty slash rejected", true, "/", http.StatusBadRequest, false},
 		{"empty host rejected", true, "http://", http.StatusBadRequest, false},
 		{"CR-LF injection attempt rejected", true, "http://foo\r\nX-Injected: 1", http.StatusBadRequest, false},

--- a/validate_url_test.go
+++ b/validate_url_test.go
@@ -38,10 +38,6 @@ func TestValidateGrafanaURL(t *testing.T) {
 		// Invalid inputs.
 		{"empty string", "", true},
 		{"slash-only trims to empty", "/", true},
-		// A schemeless value is accepted from GRAFANA_URL, where
-		// normalizeGrafanaURL supplies the scheme, but not from a caller-supplied
-		// header: guessing a scheme for a caller-controlled host would widen what
-		// the header is allowed to name.
 		{"schemeless host rejected", "grafana.example.com", true},
 		{"schemeless host and port rejected", "grafana.example.com:3000", true},
 		{"plain text", "not a url", true},


### PR DESCRIPTION
## Summary

`normalizeGrafanaURL` trims the trailing slash and supplies a missing scheme, and `TestNormalizeGrafanaURL` pins that behavior — including `"127.0.0.1:3000" → "http://127.0.0.1:3000"`. But it ran only at the end of the chain, in `WithGrafanaConfig`. Consumers that read the environment value earlier (`ExtractGrafanaInfoFromEnv`, `ExtractGrafanaClientFromEnv`, and the cached extractors) saw the raw string, so they disagreed with `GrafanaConfig.URL` about which instance to talk to.

This moves the normalization into `urlAndAPIKeyFromEnv`, where the value enters the process, so the config, the API client and the cache key all derive from one URL.

## Before / after

Measured with `-t stdio` on a build of this branch versus `main`:

| `GRAFANA_URL` | before | after |
| --- | --- | --- |
| `127.0.0.1:3000` | `panic: invalid Grafana URL 127.0.0.1:3000: parse …: first path segment in URL cannot contain colon` | starts; requests go to `http://127.0.0.1:3000` |
| `grafana.example.com` | `Get "https:///grafana.example.com/api/datasources": http: no Host in request URL` | `Get "https://grafana.example.com/api/datasources"` |
| `grafana.example.com/grafana` | hostless request | `https://grafana.example.com/grafana/api/frontend/settings` |
| `http://localhost:3000` | works | unchanged |

In the schemeless cases `GrafanaConfig.URL` was already correct, so tools that build requests from it kept working while everything going through the generated OpenAPI client failed — a tool surface split in half by one configuration value.

## Scope: the header path is deliberately untouched

`X-Grafana-URL` is still taken as-is. `ValidateGrafanaURLMiddleware` rejects a schemeless header today, and having the server guess a scheme for a caller-supplied host would widen what that header is allowed to name — a decision for maintainers, not a side effect of this fix. This PR adds test cases pinning that boundary (`schemeless host rejected`, `schemeless header rejected` → 400).

I also tried normalizing the client-cache key so that spellings of one instance share an entry, and dropped it: the cached client is still constructed from the raw URL, so a normalized key would let a broken client built from one spelling be reused by every other spelling. Normalizing at the source gives the same collapsing for environment-derived URLs without that hazard.

## Validation

New coverage, and what each part is for:

- proves the fix (fails if the normalization is reverted to the old `strings.TrimRight`): schemeless, whitespace-padded and schemeless-subpath spellings of `GRAFANA_URL` all resolve to the same URL in `GrafanaConfig`, in the path the API client actually requests, and in the value the cached extractors key on;
- regression guards (green either way, by design): `normalizeGrafanaURL` is idempotent — it now runs twice, at the boundary and in `WithGrafanaConfig`; environment credentials are still bound to the environment instance when `GRAFANA_URL` is schemeless (same instance keeps the token, a foreign host does not); a blank `GRAFANA_URL` still falls back to the default.

`go test -race -count=1 -tags unit ./...` and `make lint` are clean.

Fixes #1032
