### PR TITLE
fix(http): drop support for undocumented X-Grafana-URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,16 +996,16 @@ grafanaConfig := mcpgrafana.GrafanaConfig{
 contextFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
 ```
 
-**URL validation when creating clients programmatically:**
+**URL validation:**
 
-When calling `NewGrafanaClient` directly, pre-validate untrusted URLs to avoid a reachable panic:
+When calling `NewGrafanaClient` directly (stdio or programmatic construction), pre-validate URLs to avoid a reachable panic:
 
 ```go
-if err := mcpgrafana.ValidateGrafanaURL(untrustedURL); err != nil {
+if err := mcpgrafana.ValidateGrafanaURL(urlFromHeader); err != nil {
     http.Error(w, err.Error(), http.StatusBadRequest)
     return
 }
-client := mcpgrafana.NewGrafanaClient(ctx, untrustedURL, apiKey, nil)
+client := mcpgrafana.NewGrafanaClient(ctx, urlFromHeader, apiKey, nil)
 ```
 
 ### Server TLS Configuration (Streamable HTTP Transport Only)

--- a/README.md
+++ b/README.md
@@ -996,25 +996,17 @@ grafanaConfig := mcpgrafana.GrafanaConfig{
 contextFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
 ```
 
-**URL validation when wiring your own HTTP server:**
+**URL validation when creating clients programmatically:**
 
-When library consumers wire mcp-grafana's context functions into their own `http.Server`, install `ValidateGrafanaURLMiddleware` to reject malformed `X-Grafana-URL` headers with 400 Bad Request (matching the binary's behavior):
-
-```go
-mux.Handle(path, mcpgrafana.ValidateGrafanaURLMiddleware(yourMCPHandler))
-```
-
-When calling `NewGrafanaClient` directly (stdio or programmatic construction), pre-validate untrusted URLs to avoid a reachable panic:
+When calling `NewGrafanaClient` directly, pre-validate untrusted URLs to avoid a reachable panic:
 
 ```go
-if err := mcpgrafana.ValidateGrafanaURL(urlFromHeader); err != nil {
+if err := mcpgrafana.ValidateGrafanaURL(untrustedURL); err != nil {
     http.Error(w, err.Error(), http.StatusBadRequest)
     return
 }
-client := mcpgrafana.NewGrafanaClient(ctx, urlFromHeader, apiKey, nil)
+client := mcpgrafana.NewGrafanaClient(ctx, untrustedURL, apiKey, nil)
 ```
-
-Both patterns share `ValidateGrafanaURL` as the single validator.
 
 ### Server TLS Configuration (Streamable HTTP Transport Only)
 

--- a/client_cache.go
+++ b/client_cache.go
@@ -334,7 +334,7 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 			logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 		}
 
-		u, apiKey, basicAuth, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
+		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		grafanaClient := cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {
@@ -352,7 +352,7 @@ func extractIncidentClientCached(cache *ClientCache) httpContextFunc {
 		config := GrafanaConfigFromContext(ctx)
 		logger := config.LoggerOrDefault()
 
-		grafanaURL, apiKey, _, orgID, _ := extractKeyGrafanaInfoFromReq(req, logger)
+		grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(grafanaURL, apiKey, nil, orgID, req)
 
 		incidentClient := cache.GetOrCreateIncidentClient(key, func() *incident.Client {
@@ -381,7 +381,7 @@ func extractKubernetesClientCached(cache *ClientCache) httpContextFunc {
 		config := GrafanaConfigFromContext(ctx)
 		logger := config.LoggerOrDefault()
 
-		u, apiKey, basicAuth, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
+		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		k8sClient := cache.GetOrCreateK8sClient(key, func() *KubernetesClient {

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -587,7 +587,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			basePath = "/"
 		}
 		mux.Handle(basePath, observability.WrapHandler(
-			mcpgrafana.ValidateGrafanaURLMiddleware(srv),
+			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			basePath,
 		))
 		mux.HandleFunc("/healthz", handleHealthz)
@@ -627,7 +627,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		srv := server.NewStreamableHTTPServer(s, opts...)
 		mux := http.NewServeMux()
 		mux.Handle(endpointPath, observability.WrapHandler(
-			mcpgrafana.ValidateGrafanaURLMiddleware(srv),
+			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			endpointPath,
 		))
 		mux.HandleFunc("/healthz", handleHealthz)

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -194,18 +194,15 @@ func orgIdFromHeaders(req *http.Request, logger *slog.Logger) int64 {
 	return orgID
 }
 
-func urlAndAPIKeyFromHeaders(req *http.Request) (string, string) {
-	u := strings.TrimRight(req.Header.Get(grafanaURLHeader), "/")
-
+func apiKeyFromHeaders(req *http.Request) string {
 	// Check for the new service account token header first
 	apiKey := req.Header.Get(grafanaServiceAccountTokenHeader)
 	if apiKey != "" {
-		return u, apiKey
+		return apiKey
 	}
 
 	// Fall back to the deprecated API key header
-	apiKey = req.Header.Get(grafanaAPIKeyHeader)
-	return u, apiKey
+	return req.Header.Get(grafanaAPIKeyHeader)
 }
 
 // grafanaConfigKey is the context key for Grafana configuration.
@@ -777,37 +774,23 @@ func extractKeyGrafanaInfoFromEnv(logger *slog.Logger) (url, apiKey string, auth
 	return
 }
 
-// Tries to get grafana info from a request.
-// Gets info from environment if it can't get it from request.
-//
-// envCredsAllowed reports whether environment-configured credentials were
-// eligible to be used for this request. Environment credentials are bound to the
-// environment-configured Grafana URL: if a request supplies an X-Grafana-URL
-// header pointing at a different instance, environment credentials are withheld
-// so that a caller-controlled URL cannot receive them.
-func extractKeyGrafanaInfoFromReq(req *http.Request, logger *slog.Logger) (grafanaUrl, apiKey string, auth *url.Userinfo, orgId int64, envCredsAllowed bool) {
+// Gets the Grafana URL from the environment and request-scoped credentials and
+// organization information from HTTP headers, with environment fallbacks.
+func extractKeyGrafanaInfoFromReq(req *http.Request, logger *slog.Logger) (grafanaUrl, apiKey string, auth *url.Userinfo, orgId int64) {
 	eUrl, eApiKey, eAuth, eOrgId := extractKeyGrafanaInfoFromEnv(logger)
 	username, password, _ := req.BasicAuth()
 
-	grafanaUrl, apiKey = urlAndAPIKeyFromHeaders(req)
-	envCredsAllowed = requestTargetsEnvURL(grafanaUrl, eUrl)
+	grafanaUrl = eUrl
+	apiKey = apiKeyFromHeaders(req)
 
-	// If no URL was supplied in the request, use the environment URL.
-	if grafanaUrl == "" {
-		grafanaUrl = eUrl
-	}
-
-	// Fall back to the environment token only when it is bound to the target URL.
-	if apiKey == "" && envCredsAllowed {
+	// Fall back to the environment token when none was supplied in the request.
+	if apiKey == "" {
 		apiKey = eApiKey
 	}
 
-	// Use request basic auth if supplied; otherwise fall back to the environment
-	// credentials only when they are bound to the target URL.
+	// Use request basic auth if supplied; otherwise fall back to the environment.
 	if username == "" && password == "" {
-		if envCredsAllowed {
-			auth = eAuth
-		}
+		auth = eAuth
 	} else {
 		auth = url.UserPassword(username, password)
 	}
@@ -820,20 +803,6 @@ func extractKeyGrafanaInfoFromReq(req *http.Request, logger *slog.Logger) (grafa
 	}
 
 	return
-}
-
-// requestTargetsEnvURL reports whether a request's X-Grafana-URL points at the
-// same Grafana instance as the environment configuration, meaning it is safe to
-// attach environment-configured credentials. An empty requestURL means the
-// caller did not override the URL, so the environment URL (and its credentials)
-// apply. A non-empty requestURL only matches when it normalizes to the same
-// value as the environment URL; anything else is treated as a foreign target and
-// environment credentials are withheld.
-func requestTargetsEnvURL(requestURL, envURL string) bool {
-	if requestURL == "" {
-		return true
-	}
-	return normalizeGrafanaURL(requestURL) == normalizeGrafanaURL(envURL)
 }
 
 // ExtractGrafanaInfoFromEnv is a StdioContextFunc that extracts Grafana configuration from environment variables.
@@ -866,8 +835,8 @@ var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context
 // identical, they have distinct types and cannot be passed around interchangeably.
 type httpContextFunc func(ctx context.Context, req *http.Request) context.Context
 
-// ExtractGrafanaInfoFromHeaders is a HTTPContextFunc that extracts Grafana configuration from HTTP request headers.
-// It reads X-Grafana-URL and X-Grafana-API-Key headers, falling back to environment variables if headers are not present.
+// ExtractGrafanaInfoFromHeaders is a HTTPContextFunc that extracts request-scoped Grafana configuration from HTTP headers.
+// The Grafana URL is always read from GRAFANA_URL. Authentication and organization headers fall back to environment variables when absent.
 // Headers listed in GRAFANA_FORWARD_HEADERS are copied from the incoming request and merged with GRAFANA_EXTRA_HEADERS.
 var ExtractGrafanaInfoFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	// Get existing config or create a new one.
@@ -875,22 +844,14 @@ var ExtractGrafanaInfoFromHeaders httpContextFunc = func(ctx context.Context, re
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
 
-	u, apiKey, basicAuth, orgID, envCredsAllowed := extractKeyGrafanaInfoFromReq(req, logger)
+	u, apiKey, basicAuth, orgID := extractKeyGrafanaInfoFromReq(req, logger)
 
 	config.URL = u
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
 	config.OrgID = orgID
 
-	// Environment extra headers may carry credentials (e.g. an Authorization
-	// header), so they are bound to the environment-configured URL just like the
-	// service-account token. When a request targets a foreign URL, only headers
-	// the operator explicitly opted to forward (GRAFANA_FORWARD_HEADERS) are sent.
-	var envHeaders map[string]string
-	if envCredsAllowed {
-		envHeaders = extraHeadersFromEnv(logger)
-	}
-	config.ExtraHeaders = mergeHeaders(envHeaders, forwardedHeadersFromRequest(req))
+	config.ExtraHeaders = mergeHeaders(extraHeadersFromEnv(logger), forwardedHeadersFromRequest(req))
 	return WithGrafanaConfig(ctx, config)
 }
 
@@ -1299,7 +1260,7 @@ var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Conte
 }
 
 // ExtractGrafanaClientFromHeaders is a HTTPContextFunc that creates and injects a Grafana client into the context.
-// It prioritizes configuration from HTTP headers (X-Grafana-URL, X-Grafana-API-Key) over environment variables for multi-tenant scenarios.
+// It uses GRAFANA_URL with request-scoped authentication headers and environment fallbacks.
 var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
@@ -1308,7 +1269,7 @@ var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, 
 	}
 
 	// Extract transport config from request headers, and set it on the context.
-	u, apiKey, basicAuth, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
+	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
 	logger.Debug("Creating Grafana client", "url", u, "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil)
 
 	grafanaClient := NewGrafanaClient(ctx, u, apiKey, basicAuth)
@@ -1406,11 +1367,11 @@ var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Cont
 }
 
 // ExtractIncidentClientFromHeaders is a HTTPContextFunc that creates and injects a Grafana Incident client into the context.
-// It uses HTTP headers for configuration with environment variable fallbacks, enabling per-request incident management configuration.
+// It uses GRAFANA_URL with request-scoped authentication and organization headers and environment fallbacks.
 var ExtractIncidentClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
-	grafanaURL, apiKey, _, orgID, _ := extractKeyGrafanaInfoFromReq(req, logger)
+	grafanaURL, apiKey, _, orgID := extractKeyGrafanaInfoFromReq(req, logger)
 	incidentURL := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/v1/", grafanaURL)
 	client := incident.NewClient(incidentURL, apiKey)
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -57,7 +57,7 @@ func TestExtractIncidentClientFromHeaders(t *testing.T) {
 		assert.Equal(t, "http://my-test-url.grafana.com/api/plugins/grafana-irm-app/resources/api/v1/", client.RemoteHost)
 	})
 
-	t.Run("with headers, no env", func(t *testing.T) {
+	t.Run("URL header ignored without env", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://example.com", nil)
 		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
 		require.NoError(t, err)
@@ -65,11 +65,11 @@ func TestExtractIncidentClientFromHeaders(t *testing.T) {
 
 		client := IncidentClientFromContext(ctx)
 		require.NotNil(t, client)
-		assert.Equal(t, "http://my-test-url.grafana.com/api/plugins/grafana-irm-app/resources/api/v1/", client.RemoteHost)
+		assert.Equal(t, "http://localhost:3000/api/plugins/grafana-irm-app/resources/api/v1/", client.RemoteHost)
 	})
 
-	t.Run("with headers, with env", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", "will-not-be-used")
+	t.Run("URL header ignored with env", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "http://configured.grafana.com")
 		req, err := http.NewRequest("GET", "http://example.com", nil)
 		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
 		require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestExtractIncidentClientFromHeaders(t *testing.T) {
 
 		client := IncidentClientFromContext(ctx)
 		require.NotNil(t, client)
-		assert.Equal(t, "http://my-test-url.grafana.com/api/plugins/grafana-irm-app/resources/api/v1/", client.RemoteHost)
+		assert.Equal(t, "http://configured.grafana.com/api/plugins/grafana-irm-app/resources/api/v1/", client.RemoteHost)
 	})
 }
 
@@ -134,20 +134,19 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 		assert.Equal(t, "my-service-account-token", config.APIKey)
 	})
 
-	t.Run("with headers, no env", func(t *testing.T) {
+	t.Run("URL header ignored without env", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://example.com", nil)
 		require.NoError(t, err)
 		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
 		req.Header.Set(grafanaAPIKeyHeader, "my-test-api-key")
 		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
 		config := GrafanaConfigFromContext(ctx)
-		assert.Equal(t, "http://my-test-url.grafana.com", config.URL)
+		assert.Equal(t, defaultGrafanaURL, config.URL)
 		assert.Equal(t, "my-test-api-key", config.APIKey)
 	})
 
-	t.Run("with headers, with env", func(t *testing.T) {
-		// Env vars should be ignored if headers are present.
-		t.Setenv("GRAFANA_URL", "will-not-be-used")
+	t.Run("URL header ignored with env", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "http://configured.grafana.com")
 		t.Setenv("GRAFANA_API_KEY", "will-not-be-used")
 		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "will-not-be-used")
 
@@ -157,7 +156,7 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 		req.Header.Set(grafanaAPIKeyHeader, "my-test-api-key")
 		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
 		config := GrafanaConfigFromContext(ctx)
-		assert.Equal(t, "http://my-test-url.grafana.com", config.URL)
+		assert.Equal(t, "http://configured.grafana.com", config.URL)
 		assert.Equal(t, "my-test-api-key", config.APIKey)
 	})
 
@@ -172,7 +171,7 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 		req.Header.Set(grafanaServiceAccountTokenHeader, "my-service-account-token")
 		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
 		config := GrafanaConfigFromContext(ctx)
-		assert.Equal(t, "http://my-test-url.grafana.com", config.URL)
+		assert.Equal(t, defaultGrafanaURL, config.URL)
 		assert.Equal(t, "my-service-account-token", config.APIKey)
 	})
 
@@ -188,7 +187,7 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 		req.Header.Set(grafanaAPIKeyHeader, "my-deprecated-api-key")
 		ctx := ExtractGrafanaInfoFromHeaders(context.Background(), req)
 		config := GrafanaConfigFromContext(ctx)
-		assert.Equal(t, "http://my-test-url.grafana.com", config.URL)
+		assert.Equal(t, defaultGrafanaURL, config.URL)
 		assert.Equal(t, "my-service-account-token", config.APIKey)
 	})
 
@@ -280,92 +279,25 @@ func TestExtractGrafanaInfoFromHeaders(t *testing.T) {
 	})
 }
 
-// TestExtractGrafanaInfoFromHeadersCredentialBinding verifies that
-// environment-configured credentials are bound to the environment-configured
-// Grafana URL. A request that supplies an X-Grafana-URL pointing at a different
-// instance must not receive the environment service-account token, basic auth,
-// or extra headers.
-func TestExtractGrafanaInfoFromHeadersCredentialBinding(t *testing.T) {
+func TestExtractGrafanaInfoFromHeadersIgnoresURLHeader(t *testing.T) {
 	const envURL = "http://my-grafana.internal:3000"
 	const envToken = "env-service-account-token"
+	t.Setenv("GRAFANA_URL", envURL)
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+	t.Setenv("GRAFANA_USERNAME", "env-user")
+	t.Setenv("GRAFANA_PASSWORD", "env-pass")
+	t.Setenv("GRAFANA_EXTRA_HEADERS", `{"Authorization": "Bearer configured-secret"}`)
 
-	t.Run("foreign URL header does not receive env service account token", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", envURL)
-		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set(grafanaURLHeader, "http://other.example.com")
 
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
-
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Equal(t, "http://attacker.example.com", config.URL)
-		assert.Empty(t, config.APIKey, "env token must not be sent to a caller-specified URL")
-	})
-
-	t.Run("foreign URL header does not receive env deprecated api key", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", envURL)
-		t.Setenv("GRAFANA_API_KEY", "env-deprecated-key")
-
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
-
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Empty(t, config.APIKey, "env api key must not be sent to a caller-specified URL")
-	})
-
-	t.Run("foreign URL header does not receive env basic auth", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", envURL)
-		t.Setenv("GRAFANA_USERNAME", "env-user")
-		t.Setenv("GRAFANA_PASSWORD", "env-pass")
-
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
-
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Nil(t, config.BasicAuth, "env basic auth must not be sent to a caller-specified URL")
-	})
-
-	t.Run("foreign URL header does not receive env extra headers", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", envURL)
-		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
-		t.Setenv("GRAFANA_EXTRA_HEADERS", `{"Authorization": "Bearer smuggled-secret"}`)
-
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		req.Header.Set(grafanaURLHeader, "http://attacker.example.com")
-
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Empty(t, config.ExtraHeaders, "env extra headers must not be sent to a caller-specified URL")
-	})
-
-	t.Run("URL header matching env URL still receives env token", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", envURL)
-		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
-
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		// Same instance, only differing by a trailing slash — must still match.
-		req.Header.Set(grafanaURLHeader, envURL+"/")
-
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Equal(t, envToken, config.APIKey, "env token should still be used for the env-configured instance")
-	})
-
-	t.Run("foreign URL with its own token uses the request token", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", envURL)
-		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
-
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		req.Header.Set(grafanaURLHeader, "http://tenant.example.com")
-		req.Header.Set(grafanaServiceAccountTokenHeader, "tenant-token")
-
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Equal(t, "http://tenant.example.com", config.URL)
-		assert.Equal(t, "tenant-token", config.APIKey, "caller-supplied token must be used, not the env token")
-	})
+	config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+	assert.Equal(t, envURL, config.URL)
+	assert.Equal(t, envToken, config.APIKey)
+	require.NotNil(t, config.BasicAuth)
+	assert.Equal(t, "env-user", config.BasicAuth.Username())
+	assert.Equal(t, "Bearer configured-secret", config.ExtraHeaders["Authorization"])
 }
 
 func TestExtractGrafanaClientPath(t *testing.T) {
@@ -435,20 +367,19 @@ func TestExtractGrafanaClientFromHeaders(t *testing.T) {
 		assert.Equal(t, "/api", url.basePath)
 	})
 
-	t.Run("with headers, no env", func(t *testing.T) {
+	t.Run("URL header ignored without env", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://example.com", nil)
 		require.NoError(t, err)
 		req.Header.Set(grafanaURLHeader, "http://my-test-url.grafana.com")
 		ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
 		c := GrafanaClientFromContext(ctx)
 		url := minURLFromClient(c)
-		assert.Equal(t, "my-test-url.grafana.com", url.host)
+		assert.Equal(t, "localhost:3000", url.host)
 		assert.Equal(t, "/api", url.basePath)
 	})
 
-	t.Run("with headers, with env", func(t *testing.T) {
-		// Env vars should be ignored if headers are present.
-		t.Setenv("GRAFANA_URL", "will-not-be-used")
+	t.Run("URL header ignored with env", func(t *testing.T) {
+		t.Setenv("GRAFANA_URL", "http://configured.grafana.com")
 
 		req, err := http.NewRequest("GET", "http://example.com", nil)
 		require.NoError(t, err)
@@ -456,7 +387,7 @@ func TestExtractGrafanaClientFromHeaders(t *testing.T) {
 		ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
 		c := GrafanaClientFromContext(ctx)
 		url := minURLFromClient(c)
-		assert.Equal(t, "my-test-url.grafana.com", url.host)
+		assert.Equal(t, "configured.grafana.com", url.host)
 		assert.Equal(t, "/api", url.basePath)
 	})
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,6 @@ def grafana_env():
 @pytest.fixture
 def grafana_headers():
     headers = {
-        "X-Grafana-URL": os.environ.get("GRAFANA_URL", DEFAULT_GRAFANA_URL),
     }
     # Check for the new service account token environment variable first
     if key := os.environ.get("GRAFANA_SERVICE_ACCOUNT_TOKEN"):

--- a/tools/http_redirect.go
+++ b/tools/http_redirect.go
@@ -41,7 +41,7 @@ func refuseRedirect(req *http.Request, via []*http.Request) error {
 
 	return fmt.Errorf(
 		"refusing to follow HTTP redirect from %s to %s: it changes the request method from %s to %s and drops the request body, which would silently corrupt the query; "+
-			"check that your Grafana URL (GRAFANA_URL or X-Grafana-URL) uses the correct scheme and host and matches Grafana's configured root_url",
+			"check that GRAFANA_URL uses the correct scheme and host and matches Grafana's configured root_url",
 		prev.URL, req.URL, prev.Method, req.Method,
 	)
 }

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -57,17 +57,15 @@ func grafanaBaseURLFromContext(ctx context.Context) (string, error) {
 	}
 
 	if baseURL == "" {
-		return "", fmt.Errorf("grafana url not configured. Please set GRAFANA_URL environment variable or X-Grafana-URL header")
+		return "", fmt.Errorf("grafana url not configured. Please set GRAFANA_URL environment variable")
 	}
 
-	// Validate baseURL separately from the inbound X-Grafana-URL middleware:
-	// gc.PublicURL is populated by fetchPublicURL from Grafana's
+	// Validate baseURL because gc.PublicURL is populated by fetchPublicURL from Grafana's
 	// /api/frontend/settings appUrl response, which is not covered by the
-	// middleware at the HTTP transport boundary. A misconfigured Grafana can
-	// therefore return a malformed appUrl that flows into deeplink construction
+	// configured URL validation. A misconfigured Grafana can return a malformed appUrl that flows into deeplink construction
 	// (e.g. http://%gg/d/<uid>) unless checked here.
 	if err := mcpgrafana.ValidateGrafanaURL(baseURL); err != nil {
-		return "", fmt.Errorf("grafana url is invalid: %w. Please set GRAFANA_URL environment variable or X-Grafana-URL header", err)
+		return "", fmt.Errorf("grafana url is invalid: %w. Please set GRAFANA_URL environment variable", err)
 	}
 	return baseURL, nil
 }

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -100,7 +100,7 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 	baseURL := config.URL
 
 	if baseURL == "" {
-		return nil, fmt.Errorf("grafana URL not configured. Please set GRAFANA_URL environment variable or X-Grafana-URL header")
+		return nil, fmt.Errorf("grafana URL not configured. Please set GRAFANA_URL environment variable")
 	}
 
 	// Build the render URL

--- a/validate_url.go
+++ b/validate_url.go
@@ -54,14 +54,11 @@ func ValidateGrafanaURL(u string) error {
 
 // ValidateGrafanaURLMiddleware returns an http.Handler middleware that rejects
 // requests whose X-Grafana-URL header is present but fails ValidateGrafanaURL,
-// responding with 400 Bad Request. Requests without the header pass through
-// unchanged (downstream extractors apply the env-variable fallback).
+// responding with 400 Bad Request. Valid values pass through but do not affect
+// the configured Grafana URL.
 //
-// Library consumers that wire mcp-grafana's context functions into their own
-// http.Server should install this middleware to match the binary's defensive
-// behavior. Consumers that call NewGrafanaClient directly (stdio or
-// programmatic construction) should pre-validate the URL with
-// ValidateGrafanaURL instead.
+// Deprecated: X-Grafana-URL no longer configures the Grafana client. This
+// middleware is retained temporarily to preserve malformed-header handling.
 func ValidateGrafanaURLMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if raw := r.Header.Get(grafanaURLHeader); raw != "" {

--- a/validate_url_test.go
+++ b/validate_url_test.go
@@ -189,45 +189,47 @@ func TestValidateGrafanaURLMiddleware(t *testing.T) {
 }
 
 // Smoke coverage for ExtractGrafanaClientFromHeaders client construction.
-// These two tests exercise the extractor end-to-end (header parsing -> client
-// wiring -> real HTTP call against a test server) without depending on
-// sentinel-specific machinery.
+// These tests exercise the extractor end-to-end through a real HTTP call.
 
-func TestExtractGrafanaClientFromHeaders_ValidURL(t *testing.T) {
-	t.Setenv("GRAFANA_URL", "")
+func TestExtractGrafanaClientFromHeaders_IgnoresURLHeader(t *testing.T) {
 	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "test-token")
 
-	// hitCount tracks that the extractor wired a client pointed at THIS test
-	// server (not defaultGrafanaURL or anything else). A request counter is
-	// the cheapest durable assertion that the header-URL actually flowed
-	// through to client construction.
-	var hitCount int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&hitCount, 1)
+	var configuredHitCount int32
+	configuredServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&configuredHitCount, 1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"meta":{},"dashboard":{}}`))
 	}))
-	defer srv.Close()
+	defer configuredServer.Close()
+	t.Setenv("GRAFANA_URL", configuredServer.URL)
+
+	var headerHitCount int32
+	headerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&headerHitCount, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer headerServer.Close()
 
 	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
-	req.Header.Set(grafanaURLHeader, srv.URL)
+	req.Header.Set(grafanaURLHeader, headerServer.URL)
 
 	ctx := ExtractGrafanaClientFromHeaders(context.Background(), req)
 	c := GrafanaClientFromContext(ctx)
-	require.NotNil(t, c, "extractor must attach a client when header URL is valid")
+	require.NotNil(t, c, "extractor must attach a client")
 
 	_, apiErr := c.Dashboards.GetDashboardByUID("any-uid")
-	// The call reaches the test server, which returns skeletal JSON. The
+	// The call reaches the configured test server, which returns skeletal JSON. The
 	// openapi client may succeed or return a schema-mismatch error; either
-	// is acceptable. What's NOT acceptable is a URL-parse error, which
-	// would indicate the extractor wired garbage instead of the header URL.
+	// is acceptable. A URL-parse error would indicate invalid client wiring.
 	if apiErr != nil {
 		assert.NotContains(t, apiErr.Error(), "parse",
-			"valid-header path must not produce a URL-parse error; got %v", apiErr)
+			"configured URL must not produce a URL-parse error; got %v", apiErr)
 	}
-	assert.Greater(t, int(atomic.LoadInt32(&hitCount)), 0,
-		"extractor must wire a client that actually reaches the header-supplied URL")
+	assert.Greater(t, int(atomic.LoadInt32(&configuredHitCount)), 0,
+		"extractor must wire a client that reaches GRAFANA_URL")
+	assert.Zero(t, atomic.LoadInt32(&headerHitCount),
+		"extractor must ignore X-Grafana-URL when selecting the destination")
 }
 
 func TestExtractGrafanaClientFromHeaders_NoHeader(t *testing.T) {


### PR DESCRIPTION
Drop undocumented `X-Grafana-URL` support from HTTP transports and use the configured Grafana URL consistently.

Deprecate the related validation middleware and remove its README guidance.

**Testing:**
- `go test -count=1 -tags unit . ./tools ./cmd/mcp-grafana`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run . ./tools ./cmd/mcp-grafana`
