### PR TITLE
fix(run_panel_query): resolve constant and textbox variables from their query field

### DIFF
--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -410,6 +410,19 @@ func extractTemplateVariables(db map[string]interface{}) map[string]string {
 				}
 			}
 		}
+
+		// Constant and textbox variables hold their value in "query" and are
+		// frequently saved without a "current" at all. Without this fallback
+		// the raw $name survives substitution and reaches the datasource,
+		// which for SQL datasources is a syntax error.
+		if variables[name] == "" {
+			switch safeString(variable, "type") {
+			case "constant", "textbox":
+				if q := safeString(variable, "query"); q != "" {
+					variables[name] = q
+				}
+			}
+		}
 	}
 
 	return variables

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -408,6 +408,19 @@ func extractTemplateVariables(db map[string]interface{}) map[string]string {
 				}
 			}
 		}
+
+		// Constant and textbox variables hold their value in "query" and are
+		// frequently saved without a "current" at all. Without this fallback
+		// the raw $name survives substitution and reaches the datasource,
+		// which for SQL datasources is a syntax error.
+		if variables[name] == "" {
+			switch safeString(variable, "type") {
+			case "constant", "textbox":
+				if q := safeString(variable, "query"); q != "" {
+					variables[name] = q
+				}
+			}
+		}
 	}
 
 	return variables

--- a/tools/run_panel_query_test.go
+++ b/tools/run_panel_query_test.go
@@ -439,6 +439,75 @@ func TestExtractTemplateVariables(t *testing.T) {
 			},
 			want: map[string]string{},
 		},
+		{
+			name: "constant variable without current falls back to query",
+			dashboard: map[string]interface{}{
+				"templating": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":  "conversionRate",
+							"type":  "constant",
+							"query": "158.87",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"conversionRate": "158.87",
+			},
+		},
+		{
+			name: "textbox variable without current falls back to query",
+			dashboard: map[string]interface{}{
+				"templating": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":  "daysBack",
+							"type":  "textbox",
+							"query": "30",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"daysBack": "30",
+			},
+		},
+		{
+			name: "current takes precedence over query for constant",
+			dashboard: map[string]interface{}{
+				"templating": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":  "margin",
+							"type":  "constant",
+							"query": "1",
+							"current": map[string]interface{}{
+								"value": "1.5",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"margin": "1.5",
+			},
+		},
+		{
+			name: "query variable does not fall back to its datasource query",
+			dashboard: map[string]interface{}{
+				"templating": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":  "job",
+							"type":  "query",
+							"query": "label_values(up, job)",
+						},
+					},
+				},
+			},
+			want: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`extractTemplateVariables` reads `current.value`, falling back to `current.text`. Variables of type `constant` and `textbox` keep their value in the `query` field, and Grafana routinely saves them with no `current` object at all — so they resolve to nothing and the raw `$name` survives `substituteTemplateVariables`.

Prometheus and Loki tolerate the leftover token in most cases. SQL datasources do not: the statement reaches the backend plugin with a bare `$name` in it and fails as a syntax error.

Concretely, a dashboard whose templating list is

```json
{ "name": "conversionRate", "type": "constant", "query": "158.87" }
```

sends `... WHERE rate > $conversionRate` to the datasource unchanged.

On the dashboard set I hit this with, 6 of 23 dashboards were affected, all of them using `constant` variables for conversion rates and lookback windows.

## Change

Fall back to the `query` field when `current` yields nothing, restricted to the two types where that field holds a literal value:

- `constant`
- `textbox`

Type `query` is deliberately excluded — there `query` holds a datasource expression such as `label_values(up, job)`, which must never be substituted as a value. An existing `current` still takes precedence.

## Tests

Four cases added to `TestExtractTemplateVariables`:

- constant without `current` resolves from `query`
- textbox without `current` resolves from `query`
- `current` wins over `query` when both are present
- type `query` does not fall back

`go test -tags unit ./tools/` passes.
