### PR TITLE
fix: clarify Loki index stats limitations

### DIFF
--- a/tools/loki.go
+++ b/tools/loki.go
@@ -38,10 +38,11 @@ type LabelResponse struct {
 
 // Stats represents the statistics returned by Loki's index/stats endpoint
 type Stats struct {
-	Streams int `json:"streams"`
-	Chunks  int `json:"chunks"`
-	Entries int `json:"entries"`
-	Bytes   int `json:"bytes"`
+	Streams int      `json:"streams"`
+	Chunks  int      `json:"chunks"`
+	Entries int      `json:"entries"`
+	Bytes   int      `json:"bytes"`
+	Caveats []string `json:"caveats,omitempty"`
 }
 
 // patternsAPIResponse represents the raw response from Loki's patterns API
@@ -742,7 +743,7 @@ func queryLokiLogs(ctx context.Context, args QueryLokiLogsParams) (*QueryLokiLog
 // QueryLokiLogs is a tool for querying logs from Loki
 var QueryLokiLogs = mcpgrafana.MustTool(
 	"query_loki_logs",
-	"Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki and LogsQL on VictoriaLogs (e.g., Loki: `{app=\"foo\"} |= \"error\"`; VictoriaLogs: `{app=\"foo\"} \"error\"`). To count matching log lines precisely, use a `count_over_time()` metric query with queryType='instant'. Prefer using `query_loki_stats` first to cheaply check whether a stream contains data (avoiding expensive queries against empty streams) and `list_loki_label_names` / `list_loki_label_values` to verify labels exist before querying. Note: `query_loki_stats` returns approximate storage-level counts, not exact log line counts.",
+	"Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki and LogsQL on VictoriaLogs (e.g., Loki: `{app=\"foo\"} |= \"error\"`; VictoriaLogs: `{app=\"foo\"} \"error\"`). To count matching log lines precisely, use a `count_over_time()` metric query with queryType='instant'. Use `list_loki_label_names` / `list_loki_label_values` to verify labels before querying. `query_loki_stats` is advisory only: native Loki index statistics are approximate and exclude data still held in ingesters, so zero stats do not prove that a selector is empty.",
 	queryLokiLogs,
 	mcp.WithTitleAnnotation("Query Loki logs"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -768,6 +769,9 @@ func (c *Client) fetchStats(ctx context.Context, query, startRFC3339, endRFC3339
 	err = json.Unmarshal(bodyBytes, &stats)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling response (content: %s): %w", string(bodyBytes), err)
+	}
+	stats.Caveats = []string{
+		"Native Loki index statistics are approximate and exclude data still held in ingesters; zero values do not prove that the selector is empty.",
 	}
 
 	return &stats, nil
@@ -854,7 +858,7 @@ func queryLokiStats(ctx context.Context, args QueryLokiStatsParams) (*Stats, err
 // QueryLokiStats is a tool for querying stats from Loki
 var QueryLokiStats = mcpgrafana.MustTool(
 	"query_loki_stats",
-	"Retrieves index-level statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). **Important**: the `entries` count reflects storage-level index entries (chunk metadata), NOT the number of individual log lines matching the selector. To count actual matching log lines, use `query_loki_logs` with a `count_over_time()` metric query instead. On VictoriaLogs only `entries` is populated; the other fields remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
+	"Retrieves advisory index-level statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). **Important**: the `entries` count reflects storage-level index entries (chunk metadata), NOT the number of individual log lines matching the selector. Native Loki index statistics are approximate and exclude data still held in ingesters, so all-zero values do not prove that the selector is empty; the response includes this caveat. To count actual matching log lines or verify recent data, use `query_loki_logs` with a `count_over_time()` metric query or a bounded log query. On VictoriaLogs only `entries` is populated; the other fields remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
 	queryLokiStats,
 	mcp.WithTitleAnnotation("Get Loki log statistics"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/loki_unit_test.go
+++ b/tools/loki_unit_test.go
@@ -3,12 +3,31 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFetchStats_IncludesIngesterCaveat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/loki/api/v1/index/stats", r.URL.Path)
+		assert.Equal(t, `{container="mcp-envoy"}`, r.URL.Query().Get("query"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"streams":0,"chunks":0,"entries":0,"bytes":0}`))
+	}))
+	defer server.Close()
+
+	client := &Client{httpClient: server.Client(), baseURL: server.URL}
+	stats, err := client.fetchStats(context.Background(), `{container="mcp-envoy"}`, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.Streams)
+	require.Len(t, stats.Caveats, 1)
+	assert.Contains(t, stats.Caveats[0], "exclude data still held in ingesters")
+}
 
 func TestEnforceLogLimit(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- add an explicit `caveats` field to native Loki `query_loki_stats` responses
- document that `/loki/api/v1/index/stats` is approximate and excludes data still held in ingesters
- remove the misleading guidance to use stats as an existence check before querying logs
- add a regression test for an all-zero index-stats response

## Why

`query_loki_stats` returned zero streams/chunks/entries/bytes while a bounded `query_loki_logs` query returned log lines. This is consistent with Loki index stats excluding data still in ingesters; an all-zero result must not be interpreted as proof that a selector is empty.

Loki documents this endpoint as approximate and excluding ingester data: https://grafana.com/docs/loki/latest/reference/loki-http-api/#query-ingester-and-store

## Behavior

The numeric stats remain unchanged and advisory. The response now carries the limitation alongside the values, and the tool descriptions direct callers to a bounded log query or `count_over_time()` when they need to verify recent data or count matching lines. No synthetic counts or expensive fallback query are introduced.

## Validation

- `GOTOOLCHAIN=auto go test -tags unit ./tools -count=1`