### PR TITLE
fix(tools): declare readOnly/destructive/openWorld hints on every tool

### DIFF
--- a/cmd/mcp-grafana/annotations_test.go
+++ b/cmd/mcp-grafana/annotations_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// listAllTools registers every tool category on a fresh server (with write
+// tools enabled or disabled) and returns the tools exactly as a client would
+// see them from tools/list.
+func listAllTools(t *testing.T, disableWrite bool) []mcp.Tool {
+	t.Helper()
+
+	dt := disabledTools{write: disableWrite}
+	var categories []string
+	for _, e := range dt.toolEntries() {
+		categories = append(categories, e.category)
+	}
+	dt.enabledTools = strings.Join(categories, ",")
+
+	srv := server.NewMCPServer("test", "0")
+	dt.processTools(srv)
+
+	response := srv.HandleMessage(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	raw, err := json.Marshal(response)
+	require.NoError(t, err)
+
+	var parsed struct {
+		Result mcp.ListToolsResult `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	require.Nil(t, parsed.Error, "tools/list returned an error")
+	require.NotEmpty(t, parsed.Result.Tools)
+	return parsed.Result.Tools
+}
+
+// TestAllToolsDeclareAnnotationHints asserts that every tool exposed by the
+// server explicitly sets the three MCP tool annotations readOnlyHint,
+// destructiveHint and openWorldHint. Directory listings (e.g. the OpenAI
+// plugin directory) fail closed on any omission, so a tool missing any of the
+// three would silently delist the hosted server. See
+// https://github.com/grafana/mcp-grafana/issues/1009.
+func TestAllToolsDeclareAnnotationHints(t *testing.T) {
+	for _, disableWrite := range []bool{false, true} {
+		name := "write-enabled"
+		if disableWrite {
+			name = "write-disabled"
+		}
+		t.Run(name, func(t *testing.T) {
+			var violations []string
+			for _, tool := range listAllTools(t, disableWrite) {
+				ann := tool.Annotations
+				var missing []string
+				if ann.ReadOnlyHint == nil {
+					missing = append(missing, "readOnlyHint")
+				}
+				if ann.DestructiveHint == nil {
+					missing = append(missing, "destructiveHint")
+				}
+				if ann.OpenWorldHint == nil {
+					missing = append(missing, "openWorldHint")
+				}
+				if len(missing) > 0 {
+					violations = append(violations, fmt.Sprintf("%s: missing %s", tool.Name, strings.Join(missing, ", ")))
+					continue
+				}
+				// destructiveHint is only meaningful for write tools; a
+				// read-only tool claiming to be destructive indicates a
+				// mislabelled annotation on one side or the other.
+				if *ann.ReadOnlyHint && *ann.DestructiveHint {
+					violations = append(violations, fmt.Sprintf("%s: readOnlyHint=true conflicts with destructiveHint=true", tool.Name))
+				}
+			}
+			if len(violations) > 0 {
+				t.Errorf("tools with missing or inconsistent annotations (%d):\n%s", len(violations), strings.Join(violations, "\n"))
+			}
+		})
+	}
+}

--- a/tools/admin.go
+++ b/tools/admin.go
@@ -38,6 +38,8 @@ var ListTeams = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List teams"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListUsersByOrgParams struct{}
@@ -60,6 +62,8 @@ var ListUsersByOrg = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List users by org"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListAllRolesParams struct {
@@ -89,6 +93,8 @@ var ListAllRoles = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List all roles"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type GetRoleDetailsParams struct {
@@ -113,6 +119,8 @@ var GetRoleDetails = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get role details"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type GetRoleAssignmentsParams struct {
@@ -137,6 +145,8 @@ var GetRoleAssignments = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get role assignments"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListUserRolesParams struct {
@@ -162,6 +172,8 @@ var ListUserRoles = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List user roles"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListTeamRolesParams struct {
@@ -187,6 +199,8 @@ var ListTeamRoles = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List team roles"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type GetResourcePermissionsParams struct {
@@ -212,6 +226,8 @@ var GetResourcePermissions = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get resource permissions"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type GetResourceDescriptionParams struct {
@@ -239,6 +255,8 @@ var GetResourceDescription = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get resource description"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddAdminTools(mcp *server.MCPServer) {

--- a/tools/agento11y.go
+++ b/tools/agento11y.go
@@ -469,6 +469,8 @@ When NOT to use:
 	mcp.WithTitleAnnotation("Manage Agent Observability conversations"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yGenerations = mcpgrafana.MustTool(
@@ -489,6 +491,8 @@ When NOT to use:
 	mcp.WithTitleAnnotation("Manage Agent Observability generations"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 const manageAgento11yEvaluatorsDescriptionFmt = `%s
@@ -658,6 +662,8 @@ var ManageAgento11yEvaluatorsRead = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Manage Agent Observability evaluators"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalRulesRead = mcpgrafana.MustTool(
@@ -667,6 +673,8 @@ var ManageAgento11yEvalRulesRead = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Manage Agent Observability eval rules and guards"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalCollectionsRead = mcpgrafana.MustTool(
@@ -676,6 +684,8 @@ var ManageAgento11yEvalCollectionsRead = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Manage Agent Observability saved conversations and collections"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvaluatorsReadWrite = mcpgrafana.MustTool(
@@ -683,7 +693,9 @@ var ManageAgento11yEvaluatorsReadWrite = mcpgrafana.MustTool(
 	manageAgento11yEvaluatorsDescription(false),
 	manageAgento11yEvaluatorsReadWrite,
 	mcp.WithTitleAnnotation("Manage Agent Observability evaluators"),
+	mcp.WithReadOnlyHintAnnotation(false),
 	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalRulesReadWrite = mcpgrafana.MustTool(
@@ -691,7 +703,9 @@ var ManageAgento11yEvalRulesReadWrite = mcpgrafana.MustTool(
 	manageAgento11yEvalRulesDescription(false),
 	manageAgento11yEvalRulesReadWrite,
 	mcp.WithTitleAnnotation("Manage Agent Observability eval rules and guards"),
+	mcp.WithReadOnlyHintAnnotation(false),
 	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalCollectionsReadWrite = mcpgrafana.MustTool(
@@ -699,7 +713,9 @@ var ManageAgento11yEvalCollectionsReadWrite = mcpgrafana.MustTool(
 	manageAgento11yEvalCollectionsDescription(false),
 	manageAgento11yEvalCollectionsReadWrite,
 	mcp.WithTitleAnnotation("Manage Agent Observability saved conversations and collections"),
+	mcp.WithReadOnlyHintAnnotation(false),
 	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddAgento11yTools(mcp *server.MCPServer, enableWriteTools bool) {

--- a/tools/agento11y_agents.go
+++ b/tools/agento11y_agents.go
@@ -329,4 +329,6 @@ When NOT to use:
 	mcp.WithTitleAnnotation("Manage Agent Observability agents"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -46,6 +46,8 @@ var ManageRulesRead = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Manage alert rules"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageRulesReadWrite = mcpgrafana.MustTool(
@@ -53,7 +55,9 @@ var ManageRulesReadWrite = mcpgrafana.MustTool(
 	manageAlertRulesDescription(false),
 	manageRulesReadWrite,
 	mcp.WithTitleAnnotation("Manage alert rules"),
+	mcp.WithReadOnlyHintAnnotation(false),
 	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddAlertingTools(mcp *server.MCPServer, enableWriteTools bool) {

--- a/tools/alerting_routing.go
+++ b/tools/alerting_routing.go
@@ -160,4 +160,6 @@ var ManageRouting = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Manage alerting routing"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/annotations.go
+++ b/tools/annotations.go
@@ -61,6 +61,8 @@ var GetAnnotationsTool = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get Annotations"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // CreateAnnotationInput creates a new annotation, optionally in Graphite format.
@@ -134,6 +136,9 @@ var CreateAnnotationTool = mcpgrafana.MustTool(
 	createAnnotation,
 	mcp.WithTitleAnnotation("Create Annotation"),
 	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // UpdateAnnotationInput updates only the provided fields of an annotation (PATCH semantics).
@@ -183,8 +188,10 @@ var UpdateAnnotationTool = mcpgrafana.MustTool(
 	"Updates the provided properties of an annotation by ID. Only fields included in the request are modified; omitted fields are left unchanged.",
 	updateAnnotation,
 	mcp.WithTitleAnnotation("Update Annotation"),
-	mcp.WithDestructiveHintAnnotation(true),
 	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // GetAnnotationTagsInput defines filters for retrieving annotation tags.
@@ -217,6 +224,8 @@ var GetAnnotationTagsTool = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get Annotation Tags"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddAnnotationTools(mcp *server.MCPServer, enableWriteTools bool) {

--- a/tools/api.go
+++ b/tools/api.go
@@ -177,6 +177,9 @@ var APIRequest = mcpgrafana.MustTool(
 		"Use this for API endpoints that don't have a dedicated tool.",
 	apiRequest,
 	mcp.WithTitleAnnotation("Grafana API request"),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var APIRequestReadOnly = mcpgrafana.MustTool(
@@ -189,6 +192,8 @@ var APIRequestReadOnly = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Grafana API request"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddAPITools(mcp *server.MCPServer, enableWriteTools bool) {

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -148,6 +148,8 @@ var GetAssertions = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get assertions summary"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddAssertsTools(mcp *server.MCPServer) {

--- a/tools/assistant.go
+++ b/tools/assistant.go
@@ -179,9 +179,10 @@ var AskAssistant = mcpgrafana.MustTool(
 	askAssistantDescription,
 	askAssistant,
 	mcp.WithTitleAnnotation("Ask Grafana Assistant"),
-	mcp.WithReadOnlyHintAnnotation(false),
 	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddAssistantTools registers the assistant tools with the MCP server. The

--- a/tools/athena.go
+++ b/tools/athena.go
@@ -526,8 +526,11 @@ Example: SELECT request_time, status FROM my_table WHERE $__timeFilter(request_t
 	queryAthena,
 	mcp.WithTitleAnnotation("Query Athena"),
 	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
+	// The raw SQL is passed through unfiltered, so DML/DDL (INSERT, DROP,
+	// CREATE TABLE AS) executes if the datasource credentials permit it —
+	// not read-only, potentially destructive.
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
 	mcp.WithOpenWorldHintAnnotation(false),
 )
 

--- a/tools/athena.go
+++ b/tools/athena.go
@@ -525,7 +525,7 @@ Athena queries are async — Grafana handles polling. Use LIMIT and partition-aw
 Example: SELECT request_time, status FROM my_table WHERE $__timeFilter(request_time) LIMIT 100`,
 	queryAthena,
 	mcp.WithTitleAnnotation("Query Athena"),
-	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithIdempotentHintAnnotation(false),
 	// The raw SQL is passed through unfiltered, so DML/DDL (INSERT, DROP,
 	// CREATE TABLE AS) executes if the datasource credentials permit it —
 	// not read-only, potentially destructive.

--- a/tools/athena.go
+++ b/tools/athena.go
@@ -241,6 +241,8 @@ var ListAthenaCatalogs = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Athena catalogs"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListAthenaDatabasesParams struct {
@@ -282,6 +284,8 @@ var ListAthenaDatabases = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Athena databases"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListAthenaTablesParams struct {
@@ -327,6 +331,8 @@ var ListAthenaTables = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Athena tables"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type DescribeAthenaTableParams struct {
@@ -379,6 +385,8 @@ var DescribeAthenaTable = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Describe Athena table"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type AthenaQueryParams struct {
@@ -519,6 +527,8 @@ Example: SELECT request_time, status FROM my_table WHERE $__timeFilter(request_t
 	mcp.WithTitleAnnotation("Query Athena"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddAthenaTools registers all Athena tools with the MCP server.

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -240,6 +240,8 @@ Example: SELECT Timestamp, Body FROM otel_logs WHERE $__timeFilter(Timestamp)`,
 	mcp.WithTitleAnnotation("Query ClickHouse"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListClickHouseTablesParams defines the parameters for listing ClickHouse tables
@@ -306,6 +308,8 @@ var ListClickHouseTables = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List ClickHouse tables"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // DescribeClickHouseTableParams defines the parameters for describing a ClickHouse table
@@ -383,6 +387,8 @@ var DescribeClickHouseTable = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Describe ClickHouse table"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddClickHouseTools registers all ClickHouse tools with the MCP server

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -239,8 +239,11 @@ Example: SELECT Timestamp, Body FROM otel_logs WHERE $__timeFilter(Timestamp)`,
 	queryClickHouse,
 	mcp.WithTitleAnnotation("Query ClickHouse"),
 	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
+	// The raw SQL is passed through unfiltered, so a DELETE/DROP executes if
+	// the datasource credentials permit it — not read-only, potentially
+	// destructive.
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
 	mcp.WithOpenWorldHintAnnotation(false),
 )
 

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -238,7 +238,7 @@ Time formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)
 Example: SELECT Timestamp, Body FROM otel_logs WHERE $__timeFilter(Timestamp)`,
 	queryClickHouse,
 	mcp.WithTitleAnnotation("Query ClickHouse"),
-	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithIdempotentHintAnnotation(false),
 	// The raw SQL is passed through unfiltered, so a DELETE/DROP executes if
 	// the datasource credentials permit it — not read-only, potentially
 	// destructive.

--- a/tools/cloudwatch.go
+++ b/tools/cloudwatch.go
@@ -318,6 +318,8 @@ Cross-account monitoring: Use accountId to query metrics from a specific source 
 	mcp.WithTitleAnnotation("Query CloudWatch"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListCloudWatchNamespacesParams defines the parameters for listing CloudWatch namespaces
@@ -423,6 +425,8 @@ var ListCloudWatchNamespaces = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List CloudWatch namespaces"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListCloudWatchMetricsParams defines the parameters for listing CloudWatch metrics
@@ -483,6 +487,8 @@ var ListCloudWatchMetrics = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List CloudWatch metrics"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListCloudWatchDimensionsParams defines the parameters for listing CloudWatch dimensions
@@ -545,6 +551,8 @@ var ListCloudWatchDimensions = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List CloudWatch dimensions"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddCloudWatchTools registers all CloudWatch tools with the MCP server

--- a/tools/config.go
+++ b/tools/config.go
@@ -120,6 +120,8 @@ var SuggestLokiAlloyLabelConfig = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Suggest Alloy label enforcement config"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddConfigTools registers the config-generation tool set.

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -674,6 +674,8 @@ var GetDashboardByUID = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get dashboard details"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var UpdateDashboard = mcpgrafana.MustTool(
@@ -681,7 +683,9 @@ var UpdateDashboard = mcpgrafana.MustTool(
 	"Create or update a dashboard. Two modes: (1) Full JSON — provide 'dashboard' for new dashboards or complete replacements. (2) Patch — provide 'uid' + 'operations' to make targeted changes to an existing dashboard. One of these two modes is required; 'folderUid'\\, 'message'\\, and 'overwrite' are supplementary and do nothing on their own. Dashboard authoring guidance: if a saved query must support one\\, many\\, or All values from a multi-select variable inside a regex expression or matcher\\, save '${var:regex}' rather than plain '$var'. Saved dashboard annotation queries/definitions must be written into dashboard JSON under 'annotations.list'; the create_annotation tool creates annotation events and does not add a reusable dashboard annotation query/definition to the saved dashboard. For stat panels over the current dashboard range\\, make the query return the range-level result the stat should display; panel-side reduction only reduces returned series and does not compute peak-over-range or ratio-of-peaks semantics for you. Patch operations support JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'\\, '$.templating.list/-'\\, and '$.annotations.list/-'. Append to arrays with '/- ' syntax: '$.panels/- '. Remove by index: {\"op\": \"remove\"\\, \"path\": \"$.panels[2]\"}. Multiple removes on the same array are automatically reordered to avoid index-shifting issues. Note: only numeric array indices are supported in patch paths; filter expressions like [?(@.id==2)] and wildcards like [*] are not supported. v2 dashboards (check 'isV2' from get_dashboard_by_uid) use a different shape: patch '$.elements.<name>.spec.title' or '$.elements.<name>.spec.data.spec.queries[0].spec' and edit '$.variables'/'$.layout' rather than '$.panels'/'$.templating.list'. Full-JSON saves containing top-level 'elements'/'layout' are written as v2 and require a Kubernetes-capable Grafana. After creating or updating a dashboard\\, verify that panel queries return data by using `run_panel_query` or the appropriate query tool (`query_prometheus`\\, `query_loki_logs`\\, etc.) to validate expressions before considering the task complete.",
 	updateDashboard,
 	mcp.WithTitleAnnotation("Create or update dashboard"),
+	mcp.WithReadOnlyHintAnnotation(false),
 	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type DashboardPanelQueriesParams struct {
@@ -753,6 +757,8 @@ var GetDashboardPanelQueries = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get dashboard panel queries"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // GetDashboardPropertyParams defines parameters for getting specific dashboard properties
@@ -803,6 +809,8 @@ var GetDashboardProperty = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get dashboard property"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // GetDashboardSummaryParams defines parameters for getting a dashboard summary
@@ -916,6 +924,8 @@ var GetDashboardSummary = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get dashboard summary"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // applyJSONPath applies a value to a JSONPath or removes it if remove=true

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -430,6 +430,8 @@ var ListDatasources = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List datasources"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var CreateDatasource = mcpgrafana.MustTool(
@@ -439,6 +441,8 @@ var CreateDatasource = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Create datasource"),
 	mcp.WithIdempotentHintAnnotation(false),
 	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var UpdateDatasource = mcpgrafana.MustTool(
@@ -448,6 +452,8 @@ var UpdateDatasource = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Update datasource"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type GetDatasourceByUIDParams struct {
@@ -507,6 +513,8 @@ var GetDatasource = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get datasource"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type UpdateDatasourceParams struct {
@@ -809,6 +817,8 @@ var CheckDatasourcesHealth = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Check datasources health"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddDatasourceTools registers the datasource tools on the MCP server; write tools are registered only when enableWriteTools is true.

--- a/tools/elasticsearch.go
+++ b/tools/elasticsearch.go
@@ -56,6 +56,8 @@ var QueryElasticsearch = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Elasticsearch"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddElasticsearchTools registers all Elasticsearch and OpenSearch tools with the MCP server

--- a/tools/examples.go
+++ b/tools/examples.go
@@ -294,6 +294,8 @@ var GetQueryExamples = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get query examples"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddExamplesTools registers all example-related tools to the MCP server.

--- a/tools/folder.go
+++ b/tools/folder.go
@@ -47,6 +47,9 @@ var CreateFolder = mcpgrafana.MustTool(
 	createFolder,
 	mcp.WithTitleAnnotation("Create folder"),
 	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddFolderTools(mcp *server.MCPServer, enableWriteTools bool) {

--- a/tools/graphite.go
+++ b/tools/graphite.go
@@ -233,6 +233,8 @@ var QueryGraphite = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Graphite metrics"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // GraphiteMetricNode is a node in the Graphite metric hierarchy as returned
@@ -308,6 +310,8 @@ var ListGraphiteMetrics = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Graphite metrics"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListGraphiteTagsParams defines the parameters for the list_graphite_tags tool.
@@ -355,6 +359,8 @@ var ListGraphiteTags = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Graphite tags"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // computeSeriesDensity derives data-density statistics from the parsed
@@ -499,6 +505,8 @@ var QueryGraphiteDensity = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Graphite metric density"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddGraphiteTools registers all Graphite tools with the MCP server.

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -89,6 +89,8 @@ var ListIncidents = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List incidents"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type CreateIncidentParams struct {
@@ -126,6 +128,9 @@ var CreateIncident = mcpgrafana.MustTool(
 	"Create a new Grafana incident. Requires title, severity, and room prefix. Allows setting status and labels. This tool should be used judiciously and sparingly, and only after confirmation from the user, as it may notify or alarm lots of people.",
 	createIncident,
 	mcp.WithTitleAnnotation("Create incident"),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type AddActivityToIncidentParams struct {
@@ -154,6 +159,9 @@ var AddActivityToIncident = mcpgrafana.MustTool(
 	"Add a note (userNote activity) to an existing incident's timeline using its ID. The note body can include URLs which will be attached as context. Use this to add context to an incident.",
 	addActivityToIncident,
 	mcp.WithTitleAnnotation("Add activity to incident"),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddIncidentTools(mcp *server.MCPServer, enableWriteTools bool) {
@@ -190,4 +198,6 @@ var GetIncident = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get incident details"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/influxdb.go
+++ b/tools/influxdb.go
@@ -217,8 +217,11 @@ Flux example:    from(bucket: "metrics") |> range(start: -1h) |> filter(fn: (r) 
 	queryInfluxDB,
 	mcp.WithTitleAnnotation("Query InfluxDB"),
 	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
+	// The query is passed through unfiltered: InfluxQL supports DELETE/DROP
+	// and Flux can write via to(), so this executes writes if the datasource
+	// credentials permit it — not read-only, potentially destructive.
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
 	mcp.WithOpenWorldHintAnnotation(false),
 )
 

--- a/tools/influxdb.go
+++ b/tools/influxdb.go
@@ -216,7 +216,7 @@ InfluxQL example: SELECT mean("value") FROM "cpu" WHERE time > now() - 1h GROUP 
 Flux example:    from(bucket: "metrics") |> range(start: -1h) |> filter(fn: (r) => r._measurement == "cpu")`,
 	queryInfluxDB,
 	mcp.WithTitleAnnotation("Query InfluxDB"),
-	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithIdempotentHintAnnotation(false),
 	// The query is passed through unfiltered: InfluxQL supports DELETE/DROP
 	// and Flux can write via to(), so this executes writes if the datasource
 	// credentials permit it — not read-only, potentially destructive.

--- a/tools/influxdb.go
+++ b/tools/influxdb.go
@@ -218,6 +218,8 @@ Flux example:    from(bucket: "metrics") |> range(start: -1h) |> filter(fn: (r) 
 	mcp.WithTitleAnnotation("Query InfluxDB"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddInfluxDBTools registers all InfluxDB tools with the MCP server.

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -222,6 +222,8 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Loki label names"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListLokiLabelValuesParams defines the parameters for listing Loki label values
@@ -269,6 +271,8 @@ var ListLokiLabelValues = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Loki label values"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // LokiLogStream represents a stream of log entries from Loki (resultType: "streams")
@@ -747,6 +751,8 @@ var QueryLokiLogs = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Loki logs"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // fetchStats is a method to fetch stats data from Loki API
@@ -859,6 +865,8 @@ var QueryLokiStats = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get Loki log statistics"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // QueryLokiPatternsParams defines the parameters for querying Loki patterns
@@ -900,6 +908,8 @@ var QueryLokiPatterns = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Loki patterns"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddLokiTools registers all Loki tools with the MCP server.

--- a/tools/loki_label_analyzer.go
+++ b/tools/loki_label_analyzer.go
@@ -1011,4 +1011,6 @@ var AnalyzeLokiLabels = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Analyze Loki label strategy"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -315,6 +315,9 @@ var GenerateDeeplink = mcpgrafana.MustTool(
 	generateDeeplink,
 	mcp.WithTitleAnnotation("Generate navigation deeplink"),
 	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var GenerateDeeplinkReadOnly = mcpgrafana.MustTool(
@@ -324,6 +327,8 @@ var GenerateDeeplinkReadOnly = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Generate navigation deeplink"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddNavigationTools(mcp *server.MCPServer, enableWriteTools bool) {

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -192,6 +192,8 @@ var ListOnCallSchedules = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List OnCall schedules"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Shifts ---
@@ -242,6 +244,8 @@ var GetOnCallShift = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get OnCall shift"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Current On-Call Users ---
@@ -310,6 +314,8 @@ var GetCurrentOnCallUsers = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get current on-call users"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Teams ---
@@ -361,6 +367,8 @@ var ListOnCallTeams = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List OnCall teams"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Users ---
@@ -431,6 +439,8 @@ var ListOnCallUsers = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List OnCall users"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Alert Groups ---
@@ -520,6 +530,8 @@ var ListAlertGroups = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List IRM alert groups"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type GetAlertGroupParams struct {
@@ -565,6 +577,8 @@ var GetAlertGroup = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get IRM alert group"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddOnCallTools(mcp *server.MCPServer) {

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -129,6 +129,8 @@ var GetPlugin = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get plugin"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type InstallPluginParams struct {
@@ -230,9 +232,10 @@ var InstallPlugin = mcpgrafana.MustTool(
 	"Install a Grafana plugin by its plugin ID. If the version is not already confirmed with the user, omit it — the tool will look up the latest version and return it for confirmation before installing.",
 	installPlugin,
 	mcp.WithTitleAnnotation("Install plugin"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
 	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(true),
 )
 
 // catalogPlugin mirrors the relevant fields from the Grafana plugin catalog list API.
@@ -398,6 +401,8 @@ var SearchPlugins = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Search plugins"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(true),
 )
 
 func AddPluginTools(s *server.MCPServer, enableWrite bool) {

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -60,6 +60,8 @@ var ListPrometheusMetricMetadata = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Prometheus metric metadata"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type QueryPrometheusParams struct {
@@ -182,6 +184,8 @@ var QueryPrometheus = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Prometheus metrics"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPrometheusMetricNamesParams struct {
@@ -262,6 +266,8 @@ var ListPrometheusMetricNames = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Prometheus metric names"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type LabelMatcher struct {
@@ -365,6 +371,8 @@ var ListPrometheusLabelNames = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Prometheus label names"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPrometheusLabelValuesParams struct {
@@ -422,6 +430,8 @@ var ListPrometheusLabelValues = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Prometheus label values"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // PrometheusHistogramResult wraps histogram query results with debugging info
@@ -576,6 +586,8 @@ Time formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)`,
 	mcp.WithTitleAnnotation("Query Prometheus histogram percentile"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddPrometheusTools(mcp *server.MCPServer) {

--- a/tools/provisioning.go
+++ b/tools/provisioning.go
@@ -161,6 +161,8 @@ var ListProvisioningRepositories = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List provisioning repositories"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ValidateProvisioningFileParams identifies a single file to validate inside
@@ -379,6 +381,8 @@ var ValidateProvisioningFile = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Validate provisioning file"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddProvisioningTools(s *server.MCPServer) {

--- a/tools/pyroscope.go
+++ b/tools/pyroscope.go
@@ -44,6 +44,8 @@ var ListPyroscopeLabelNames = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Pyroscope label names"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPyroscopeLabelNamesParams struct {
@@ -103,6 +105,8 @@ var ListPyroscopeLabelValues = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Pyroscope label values"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPyroscopeLabelValuesParams struct {
@@ -169,6 +173,8 @@ var ListPyroscopeProfileTypes = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Pyroscope profile types"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPyroscopeProfileTypesParams struct {
@@ -622,6 +628,8 @@ var QueryPyroscope = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Pyroscope"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type QueryPyroscopeParams struct {

--- a/tools/quickwit.go
+++ b/tools/quickwit.go
@@ -262,6 +262,8 @@ var QueryQuickwit = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Query Quickwit"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddQuickwitTools registers all Quickwit tools with the MCP server.

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -359,8 +359,10 @@ var GetPanelImage = mcpgrafana.MustTool(
 	getPanelImage,
 	mcp.WithTitleAnnotation("Get panel or dashboard image"),
 	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
 	mcpgrafana.WithUIResource(mcpgrafana.PanelViewerResourceURI),
+	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddRenderingTools(mcp *server.MCPServer) {

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -843,6 +843,8 @@ var RunPanelQuery = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Run panel query"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddRunPanelQueryTools registers run panel query tools with the MCP server

--- a/tools/search.go
+++ b/tools/search.go
@@ -107,6 +107,8 @@ var SearchDashboards = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Search dashboards"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 type SearchFoldersParams struct {
@@ -137,6 +139,8 @@ var SearchFolders = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Search folders"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddSearchTools(mcp *server.MCPServer) {

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -177,6 +177,8 @@ var GetSiftInvestigation = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get Sift investigation"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // GetSiftAnalysisParams defines the parameters for retrieving a specific analysis
@@ -219,6 +221,8 @@ var GetSiftAnalysis = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get Sift analysis"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListSiftInvestigationsParams defines the parameters for retrieving investigations
@@ -254,6 +258,8 @@ var ListSiftInvestigations = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Sift investigations"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // FindErrorPatternLogsParams defines the parameters for running an ErrorPatternLogs check
@@ -345,7 +351,9 @@ var FindErrorPatternLogs = mcpgrafana.MustTool(
 	"Searches Loki logs for elevated error patterns compared to the last day's average, waits for the analysis to complete, and returns the results including any patterns found.",
 	findErrorPatternLogs,
 	mcp.WithTitleAnnotation("Find error patterns in logs"),
-	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // FindSlowRequestsParams defines the parameters for running an SlowRequests check
@@ -412,7 +420,9 @@ var FindSlowRequests = mcpgrafana.MustTool(
 	"Searches relevant Tempo datasources for slow requests, waits for the analysis to complete, and returns the results.",
 	findSlowRequests,
 	mcp.WithTitleAnnotation("Find slow requests"),
-	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddSiftTools registers all Sift tools with the MCP server

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -231,6 +231,8 @@ var ListSnapshotsTool = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List snapshots"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var GetSnapshotTool = mcpgrafana.MustTool(
@@ -240,6 +242,8 @@ var GetSnapshotTool = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Get snapshot"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var CreateSnapshotTool = mcpgrafana.MustTool(
@@ -248,6 +252,9 @@ var CreateSnapshotTool = mcpgrafana.MustTool(
 	createSnapshot,
 	mcp.WithTitleAnnotation("Create snapshot"),
 	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 var DeleteSnapshotTool = mcpgrafana.MustTool(
@@ -256,7 +263,9 @@ var DeleteSnapshotTool = mcpgrafana.MustTool(
 	deleteSnapshot,
 	mcp.WithTitleAnnotation("Delete snapshot"),
 	mcp.WithIdempotentHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
 	mcp.WithDestructiveHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 func AddSnapshotTools(s *server.MCPServer, enableWriteTools bool) {

--- a/tools/snowflake.go
+++ b/tools/snowflake.go
@@ -241,6 +241,8 @@ Example: SELECT TIMESTAMP, RECORD['severity_text']::STRING AS LEVEL, VALUE FROM 
 	mcp.WithTitleAnnotation("Query Snowflake"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // ListSnowflakeTablesParams defines the parameters for listing Snowflake tables
@@ -319,6 +321,8 @@ var ListSnowflakeTables = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("List Snowflake tables"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // DescribeSnowflakeTableParams defines the parameters for describing a Snowflake table
@@ -401,6 +405,8 @@ var DescribeSnowflakeTable = mcpgrafana.MustTool(
 	mcp.WithTitleAnnotation("Describe Snowflake table"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
 )
 
 // AddSnowflakeTools registers all Snowflake tools with the MCP server

--- a/tools/snowflake.go
+++ b/tools/snowflake.go
@@ -240,8 +240,11 @@ Example: SELECT TIMESTAMP, RECORD['severity_text']::STRING AS LEVEL, VALUE FROM 
 	querySnowflake,
 	mcp.WithTitleAnnotation("Query Snowflake"),
 	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
+	// The raw SQL is passed through unfiltered, so a DELETE/DROP executes if
+	// the datasource credentials permit it — not read-only, potentially
+	// destructive.
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
 	mcp.WithOpenWorldHintAnnotation(false),
 )
 

--- a/tools/snowflake.go
+++ b/tools/snowflake.go
@@ -239,7 +239,7 @@ Snowflake event tables (telemetry from logging APIs/auto-instrumentation) live i
 Example: SELECT TIMESTAMP, RECORD['severity_text']::STRING AS LEVEL, VALUE FROM SNOWFLAKE.TELEMETRY.EVENTS WHERE $__timeFilter(TIMESTAMP) AND RECORD_TYPE = 'LOG'`,
 	querySnowflake,
 	mcp.WithTitleAnnotation("Query Snowflake"),
-	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithIdempotentHintAnnotation(false),
 	// The raw SQL is passed through unfiltered, so a DELETE/DROP executes if
 	// the datasource credentials permit it — not read-only, potentially
 	// destructive.


### PR DESCRIPTION
Closes #1009.

## Summary

Every tool now explicitly sets the three MCP tool annotations — `readOnlyHint`, `destructiveHint`, `openWorldHint`. The OpenAI plugin-directory tool scan fails closed on any omission, and before this change 105 of 111 tools were missing at least one hint (most were missing `destructiveHint` and `openWorldHint`; the mcp-go `omitempty` pointer fields drop unset hints from `tools/list` entirely).

Annotation policy, as confirmed in #1009:

- **Pure-read tools** → `readOnlyHint: true, destructiveHint: false, openWorldHint: false`.
- **Additive writes** (`create_*`, `add_activity_to_incident`, `create_datasource`, `create_snapshot`) → `readOnlyHint: false, destructiveHint: false`.
- **Overwriting/deleting writes** (`update_*`, `delete_snapshot`, `alerting_manage_rules`, `grafana_api_request`, `ask_assistant`) → `destructiveHint: true`.
- **`openWorldHint: true` is reserved for the public plugin-catalog tools** (`install_plugin`, `search_plugin_information`, both of which call `grafana.com/api/plugins`). Everything else — including the cloud-datasource query tools — stays `false` since they are scoped to the user's stack and configured datasources.
- Write-gated read-only variants (`grafana_api_request`, `generate_deeplink`, `alerting_manage_rules`, the agento11y eval tools) are annotated per variant, so both `--disable-write` and write-enabled deployments advertise accurate hints.

## Value corrections beyond filling gaps

- `ask_assistant`: `openWorldHint` **true → false** — per the issue, open-world is reserved for public-catalog tools; the assistant is scoped to the user's stack.
- `install_plugin`: `destructiveHint` **true → false** — additive install, per the issue table.
- `find_error_pattern_logs` / `find_slow_requests` (Sift): `readOnlyHint` **true → false** — they POST new investigations to the Sift API, and are already write-gated in `AddSiftTools`. Marking a write-capable tool read-only is exactly what the scan (and the issue) forbids.
- `generate_deeplink` (write variant): `readOnlyHint: false` — with `shorten=true` it creates a Grafana short URL. This deviates from the issue's read-only list, which appears not to account for the short-URL write path; the read-only variant (registered under `--disable-write`) is `readOnlyHint: true`. Happy to revisit if we'd rather match the issue list verbatim.
- `query_clickhouse` / `query_snowflake` / `query_athena` / `query_influxdb`: `readOnlyHint` **true → false**, `destructiveHint` **false → true** (per review) — these pass the caller's raw SQL/InfluxQL/Flux through to `/api/ds/query` unfiltered, so `DELETE`/`DROP` (and Flux `to()`) execute whenever the datasource credentials permit it. This also deviates from the issue's read-only list, which didn't account for the raw-statement passthrough. `query_cloudwatch` stays read-only: it builds a structured `GetMetricData` request from namespace/metric/dimension parameters, with no statement language that could mutate anything. The remaining query tools (Loki, Prometheus, Elasticsearch, Graphite, Pyroscope, Quickwit) use read-only query languages/APIs and stay read-only.

## Regression guard

`cmd/mcp-grafana/annotations_test.go` registers every tool category from `toolEntries()` (the same single source of truth `main.go` uses) in both write modes, lists tools exactly as a client would via `tools/list`, and fails if any tool omits one of the three hints or claims `readOnlyHint: true` together with `destructiveHint: true`. A future tool shipped without hints now fails CI instead of silently delisting the hosted server.

## Notes

- Proxied tools (from app-plugin MCP servers) pass through whatever annotations the plugin declares; they are dynamic per session and out of scope here.
- `outputSchema` (the issue's non-blocking nice-to-have) is not included.

## Testing

- `make test-unit` — all green, including the new annotation test (was failing with 105 violations before the fix).
- `make lint` — clean.
