### PR TITLE
feat(run_panel_query): support MSSQL panels

### DIFF
--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -24,7 +24,7 @@ type RunPanelQueryParams struct {
 	End            string            `json:"end" jsonschema:"description=Override end time (e.g. 'now'\\, RFC3339\\, Unix ms)"`
 	Variables      map[string]string `json:"variables" jsonschema:"description=Override dashboard variables (e.g. {\"job\": \"api-server\"})"`
 	DatasourceUID  string            `json:"datasourceUid,omitempty" jsonschema:"description=Override datasource UID"`
-	DatasourceType string            `json:"datasourceType,omitempty" jsonschema:"description=Override datasource type (prometheus\\, loki\\, grafana-clickhouse-datasource\\, cloudwatch\\, influxdb\\, grafana-bigquery-datasource)"`
+	DatasourceType string            `json:"datasourceType,omitempty" jsonschema:"description=Override datasource type (prometheus\\, loki\\, grafana-clickhouse-datasource\\, cloudwatch\\, influxdb\\, grafana-bigquery-datasource\\, mssql)"`
 }
 
 // QueryTimeRange represents the actual time range used for a panel query
@@ -223,7 +223,9 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 	case "influxdb":
 		results, err = executeInfluxDBQuery(ctx, datasourceUID, panelData, query, params.Start, params.End)
 	case "bigquery":
-		results, err = executeBigQueryPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars)
+		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, BigQueryDatasourceType)
+	case "mssql":
+		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, MSSQLDatasourceType)
 	default:
 		return nil, fmt.Errorf("datasource type '%s' is not supported by run_panel_query; use the native query tool (e.g. query_prometheus\\, query_loki_logs\\, query_clickhouse\\, query_cloudwatch\\, query_influxdb) directly", datasourceType)
 	}
@@ -540,26 +542,43 @@ func executeInfluxDBQuery(ctx context.Context, datasourceUID string, panelData *
 // BigQueryDatasourceType is the type identifier for BigQuery datasources.
 const BigQueryDatasourceType = "grafana-bigquery-datasource"
 
-// BigQueryFormatTable is the format value for table/tabular query results.
-const BigQueryFormatTable = 1
+// MSSQLDatasourceType is the type identifier for Microsoft SQL Server datasources.
+const MSSQLDatasourceType = "mssql"
 
-// BigQueryQueryResult represents the tabular result of a BigQuery panel query.
-type BigQueryQueryResult struct {
+// SQLFormatTable is the format value for table/tabular query results on sqlds-based
+// datasources such as BigQuery, whose query model takes a numeric format enum.
+const SQLFormatTable = 1
+
+// MSSQLFormatTable is the format value for table/tabular query results on MSSQL, whose
+// sqleng-based query model unmarshals format into a string and fails on a number.
+const MSSQLFormatTable = "table"
+
+// defaultSQLFormat returns the table format value understood by the given datasource.
+func defaultSQLFormat(datasourceType string) interface{} {
+	if datasourceType == MSSQLDatasourceType {
+		return MSSQLFormatTable
+	}
+	return SQLFormatTable
+}
+
+// SQLQueryResult represents the tabular result of a SQL panel query.
+type SQLQueryResult struct {
 	Columns        []string                 `json:"columns"`
 	Rows           []map[string]interface{} `json:"rows"`
 	RowCount       int                      `json:"rowCount"`
 	ProcessedQuery string                   `json:"processedQuery,omitempty"`
 }
 
-// executeBigQueryPanelQuery runs a BigQuery panel query via Grafana's /api/ds/query
-// endpoint. BigQuery is a SQL datasource (sqlds-based) whose backend plugin resolves
-// SQL macros such as $__timeFilter/$__timeFrom/$__timeGroup server-side, so we only
-// substitute the frontend-only macros ($__interval, $__range, etc.) here. The panel's
-// raw target is preserved so BigQuery-specific fields (location, project, dataset) reach
-// the backend; only rawSql, datasource, refId, and format are overridden.
-func executeBigQueryPanelQuery(ctx context.Context, datasourceUID string, panelData *panelInfo, query, start, end string, variables map[string]string) (*BigQueryQueryResult, error) {
+// executeSQLPanelQuery runs a panel query against a SQL datasource via Grafana's
+// /api/ds/query endpoint. Those datasources resolve SQL macros such as
+// $__timeFilter/$__timeFrom/$__timeGroup server-side in their backend plugin, so we
+// only substitute the frontend-only macros ($__interval, $__range, etc.) here. The
+// panel's raw target is preserved so datasource-specific fields (BigQuery's location,
+// project and dataset, for example) reach the backend; only rawSql, datasource, refId
+// and format are overridden.
+func executeSQLPanelQuery(ctx context.Context, datasourceUID string, panelData *panelInfo, query, start, end string, variables map[string]string, datasourceType string) (*SQLQueryResult, error) {
 	if panelData == nil || panelData.RawTarget == nil {
-		return nil, fmt.Errorf("BigQuery panel target not available")
+		return nil, fmt.Errorf("SQL panel target not available")
 	}
 
 	// Parse time range
@@ -580,12 +599,12 @@ func executeBigQueryPanelQuery(ctx context.Context, datasourceUID string, panelD
 
 	// Override the SQL with the fully-processed query and ensure required fields are set.
 	target["rawSql"] = processedQuery
-	target["datasource"] = map[string]interface{}{"uid": datasourceUID, "type": BigQueryDatasourceType}
+	target["datasource"] = map[string]interface{}{"uid": datasourceUID, "type": datasourceType}
 	if safeString(target, "refId") == "" {
 		target["refId"] = "A"
 	}
 	if _, ok := target["format"]; !ok {
-		target["format"] = BigQueryFormatTable
+		target["format"] = defaultSQLFormat(datasourceType)
 	}
 
 	client, baseURL, err := newDSQueryHTTPClient(ctx)
@@ -603,7 +622,7 @@ func executeBigQueryPanelQuery(ctx context.Context, datasourceUID string, panelD
 		return nil, err
 	}
 
-	return &BigQueryQueryResult{
+	return &SQLQueryResult{
 		Columns:        columns,
 		Rows:           rows,
 		RowCount:       len(rows),
@@ -738,6 +757,8 @@ func normalizeDatasourceType(dsType string) string {
 		return "influxdb"
 	case strings.Contains(lower, "clickhouse"):
 		return "clickhouse"
+	case lower == "mssql":
+		return "mssql"
 	case strings.Contains(lower, "bigquery"):
 		return "bigquery"
 	default:
@@ -759,7 +780,7 @@ func isEmptyPanelResult(results interface{}) bool {
 		return v == nil || len(v.Rows) == 0
 	case *InfluxDBQueryResult:
 		return v == nil || len(v.Rows) == 0
-	case *BigQueryQueryResult:
+	case *SQLQueryResult:
 		return v == nil || len(v.Rows) == 0
 	case model.Value:
 		switch m := v.(type) {
@@ -817,6 +838,13 @@ func generatePanelQueryHints(datasourceType, query string) []string {
 			"- Column names or WHERE clause may not match the schema - check the table definition in BigQuery",
 			"- The $__timeFilter(column) macro may reference a column whose type or timezone doesn't match the time range",
 			"- The datasource's processing location may not match the dataset's region",
+		)
+	case "mssql":
+		hints = append(hints,
+			"- Table may be empty for this time range - try a COUNT(*) without the time filter to verify",
+			"- Column names or WHERE clause may not match the schema - check the table definition in SQL Server",
+			"- The $__timeFilter(column) macro may reference a column whose type or timezone doesn't match the time range",
+			"- The datasource login may lack SELECT permission on the referenced tables",
 		)
 	}
 

--- a/tools/run_panel_query_test.go
+++ b/tools/run_panel_query_test.go
@@ -831,18 +831,18 @@ func TestIsEmptyPanelResult(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "nil BigQueryQueryResult",
-			results:  (*BigQueryQueryResult)(nil),
+			name:     "nil SQLQueryResult",
+			results:  (*SQLQueryResult)(nil),
 			expected: true,
 		},
 		{
-			name:     "empty BigQueryQueryResult",
-			results:  &BigQueryQueryResult{Rows: []map[string]interface{}{}},
+			name:     "empty SQLQueryResult",
+			results:  &SQLQueryResult{Rows: []map[string]interface{}{}},
 			expected: true,
 		},
 		{
-			name: "non-empty BigQueryQueryResult",
-			results: &BigQueryQueryResult{
+			name: "non-empty SQLQueryResult",
+			results: &SQLQueryResult{
 				Rows: []map[string]interface{}{{"count": 42}},
 			},
 			expected: false,
@@ -927,6 +927,17 @@ func TestGeneratePanelQueryHints(t *testing.T) {
 				"processing location",
 			},
 		},
+		{
+			name:           "mssql hints",
+			datasourceType: "mssql",
+			query:          "SELECT COUNT(*) FROM revenue WHERE $__timeFilter(ts)",
+			containsHints: []string{
+				"No data found",
+				"Time range",
+				"COUNT(*)",
+				"SELECT permission",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1002,6 +1013,8 @@ func TestNormalizeDatasourceType(t *testing.T) {
 		{"influxdb", "influxdb"},
 		{"InfluxDB", "influxdb"},
 		{"grafana-bigquery-datasource", "bigquery"},
+		{"mssql", "mssql"},
+		{"MSSQL", "mssql"},
 		{"bigquery", "bigquery"},
 		{"BigQuery", "bigquery"},
 		{"some-other-type", "some-other-type"},
@@ -1148,11 +1161,49 @@ func TestExtractPanelInfo_BigQuery(t *testing.T) {
 	assert.Equal(t, "US", info.RawTarget["location"])
 }
 
-func TestExecuteBigQueryPanelQuery_NilTarget(t *testing.T) {
+func TestExecuteSQLPanelQuery_NilTarget(t *testing.T) {
 	// A missing raw target should produce a clear error rather than panicking.
-	_, err := executeBigQueryPanelQuery(t.Context(), "bigquery-uid", &panelInfo{}, "SELECT 1", "now-1h", "now", nil)
+	_, err := executeSQLPanelQuery(t.Context(), "bigquery-uid", &panelInfo{}, "SELECT 1", "now-1h", "now", nil, BigQueryDatasourceType)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "BigQuery panel target not available")
+	assert.Contains(t, err.Error(), "SQL panel target not available")
+
+	_, err = executeSQLPanelQuery(t.Context(), "mssql-uid", &panelInfo{}, "SELECT 1", "now-1h", "now", nil, MSSQLDatasourceType)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SQL panel target not available")
+}
+
+func TestDefaultSQLFormat(t *testing.T) {
+	// BigQuery's sqlds query model takes a numeric format enum, MSSQL's sqleng model
+	// unmarshals format into a string and errors on a number.
+	assert.Equal(t, SQLFormatTable, defaultSQLFormat(BigQueryDatasourceType))
+	assert.Equal(t, MSSQLFormatTable, defaultSQLFormat(MSSQLDatasourceType))
+}
+
+func TestExtractPanelInfoMSSQL(t *testing.T) {
+	// MSSQL panels carry their statement in rawSql, like the other SQL datasources,
+	// and the raw target must survive so format is not overridden.
+	panel := map[string]interface{}{
+		"id":    81,
+		"title": "Revenue",
+		"datasource": map[string]interface{}{
+			"uid":  "mssql-uid",
+			"type": "mssql",
+		},
+		"targets": []interface{}{
+			map[string]interface{}{
+				"refId":  "A",
+				"rawSql": "DECLARE @From datetime = $__timeFrom(); SELECT SUM(amount) FROM revenue WHERE ts >= @From",
+				"format": "table",
+			},
+		},
+	}
+
+	info, err := extractPanelInfo(panel, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "mssql-uid", info.DatasourceUID)
+	assert.Equal(t, "mssql", info.DatasourceType)
+	assert.Contains(t, info.Query, "$__timeFrom()")
+	assert.Equal(t, "table", info.RawTarget["format"])
 }
 
 func TestSubstituteTemplateVariablesInMap(t *testing.T) {


### PR DESCRIPTION
Closes #999.

## Why this is small

MSSQL panels reach `/api/ds/query` with the same `rawSql` and `format` fields as BigQuery, and their backend plugin resolves the SQL macros (`$__timeFilter`, `$__timeFrom`, `$__timeGroup`) server-side. `executeBigQueryPanelQuery` was therefore already almost datasource-agnostic — as its own doc comment says. The only BigQuery-specific parts were the datasource type written into the target and the default `format` value:

```go
target["datasource"] = map[string]interface{}{"uid": datasourceUID, "type": BigQueryDatasourceType}
if _, ok := target["format"]; !ok {
    target["format"] = BigQueryFormatTable
}
```

## The one place the two differ

They are not the same stack. BigQuery is sqlds-based; MSSQL is sqleng-based ([`grafana-mssql-datasource`](https://github.com/grafana/grafana-mssql-datasource/blob/main/pkg/mssql/sqleng/sql_engine.go)), and its query model declares:

```go
type QueryJson struct {
	RawSql string `json:"rawSql"`
	...
	Format string `json:"format"`
}
```

So `format` is a string there, not the numeric enum sqlds uses. Sending `1` fails `json.Unmarshal` and the query errors out; omitting `format` altogether hits `default: panic("Unrecognized query model format")` in the plugin's format switch. The default value is consequently resolved per datasource type rather than shared.

## Change

- Generalise the executor into `executeSQLPanelQuery`, parameterised by datasource type, and route both `bigquery` and `mssql` through it.
- `defaultSQLFormat` returns the numeric `SQLFormatTable` for sqlds datasources and the string `MSSQLFormatTable` (`"table"`) for MSSQL.
- `normalizeDatasourceType` maps `mssql` (case-insensitive).
- Rename `BigQueryQueryResult` → `SQLQueryResult` and `BigQueryFormatTable` → `SQLFormatTable`; neither was ever BigQuery-specific. `BigQueryDatasourceType` is kept as-is.
- Add MSSQL entries to the empty-result hints and to the `datasourceType` override description.

BigQuery behaviour is unchanged. The raw target is still preserved so `location`, `project` and `dataset` reach the backend — and, for MSSQL, so do `fill`, `fillInterval`, `fillMode` and `fillValue`, which sqleng reads from the same JSON. `format` is still only defaulted when the panel does not set one, which is the common case for UI-authored panels; the default matters for hand-written and provisioned dashboards that omit it.

## Tests

- `TestExecuteSQLPanelQuery_NilTarget` covers both datasource types
- `TestDefaultSQLFormat` pins the numeric/string split
- `TestExtractPanelInfoMSSQL` asserts `rawSql` extraction and that the raw target survives with its own `format`
- `mssql` and `MSSQL` added to the `normalizeDatasourceType` table
- an `mssql` case added to the hints table

`go test -tags unit ./tools/` passes, `go vet` clean, `gofmt` clean.

## Note

Panels using `constant` template variables will still fail without #1041, which fixes those resolving to nothing and leaving a bare `$name` in the statement. The two changes are independent; this one is enough for panels that only use macros.
