### PR TITLE
insight-cell 1/3: render substrate — contract, tool, and app registry (Go only)

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -78,6 +78,7 @@ var categoryDescription = map[string]string{
 	"provisioning":  "Provisioning: List provisioning repositories (e.g. git-sync sources) to discover repository slugs for use with rendering tools.",
 	"agento11y":     "Agent Observability: Search and inspect LLM conversations, generations, and evaluation scores from Grafana Agent Observability, and read or manage its eval configuration (evaluators, templates, eval rules, and guards) and its curated saved conversations and collections.",
 	"assistant":     "Assistant: Ask Grafana Assistant open-ended questions and get a full text reply (requires the Grafana Assistant plugin).",
+	"insight-cell":  "Insight Cell: Package data you've gathered as a structured 'insight cell' result (a core panel, logs, trace, or a synthesis view: worklist/rca/timeline/cost) with a verdict, attestation and provenance.",
 }
 
 // disabledTools indicates whether each category of tools should be disabled.
@@ -90,7 +91,7 @@ type disabledTools struct {
 	pyroscope, navigation, proxied, annotations, rendering, cloudwatch, write,
 	snapshot, examples, clickhouse, snowflake, graphite,
 	runpanelquery, athena, plugin, api, config, provisioning,
-	agento11y, assistant bool
+	agento11y, assistant, insightcell bool
 }
 
 // Configuration for the Grafana client.
@@ -151,6 +152,7 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.provisioning, "disable-provisioning", false, "Disable provisioning tools")
 	flag.BoolVar(&dt.agento11y, "disable-agento11y", false, "Disable Agent Observability tools")
 	flag.BoolVar(&dt.assistant, "disable-assistant", false, "Disable Grafana Assistant tools")
+	flag.BoolVar(&dt.insightcell, "disable-insight-cell", false, "Disable insight-cell tools. Opt-in: not in the default --enabled-tools list; add 'insight-cell' there to enable.")
 }
 
 func (gc *grafanaConfig) addFlags() {
@@ -215,6 +217,7 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{tools.AddProvisioningTools, dt.provisioning, "provisioning"},
 		{func(mcp *server.MCPServer) { tools.AddAgento11yTools(mcp, enableWriteTools) }, dt.agento11y, "agento11y"},
 		{func(mcp *server.MCPServer) { tools.AddAssistantTools(mcp, enableWriteTools) }, dt.assistant, "assistant"},
+		{tools.AddInsightCellTools, dt.insightcell, "insight-cell"},
 	}
 }
 

--- a/tools/insight_cell.go
+++ b/tools/insight_cell.go
@@ -1,0 +1,628 @@
+// The insight-cell tool packages any Grafana result the agent has gathered as a
+// structured "insight cell" — a core panel (timeseries/stat/bar/table), a
+// logs/trace view, or a synthesis view (worklist/rca/timeline/cost) — carrying
+// a verdict, attestation, provenance and follow-up actions.
+//
+// It is a *render substrate*: the agent does the analysis with the existing query
+// tools (query_prometheus, query_loki_logs, alerting_manage_rules, get_annotations,
+// …) and hands the assembled data here; the tool packages it into the render
+// contract and the trust metadata. It does NOT query datasources or fabricate data
+// itself, and the cell is structurally read-only: it can never invoke another MCP
+// tool (see sanitizeActions). Writes go through the agent.
+//
+// The result rides three channels so it degrades across hosts:
+//   - content[0]  a text verdict (what hosts without MCP Apps surface)
+//   - content[1]  an embedded application/json resource block (kept by hosts that
+//     drop structuredContent, e.g. Claude Desktop, which converts it
+//     to a text block an app can scan)
+//   - structuredContent  the insightCell (the spec channel)
+//
+// plus _meta = { "grafana.insightCell/v0": <trust profile> }.
+//
+// The MCP App that renders this contract visually (a sandboxed-iframe UI served
+// over the Resources API, per docs/mcp-apps.md) ships in a follow-up PR; until
+// then hosts consume the text verdict and the JSON payload.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// insightCellMetaKey is the _meta namespace for the insight-cell trust profile.
+const insightCellMetaKey = "grafana.insightCell/v0"
+
+// --- Render contract ----------------------------------------------------------
+// JSON field names are the contract the (follow-up) insight-cell UI reads —
+// they must stay in lockstep with its schema.ts mirror once that lands.
+
+type icField struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"` // time | number | string
+	Values []any  `json:"values"`
+	Unit   string `json:"unit,omitempty"`
+	Color  string `json:"color,omitempty"`
+}
+
+type icDataFrame struct {
+	Name   string    `json:"name,omitempty"`
+	RefID  string    `json:"refId,omitempty"`
+	Fields []icField `json:"fields"`
+}
+
+type icThreshold struct {
+	Value float64 `json:"value"`
+	Color string  `json:"color"`
+	Label string  `json:"label,omitempty"`
+}
+
+type icValueMapping struct {
+	Type  string   `json:"type"` // value | range
+	Value any      `json:"value,omitempty"`
+	From  *float64 `json:"from,omitempty"` // pointer so a legitimate 0 bound isn't dropped
+	To    *float64 `json:"to,omitempty"`   // pointer so a legitimate 0 bound isn't dropped
+	Text  string   `json:"text,omitempty"`
+	Color string   `json:"color,omitempty"`
+}
+
+type icRenderHint struct {
+	Type        string           `json:"type"`
+	Title       string           `json:"title"`
+	Unit        string           `json:"unit,omitempty"`
+	Decimals    *int             `json:"decimals,omitempty"`
+	Thresholds  []icThreshold    `json:"thresholds,omitempty"`
+	Mappings    []icValueMapping `json:"mappings,omitempty"`
+	Description string           `json:"description,omitempty"`
+	ValueField  string           `json:"valueField,omitempty"`
+	Sort        string           `json:"sort,omitempty"`
+	Target      *float64         `json:"target,omitempty"` // bullet: target/SLO marker
+	Max         *float64         `json:"max,omitempty"`    // bullet: axis max
+}
+
+type icLogLine struct {
+	Time   string            `json:"time"`
+	Level  string            `json:"level"`
+	Line   string            `json:"line"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type icTraceSpan struct {
+	ID         string         `json:"id"`
+	ParentID   string         `json:"parentId,omitempty"`
+	Name       string         `json:"name"`
+	Service    string         `json:"service"`
+	StartMs    float64        `json:"startMs"`
+	DurationMs float64        `json:"durationMs"`
+	Status     string         `json:"status,omitempty"`
+	Tags       map[string]any `json:"tags,omitempty"`
+	RootCause  bool           `json:"rootCause,omitempty"`
+}
+
+type icTracePayload struct {
+	TraceID    string        `json:"traceId"`
+	DurationMs float64       `json:"durationMs"`
+	Spans      []icTraceSpan `json:"spans"`
+}
+
+// icAction is a cell action. Kinds are deliberately limited to ones that keep
+// the cell read-only: "link" opens a URL via the host, "refresh" re-runs
+// render_insight_cell with the same payload, and "ask" hands text back to the
+// agent as the next message. There is no kind that invokes an arbitrary MCP
+// tool from inside the cell — that would make the tool's ReadOnlyHint a lie.
+type icAction struct {
+	Label   string `json:"label"`
+	Kind    string `json:"kind"` // link | refresh | ask
+	URL     string `json:"url,omitempty"`
+	Text    string `json:"text,omitempty"`
+	Primary bool   `json:"primary,omitempty"`
+	Icon    string `json:"icon,omitempty"`
+}
+
+type icWorklistItem struct {
+	Title      string     `json:"title"`
+	Priority   string     `json:"priority,omitempty"`
+	Status     string     `json:"status,omitempty"`
+	StatusTone string     `json:"statusTone,omitempty"`
+	Why        string     `json:"why,omitempty"`
+	Actions    []icAction `json:"actions,omitempty"`
+}
+
+type icRcaRoot struct {
+	Title      string `json:"title"`
+	Confidence string `json:"confidence"`
+	Detail     string `json:"detail,omitempty"`
+}
+
+type icRcaFinding struct {
+	Title    string `json:"title"`
+	Kind     string `json:"kind,omitempty"`
+	Severity string `json:"severity,omitempty"`
+	Detail   string `json:"detail,omitempty"`
+	Evidence string `json:"evidence,omitempty"`
+}
+
+type icRcaPayload struct {
+	RootCause *icRcaRoot     `json:"rootCause,omitempty"`
+	Checks    []string       `json:"checks,omitempty"`
+	Findings  []icRcaFinding `json:"findings"`
+}
+
+type icChangeEvent struct {
+	Time       string   `json:"time"`
+	Title      string   `json:"title"`
+	Kind       string   `json:"kind,omitempty"`
+	Detail     string   `json:"detail,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+	Correlated bool     `json:"correlated,omitempty"`
+}
+
+type icTimelinePayload struct {
+	From   string          `json:"from"`
+	To     string          `json:"to"`
+	Events []icChangeEvent `json:"events"`
+}
+
+type icCostDriver struct {
+	Name   string   `json:"name"`
+	Series *float64 `json:"series,omitempty"` // pointer so a legitimate 0 isn't dropped
+	Value  *float64 `json:"value,omitempty"`  // pointer so a legitimate 0 isn't dropped
+	Unit   string   `json:"unit,omitempty"`
+	Pct    *float64 `json:"pct,omitempty"` // pointer so a legitimate 0% isn't dropped
+	Note   string   `json:"note,omitempty"`
+}
+
+type icCostTotal struct {
+	Label string  `json:"label"`
+	Value float64 `json:"value"`
+	Unit  string  `json:"unit,omitempty"`
+}
+
+type icCostHeadroom struct {
+	Label  string `json:"label"`
+	Detail string `json:"detail"`
+}
+
+type icCostPayload struct {
+	Total    *icCostTotal    `json:"total,omitempty"`
+	Drivers  []icCostDriver  `json:"drivers"`
+	Headroom *icCostHeadroom `json:"headroom,omitempty"`
+}
+
+type icCallout struct {
+	Tone  string `json:"tone"` // warn | crit | info
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+type icQueryRef struct {
+	Ref           string `json:"ref"`
+	Expr          string `json:"expr"`
+	DatasourceUID string `json:"datasourceUid"`
+}
+
+// icAttestation and icProvenance are agent-declared, not verified: the server
+// cannot check that the frames actually came from the recorded query and
+// datasource — it repackages what the agent gathered. Hence "renderedBy"
+// (what this server did) rather than "author" (which would imply the data
+// itself is vouched for), and "declaredLive"/"declared" wording in the UI.
+type icAttestation struct {
+	AsOf string `json:"asOf"`
+	Live bool   `json:"live"` // agent declared a query + datasource; not verified
+}
+
+type icProvenance struct {
+	RenderedBy string `json:"renderedBy"` // who packaged/rendered the cell, not who produced the data
+	Datasource string `json:"datasource"` // agent-declared origin of the data
+	OrgID      int    `json:"orgId,omitempty"`
+	RBACScope  string `json:"rbacScope,omitempty"`
+}
+
+type icMeta struct {
+	Question    string        `json:"question"`
+	Verdict     string        `json:"verdict"`
+	Confidence  string        `json:"confidence"`
+	TimeRange   icTimeRange   `json:"timeRange"`
+	Attestation icAttestation `json:"attestation"`
+	Provenance  icProvenance  `json:"provenance"`
+	Query       []icQueryRef  `json:"query"`
+	DataMode    string        `json:"dataMode"` // agent-supplied | synthesized (declared, not verified)
+}
+
+type icTimeRange struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// insightCell is the full render contract emitted as structuredContent.
+type insightCell struct {
+	RenderHint icRenderHint       `json:"renderHint"`
+	Frames     []icDataFrame      `json:"frames,omitempty"`
+	Logs       []icLogLine        `json:"logs,omitempty"`
+	Trace      *icTracePayload    `json:"trace,omitempty"`
+	Worklist   []icWorklistItem   `json:"worklist,omitempty"`
+	RCA        *icRcaPayload      `json:"rca,omitempty"`
+	Timeline   *icTimelinePayload `json:"timeline,omitempty"`
+	Cost       *icCostPayload     `json:"cost,omitempty"`
+	Callout    *icCallout         `json:"callout,omitempty"`
+	Actions    []icAction         `json:"actions"`
+	Meta       icMeta             `json:"meta"`
+}
+
+// --- Tool input --------------------------------------------------------------
+
+// RenderInsightCellParams is what the agent supplies after it has gathered the
+// data. Populate only the fields relevant to `panel`; everything else is optional.
+type RenderInsightCellParams struct {
+	Panel string `json:"panel" jsonschema:"required,enum=timeseries,enum=stat,enum=bullet,enum=bar,enum=table,enum=logs,enum=trace,enum=worklist,enum=rca,enum=timeline,enum=cost,description=Which panel type to render. Core panels (timeseries/stat/bar/table) read 'frames'. 'bullet' = a single value vs a target/SLO with qualitative threshold bands (reads 'frames' + target/max; more compact than a gauge). 'logs'/'trace' read their own fields. Synthesis views: 'worklist' = ranked actionable findings (alert triage/deprecations); 'rca' = root-cause investigation (findings->root cause->evidence); 'timeline' = change-correlation (deploys/config/alerts on a time axis); 'cost' = cost/cardinality drivers."`
+
+	Title      string `json:"title,omitempty" jsonschema:"description=Panel title / the question being answered."`
+	Verdict    string `json:"verdict,omitempty" jsonschema:"description=One-line answer shown as the insight title (your conclusion about the data)."`
+	Insight    string `json:"insight,omitempty" jsonschema:"description=2-4 sentence explanation shown under the title: what the data shows and why it matters."`
+	Confidence string `json:"confidence,omitempty" jsonschema:"enum=low,enum=medium,enum=high,description=Your confidence in the verdict. Defaults to medium."`
+
+	Query         string `json:"query,omitempty" jsonschema:"description=The PromQL/LogQL/TraceQL expression the data came from (recorded as agent-declared provenance; not executed or verified here)."`
+	DatasourceUID string `json:"datasourceUid,omitempty" jsonschema:"description=UID of the datasource the data came from (recorded as agent-declared provenance; not verified here)."`
+	RangeHours    *int   `json:"rangeHours,omitempty" jsonschema:"description=Look-back window in hours for the recorded time range (default 1)."`
+	DataAsOf      string `json:"dataAsOf,omitempty" jsonschema:"description=RFC3339 timestamp of when you actually gathered the data from the query tools. Defaults to now\\, which is only correct if you just fetched it. Keep the original stamp when re-rendering the same data (the cell's refresh action does this automatically) so stale data never claims to be fresh."`
+
+	// renderHint field config (chart types)
+	Unit       string           `json:"unit,omitempty" jsonschema:"description=Grafana unit id so values format like Grafana: bytes\\, s\\, ms\\, percent\\, percentunit\\, reqps\\, short\\, Bps\\, ..."`
+	Decimals   *int             `json:"decimals,omitempty" jsonschema:"description=Fixed decimal places; omit for automatic precision."`
+	Thresholds []icThreshold    `json:"thresholds,omitempty" jsonschema:"description=Threshold steps: a value at/above a step takes its color (colors the stat value and draws a line on timeseries)."`
+	Mappings   []icValueMapping `json:"mappings,omitempty" jsonschema:"description=Value mappings: map a specific value or numeric range to display text/color."`
+	ValueField string           `json:"valueField,omitempty" jsonschema:"description=stat: which field to read as the value (default: last numeric field)."`
+	Sort       string           `json:"sort,omitempty" jsonschema:"enum=desc,enum=asc,enum=none,description=bar: sort direction for ranked bars."`
+	Target     *float64         `json:"target,omitempty" jsonschema:"description=bullet: the target/SLO marker drawn as a tick."`
+	Max        *float64         `json:"max,omitempty" jsonschema:"description=bullet: axis max; omit to derive from value/target/thresholds."`
+
+	// Data channels (populate the one matching `panel`)
+	Frames []icDataFrame    `json:"frames,omitempty" jsonschema:"description=For timeseries/stat/bar/table: the columnar data (Grafana-style frames) you got from a query tool. A frame has fields[] each with name\\, type (time|number|string) and values[]."`
+	Logs   []icLogLine      `json:"logs,omitempty" jsonschema:"description=For panel='logs': the log lines (time ISO\\, level\\, line\\, optional labels)."`
+	Trace  *icTracePayload  `json:"trace,omitempty" jsonschema:"description=For panel='trace': the trace waterfall (traceId\\, durationMs\\, spans[])."`
+	Items  []icWorklistItem `json:"items,omitempty" jsonschema:"description=For panel='worklist': the ranked findings you synthesized. Rank by priority and put your correlation in each item's 'why' — that reasoning is the value."`
+
+	// rca
+	RootCause *icRcaRoot     `json:"rootCause,omitempty" jsonschema:"description=For panel='rca': your root-cause hypothesis (title\\, confidence\\, detail)."`
+	Checks    []string       `json:"checks,omitempty" jsonschema:"description=For panel='rca': what you examined (error logs\\, slow requests\\, recent deploys\\, ...)."`
+	Findings  []icRcaFinding `json:"findings,omitempty" jsonschema:"description=For panel='rca': ranked findings with evidence\\, ideally from Sift / find_slow_requests / find_error_pattern_logs / get_annotations."`
+
+	// timeline
+	Events []icChangeEvent `json:"events,omitempty" jsonschema:"description=For panel='timeline': change events (deploys/config/alerts) to correlate against an incident. Mark the correlated one."`
+	From   string          `json:"from,omitempty" jsonschema:"description=For panel='timeline': ISO window start."`
+	To     string          `json:"to,omitempty" jsonschema:"description=For panel='timeline': ISO window end."`
+
+	// cost
+	Drivers   []icCostDriver  `json:"drivers,omitempty" jsonschema:"description=For panel='cost': ranked cost/cardinality drivers."`
+	CostTotal *icCostTotal    `json:"costTotal,omitempty" jsonschema:"description=For panel='cost': the headline total\\, e.g. {label:'1.2M active series'\\, value:1200000}."`
+	Headroom  *icCostHeadroom `json:"headroom,omitempty" jsonschema:"description=For panel='cost': the headroom trade-off making 'adding headroom costs money' explicit."`
+
+	// chrome
+	Callout *icCallout `json:"callout,omitempty" jsonschema:"description=Optional callout banner shown above the panel (tone: warn|crit|info)."`
+	Actions []icAction `json:"actions,omitempty" jsonschema:"description=Follow-up actions shown under the panel. kind 'link' opens a URL; 'refresh' re-runs render_insight_cell with the same payload; 'ask' sends the action's text back to you (the agent) as the next message. The cell is read-only and cannot invoke MCP tools itself — for a write\\, add an 'ask' action (e.g. label 'Apply this change') whose text asks you to perform it with the appropriate write-gated tool\\, then re-render the cell."`
+}
+
+// --- Handler -----------------------------------------------------------------
+
+// panelNames mirrors the enum on RenderInsightCellParams.Panel. The jsonschema
+// enum is advisory to the model only — nothing enforces it at call time — so
+// the handler validates against this list itself.
+var panelNames = []string{
+	"timeseries", "stat", "bullet", "bar", "table",
+	"logs", "trace",
+	"worklist", "rca", "timeline", "cost",
+}
+
+var validPanels = func() map[string]bool {
+	m := make(map[string]bool, len(panelNames))
+	for _, p := range panelNames {
+		m[p] = true
+	}
+	return m
+}()
+
+func renderInsightCell(ctx context.Context, args RenderInsightCellParams) (*mcp.CallToolResult, error) {
+	cell, err := buildInsightCell(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return insightCellResult(cell)
+}
+
+func buildInsightCell(ctx context.Context, args RenderInsightCellParams) (*insightCell, error) {
+	if args.Panel == "" {
+		return nil, fmt.Errorf("panel is required")
+	}
+	if !validPanels[args.Panel] {
+		return nil, fmt.Errorf("unknown panel %q, must be one of: %s", args.Panel, strings.Join(panelNames, ", "))
+	}
+
+	confidence := args.Confidence
+	if confidence == "" {
+		confidence = "medium"
+	}
+
+	title := args.Title
+	if title == "" {
+		title = args.Verdict
+	}
+	if title == "" {
+		title = defaultTitleForPanel(args.Panel)
+	}
+
+	// Anchor the recorded time range and attestation on when the data was
+	// gathered, not on when this handler runs: a refresh replays the same data
+	// through this tool, and stamping time.Now() would make stale data claim to
+	// be fresh. First renders (no dataAsOf) default to now, which matches the
+	// "query first, then render" flow the tool description prescribes.
+	anchor := time.Now().UTC()
+	if args.DataAsOf != "" {
+		parsed, err := time.Parse(time.RFC3339, args.DataAsOf)
+		if err != nil {
+			return nil, fmt.Errorf("dataAsOf must be an RFC3339 timestamp, got %q: %w", args.DataAsOf, err)
+		}
+		anchor = parsed.UTC()
+	}
+	rangeHours := 1
+	if args.RangeHours != nil && *args.RangeHours > 0 {
+		rangeHours = *args.RangeHours
+	}
+	fromISO := anchor.Add(-time.Duration(rangeHours) * time.Hour).Format(time.RFC3339)
+	toISO := anchor.Format(time.RFC3339)
+
+	// Provenance / attestation. "agent-supplied" means the agent *declared* a
+	// query + datasource it read the data from — it should be real, but the
+	// server cannot verify that the frames actually came from that query.
+	// "synthesized" means no such declaration: representative/sample content or
+	// synthesis-view material assembled by the agent. Deliberately not called
+	// "live"/"mock" so the label never claims more than the server can check —
+	// see the icAttestation/icProvenance comment.
+	live := args.Query != "" && args.DatasourceUID != ""
+	dataMode := "synthesized"
+	if live {
+		dataMode = "agent-supplied"
+	}
+	datasource := "sample (no datasource declared)"
+	if live {
+		// Prefer the public app URL (what a user can actually open) over the
+		// configured URL, which may be an in-cluster endpoint. This string shows
+		// in the cell header, text fallback, and trust _meta.
+		base, err := grafanaBaseURLFromContext(ctx)
+		if err != nil || base == "" {
+			base = mcpgrafana.GrafanaConfigFromContext(ctx).URL
+		}
+		if base != "" {
+			datasource = fmt.Sprintf("%s (%s)", base, args.DatasourceUID)
+		} else {
+			datasource = args.DatasourceUID
+		}
+	} else if args.DatasourceUID != "" {
+		datasource = args.DatasourceUID
+	}
+
+	// Always an array (never nil): the UI iterates meta.query and refresh reads
+	// query[0], so a JSON null would blank the common no-query (sample) path.
+	queries := []icQueryRef{}
+	if args.Query != "" {
+		queries = []icQueryRef{{Ref: "A", Expr: args.Query, DatasourceUID: args.DatasourceUID}}
+	}
+
+	hint := icRenderHint{
+		Type:        args.Panel,
+		Title:       title,
+		Unit:        args.Unit,
+		Decimals:    args.Decimals,
+		Thresholds:  args.Thresholds,
+		Mappings:    args.Mappings,
+		Description: args.Insight,
+		ValueField:  args.ValueField,
+		Sort:        args.Sort,
+		Target:      args.Target,
+		Max:         args.Max,
+	}
+
+	cell := &insightCell{
+		RenderHint: hint,
+		Frames:     args.Frames,
+		Logs:       args.Logs,
+		Trace:      args.Trace,
+		Worklist:   args.Items,
+		Callout:    args.Callout,
+		Actions:    args.Actions,
+		Meta: icMeta{
+			Question:    title,
+			Verdict:     verdictOrDefault(args.Verdict, args.Panel),
+			Confidence:  confidence,
+			TimeRange:   icTimeRange{From: fromISO, To: toISO},
+			Attestation: icAttestation{AsOf: toISO, Live: live},
+			Provenance:  icProvenance{RenderedBy: "Grafana MCP", Datasource: datasource},
+			Query:       queries,
+			DataMode:    dataMode,
+		},
+	}
+	// These slice fields are marshalled without omitempty and the UI iterates
+	// them, so a nil slice (JSON `null`) would make the renderer throw and blank
+	// the cell. Normalise every such field to an empty slice via orEmpty.
+	cell.Actions = sanitizeActions(orEmpty(cell.Actions))
+	for i := range cell.Worklist {
+		cell.Worklist[i].Actions = sanitizeActions(cell.Worklist[i].Actions)
+	}
+	if cell.Trace != nil {
+		cell.Trace.Spans = orEmpty(cell.Trace.Spans)
+	}
+	for i := range cell.Frames {
+		cell.Frames[i].Fields = orEmpty(cell.Frames[i].Fields)
+		for j := range cell.Frames[i].Fields {
+			cell.Frames[i].Fields[j].Values = orEmpty(cell.Frames[i].Fields[j].Values)
+		}
+	}
+
+	// Synthesis-view payloads.
+	if args.RootCause != nil || len(args.Findings) > 0 || len(args.Checks) > 0 {
+		cell.RCA = &icRcaPayload{RootCause: args.RootCause, Checks: args.Checks, Findings: orEmpty(args.Findings)}
+	}
+	if len(args.Events) > 0 {
+		// Default the axis bounds to the computed time range so the UI never builds
+		// the timeline from empty (Invalid Date -> NaN pin positions).
+		from, to := args.From, args.To
+		if from == "" {
+			from = fromISO
+		}
+		if to == "" {
+			to = toISO
+		}
+		cell.Timeline = &icTimelinePayload{From: from, To: to, Events: args.Events}
+	}
+	if len(args.Drivers) > 0 || args.CostTotal != nil {
+		cell.Cost = &icCostPayload{Total: args.CostTotal, Drivers: orEmpty(args.Drivers), Headroom: args.Headroom}
+	}
+
+	return cell, nil
+}
+
+// sanitizeActions keeps the cell structurally read-only: the tool is annotated
+// ReadOnlyHint, so an action that isn't one of the safe kinds (link / refresh /
+// ask) is dropped here and never reaches the UI — regardless of what an agent
+// put in `actions`. Writes happen when the agent itself calls a write-gated
+// tool (e.g. alerting_manage_rules), typically prompted by an "ask" action.
+func sanitizeActions(actions []icAction) []icAction {
+	out := actions[:0]
+	for _, a := range actions {
+		switch a.Kind {
+		case "link", "refresh", "ask":
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// orEmpty returns s, or an empty (non-nil) slice when s is nil, so a UI-iterated
+// contract field never marshals as JSON `null`. Prefer this over per-field
+// guards so a newly added slice field is one call away from being safe.
+func orEmpty[T any](s []T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return s
+}
+
+func defaultTitleForPanel(panel string) string {
+	switch panel {
+	case "worklist":
+		return "Worklist"
+	case "rca":
+		return "Root cause"
+	case "timeline":
+		return "Change timeline"
+	case "cost":
+		return "Cost & cardinality"
+	case "bullet":
+		return "Value vs target"
+	default:
+		return strings.Title(panel) //nolint:staticcheck // simple ASCII panel names
+	}
+}
+
+func verdictOrDefault(verdict, panel string) string {
+	if verdict != "" {
+		return verdict
+	}
+	return defaultTitleForPanel(panel)
+}
+
+// insightCellResult packages a cell into the three-channel tool result plus the
+// _meta trust profile.
+//
+// The full cell is deliberately emitted twice — structuredContent (the spec
+// channel) and an embedded application/json resource block — because host
+// support is inconsistent: some hosts drop structuredContent entirely, and
+// Claude Desktop converts the resource block to a text block the app then
+// scans (see extractCell in ui/insight-cell/src/mcp-app.ts for the fallback
+// order). Together with the tool-call arguments the same frames/table payload
+// can therefore travel through model context ~2-3x. That token cost is the
+// price of rendering on hosts we don't control; revisit dropping the embedded
+// block once structuredContent forwarding is reliable across major hosts.
+// Keep payloads small: the tool description steers agents to pass shaped,
+// analysis-sized data, not raw query dumps.
+func insightCellResult(cell *insightCell) (*mcp.CallToolResult, error) {
+	payload, err := json.Marshal(cell)
+	if err != nil {
+		return nil, fmt.Errorf("marshal insight cell: %w", err)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s [%s, %s data]\n", cell.RenderHint.Title, cell.RenderHint.Type, cell.Meta.DataMode)
+	fmt.Fprintf(&b, "Verdict: %s\n", cell.Meta.Verdict)
+	// The agent's 2–4 sentence explanation rides on renderHint.description; include
+	// it so hosts without MCP Apps still surface the analysis, not just the verdict.
+	if cell.RenderHint.Description != "" {
+		fmt.Fprintf(&b, "%s\n", cell.RenderHint.Description)
+	}
+	if cell.Callout != nil {
+		fmt.Fprintf(&b, "%s: %s\n", cell.Callout.Title, cell.Callout.Body)
+	}
+	fmt.Fprintf(&b, "As of %s · %s data.", cell.Meta.Attestation.AsOf, cell.Meta.DataMode)
+
+	// The insight-cell trust profile (Layer A) carried in _meta.
+	trust := map[string]any{
+		"query":       cell.Meta.Query,
+		"attestation": cell.Meta.Attestation,
+		"provenance":  cell.Meta.Provenance,
+		"renderHint":  cell.RenderHint,
+		"reasoning": map[string]any{
+			"question":   cell.Meta.Question,
+			"verdict":    cell.Meta.Verdict,
+			"confidence": cell.Meta.Confidence,
+			"source":     "agent",
+		},
+	}
+
+	return &mcp.CallToolResult{
+		Result: mcp.Result{
+			Meta: &mcp.Meta{
+				AdditionalFields: map[string]any{
+					insightCellMetaKey: trust,
+				},
+			},
+		},
+		Content: []mcp.Content{
+			mcp.TextContent{Type: "text", Text: b.String()},
+			mcp.EmbeddedResource{
+				Type: "resource",
+				Resource: mcp.TextResourceContents{
+					URI:      "insightcell://payload.json",
+					MIMEType: "application/json",
+					Text:     string(payload),
+				},
+			},
+		},
+		StructuredContent: cell,
+	}, nil
+}
+
+var RenderInsightCell = mcpgrafana.MustTool(
+	"render_insight_cell",
+	"Package a Grafana result you have gathered as a structured 'insight cell': a core panel "+
+		"(timeseries, stat, bar, table), a logs view, a trace waterfall, or a synthesis view — 'worklist' (ranked, "+
+		"actionable findings for alert triage / deprecations), 'rca' (root-cause investigation), 'timeline' (change "+
+		"correlation) or 'cost' (cardinality/cost drivers) — with a verdict, attestation, provenance and follow-up "+
+		"actions. The result is a text verdict plus the cell as JSON; it is not rendered visually in the chat (the "+
+		"MCP App surface for that ships separately). This packages data you already have: first use the query tools "+
+		"(query_prometheus, query_loki_logs, alerting_manage_rules, get_annotations, Sift, ...), do the analysis, "+
+		"then pass the results here as 'frames' (chart types) or the matching payload (items/findings/events/drivers), "+
+		"along with a one-line 'verdict' and a 2-4 sentence 'insight'. It does not query datasources itself, and the "+
+		"cell is read-only — it never invokes other MCP tools; writes happen when you call the write-gated tool yourself.",
+	renderInsightCell,
+	mcp.WithTitleAnnotation("Package a Grafana insight cell"),
+	mcp.WithReadOnlyHintAnnotation(true),
+)
+
+func AddInsightCellTools(mcp *server.MCPServer) {
+	RenderInsightCell.Register(mcp)
+}

--- a/tools/insight_cell_integration_test.go
+++ b/tools/insight_cell_integration_test.go
@@ -1,0 +1,238 @@
+// Protocol-level integration test for render_insight_cell. Unlike the other
+// integration tests this needs no external services: the tool is a render
+// substrate (it repackages agent-supplied data), so the whole path —
+// tools/call over MCP for every panel type, the three output channels and the
+// trust _meta — is exercised against an in-process server.
+//go:build integration
+// +build integration
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newInsightCellClient(t *testing.T) *client.Client {
+	t.Helper()
+
+	s := server.NewMCPServer("mcp-grafana-test", "0.0.0")
+	AddInsightCellTools(s)
+
+	c, err := client.NewInProcessClient(s)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx := context.Background()
+	require.NoError(t, c.Start(ctx))
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "insight-cell-integration-test", Version: "0.0.0"}
+	_, err = c.Initialize(ctx, initReq)
+	require.NoError(t, err)
+
+	return c
+}
+
+func callRenderInsightCell(t *testing.T, c *client.Client, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "render_insight_cell"
+	req.Params.Arguments = args
+	res, err := c.CallTool(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "tool call errored: %+v", res.Content)
+	return res
+}
+
+// cellFromResult decodes the embedded application/json resource block — the
+// channel hosts keep when they drop structuredContent.
+func cellFromResult(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	require.GreaterOrEqual(t, len(res.Content), 2, "expected text + embedded resource content")
+
+	embedded, ok := res.Content[1].(mcp.EmbeddedResource)
+	require.True(t, ok, "content[1] should be an embedded resource, got %T", res.Content[1])
+	trc, ok := embedded.Resource.(mcp.TextResourceContents)
+	require.True(t, ok, "embedded resource should carry text contents, got %T", embedded.Resource)
+	assert.Equal(t, "application/json", trc.MIMEType)
+
+	var cell map[string]any
+	require.NoError(t, json.Unmarshal([]byte(trc.Text), &cell))
+	return cell
+}
+
+func renderHintType(t *testing.T, cell map[string]any) string {
+	t.Helper()
+	hint, ok := cell["renderHint"].(map[string]any)
+	require.True(t, ok, "cell should have a renderHint object")
+	typ, _ := hint["type"].(string)
+	return typ
+}
+
+// TestInsightCellIntegrationPanelTypes drives every panel type over the
+// protocol and checks the three output channels plus the trust _meta.
+func TestInsightCellIntegrationPanelTypes(t *testing.T) {
+	c := newInsightCellClient(t)
+
+	timeFrame := map[string]any{"fields": []any{
+		map[string]any{"name": "time", "type": "time", "values": []any{1700000000000, 1700000060000, 1700000120000}},
+		map[string]any{"name": "p99", "type": "number", "values": []any{0.21, 0.34, 0.29}},
+	}}
+
+	cases := map[string]map[string]any{
+		"stat": {
+			"frames": []any{map[string]any{"fields": []any{
+				map[string]any{"name": "value", "type": "number", "values": []any{0.42}},
+			}}},
+			"unit": "percent",
+		},
+		"timeseries": {"frames": []any{timeFrame}},
+		"bullet": {
+			"frames": []any{map[string]any{"fields": []any{
+				map[string]any{"name": "value", "type": "number", "values": []any{0.91}},
+			}}},
+			"target": 0.99,
+		},
+		"bar": {
+			"frames": []any{map[string]any{"fields": []any{
+				map[string]any{"name": "service", "type": "string", "values": []any{"api", "web"}},
+				map[string]any{"name": "errors", "type": "number", "values": []any{14, 3}},
+			}}},
+			"sort": "desc",
+		},
+		"table": {"frames": []any{timeFrame}},
+		"logs": {"logs": []any{
+			map[string]any{"time": "2026-07-27T10:00:00Z", "level": "error", "line": "connection refused"},
+		}},
+		"trace": {"trace": map[string]any{
+			"traceId": "abc123", "durationMs": 120.0,
+			"spans": []any{map[string]any{"id": "s1", "name": "GET /", "service": "api", "startMs": 0.0, "durationMs": 120.0}},
+		}},
+		"worklist": {"items": []any{
+			map[string]any{"title": "Silence flapping alert", "priority": "high", "why": "fired 41 times in 6h"},
+		}},
+		"rca": {
+			"rootCause": map[string]any{"title": "Pod OOM", "confidence": "high"},
+			"findings":  []any{map[string]any{"title": "restarts spiked", "evidence": "kube_pod_container_status_restarts_total"}},
+		},
+		"timeline": {"events": []any{
+			map[string]any{"time": "2026-07-27T09:30:00Z", "title": "deploy api v2", "kind": "deploy", "correlated": true},
+		}},
+		"cost": {
+			"drivers":   []any{map[string]any{"name": "http_requests_total", "series": 40000}},
+			"costTotal": map[string]any{"label": "1.2M active series", "value": 1200000},
+		},
+	}
+
+	for panel, args := range cases {
+		t.Run(panel, func(t *testing.T) {
+			args["panel"] = panel
+			args["verdict"] = "verdict for " + panel
+			res := callRenderInsightCell(t, c, args)
+
+			// Channel 1: the text verdict fallback.
+			text, ok := res.Content[0].(mcp.TextContent)
+			require.True(t, ok, "content[0] should be text, got %T", res.Content[0])
+			assert.Contains(t, text.Text, "verdict for "+panel)
+
+			// Channel 2: the embedded JSON resource block.
+			cell := cellFromResult(t, res)
+			assert.Equal(t, panel, renderHintType(t, cell))
+
+			// Channel 3: structuredContent.
+			sc, ok := res.StructuredContent.(map[string]any)
+			require.True(t, ok, "structuredContent should be an object, got %T", res.StructuredContent)
+			assert.Equal(t, panel, renderHintType(t, sc))
+
+			// _meta: the trust profile.
+			require.NotNil(t, res.Meta)
+			trust, ok := res.Meta.AdditionalFields["grafana.insightCell/v0"].(map[string]any)
+			require.True(t, ok, "_meta should carry the grafana.insightCell/v0 trust profile")
+			reasoning, ok := trust["reasoning"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "agent", reasoning["source"])
+
+			// No query supplied -> synthesized data mode.
+			meta, ok := cell["meta"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "synthesized", meta["dataMode"])
+		})
+	}
+}
+
+// TestInsightCellIntegrationLiveDataMode checks that supplying a query and a
+// datasource UID flips the attestation to live.
+func TestInsightCellIntegrationLiveDataMode(t *testing.T) {
+	c := newInsightCellClient(t)
+
+	res := callRenderInsightCell(t, c, map[string]any{
+		"panel":   "stat",
+		"verdict": "error rate is nominal",
+		"frames": []any{map[string]any{"fields": []any{
+			map[string]any{"name": "value", "type": "number", "values": []any{0.003}},
+		}}},
+		"query":         `sum(rate(errors_total[5m]))`,
+		"datasourceUid": "prom-uid",
+	})
+
+	meta, ok := cellFromResult(t, res)["meta"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "agent-supplied", meta["dataMode"])
+	attestation, ok := meta["attestation"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, attestation["live"])
+	queries, ok := meta["query"].([]any)
+	require.True(t, ok)
+	require.Len(t, queries, 1)
+}
+
+// TestInsightCellIntegrationReadOnly asserts the read-only contract at the
+// protocol boundary: the tool is annotated read-only, and action kinds that
+// could reach other tools are stripped before the cell is emitted.
+func TestInsightCellIntegrationReadOnly(t *testing.T) {
+	c := newInsightCellClient(t)
+	ctx := context.Background()
+
+	// The tool advertises ReadOnlyHint.
+	tools, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	require.NoError(t, err)
+	var found bool
+	for _, tool := range tools.Tools {
+		if tool.Name == "render_insight_cell" {
+			found = true
+			require.NotNil(t, tool.Annotations.ReadOnlyHint)
+			assert.True(t, *tool.Annotations.ReadOnlyHint)
+		}
+	}
+	require.True(t, found, "render_insight_cell should be listed")
+
+	// Actions with a kind that isn't link/refresh/ask never reach the cell.
+	res := callRenderInsightCell(t, c, map[string]any{
+		"panel":   "worklist",
+		"verdict": "one alert needs action now",
+		"items":   []any{map[string]any{"title": "Silence flapping alert", "priority": "high"}},
+		"actions": []any{
+			map[string]any{"label": "Apply via tool", "kind": "tool"},
+			map[string]any{"label": "Runbook", "kind": "link", "url": "https://example.com/runbook"},
+			map[string]any{"label": "Silence it", "kind": "ask", "text": "Silence the flapping alert via the appropriate write-gated tool."},
+		},
+	})
+
+	cell := cellFromResult(t, res)
+	actions, ok := cell["actions"].([]any)
+	require.True(t, ok, "actions should be an array")
+	require.Len(t, actions, 2, "the kind:tool action should be stripped")
+	for _, a := range actions {
+		kind, _ := a.(map[string]any)["kind"].(string)
+		assert.Contains(t, []string{"link", "refresh", "ask"}, kind)
+	}
+}

--- a/tools/insight_cell_test.go
+++ b/tools/insight_cell_test.go
@@ -1,0 +1,264 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeCellPayload finds the embedded application/json resource block and
+// unmarshals it back into a generic map — the channel Claude Desktop keeps.
+func decodeCellPayload(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	require.GreaterOrEqual(t, len(res.Content), 2, "expected text + resource content items")
+
+	_, ok := res.Content[0].(mcp.TextContent)
+	require.True(t, ok, "first content item should be the text verdict")
+
+	embedded, ok := res.Content[1].(mcp.EmbeddedResource)
+	require.True(t, ok, "second content item should be an embedded resource")
+	rc, ok := embedded.Resource.(mcp.TextResourceContents)
+	require.True(t, ok)
+	assert.Equal(t, "application/json", rc.MIMEType)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(rc.Text), &payload))
+	return payload
+}
+
+func TestRenderInsightCellStat(t *testing.T) {
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:   "stat",
+		Title:   "Error rate",
+		Verdict: "Error rate is nominal",
+		Insight: "Errors held under 1% across the window.",
+		Unit:    "percent",
+		Frames: []icDataFrame{{
+			Fields: []icField{{Name: "value", Type: "number", Values: []any{0.42}}},
+		}},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	// structuredContent carries the typed cell.
+	cell, ok := res.StructuredContent.(*insightCell)
+	require.True(t, ok, "structuredContent should be an *insightCell")
+	assert.Equal(t, "stat", cell.RenderHint.Type)
+	assert.Equal(t, "percent", cell.RenderHint.Unit)
+	assert.Equal(t, "synthesized", cell.Meta.DataMode, "no query -> synthesized data mode")
+	assert.False(t, cell.Meta.Attestation.Live)
+
+	// _meta carries the trust profile.
+	require.NotNil(t, res.Meta)
+	fields := res.Meta.AdditionalFields
+	trust, ok := fields[insightCellMetaKey].(map[string]any)
+	require.True(t, ok, "expected the %s trust block", insightCellMetaKey)
+	reasoning, ok := trust["reasoning"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "agent", reasoning["source"])
+	assert.Equal(t, "Error rate is nominal", reasoning["verdict"])
+
+	// The embedded JSON resource round-trips to a cell, and provenance names
+	// who rendered the cell (renderedBy), not an implied data author.
+	payload := decodeCellPayload(t, res)
+	assert.Contains(t, payload, "renderHint")
+	meta, ok := payload["meta"].(map[string]any)
+	require.True(t, ok)
+	prov, ok := meta["provenance"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Grafana MCP", prov["renderedBy"])
+	assert.NotContains(t, prov, "author")
+}
+
+func TestRenderInsightCellWorklistLive(t *testing.T) {
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:         "worklist",
+		Verdict:       "1 needs action now",
+		Query:         `ALERTS{alertstate="firing"}`,
+		DatasourceUID: "prom-uid",
+		Items: []icWorklistItem{
+			{Title: "HighErrorRate", Priority: "critical", Status: "firing 22m", Why: "Sustained and climbing."},
+		},
+	})
+	require.NoError(t, err)
+
+	cell, ok := res.StructuredContent.(*insightCell)
+	require.True(t, ok)
+	assert.Equal(t, "worklist", cell.RenderHint.Type)
+	require.Len(t, cell.Worklist, 1)
+	assert.Equal(t, "HighErrorRate", cell.Worklist[0].Title)
+
+	// A query + datasource -> live attestation and a recorded query.
+	assert.Equal(t, "agent-supplied", cell.Meta.DataMode)
+	assert.True(t, cell.Meta.Attestation.Live)
+	require.Len(t, cell.Meta.Query, 1)
+	assert.Equal(t, `ALERTS{alertstate="firing"}`, cell.Meta.Query[0].Expr)
+	assert.Equal(t, "prom-uid", cell.Meta.Query[0].DatasourceUID)
+
+	// actions is always a (possibly empty) array, never null, so the UI can iterate.
+	assert.NotNil(t, cell.Actions)
+}
+
+func TestRenderInsightCellBullet(t *testing.T) {
+	target := 1.0
+	max := 1.2
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:   "bullet",
+		Verdict: "p95 latency 0.82s vs 1s SLO",
+		Unit:    "s",
+		Target:  &target,
+		Max:     &max,
+		Frames: []icDataFrame{{
+			Fields: []icField{{Name: "value", Type: "number", Values: []any{0.82}}},
+		}},
+	})
+	require.NoError(t, err)
+
+	cell, ok := res.StructuredContent.(*insightCell)
+	require.True(t, ok)
+	assert.Equal(t, "bullet", cell.RenderHint.Type)
+	require.NotNil(t, cell.RenderHint.Target)
+	assert.Equal(t, 1.0, *cell.RenderHint.Target)
+	require.NotNil(t, cell.RenderHint.Max)
+	assert.Equal(t, 1.2, *cell.RenderHint.Max)
+}
+
+func TestRenderInsightCellSurfacesInsight(t *testing.T) {
+	insight := "Errors held under 1% across the window; no action needed."
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:   "stat",
+		Verdict: "Nominal",
+		Insight: insight,
+		Frames:  []icDataFrame{{Fields: []icField{{Name: "value", Type: "number", Values: []any{0.4}}}}},
+	})
+	require.NoError(t, err)
+
+	cell := res.StructuredContent.(*insightCell)
+	assert.Equal(t, insight, cell.RenderHint.Description, "insight rides on renderHint.description")
+
+	text := res.Content[0].(mcp.TextContent).Text
+	assert.Contains(t, text, insight, "insight must appear in the text fallback")
+}
+
+func TestRenderInsightCellNilArraysDefaultToEmpty(t *testing.T) {
+	// rca with a root cause but no findings — findings must serialize as [] not null.
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:     "rca",
+		RootCause: &icRcaRoot{Title: "Bad deploy", Confidence: "high"},
+	})
+	require.NoError(t, err)
+	payload := decodeCellPayload(t, res)
+
+	rca, ok := payload["rca"].(map[string]any)
+	require.True(t, ok)
+	findings, ok := rca["findings"].([]any)
+	require.True(t, ok, "findings must be a JSON array, not null")
+	assert.Empty(t, findings)
+}
+
+func TestRenderInsightCellKeepsZeroRangeBound(t *testing.T) {
+	zero := 0.0
+	five := 5.0
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:    "stat",
+		Mappings: []icValueMapping{{Type: "range", From: &zero, To: &five, Text: "low"}},
+		Frames:   []icDataFrame{{Fields: []icField{{Name: "value", Type: "number", Values: []any{2.0}}}}},
+	})
+	require.NoError(t, err)
+	payload := decodeCellPayload(t, res)
+
+	mappings := payload["renderHint"].(map[string]any)["mappings"].([]any)
+	require.Len(t, mappings, 1)
+	m := mappings[0].(map[string]any)
+	from, ok := m["from"]
+	require.True(t, ok, "a range bound of 0 must not be dropped")
+	assert.Equal(t, 0.0, from)
+}
+
+func TestRenderInsightCellKeepsZeroCostMetric(t *testing.T) {
+	zero := 0.0
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:   "cost",
+		Drivers: []icCostDriver{{Name: "idle_series", Pct: &zero, Series: &zero}},
+	})
+	require.NoError(t, err)
+	payload := decodeCellPayload(t, res)
+
+	d := payload["cost"].(map[string]any)["drivers"].([]any)[0].(map[string]any)
+	pct, ok := d["pct"]
+	require.True(t, ok, "a 0%% cost share must not be dropped")
+	assert.Equal(t, 0.0, pct)
+}
+
+func TestRenderInsightCellTimelineDefaultsBounds(t *testing.T) {
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:  "timeline",
+		Events: []icChangeEvent{{Time: "2026-07-23T10:00:00Z", Title: "deploy v2", Kind: "deploy"}},
+		// from/to intentionally omitted
+	})
+	require.NoError(t, err)
+
+	cell := res.StructuredContent.(*insightCell)
+	require.NotNil(t, cell.Timeline)
+	assert.NotEmpty(t, cell.Timeline.From, "timeline.from must default to the computed range, not empty")
+	assert.NotEmpty(t, cell.Timeline.To, "timeline.to must default to the computed range, not empty")
+}
+
+func TestRenderInsightCellQueryAlwaysArray(t *testing.T) {
+	// The common no-query (sample) path must still emit query as [] not null —
+	// the UI iterates meta.query and refresh reads query[0].
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{Panel: "stat"})
+	require.NoError(t, err)
+	payload := decodeCellPayload(t, res)
+
+	meta, ok := payload["meta"].(map[string]any)
+	require.True(t, ok, "meta must be a JSON object")
+	_, isArray := meta["query"].([]any)
+	require.True(t, isArray, "meta.query must be a JSON array, not null")
+}
+
+func TestRenderInsightCellRequiresPanel(t *testing.T) {
+	_, err := renderInsightCell(context.Background(), RenderInsightCellParams{})
+	require.Error(t, err)
+}
+
+func TestRenderInsightCellRejectsUnknownPanel(t *testing.T) {
+	// The jsonschema enum is advisory to the model only; the handler must
+	// enforce it itself.
+	_, err := renderInsightCell(context.Background(), RenderInsightCellParams{Panel: "gauge"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown panel")
+	assert.Contains(t, err.Error(), "timeseries", "error should list the valid panels")
+}
+
+func TestRenderInsightCellPreservesDataAsOf(t *testing.T) {
+	// A refresh replays the same data through the tool with the original
+	// attestation stamp; the server must anchor asOf and the time range on it
+	// instead of restamping time.Now(), or stale data would claim to be fresh.
+	rangeHours := 2
+	res, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:      "stat",
+		DataAsOf:   "2026-07-28T10:00:00Z",
+		RangeHours: &rangeHours,
+	})
+	require.NoError(t, err)
+
+	cell, ok := res.StructuredContent.(*insightCell)
+	require.True(t, ok)
+	assert.Equal(t, "2026-07-28T10:00:00Z", cell.Meta.Attestation.AsOf)
+	assert.Equal(t, "2026-07-28T10:00:00Z", cell.Meta.TimeRange.To)
+	assert.Equal(t, "2026-07-28T08:00:00Z", cell.Meta.TimeRange.From)
+}
+
+func TestRenderInsightCellRejectsMalformedDataAsOf(t *testing.T) {
+	_, err := renderInsightCell(context.Background(), RenderInsightCellParams{
+		Panel:    "stat",
+		DataAsOf: "yesterday",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dataAsOf")
+}

--- a/ui_apps.go
+++ b/ui_apps.go
@@ -8,12 +8,41 @@ import (
 )
 
 const (
-	appMIMEType            = "text/html;profile=mcp-app"
+	appMIMEType = "text/html;profile=mcp-app"
+
+	// PanelViewerResourceURI is the MCP App that renders get_panel_image results.
 	PanelViewerResourceURI = "ui://mcp-grafana/panel-viewer.html"
 
 	// UIContentKindDeeplink is the `_meta.ui.kind` value for a Grafana deeplink.
 	UIContentKindDeeplink = "deeplink"
 )
+
+// UIApp describes an MCP App HTML resource that the server serves via the MCP
+// Resources API. A tool links itself to one with WithUIResource(app.URI); a
+// host that supports the MCP Apps extension then fetches the resource and
+// renders it in a sandboxed iframe. Adding a new app is one entry in
+// appResources plus a //go:embed line (see ui_embed.go) — not a new code path.
+type UIApp struct {
+	// URI is the ui:// resource URI referenced from a tool's _meta.ui.resourceUri.
+	URI string
+	// Name is the human-readable resource name shown in resource listings.
+	Name string
+	// Description explains what the app renders.
+	Description string
+	// HTML is the self-contained (single-file) app bundle, embedded at build time.
+	HTML string
+}
+
+// appResources is the registry of MCP App UI resources served by the server.
+// Each built bundle is embedded in ui_embed.go and listed here once.
+var appResources = []UIApp{
+	{
+		URI:         PanelViewerResourceURI,
+		Name:        "Panel Viewer",
+		Description: "Interactive HTML viewer for Grafana panel images",
+		HTML:        panelViewerAppHTML,
+	},
+}
 
 // WithUIResource attaches a _meta.ui.resourceUri to a tool definition,
 // linking it to an MCP App HTML resource for inline rendering.
@@ -43,23 +72,27 @@ func NewUIContentMeta(kind string) *mcp.Meta {
 	}
 }
 
-// RegisterAppResources registers MCP App UI resources with the server.
+// RegisterAppResources registers every MCP App UI resource in the appResources
+// registry with the server.
 func RegisterAppResources(s *server.MCPServer) {
-	s.AddResource(
-		mcp.NewResource(
-			PanelViewerResourceURI,
-			"Panel Viewer",
-			mcp.WithResourceDescription("Interactive HTML viewer for Grafana panel images"),
-			mcp.WithMIMEType(appMIMEType),
-		),
-		func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-			return []mcp.ResourceContents{
-				mcp.TextResourceContents{
-					URI:      PanelViewerResourceURI,
-					MIMEType: appMIMEType,
-					Text:     panelViewerAppHTML,
-				},
-			}, nil
-		},
-	)
+	for _, app := range appResources {
+		app := app // capture per-iteration for the closure
+		s.AddResource(
+			mcp.NewResource(
+				app.URI,
+				app.Name,
+				mcp.WithResourceDescription(app.Description),
+				mcp.WithMIMEType(appMIMEType),
+			),
+			func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+				return []mcp.ResourceContents{
+					mcp.TextResourceContents{
+						URI:      app.URI,
+						MIMEType: appMIMEType,
+						Text:     app.HTML,
+					},
+				}, nil
+			},
+		)
+	}
 }

--- a/ui_apps_test.go
+++ b/ui_apps_test.go
@@ -1,0 +1,43 @@
+package mcpgrafana
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every registered app must carry an embedded, non-empty, single-file HTML
+// bundle at its ui:// URI.
+func TestAppResourcesRegistry(t *testing.T) {
+	byURI := map[string]UIApp{}
+	for _, app := range appResources {
+		byURI[app.URI] = app
+	}
+
+	for _, uri := range []string{PanelViewerResourceURI} {
+		app, ok := byURI[uri]
+		require.True(t, ok, "expected an app registered at %s", uri)
+		assert.NotEmpty(t, app.Name)
+		assert.NotEmpty(t, app.HTML, "app %s should embed a built HTML bundle (run make build-ui)", uri)
+	}
+}
+
+// RegisterAppResources should register every app so it is discoverable via the
+// MCP Resources API (resources/list).
+func TestRegisterAppResourcesListsEachApp(t *testing.T) {
+	s := server.NewMCPServer("test", "0.0.0", server.WithResourceCapabilities(false, true))
+	RegisterAppResources(s)
+
+	req := json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"resources/list"}`)
+	resp := s.HandleMessage(context.Background(), req)
+	out, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	for _, app := range appResources {
+		assert.Contains(t, string(out), app.URI, "resources/list should advertise %s", app.URI)
+	}
+}


### PR DESCRIPTION
First of three PRs splitting #1008 along the lines proposed in review ([discussion](https://github.com/grafana/mcp-grafana/pull/1008#issuecomment-5131222475)): **1/3 substrate (this, Go only) → 2/3 the MCP App UI → 3/3 the rulediff panel**.

## What this adds

- **`tools/insight_cell.go`** — the render contract and the `render_insight_cell` tool: contract types, params, `buildInsightCell` (panel-enum validation, `dataAsOf` anchoring, nil-slice normalisation via `orEmpty`, the `sanitizeActions` whitelist), and the three-channel result builder + trust `_meta`.
- **`ui_apps.go`** — generalises the single panel-viewer resource into a registry (`UIApp` + `appResources` + one registration loop). Only the panel-viewer entry lands here; adding an app becomes one entry plus one `//go:embed` line.
- **Tests** — contract tests over the marshaled JSON channel (the `omitempty`/nil-slice bugs only show there) and a protocol-level integration test (in-process MCP server, no external services) driving every panel type.
- Four lines of `main.go` wiring. The `insight-cell` category is **opt-in** — not in the default `--enabled-tools` list.

## What deliberately does NOT land here

- **No UI, and no reference to one.** The tool has no `WithUIResource` and results carry no `_meta.ui` — both references to `InsightCellResourceURI` wait for PR 2, so this PR never advertises a resource a host can't read. The interim tool description says explicitly that the result is a text verdict + cell JSON, not rendered visually.
- **No `rulediff`.** The alerting-adjacent panel is PR 3, so it can be reviewed by alerting owners on its own.

Landing a tool that renders nowhere is safe *because* of the opt-in gate — that's doing real work for the incremental landing.

## The trust model (the part most worth review)

Everything in a cell is **agent-declared, recorded, and not verified** — the substrate cannot cross-check frames against the declared query. The contract wording is chosen to never claim otherwise:

- `dataMode` is `"agent-supplied"` (a query + datasource were declared; should be real, unverifiable) or `"synthesized"` — deliberately not `"live"`/`"mock"`
- `provenance.renderedBy` (not `author`) names who packaged the cell
- `attestation.asOf` anchors on the agent-supplied `dataAsOf`, and a refresh replay preserves the original stamp, so stale data can never claim to be fresh
- read-only is structural: `ReadOnlyHint` + server-side action-kind whitelist (`link`/`refresh`/`ask`)

## Test plan

- `go test ./tools/ -run InsightCell` and `go test . -run AppResources`
- `go test -tags integration ./tools/ -run InsightCell` (in-process, no services)
- `go build`, `go vet`, gofmt, jsonschema-comma lint all green

