### PR TITLE
feat(auth): add browser session cookie authentication for stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 **Grafana Client Options:**
 - `--grafana-timeout`: Time limit for requests made by the Grafana client. Accepts Go duration strings (e.g., `10s`, `500ms`) - default: `10s`
 - `--include-args-in-spans`: Include tool call arguments in OpenTelemetry spans. Only enable in non-production environments or when arguments are known not to contain PII - default: `false`
+- `--browser-cookie-auth`: Authenticate with the Grafana session cookie from your browser, refreshing it automatically when Grafana rotates it. Requires `-t stdio`, and is skipped when a service account token or basic auth is configured. See [Browser Session Cookie Authentication](#browser-session-cookie-authentication-stdio-only) - default: `false`
 
 **Observability:**
 - `--metrics`: Enable Prometheus metrics endpoint at `/metrics`
@@ -559,6 +560,44 @@ volumes:
 ```
 
 Surrounding whitespace (including a trailing newline) is trimmed from the file contents. If both `GRAFANA_SERVICE_ACCOUNT_TOKEN` and `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` are set, the inline token takes precedence.
+
+### Browser Session Cookie Authentication (stdio only)
+
+If your Grafana is behind SSO and you cannot easily mint a service account token, `mcp-grafana` can authenticate as *you* by reusing the `grafana_session` cookie your browser already holds:
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "mcp-grafana",
+      "args": ["-t", "stdio", "--browser-cookie-auth"],
+      "env": {
+        "GRAFANA_URL": "https://grafana.internal"
+      }
+    }
+  }
+}
+```
+
+Equivalently, set `GRAFANA_BROWSER_COOKIE_AUTH=true`.
+
+On startup the server looks for a session in this order, **validating each candidate against `/api/user` before trusting it**:
+
+1. A previously validated session saved at `~/.mcp-grafana/session.json` (skipped once past its expiry).
+2. The `grafana_session` cookie held by your installed browsers — Chrome, Chromium, Brave, Edge, Firefox, Safari, Opera and Vivaldi are searched.
+
+Grafana rotates `grafana_session` server-side, so a cookie captured once goes stale while the server is still running. When Grafana rejects a request with `401`/`403`, the server re-reads the cookie from your browser and replays the request automatically — you stay logged in without restarting anything. Concurrent failures collapse into a single re-read.
+
+Validated sessions are cached at `~/.mcp-grafana/session.json` with `0600` permissions (override the directory with `MCP_GRAFANA_HOME`). The cookie is redacted from `--debug` output.
+
+**Constraints, by design:**
+
+- **stdio transport only.** The server refuses to start with `-t sse` or `-t streamable-http`. A browser session cookie identifies the person who launched the process, so on a shared HTTP server it would authenticate every client as that person.
+- **Lowest precedence.** If `GRAFANA_SERVICE_ACCOUNT_TOKEN` or `GRAFANA_USERNAME`/`GRAFANA_PASSWORD` is set, that credential is used and cookie auth is skipped. A session cookie can never shadow an explicit credential.
+- **No headless login.** If no browser holds a live Grafana session, startup fails and asks you to log in. The server never drives a browser or prompts for credentials.
+- **You only get your own permissions.** Unlike a service account, this session carries exactly the access your Grafana user has.
+
+Platform notes: on macOS, the first read may prompt for Keychain access. On Windows, Chrome 127+ App-Bound Encryption can prevent reading Chrome's cookie store — use Firefox or a service account token there.
 
 ### Multi-Organization Support
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -112,6 +112,10 @@ type grafanaConfig struct {
 
 	// timeout is the time limit for requests made by the Grafana client.
 	timeout time.Duration
+
+	// browserCookieAuth enables authenticating with the Grafana session cookie
+	// held by the user's browser. stdio transport only.
+	browserCookieAuth bool
 }
 
 func (dt *disabledTools) addFlags() {
@@ -167,6 +171,8 @@ func (gc *grafanaConfig) addFlags() {
 
 	flag.BoolVar(&gc.includeArgsInSpans, "include-args-in-spans", false, "Include tool call arguments in OpenTelemetry spans. Only enable in non-production environments or when arguments are known not to contain PII.")
 	flag.DurationVar(&gc.timeout, "grafana-timeout", mcpgrafana.DefaultGrafanaClientTimeout, "Time limit for requests made by the Grafana client. Accepts Go duration strings, e.g. 10s, 500ms.")
+
+	flag.BoolVar(&gc.browserCookieAuth, "browser-cookie-auth", false, "Authenticate using the Grafana session cookie from your browser, refreshing it automatically when Grafana rotates it. Requires -t stdio, and is ignored when a service account token or basic auth is configured. Can also be set with GRAFANA_BROWSER_COOKIE_AUTH=true.")
 }
 
 // toolEntry pairs a tool registration function with its category and disable flag.
@@ -486,6 +492,11 @@ func runMetricsServer(addr string, o *observability.Observability) {
 	}
 }
 
+// errStartupReported signals that run failed for a reason that has already been
+// reported to the operator in a readable form. main exits non-zero on it
+// without the stack trace it prints for genuinely unexpected failures.
+var errStartupReported = errors.New("startup failed")
+
 func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, hsc httpSecurityConfig, obs observability.Config, sessionIdleTimeoutMinutes int) error {
 	stderrHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
 	slog.SetDefault(slog.New(stderrHandler))
@@ -517,6 +528,18 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 	// signals are on.
 	if o.TracerProvider() != nil {
 		slog.Info("OTLP trace export configured", "endpoint", observability.OTLPTracesEndpoint())
+	}
+
+	// Resolve a browser session cookie before any client is built, so that a
+	// missing or expired browser login is reported here rather than as a 401 on
+	// the first tool call. No-op unless cookie auth was requested.
+	//
+	// "You are not logged in" is an expected operator-facing condition, not a
+	// bug, so it is reported as a log line and a non-zero exit rather than a
+	// panic with a stack trace.
+	if err := mcpgrafana.SetupBrowserCookieAuth(context.Background(), transport, &gc); err != nil {
+		slog.Error(err.Error())
+		return errStartupReported
 	}
 
 	// Create a client cache for HTTP-based transports to avoid per-request
@@ -695,6 +718,28 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Collapse the flag onto the env var so downstream code has a single signal
+	// to read. The flag is the override: setting it on with the env var unset
+	// (or absent) still enables cookie auth.
+	if gc.browserCookieAuth {
+		if err := os.Setenv("GRAFANA_BROWSER_COOKIE_AUTH", "true"); err != nil {
+			fmt.Fprintf(os.Stderr, "could not enable browser cookie auth: %v\n", err)
+			os.Exit(2)
+		}
+	}
+	// Reject the unsupported transport combination here, alongside the other
+	// flag validation, so it reads as the configuration error it is rather than
+	// arriving as a panic out of run(). SetupBrowserCookieAuth re-checks this
+	// for callers that use the library directly.
+	if mcpgrafana.BrowserCookieAuthEnabled() && transport != "stdio" {
+		fmt.Fprintf(os.Stderr,
+			"browser cookie authentication requires -t stdio, but -t %s was given.\n"+
+				"A browser session cookie identifies the user who started the server, so on a shared HTTP\n"+
+				"server it would authenticate every client as that user. Use GRAFANA_SERVICE_ACCOUNT_TOKEN instead.\n",
+			transport)
+		os.Exit(2)
+	}
+
 	// Convert local grafanaConfig to mcpgrafana.GrafanaConfig
 	grafanaConfig := mcpgrafana.GrafanaConfig{
 		Debug:                   gc.debug,
@@ -729,6 +774,11 @@ func main() {
 	}
 
 	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, hsc, obs, *sessionIdleTimeoutMinutes); err != nil {
+		// Already-reported startup failures are operator errors, not bugs;
+		// a stack trace would only bury the explanation.
+		if errors.Is(err, errStartupReported) {
+			os.Exit(1)
+		}
 		panic(err)
 	}
 }

--- a/cookie_auth.go
+++ b/cookie_auth.go
@@ -1,0 +1,544 @@
+package mcpgrafana
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// grafanaSessionCookie is the name of the cookie Grafana uses to identify a
+	// logged-in browser session.
+	grafanaSessionCookie = "grafana_session"
+	// grafanaSessionExpiryCookie carries the session's expiry as a companion to
+	// grafanaSessionCookie. It is not required for authentication, but Grafana's
+	// frontend sends it, so it is forwarded when available.
+	grafanaSessionExpiryCookie = "grafana_session_expiry"
+
+	// browserCookieAuthEnvVar enables browser session-cookie authentication.
+	browserCookieAuthEnvVar = "GRAFANA_BROWSER_COOKIE_AUTH"
+	// mcpGrafanaHomeEnvVar overrides the directory used to persist the session.
+	mcpGrafanaHomeEnvVar = "MCP_GRAFANA_HOME"
+
+	// cookieValidateTimeout bounds a single validation probe against Grafana.
+	cookieValidateTimeout = 15 * time.Second
+)
+
+// CookieProvider supplies Grafana session cookies for outbound requests.
+//
+// It is deliberately consulted per request rather than resolved once into a
+// string: Grafana rotates grafana_session server-side, so a cookie captured at
+// startup goes stale while the process is still running. Returning cookies from
+// a live provider lets a mid-session refresh take effect without rebuilding any
+// clients.
+//
+// Implementations must be safe for concurrent use.
+type CookieProvider interface {
+	// Cookies returns the cookies to attach to a request, or nil if no valid
+	// session is available.
+	Cookies(ctx context.Context) []*http.Cookie
+
+	// Refresh attempts to acquire a new session, bypassing any in-memory or
+	// on-disk cache. It reports whether it obtained a session that differs from
+	// the one previously held, i.e. whether retrying the request is worthwhile.
+	Refresh(ctx context.Context) bool
+}
+
+// cookieCandidate is a session cookie sourced from somewhere (a saved file, a
+// browser cookie store) that has not necessarily been validated yet.
+type cookieCandidate struct {
+	// value is the raw grafana_session cookie value.
+	value string
+	// expiry is the optional grafana_session_expiry companion cookie value.
+	expiry string
+	// expires is the cookie's own expiry as a Unix timestamp, or 0 if unknown.
+	expires int64
+	// source names where the cookie came from, for logging ("Chrome", "saved").
+	source string
+}
+
+// cookies converts the candidate into the cookies to send on a request.
+func (c cookieCandidate) cookies() []*http.Cookie {
+	out := []*http.Cookie{{Name: grafanaSessionCookie, Value: c.value}}
+	if c.expiry != "" {
+		out = append(out, &http.Cookie{Name: grafanaSessionExpiryCookie, Value: c.expiry})
+	}
+	return out
+}
+
+// expired reports whether the candidate's own expiry has already passed.
+// A zero expires means "unknown", which is treated as not expired — validation
+// against Grafana is the real test.
+func (c cookieCandidate) expired(now time.Time) bool {
+	return c.expires > 0 && c.expires <= now.Unix()
+}
+
+// savedSession is the on-disk representation of a validated session cookie.
+type savedSession struct {
+	Cookie  string `json:"cookie"`
+	Expiry  string `json:"expiry,omitempty"`
+	Source  string `json:"source"`
+	Expires int64  `json:"expires,omitempty"`
+	SavedAt int64  `json:"saved_at"`
+}
+
+// sessionFilePath returns the path used to persist the validated session
+// cookie. The directory is ~/.mcp-grafana by default, overridable with
+// MCP_GRAFANA_HOME so that tests (and users with unusual homes) can redirect it.
+func sessionFilePath() (string, error) {
+	dir := os.Getenv(mcpGrafanaHomeEnvVar)
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("could not determine home directory: %w", err)
+		}
+		dir = filepath.Join(home, ".mcp-grafana")
+	}
+	return filepath.Join(dir, "session.json"), nil
+}
+
+// loadSavedSession reads a previously validated session cookie from disk.
+// A missing, unreadable, malformed, or expired file yields no candidate; none
+// of those are errors worth surfacing, since the caller falls through to a
+// browser scrape.
+func loadSavedSession(path string, now time.Time, logger *slog.Logger) (cookieCandidate, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Debug("Could not read saved Grafana session", "path", path, "error", err)
+		}
+		return cookieCandidate{}, false
+	}
+
+	var s savedSession
+	if err := json.Unmarshal(raw, &s); err != nil {
+		logger.Warn("Saved Grafana session is malformed, ignoring", "path", path, "error", err)
+		return cookieCandidate{}, false
+	}
+	if s.Cookie == "" {
+		return cookieCandidate{}, false
+	}
+
+	c := cookieCandidate{
+		value:   s.Cookie,
+		expiry:  s.Expiry,
+		expires: s.Expires,
+		source:  "saved",
+	}
+	if c.expired(now) {
+		logger.Debug("Saved Grafana session has expired", "path", path)
+		return cookieCandidate{}, false
+	}
+	return c, true
+}
+
+// saveSession persists a validated session cookie with owner-only permissions.
+// The cookie is a live credential, so the file is created 0600 and the
+// containing directory 0700.
+func saveSession(path string, c cookieCandidate, now time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("could not create session directory: %w", err)
+	}
+
+	body, err := json.MarshalIndent(savedSession{
+		Cookie:  c.value,
+		Expiry:  c.expiry,
+		Source:  c.source,
+		Expires: c.expires,
+		SavedAt: now.Unix(),
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not encode session: %w", err)
+	}
+
+	// Write via a temp file in the same directory so a crash mid-write cannot
+	// leave a truncated session behind. OpenFile with 0600 (rather than
+	// os.WriteFile then Chmod) means the credential is never briefly readable.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".session-*.json")
+	if err != nil {
+		return fmt.Errorf("could not create temp session file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		// No-op once the rename has succeeded.
+		_ = os.Remove(tmpName)
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("could not set session file permissions: %w", err)
+	}
+	if _, err := tmp.Write(append(body, '\n')); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("could not write session file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("could not close session file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("could not install session file: %w", err)
+	}
+	return nil
+}
+
+// browserCookieProvider resolves a Grafana session cookie by checking, in
+// order, a previously saved session and then the session cookies held by the
+// user's installed browsers. Every candidate is validated against Grafana
+// before it is used or persisted.
+type browserCookieProvider struct {
+	grafanaURL  string
+	sessionPath string
+	logger      *slog.Logger
+
+	// scrape returns session cookie candidates for host. It is a field rather
+	// than a direct call so tests can inject candidates without touching a real
+	// browser cookie store.
+	scrape func(host string, logger *slog.Logger) []cookieCandidate
+
+	// validate reports whether a candidate authenticates against Grafana.
+	validate func(ctx context.Context, grafanaURL string, c cookieCandidate) bool
+
+	// now supplies the current time, injectable for expiry tests.
+	now func() time.Time
+
+	mu      sync.RWMutex
+	current cookieCandidate
+	haveCur bool
+
+	// flight collapses concurrent resolve/refresh calls. A burst of tool calls
+	// all failing with 401 at once must produce one browser scrape, not one per
+	// in-flight request.
+	flight singleflight.Group
+}
+
+// NewBrowserCookieProvider creates a CookieProvider that sources Grafana
+// session cookies from the user's browsers. grafanaURL must be an absolute
+// http(s) URL; it determines both the cookie domain to search and the instance
+// that candidates are validated against.
+func NewBrowserCookieProvider(grafanaURL string, logger *slog.Logger) (CookieProvider, error) {
+	if err := ValidateGrafanaURL(grafanaURL); err != nil {
+		return nil, err
+	}
+	path, err := sessionFilePath()
+	if err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &browserCookieProvider{
+		grafanaURL:  strings.TrimRight(grafanaURL, "/"),
+		sessionPath: path,
+		logger:      logger,
+		scrape:      scrapeBrowserCookies,
+		validate:    validateSessionCookie,
+		now:         time.Now,
+	}, nil
+}
+
+// Cookies returns the cookies for the current session, resolving one on first
+// use. It never blocks on a browser scrape once a session is held.
+func (p *browserCookieProvider) Cookies(ctx context.Context) []*http.Cookie {
+	p.mu.RLock()
+	cur, ok := p.current, p.haveCur
+	p.mu.RUnlock()
+	if ok {
+		return cur.cookies()
+	}
+
+	c, ok := p.resolve(ctx, false)
+	if !ok {
+		return nil
+	}
+	return c.cookies()
+}
+
+// Refresh re-resolves the session from the browser, skipping the saved file
+// (which is what just failed). It reports whether the new session differs from
+// the one previously held.
+func (p *browserCookieProvider) Refresh(ctx context.Context) bool {
+	p.mu.RLock()
+	prev := p.current.value
+	p.mu.RUnlock()
+
+	c, ok := p.resolve(ctx, true)
+	return ok && c.value != prev
+}
+
+// Resolve acquires and validates a session cookie, returning an error if none
+// could be found. It exists so startup can fail loudly with an actionable
+// message rather than deferring the failure to the first tool call.
+func (p *browserCookieProvider) Resolve(ctx context.Context) error {
+	if _, ok := p.resolve(ctx, false); ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"no valid Grafana session found for %s: no saved session, and no logged-in session in any installed browser. "+
+			"Log in to %s in your browser and restart, or set GRAFANA_SERVICE_ACCOUNT_TOKEN to use a service account token instead",
+		p.grafanaURL, p.grafanaURL)
+}
+
+// resolve walks the candidate tiers and returns the first that validates,
+// caching and persisting it. When force is true the saved-session tier is
+// skipped, since a forced resolve follows a rejected cookie.
+func (p *browserCookieProvider) resolve(ctx context.Context, force bool) (cookieCandidate, bool) {
+	// The singleflight key distinguishes forced from unforced resolves so a
+	// refresh is never satisfied by an in-flight first-use resolve that may be
+	// about to return the very cookie the caller just saw rejected.
+	key := "resolve"
+	if force {
+		key = "refresh"
+	}
+
+	res, _, _ := p.flight.Do(key, func() (any, error) {
+		// A concurrent caller may have resolved while this one queued. Only
+		// short-circuit for unforced resolves; a forced one must really re-scrape.
+		if !force {
+			p.mu.RLock()
+			cur, ok := p.current, p.haveCur
+			p.mu.RUnlock()
+			if ok {
+				return cur, nil
+			}
+		}
+
+		now := p.now()
+		var candidates []cookieCandidate
+		if !force {
+			if saved, ok := loadSavedSession(p.sessionPath, now, p.logger); ok {
+				candidates = append(candidates, saved)
+			}
+		}
+
+		host := grafanaCookieHost(p.grafanaURL)
+		if host != "" {
+			for _, c := range p.scrape(host, p.logger) {
+				if !c.expired(now) {
+					candidates = append(candidates, c)
+				}
+			}
+		}
+
+		for _, c := range candidates {
+			if !p.validate(ctx, p.grafanaURL, c) {
+				p.logger.Debug("Grafana session cookie did not authenticate, trying next source", "source", c.source)
+				continue
+			}
+
+			p.mu.Lock()
+			p.current, p.haveCur = c, true
+			p.mu.Unlock()
+
+			if err := saveSession(p.sessionPath, c, now); err != nil {
+				// A cookie that works but could not be cached is still usable;
+				// the only cost is re-scraping on the next start.
+				p.logger.Warn("Could not persist Grafana session", "path", p.sessionPath, "error", err)
+			}
+			p.logger.Info("Authenticated to Grafana with a browser session cookie", "source", c.source)
+			return c, nil
+		}
+
+		return cookieCandidate{}, fmt.Errorf("no valid session")
+	})
+
+	c, ok := res.(cookieCandidate)
+	return c, ok && c.value != ""
+}
+
+// grafanaCookieHost extracts the hostname whose cookie jar should be searched.
+func grafanaCookieHost(grafanaURL string) string {
+	u, err := url.Parse(grafanaURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+// validateSessionCookie reports whether a candidate cookie actually
+// authenticates against Grafana.
+//
+// The probe deliberately targets /api/user rather than /api/health: /api/health
+// is unauthenticated, so a dead cookie sails through it and then fails every
+// real API call. /api/user requires a live session, which is exactly the
+// property being tested.
+func validateSessionCookie(ctx context.Context, grafanaURL string, c cookieCandidate) bool {
+	ctx, cancel := context.WithTimeout(ctx, cookieValidateTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, grafanaURL+"/api/user", nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Accept", "application/json")
+	for _, cookie := range c.cookies() {
+		req.AddCookie(cookie)
+	}
+
+	client := &http.Client{
+		Timeout: cookieValidateTimeout,
+		// Do not follow redirects: an unauthenticated Grafana behind some
+		// proxies answers with a 302 to a login page that itself returns 200,
+		// which would otherwise read as success.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	return resp.StatusCode == http.StatusOK
+}
+
+// sessionRefreshRoundTripper re-acquires a rotated Grafana session cookie when
+// a request is rejected, then replays the request once.
+//
+// It sits outside the auth layer in the middleware chain so that the replay
+// passes back through AuthRoundTripper and picks up the refreshed cookie.
+type sessionRefreshRoundTripper struct {
+	underlying http.RoundTripper
+	provider   CookieProvider
+	logger     *slog.Logger
+}
+
+// NewSessionRefreshRoundTripper wraps rt so that a 401/403 triggers one session
+// refresh and replay. It returns rt unchanged when no provider is configured.
+func NewSessionRefreshRoundTripper(rt http.RoundTripper, provider CookieProvider, logger *slog.Logger) http.RoundTripper {
+	if provider == nil {
+		return rt
+	}
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &sessionRefreshRoundTripper{underlying: rt, provider: provider, logger: logger}
+}
+
+func (rt *sessionRefreshRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.underlying.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden {
+		return resp, nil
+	}
+
+	// A request whose body has already been consumed cannot be replayed. Go
+	// populates GetBody for the body types it can rewind; anything else (an
+	// opaque io.Reader) is not retryable.
+	if req.Body != nil && req.GetBody == nil {
+		rt.logger.Debug("Grafana rejected the session but the request body is not replayable; not retrying",
+			"status", resp.StatusCode, "path", req.URL.Path)
+		return resp, nil
+	}
+
+	if !rt.provider.Refresh(req.Context()) {
+		rt.logger.Debug("Grafana session refresh produced no new cookie; not retrying",
+			"status", resp.StatusCode, "path", req.URL.Path)
+		return resp, nil
+	}
+
+	retryReq := req.Clone(req.Context())
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			rt.logger.Debug("Could not rewind request body for session retry", "error", err)
+			return resp, nil
+		}
+		retryReq.Body = body
+	}
+	// The request is replayed verbatim. Any Cookie header present here came
+	// from ExtraHeaders/forwarded headers, not from this session — the auth
+	// layer sits inside this one and adds the session cookie to its own clone,
+	// so the refreshed value is picked up without touching the caller's header.
+
+	// The original response is being discarded; drain it so the connection can
+	// be reused for the replay.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	rt.logger.Info("Grafana session was refreshed after an auth failure; retrying request",
+		"status", resp.StatusCode, "path", req.URL.Path)
+
+	// The replay is not itself retried: this round tripper is the only layer
+	// that retries, and it is not re-entered by the call below.
+	return rt.underlying.RoundTrip(retryReq)
+}
+
+// BrowserCookieAuthEnabled reports whether browser session-cookie auth has been
+// requested via GRAFANA_BROWSER_COOKIE_AUTH. Exported so cmd/mcp-grafana can
+// validate the flag combination without duplicating the parsing.
+func BrowserCookieAuthEnabled() bool {
+	v := strings.TrimSpace(os.Getenv(browserCookieAuthEnvVar))
+	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}
+
+// SetupBrowserCookieAuth configures browser session-cookie authentication on
+// cfg when it has been requested and nothing else is already authenticating.
+//
+// It resolves and validates a session up front rather than lazily, so that a
+// missing browser login fails at startup with an explanation instead of
+// surfacing as an opaque 401 on the first tool call.
+//
+// Returns an error if cookie auth was requested but cannot be used; returns nil
+// (leaving cfg untouched) when it was not requested or is not needed.
+func SetupBrowserCookieAuth(ctx context.Context, transport string, cfg *GrafanaConfig) error {
+	if !BrowserCookieAuthEnabled() {
+		return nil
+	}
+	logger := cfg.LoggerOrDefault()
+
+	// A session cookie identifies the person who started the process. On a
+	// shared HTTP server it would be applied to requests from every caller,
+	// silently authenticating all of them as that person. Refuse rather than
+	// degrade quietly.
+	if transport != "stdio" {
+		return fmt.Errorf(
+			"browser cookie authentication is only supported on the stdio transport, but the %q transport is in use: "+
+				"a browser session cookie identifies the user who started the server, so on a shared HTTP server it would "+
+				"authenticate every client as that user. Use GRAFANA_SERVICE_ACCOUNT_TOKEN instead", transport)
+	}
+
+	grafanaURL, apiKey := urlAndAPIKeyFromEnv(logger)
+	if grafanaURL == "" {
+		grafanaURL = defaultGrafanaURL
+	}
+	if apiKey != "" || userAndPassFromEnv() != nil {
+		logger.Info("Browser cookie authentication was requested but an explicit credential is configured; using that instead")
+		return nil
+	}
+
+	provider, err := NewBrowserCookieProvider(grafanaURL, logger)
+	if err != nil {
+		return fmt.Errorf("could not set up browser cookie authentication: %w", err)
+	}
+	resolver, ok := provider.(*browserCookieProvider)
+	if !ok {
+		return fmt.Errorf("could not set up browser cookie authentication: unexpected provider type %T", provider)
+	}
+	if err := resolver.Resolve(ctx); err != nil {
+		return err
+	}
+
+	cfg.CookieProvider = provider
+	return nil
+}

--- a/cookie_auth_test.go
+++ b/cookie_auth_test.go
@@ -1,0 +1,758 @@
+package mcpgrafana
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discardLogger keeps test output readable; the provider logs at Info on success.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// staticProvider is a CookieProvider whose value can be swapped, used to drive
+// the round tripper tests without any browser or filesystem involvement.
+type staticProvider struct {
+	mu           sync.Mutex
+	value        string
+	refreshTo    string
+	refreshCalls atomic.Int32
+}
+
+func (p *staticProvider) Cookies(context.Context) []*http.Cookie {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.value == "" {
+		return nil
+	}
+	return []*http.Cookie{{Name: grafanaSessionCookie, Value: p.value}}
+}
+
+func (p *staticProvider) Refresh(context.Context) bool {
+	p.refreshCalls.Add(1)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.refreshTo == "" || p.refreshTo == p.value {
+		return false
+	}
+	p.value = p.refreshTo
+	return true
+}
+
+// newTestProvider builds a browserCookieProvider with every external
+// dependency (browser stores, Grafana, the clock, the home directory) faked.
+func newTestProvider(t *testing.T, scraped []cookieCandidate, valid func(cookieCandidate) bool) *browserCookieProvider {
+	t.Helper()
+	return &browserCookieProvider{
+		grafanaURL:  "http://grafana.example.com",
+		sessionPath: filepath.Join(t.TempDir(), "session.json"),
+		logger:      discardLogger(),
+		scrape: func(string, *slog.Logger) []cookieCandidate {
+			return scraped
+		},
+		validate: func(_ context.Context, _ string, c cookieCandidate) bool {
+			return valid(c)
+		},
+		now: time.Now,
+	}
+}
+
+func TestCookieDomainMatches(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		host   string
+		want   bool
+	}{
+		{"exact match", "grafana.example.com", "grafana.example.com", true},
+		{"leading dot", ".example.com", "grafana.example.com", true},
+		{"parent domain", "example.com", "grafana.example.com", true},
+		{"case insensitive", "Example.COM", "grafana.example.com", true},
+		{"unrelated domain", "evil.com", "grafana.example.com", false},
+		// The reason a plain strings.HasSuffix is not enough: "evilexample.com"
+		// ends with "example.com" but must not match it.
+		{"suffix but not a subdomain", "example.com", "evilexample.com", false},
+		{"child does not match parent", "grafana.example.com", "example.com", false},
+		{"empty domain", "", "grafana.example.com", false},
+		{"empty host", "example.com", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, cookieDomainMatches(tt.domain, tt.host))
+		})
+	}
+}
+
+func TestSaveAndLoadSession(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("round trips and is owner-only", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "nested", "session.json")
+		c := cookieCandidate{value: "abc", expiry: "exp", expires: now.Add(time.Hour).Unix(), source: "Chrome"}
+		require.NoError(t, saveSession(path, c, now))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		// The file holds a live credential, so it must not be group/world readable.
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+		got, ok := loadSavedSession(path, now, discardLogger())
+		require.True(t, ok)
+		assert.Equal(t, "abc", got.value)
+		assert.Equal(t, "exp", got.expiry)
+		assert.Equal(t, "saved", got.source)
+	})
+
+	t.Run("expired session is not loaded", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "session.json")
+		c := cookieCandidate{value: "abc", expires: now.Add(-time.Hour).Unix()}
+		require.NoError(t, saveSession(path, c, now))
+
+		_, ok := loadSavedSession(path, now, discardLogger())
+		assert.False(t, ok)
+	})
+
+	t.Run("session without expiry is loaded", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "session.json")
+		require.NoError(t, saveSession(path, cookieCandidate{value: "abc"}, now))
+
+		got, ok := loadSavedSession(path, now, discardLogger())
+		require.True(t, ok)
+		assert.Equal(t, "abc", got.value)
+	})
+
+	t.Run("missing and malformed files yield nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		_, ok := loadSavedSession(filepath.Join(dir, "absent.json"), now, discardLogger())
+		assert.False(t, ok)
+
+		bad := filepath.Join(dir, "bad.json")
+		require.NoError(t, os.WriteFile(bad, []byte("{not json"), 0o600))
+		_, ok = loadSavedSession(bad, now, discardLogger())
+		assert.False(t, ok)
+	})
+}
+
+func TestBrowserCookieProviderResolve(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("uses a scraped cookie and persists it", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{{value: "good", source: "Chrome"}},
+			func(cookieCandidate) bool { return true },
+		)
+		require.NoError(t, p.Resolve(ctx))
+
+		cookies := p.Cookies(ctx)
+		require.Len(t, cookies, 1)
+		assert.Equal(t, "good", cookies[0].Value)
+
+		saved, ok := loadSavedSession(p.sessionPath, time.Now(), discardLogger())
+		require.True(t, ok, "a validated cookie should be persisted")
+		assert.Equal(t, "good", saved.value)
+	})
+
+	t.Run("skips candidates that do not authenticate", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{
+				{value: "stale", source: "Chrome"},
+				{value: "fresh", source: "Firefox"},
+			},
+			func(c cookieCandidate) bool { return c.value == "fresh" },
+		)
+		require.NoError(t, p.Resolve(ctx))
+
+		cookies := p.Cookies(ctx)
+		require.Len(t, cookies, 1)
+		assert.Equal(t, "fresh", cookies[0].Value)
+	})
+
+	t.Run("rejected cookies are never persisted", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{{value: "stale", source: "Chrome"}},
+			func(cookieCandidate) bool { return false },
+		)
+		err := p.Resolve(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid Grafana session")
+		assert.Nil(t, p.Cookies(ctx))
+
+		_, ok := loadSavedSession(p.sessionPath, time.Now(), discardLogger())
+		assert.False(t, ok, "a cookie that failed validation must not be cached")
+	})
+
+	t.Run("prefers a valid saved session over scraping", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{{value: "from-browser", source: "Chrome"}},
+			func(cookieCandidate) bool { return true },
+		)
+		require.NoError(t, saveSession(p.sessionPath, cookieCandidate{value: "from-disk"}, time.Now()))
+
+		require.NoError(t, p.Resolve(ctx))
+		cookies := p.Cookies(ctx)
+		require.Len(t, cookies, 1)
+		assert.Equal(t, "from-disk", cookies[0].Value)
+	})
+
+	t.Run("falls through to scraping when the saved session is expired", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{{value: "from-browser", source: "Chrome"}},
+			func(cookieCandidate) bool { return true },
+		)
+		require.NoError(t, saveSession(p.sessionPath,
+			cookieCandidate{value: "from-disk", expires: time.Now().Add(-time.Hour).Unix()}, time.Now()))
+
+		require.NoError(t, p.Resolve(ctx))
+		cookies := p.Cookies(ctx)
+		require.Len(t, cookies, 1)
+		assert.Equal(t, "from-browser", cookies[0].Value)
+	})
+
+	t.Run("skips scraped cookies that have already expired", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{
+				{value: "expired", source: "Chrome", expires: time.Now().Add(-time.Minute).Unix()},
+				{value: "live", source: "Firefox"},
+			},
+			func(cookieCandidate) bool { return true },
+		)
+		require.NoError(t, p.Resolve(ctx))
+
+		cookies := p.Cookies(ctx)
+		require.Len(t, cookies, 1)
+		assert.Equal(t, "live", cookies[0].Value)
+	})
+
+	t.Run("sends the expiry companion cookie when present", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{{value: "sess", expiry: "12345", source: "Chrome"}},
+			func(cookieCandidate) bool { return true },
+		)
+		require.NoError(t, p.Resolve(ctx))
+
+		cookies := p.Cookies(ctx)
+		require.Len(t, cookies, 2)
+		assert.Equal(t, grafanaSessionCookie, cookies[0].Name)
+		assert.Equal(t, grafanaSessionExpiryCookie, cookies[1].Name)
+		assert.Equal(t, "12345", cookies[1].Value)
+	})
+}
+
+func TestBrowserCookieProviderRefresh(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reports whether the session actually changed", func(t *testing.T) {
+		current := "v1"
+		p := newTestProvider(t, nil, func(cookieCandidate) bool { return true })
+		p.scrape = func(string, *slog.Logger) []cookieCandidate {
+			return []cookieCandidate{{value: current, source: "Chrome"}}
+		}
+
+		require.NoError(t, p.Resolve(ctx))
+		assert.False(t, p.Refresh(ctx), "an unchanged cookie is not worth a retry")
+
+		current = "v2"
+		assert.True(t, p.Refresh(ctx))
+		assert.Equal(t, "v2", p.Cookies(ctx)[0].Value)
+	})
+
+	t.Run("ignores the saved session so a rotated cookie is picked up", func(t *testing.T) {
+		p := newTestProvider(t,
+			[]cookieCandidate{{value: "rotated", source: "Chrome"}},
+			func(cookieCandidate) bool { return true },
+		)
+		require.NoError(t, saveSession(p.sessionPath, cookieCandidate{value: "on-disk"}, time.Now()))
+		require.NoError(t, p.Resolve(ctx))
+		require.Equal(t, "on-disk", p.Cookies(ctx)[0].Value)
+
+		assert.True(t, p.Refresh(ctx))
+		assert.Equal(t, "rotated", p.Cookies(ctx)[0].Value)
+	})
+
+	t.Run("concurrent refreshes collapse into a single scrape", func(t *testing.T) {
+		var scrapes atomic.Int32
+		release := make(chan struct{})
+
+		p := newTestProvider(t, nil, func(cookieCandidate) bool { return true })
+		p.scrape = func(string, *slog.Logger) []cookieCandidate {
+			scrapes.Add(1)
+			// Hold the scrape open so every goroutine is queued behind it;
+			// without singleflight each would run its own browser scrape.
+			<-release
+			return []cookieCandidate{{value: "shared", source: "Chrome"}}
+		}
+
+		const goroutines = 8
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				p.Refresh(ctx)
+			}()
+		}
+
+		// Give the goroutines time to pile up on the singleflight key.
+		time.Sleep(50 * time.Millisecond)
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int32(1), scrapes.Load(),
+			"a burst of 401s must trigger one browser scrape, not one per request")
+	})
+}
+
+func TestValidateSessionCookie(t *testing.T) {
+	ctx := context.Background()
+	candidate := cookieCandidate{value: "sess", expiry: "exp"}
+
+	t.Run("accepts a 200 and sends both cookies", func(t *testing.T) {
+		var gotPath string
+		var gotCookies []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			for _, c := range r.Cookies() {
+				gotCookies = append(gotCookies, c.Name+"="+c.Value)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		assert.True(t, validateSessionCookie(ctx, srv.URL, candidate))
+		// /api/health is unauthenticated, so probing it would pass with a dead
+		// cookie. The probe must target an endpoint that requires a session.
+		assert.Equal(t, "/api/user", gotPath)
+		assert.ElementsMatch(t, []string{"grafana_session=sess", "grafana_session_expiry=exp"}, gotCookies)
+	})
+
+	t.Run("rejects a 401", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		assert.False(t, validateSessionCookie(ctx, srv.URL, candidate))
+	})
+
+	t.Run("rejects a redirect to a login page", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/user" {
+				http.Redirect(w, r, "/login", http.StatusFound)
+				return
+			}
+			// The login page itself answers 200; following the redirect would
+			// make an unauthenticated instance look authenticated.
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		assert.False(t, validateSessionCookie(ctx, srv.URL, candidate))
+	})
+
+	t.Run("rejects an unreachable instance", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		srv.Close()
+
+		assert.False(t, validateSessionCookie(ctx, srv.URL, candidate))
+	})
+}
+
+func TestAuthRoundTripperCookiePrecedence(t *testing.T) {
+	newRequest := func() *http.Request {
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.example.com/api/user", nil)
+		require.NoError(t, err)
+		return req
+	}
+
+	t.Run("cookies are used when no other credential exists", func(t *testing.T) {
+		var captured *http.Request
+		rt := NewAuthRoundTripper(captureTransport(&captured), "", "", "", nil,
+			WithCookieProvider(&staticProvider{value: "sess"}))
+
+		_, err := rt.RoundTrip(newRequest())
+		require.NoError(t, err)
+		assert.Equal(t, "grafana_session=sess", captured.Header.Get("Cookie"))
+		assert.Empty(t, captured.Header.Get("Authorization"))
+	})
+
+	t.Run("an API key takes precedence over cookies", func(t *testing.T) {
+		var captured *http.Request
+		rt := NewAuthRoundTripper(captureTransport(&captured), "", "", "token", nil,
+			WithCookieProvider(&staticProvider{value: "sess"}))
+
+		_, err := rt.RoundTrip(newRequest())
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer token", captured.Header.Get("Authorization"))
+		assert.Empty(t, captured.Header.Get("Cookie"), "a session cookie must never shadow an explicit credential")
+	})
+
+	t.Run("basic auth takes precedence over cookies", func(t *testing.T) {
+		var captured *http.Request
+		rt := NewAuthRoundTripper(captureTransport(&captured), "", "", "", url.UserPassword("u", "p"),
+			WithCookieProvider(&staticProvider{value: "sess"}))
+
+		_, err := rt.RoundTrip(newRequest())
+		require.NoError(t, err)
+		user, pass, ok := captured.BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "u", user)
+		assert.Equal(t, "p", pass)
+		assert.Empty(t, captured.Header.Get("Cookie"))
+	})
+
+	t.Run("an existing Cookie header is preserved alongside the session cookie", func(t *testing.T) {
+		var captured *http.Request
+		rt := NewAuthRoundTripper(captureTransport(&captured), "", "", "", nil,
+			WithCookieProvider(&staticProvider{value: "sess"}))
+
+		req := newRequest()
+		// Simulates a cookie placed by GRAFANA_EXTRA_HEADERS. The auth layer is
+		// innermost, so a Header.Set here would silently discard it.
+		req.Header.Set("Cookie", "tenant=acme")
+
+		_, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		got := captured.Header.Get("Cookie")
+		assert.Contains(t, got, "tenant=acme")
+		assert.Contains(t, got, "grafana_session=sess")
+	})
+
+	t.Run("a provider in the context overrides the constructed one", func(t *testing.T) {
+		var captured *http.Request
+		rt := NewAuthRoundTripper(captureTransport(&captured), "", "", "", nil,
+			WithCookieProvider(&staticProvider{value: "built-in"}))
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+			CookieProvider: &staticProvider{value: "from-context"},
+		})
+		_, err := rt.RoundTrip(newRequest().WithContext(ctx))
+		require.NoError(t, err)
+		assert.Equal(t, "grafana_session=from-context", captured.Header.Get("Cookie"))
+	})
+}
+
+// captureTransport records the request it receives and returns an empty 200.
+func captureTransport(into **http.Request) http.RoundTripper {
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		*into = req
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// nopTransport is a comparable RoundTripper, for assertions on chain identity.
+type nopTransport struct{}
+
+func (*nopTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func TestSessionRefreshRoundTripper(t *testing.T) {
+	t.Run("refreshes and replays once on 401", func(t *testing.T) {
+		var seen []string
+		provider := &staticProvider{value: "stale", refreshTo: "fresh"}
+
+		// The auth layer sits inside the refresh layer, exactly as BuildTransport
+		// arranges it, so the replay is re-signed with the refreshed cookie.
+		inner := NewAuthRoundTripper(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			seen = append(seen, req.Header.Get("Cookie"))
+			status := http.StatusUnauthorized
+			if req.Header.Get("Cookie") == "grafana_session=fresh" {
+				status = http.StatusOK
+			}
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}), "", "", "", nil, WithCookieProvider(provider))
+
+		rt := NewSessionRefreshRoundTripper(inner, provider, discardLogger())
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.example.com/api/user", nil)
+		require.NoError(t, err)
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, []string{"grafana_session=stale", "grafana_session=fresh"}, seen)
+		assert.Equal(t, int32(1), provider.refreshCalls.Load())
+	})
+
+	t.Run("does not retry when the refresh yields the same cookie", func(t *testing.T) {
+		var calls int
+		provider := &staticProvider{value: "stale"} // refreshTo empty: Refresh reports false
+
+		rt := NewSessionRefreshRoundTripper(roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}), provider, discardLogger())
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.example.com/api/user", nil)
+		require.NoError(t, err)
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, 1, calls, "a refresh that changed nothing must not trigger a retry")
+	})
+
+	t.Run("retries at most once", func(t *testing.T) {
+		var calls int
+		// A provider that reports a change every time would loop forever if the
+		// replay were itself retried.
+		provider := &countingRefreshProvider{}
+
+		rt := NewSessionRefreshRoundTripper(roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}), provider, discardLogger())
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.example.com/api/user", nil)
+		require.NoError(t, err)
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, 2, calls, "original plus exactly one replay")
+	})
+
+	t.Run("replays a request body", func(t *testing.T) {
+		var bodies []string
+		provider := &staticProvider{value: "stale", refreshTo: "fresh"}
+
+		rt := NewSessionRefreshRoundTripper(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			b, _ := io.ReadAll(req.Body)
+			bodies = append(bodies, string(b))
+			status := http.StatusUnauthorized
+			if len(bodies) > 1 {
+				status = http.StatusOK
+			}
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}), provider, discardLogger())
+
+		req, err := http.NewRequest(http.MethodPost, "http://grafana.example.com/api/ds/query",
+			strings.NewReader(`{"queries":[]}`))
+		require.NoError(t, err)
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, []string{`{"queries":[]}`, `{"queries":[]}`}, bodies,
+			"the replay must carry the same body as the original")
+	})
+
+	t.Run("does not retry a non-replayable body", func(t *testing.T) {
+		var calls int
+		provider := &staticProvider{value: "stale", refreshTo: "fresh"}
+
+		rt := NewSessionRefreshRoundTripper(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			_, _ = io.Copy(io.Discard, req.Body)
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}), provider, discardLogger())
+
+		req, err := http.NewRequest(http.MethodPost, "http://grafana.example.com/api/ds/query", io.NopCloser(strings.NewReader("x")))
+		require.NoError(t, err)
+		req.GetBody = nil // an opaque reader Go cannot rewind
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, 1, calls, "a body that cannot be rewound must not be replayed")
+		assert.Equal(t, int32(0), provider.refreshCalls.Load())
+	})
+
+	t.Run("passes through non-auth statuses untouched", func(t *testing.T) {
+		provider := &staticProvider{value: "sess", refreshTo: "other"}
+		rt := NewSessionRefreshRoundTripper(roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}), provider, discardLogger())
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.example.com/api/user", nil)
+		require.NoError(t, err)
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, int32(0), provider.refreshCalls.Load())
+	})
+
+	t.Run("is a no-op without a provider", func(t *testing.T) {
+		// Uses a comparable transport type so identity can be asserted; func
+		// values are not comparable in Go.
+		base := &nopTransport{}
+		assert.Same(t, base, NewSessionRefreshRoundTripper(base, nil, discardLogger()),
+			"with no provider the chain must be left exactly as it was")
+	})
+}
+
+// countingRefreshProvider always claims the session changed, so it would drive
+// an unbounded retry loop if the replay were itself retried.
+type countingRefreshProvider struct{ n atomic.Int32 }
+
+func (p *countingRefreshProvider) Cookies(context.Context) []*http.Cookie {
+	return []*http.Cookie{{Name: grafanaSessionCookie, Value: "v"}}
+}
+
+func (p *countingRefreshProvider) Refresh(context.Context) bool {
+	p.n.Add(1)
+	return true
+}
+
+func TestBuildTransportWiresCookieAuth(t *testing.T) {
+	var captured *http.Request
+	provider := &staticProvider{value: "sess"}
+
+	cfg := GrafanaConfig{CookieProvider: provider}
+	transport, err := BuildTransport(&cfg, captureTransport(&captured), WithoutOtel(), WithoutUserAgent())
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "http://grafana.example.com/api/user", nil)
+	require.NoError(t, err)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "grafana_session=sess", captured.Header.Get("Cookie"))
+}
+
+func TestSetupBrowserCookieAuth(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("does nothing when not enabled", func(t *testing.T) {
+		t.Setenv(browserCookieAuthEnvVar, "")
+		cfg := GrafanaConfig{Logger: discardLogger()}
+		require.NoError(t, SetupBrowserCookieAuth(ctx, "stdio", &cfg))
+		assert.Nil(t, cfg.CookieProvider)
+	})
+
+	t.Run("refuses the HTTP transports", func(t *testing.T) {
+		for _, transport := range []string{"sse", "streamable-http"} {
+			t.Run(transport, func(t *testing.T) {
+				t.Setenv(browserCookieAuthEnvVar, "true")
+				cfg := GrafanaConfig{Logger: discardLogger()}
+
+				err := SetupBrowserCookieAuth(ctx, transport, &cfg)
+				require.Error(t, err, "cookie auth on a shared server would authenticate every client as the operator")
+				assert.Contains(t, err.Error(), "only supported on the stdio transport")
+				assert.Nil(t, cfg.CookieProvider)
+			})
+		}
+	})
+
+	t.Run("defers to an explicitly configured token", func(t *testing.T) {
+		t.Setenv(browserCookieAuthEnvVar, "true")
+		t.Setenv(grafanaServiceAccountTokenEnvVar, "a-token")
+		cfg := GrafanaConfig{Logger: discardLogger()}
+
+		require.NoError(t, SetupBrowserCookieAuth(ctx, "stdio", &cfg))
+		assert.Nil(t, cfg.CookieProvider)
+	})
+
+	t.Run("defers to explicitly configured basic auth", func(t *testing.T) {
+		t.Setenv(browserCookieAuthEnvVar, "true")
+		t.Setenv(grafanaUsernameEnvVar, "admin")
+		t.Setenv(grafanaPasswordEnvVar, "admin")
+		cfg := GrafanaConfig{Logger: discardLogger()}
+
+		require.NoError(t, SetupBrowserCookieAuth(ctx, "stdio", &cfg))
+		assert.Nil(t, cfg.CookieProvider)
+	})
+}
+
+func TestBrowserCookieAuthEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"true", true}, {"TRUE", true}, {"1", true}, {"yes", true}, {" true ", true},
+		{"", false}, {"false", false}, {"0", false}, {"no", false},
+	} {
+		t.Run("value="+tc.value, func(t *testing.T) {
+			t.Setenv(browserCookieAuthEnvVar, tc.value)
+			assert.Equal(t, tc.want, BrowserCookieAuthEnabled())
+		})
+	}
+}
+
+func TestExtractGrafanaInfoFromHeadersClearsCookieProvider(t *testing.T) {
+	// A session cookie belongs to whoever started the process. If it survived
+	// into a context built from an inbound HTTP request, every caller would be
+	// authenticated as that person.
+	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+		CookieProvider: &staticProvider{value: "operator-session"},
+		Logger:         discardLogger(),
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:8000/mcp", nil)
+	require.NoError(t, err)
+
+	got := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(ctx, req))
+	assert.Nil(t, got.CookieProvider)
+}
+
+func TestSessionFilePath(t *testing.T) {
+	t.Run("honours MCP_GRAFANA_HOME", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(mcpGrafanaHomeEnvVar, dir)
+
+		path, err := sessionFilePath()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dir, "session.json"), path)
+	})
+
+	t.Run("defaults under the home directory", func(t *testing.T) {
+		t.Setenv(mcpGrafanaHomeEnvVar, "")
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		path, err := sessionFilePath()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, ".mcp-grafana", "session.json"), path)
+	})
+}
+
+func TestNewBrowserCookieProviderRejectsBadURL(t *testing.T) {
+	_, err := NewBrowserCookieProvider("not-a-url", discardLogger())
+	assert.Error(t, err)
+}

--- a/cookie_scrape.go
+++ b/cookie_scrape.go
@@ -1,0 +1,139 @@
+package mcpgrafana
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/browserutils/kooky"
+
+	// Registers every supported browser's cookie store finder. Without this
+	// blank import kooky finds nothing.
+	_ "github.com/browserutils/kooky/browser/all"
+)
+
+// cookieScrapeTimeout bounds the search across every installed browser's cookie
+// store. Reading these stores involves per-platform decryption (macOS Keychain,
+// Windows DPAPI) that can block, so the scrape is not allowed to hang startup.
+const cookieScrapeTimeout = 30 * time.Second
+
+// scrapeBrowserCookies collects Grafana session cookies for host from the
+// cookie stores of the user's installed browsers.
+//
+// Candidates are returned in the order kooky yields them and are *not*
+// validated here — the caller probes each against Grafana, because a cookie
+// present in a browser is very often already stale (Grafana rotates
+// grafana_session server-side).
+func scrapeBrowserCookies(host string, logger *slog.Logger) []cookieCandidate {
+	if host == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cookieScrapeTimeout)
+	defer cancel()
+
+	// Filter on name before kooky.Valid so that only the handful of cookies we
+	// care about are decrypted, rather than every cookie in every store.
+	cookies, err := kooky.ReadCookies(ctx,
+		kooky.FilterFunc(func(c *kooky.Cookie) bool {
+			return c.Name == grafanaSessionCookie || c.Name == grafanaSessionExpiryCookie
+		}),
+		kooky.Valid,
+	)
+	if err != nil {
+		// Partial results are still returned alongside an error when only some
+		// stores fail (a locked profile, a browser using an unsupported
+		// encryption scheme), so this is logged rather than treated as fatal.
+		logger.Debug("Some browser cookie stores could not be read", "error", err)
+	}
+
+	return groupSessionCookies(cookies, host)
+}
+
+// groupSessionCookies pairs each grafana_session cookie with the
+// grafana_session_expiry from the same browser profile and returns one
+// candidate per profile that has a session cookie, in discovery order.
+func groupSessionCookies(cookies kooky.Cookies, host string) []cookieCandidate {
+	// index maps a profile key to its position in candidates, so results keep
+	// kooky's discovery order rather than Go's randomized map order.
+	index := make(map[string]int)
+	var candidates []cookieCandidate
+
+	for _, c := range cookies {
+		if c == nil || c.Value == "" || !cookieDomainMatches(c.Domain, host) {
+			continue
+		}
+
+		key := scrapeGroupKey(c)
+		i, ok := index[key]
+		if !ok {
+			i = len(candidates)
+			index[key] = i
+			candidates = append(candidates, cookieCandidate{source: browserLabel(c)})
+		}
+
+		switch c.Name {
+		case grafanaSessionCookie:
+			candidates[i].value = c.Value
+			if !c.Expires.IsZero() {
+				candidates[i].expires = c.Expires.Unix()
+			}
+		case grafanaSessionExpiryCookie:
+			candidates[i].expiry = c.Value
+		}
+	}
+
+	// Drop profiles that yielded only an expiry cookie; it is useless alone.
+	out := candidates[:0]
+	for _, c := range candidates {
+		if c.value != "" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// scrapeGroupKey identifies the browser profile a cookie came from, so that a
+// session cookie is only ever paired with the expiry cookie from the same
+// profile. Cookies from different profiles are independent sessions.
+func scrapeGroupKey(c *kooky.Cookie) string {
+	var browser, profile string
+	if c.Browser != nil {
+		browser, profile = c.Browser.Browser(), c.Browser.Profile()
+	}
+	return browser + "\x00" + profile + "\x00" + c.Container
+}
+
+// browserLabel produces a human-readable source name for logging.
+func browserLabel(c *kooky.Cookie) string {
+	if c.Browser == nil {
+		return "browser"
+	}
+	name := c.Browser.Browser()
+	if name == "" {
+		name = "browser"
+	}
+	if profile := c.Browser.Profile(); profile != "" && !c.Browser.IsDefaultProfile() {
+		return name + " (" + profile + ")"
+	}
+	return name
+}
+
+// cookieDomainMatches implements the standard cookie domain-match rule: a
+// cookie applies to host when its domain equals host, or when host is a
+// subdomain of it.
+//
+// A plain suffix comparison is not sufficient in either direction — a cookie
+// scoped to .grafana.net must match myinstance.grafana.net, while a cookie
+// scoped to evilgrafana.net must not match grafana.net.
+func cookieDomainMatches(domain, host string) bool {
+	domain = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(domain), "."))
+	host = strings.ToLower(strings.TrimSpace(host))
+	if domain == "" || host == "" {
+		return false
+	}
+	if domain == host {
+		return true
+	}
+	return strings.HasSuffix(host, "."+domain)
+}

--- a/cookie_scrape_test.go
+++ b/cookie_scrape_test.go
@@ -1,0 +1,147 @@
+package mcpgrafana
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/browserutils/kooky"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBrowser satisfies kooky.BrowserInfo so tests can attribute cookies to a
+// browser profile without opening a real cookie store.
+type fakeBrowser struct {
+	name      string
+	profile   string
+	isDefault bool
+}
+
+func (b fakeBrowser) Browser() string        { return b.name }
+func (b fakeBrowser) Profile() string        { return b.profile }
+func (b fakeBrowser) IsDefaultProfile() bool { return b.isDefault }
+func (b fakeBrowser) FilePath() string       { return "" }
+
+func cookie(name, value, domain string, browser kooky.BrowserInfo) *kooky.Cookie {
+	return &kooky.Cookie{
+		Cookie:  http.Cookie{Name: name, Value: value, Domain: domain},
+		Browser: browser,
+	}
+}
+
+func TestGroupSessionCookies(t *testing.T) {
+	chrome := fakeBrowser{name: "chrome", isDefault: true}
+	firefox := fakeBrowser{name: "firefox", isDefault: true}
+	const host = "grafana.example.com"
+
+	t.Run("pairs a session cookie with its expiry companion", func(t *testing.T) {
+		got := groupSessionCookies(kooky.Cookies{
+			cookie(grafanaSessionCookie, "abc", host, chrome),
+			cookie(grafanaSessionExpiryCookie, "999", host, chrome),
+		}, host)
+
+		require.Len(t, got, 1)
+		assert.Equal(t, "abc", got[0].value)
+		assert.Equal(t, "999", got[0].expiry)
+		assert.Equal(t, "chrome", got[0].source)
+	})
+
+	t.Run("keeps profiles separate", func(t *testing.T) {
+		work := fakeBrowser{name: "chrome", profile: "Work"}
+		got := groupSessionCookies(kooky.Cookies{
+			cookie(grafanaSessionCookie, "personal", host, chrome),
+			cookie(grafanaSessionCookie, "work", host, work),
+			cookie(grafanaSessionExpiryCookie, "111", host, work),
+		}, host)
+
+		require.Len(t, got, 2)
+		// Different profiles are independent sessions; pairing across them would
+		// attach one profile's expiry to another profile's cookie.
+		assert.Equal(t, "personal", got[0].value)
+		assert.Empty(t, got[0].expiry)
+		assert.Equal(t, "work", got[1].value)
+		assert.Equal(t, "111", got[1].expiry)
+		assert.Equal(t, "chrome (Work)", got[1].source)
+	})
+
+	t.Run("preserves discovery order across browsers", func(t *testing.T) {
+		got := groupSessionCookies(kooky.Cookies{
+			cookie(grafanaSessionCookie, "first", host, chrome),
+			cookie(grafanaSessionCookie, "second", host, firefox),
+		}, host)
+
+		require.Len(t, got, 2)
+		assert.Equal(t, "first", got[0].value)
+		assert.Equal(t, "second", got[1].value)
+	})
+
+	t.Run("drops cookies for other domains", func(t *testing.T) {
+		got := groupSessionCookies(kooky.Cookies{
+			cookie(grafanaSessionCookie, "other", "grafana.elsewhere.com", chrome),
+			cookie(grafanaSessionCookie, "mine", host, firefox),
+		}, host)
+
+		require.Len(t, got, 1)
+		assert.Equal(t, "mine", got[0].value)
+	})
+
+	t.Run("accepts a parent-domain cookie", func(t *testing.T) {
+		got := groupSessionCookies(kooky.Cookies{
+			cookie(grafanaSessionCookie, "abc", ".example.com", chrome),
+		}, host)
+
+		require.Len(t, got, 1)
+		assert.Equal(t, "abc", got[0].value)
+	})
+
+	t.Run("drops an expiry cookie with no session cookie", func(t *testing.T) {
+		got := groupSessionCookies(kooky.Cookies{
+			cookie(grafanaSessionExpiryCookie, "999", host, chrome),
+		}, host)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("carries the cookie's own expiry", func(t *testing.T) {
+		expires := time.Now().Add(time.Hour).Truncate(time.Second)
+		c := cookie(grafanaSessionCookie, "abc", host, chrome)
+		c.Expires = expires
+
+		got := groupSessionCookies(kooky.Cookies{c}, host)
+		require.Len(t, got, 1)
+		assert.Equal(t, expires.Unix(), got[0].expires)
+	})
+
+	t.Run("tolerates nil and empty entries", func(t *testing.T) {
+		got := groupSessionCookies(kooky.Cookies{
+			nil,
+			cookie(grafanaSessionCookie, "", host, chrome),
+			cookie(grafanaSessionCookie, "abc", host, firefox),
+		}, host)
+
+		require.Len(t, got, 1)
+		assert.Equal(t, "abc", got[0].value)
+	})
+
+	t.Run("labels a cookie with no browser info", func(t *testing.T) {
+		got := groupSessionCookies(kooky.Cookies{
+			cookie(grafanaSessionCookie, "abc", host, nil),
+		}, host)
+
+		require.Len(t, got, 1)
+		assert.Equal(t, "browser", got[0].source)
+	})
+}
+
+func TestScrapeBrowserCookiesEmptyHost(t *testing.T) {
+	// Guards against scanning every cookie store when the Grafana URL has no
+	// parseable host.
+	assert.Nil(t, scrapeBrowserCookies("", discardLogger()))
+}
+
+func TestGrafanaCookieHost(t *testing.T) {
+	assert.Equal(t, "grafana.example.com", grafanaCookieHost("https://grafana.example.com"))
+	assert.Equal(t, "localhost", grafanaCookieHost("http://localhost:3000"))
+	assert.Equal(t, "", grafanaCookieHost("://bad"))
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	github.com/PaesslerAG/gval v1.2.4
 	github.com/PaesslerAG/jsonpath v0.1.1
+	github.com/browserutils/kooky v0.2.10
 	github.com/go-openapi/runtime v0.29.3
 	github.com/go-openapi/strfmt v0.26.1
 	github.com/google/uuid v1.6.0
@@ -56,6 +57,8 @@ require (
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce // indirect
+	github.com/browserutils/sqlite3 v0.0.2 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -90,10 +93,12 @@ require (
 	github.com/go-openapi/validate v0.25.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/gonuts/binary v0.2.0 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/gnostic v0.7.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
@@ -117,6 +122,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6 // indirect
+	github.com/keybase/go-keychain v0.0.1 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
@@ -134,7 +140,7 @@ require (
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0 // indirect
 	github.com/olekukonko/tablewriter v1.1.3 // indirect
-	github.com/pierrec/lz4/v4 v4.1.23 // indirect
+	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -146,6 +152,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/zalando/go-keyring v0.2.7 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 // indirect
@@ -158,6 +165,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
@@ -170,5 +178,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/ini.v1 v1.67.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,12 @@ github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 h1:6df1vn4bBlDDo
 github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3/go.mod h1:CIWtjkly68+yqLPbvwwR/fjNJA/idrtULjZWh2v1ys0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce h1:xb/LXUukZgVLMRnTUyEiCfMNH7KUCFOS4aOZnc/N+H8=
+github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce/go.mod h1:Rj9TJxm7cExxJmdec83sr8cjvyF3raBsszTFviSo/6U=
+github.com/browserutils/kooky v0.2.10 h1:hEgbFJHf9lkMlSr0YdVEGtEo1yvqaTcGXNx0meNBgBA=
+github.com/browserutils/kooky v0.2.10/go.mod h1:ndMF+xzEi4voUsZ4dX0BL45oompbf5wqBaKR+J3lUNk=
+github.com/browserutils/sqlite3 v0.0.2 h1:RDSivmwoS5DauKYxh06G4Y+m6IX3da7Cq9Jh5x+oIUA=
+github.com/browserutils/sqlite3 v0.0.2/go.mod h1:3i7CY1ba3/D+qovGRJyCgfDnu/lGc8sg8ieM6jIUO50=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
@@ -152,6 +158,8 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -162,6 +170,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gonuts/binary v0.2.0 h1:caITwMWAoQWlL0RNvv2lTU/AHqAJlVuu6nZmNgfbKW4=
+github.com/gonuts/binary v0.2.0/go.mod h1:kM+CtBrCGDSKdv8WXTuCUsw+loiy8f/QEI8YCCC0M/E=
 github.com/google/flatbuffers v25.12.19+incompatible h1:haMV2JRRJCe1998HeW/p0X9UaMTK6SDo0ffLn2+DbLs=
 github.com/google/flatbuffers v25.12.19+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic v0.7.1 h1:t5Kc7j/8kYr8t2u11rykRrPPovlEMG4+xdc/SpekATs=
@@ -234,6 +244,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6 h1:SwcnSwBR7X/5EHJQlXBockkJVIMRVt5yKaesBPMtyZQ=
 github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6/go.mod h1:WrYiIuiXUMIvTDAQw97C+9l0CnBmCcvosPjN3XDqS/o=
+github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
+github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
@@ -295,8 +307,8 @@ github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0/go.mod h1:b52bVQRR
 github.com/olekukonko/tablewriter v1.1.3 h1:VSHhghXxrP0JHl+0NnKid7WoEmd9/urKRJLysb70nnA=
 github.com/olekukonko/tablewriter v1.1.3/go.mod h1:9VU0knjhmMkXjnMKrZ3+L2JhhtsQ/L38BbL3CRNE8tM=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
-github.com/pierrec/lz4/v4 v4.1.23 h1:oJE7T90aYBGtFNrI8+KbETnPymobAhzRrR8Mu8n1yfU=
-github.com/pierrec/lz4/v4 v4.1.23/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 h1:S1hI5JiKP7883xBzZAr1ydcxrKNSVNm7+3+JwjxZEsg=
@@ -334,6 +346,8 @@ github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qq
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
@@ -347,6 +361,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zalando/go-keyring v0.2.7 h1:YbqBw40+g4g69UNk4WsRM/fV9YErfVWwozE2+7Bn+7g=
+github.com/zalando/go-keyring v0.2.7/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
@@ -474,6 +490,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
+gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/k8s_client.go
+++ b/k8s_client.go
@@ -24,6 +24,7 @@ import (
 //  1. AccessToken + IDToken (on-behalf-of)
 //  2. APIKey (bearer token)
 //  3. BasicAuth
+//  4. CookieProvider (browser session cookie; stdio transport only)
 type KubernetesClient struct {
 	// BaseURL is the root URL of the Grafana instance (e.g. "http://localhost:3000").
 	BaseURL string

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -255,6 +255,17 @@ type GrafanaConfig struct {
 	// It is used for on-behalf-of auth in Grafana Cloud.
 	IDToken string
 
+	// CookieProvider supplies a Grafana browser session cookie for requests that
+	// have no other credential. It is an interface rather than a string because
+	// Grafana rotates grafana_session server-side: the provider is consulted per
+	// request so a mid-session refresh takes effect without rebuilding clients.
+	//
+	// Only ever set on the stdio transport. Attaching one operator's personal
+	// session cookie to requests on a shared HTTP server would authenticate
+	// every caller as that operator, so cmd/mcp-grafana refuses the combination
+	// at startup.
+	CookieProvider CookieProvider
+
 	// TLSConfig holds TLS configuration for all Grafana clients.
 	TLSConfig *TLSConfig
 
@@ -558,19 +569,33 @@ func NewExtraHeadersRoundTripper(rt http.RoundTripper, headers map[string]string
 
 // AuthRoundTripper wraps an http.RoundTripper to add authentication headers.
 // It supports on-behalf-of (OBO) auth via access/ID tokens, API key bearer
-// auth, and HTTP basic auth, in that priority order.
+// auth, HTTP basic auth, and browser session cookies, in that priority order.
+//
+// Session cookies rank last so that they can never shadow an explicitly
+// configured credential.
 type AuthRoundTripper struct {
 	accessToken string
 	idToken     string
 	apiKey      string
 	basicAuth   *url.Userinfo
+	cookies     CookieProvider
 	underlying  http.RoundTripper
+}
+
+// AuthRoundTripperOption configures optional behaviour of an AuthRoundTripper.
+type AuthRoundTripperOption func(*AuthRoundTripper)
+
+// WithCookieProvider supplies browser session cookies as a last-resort
+// credential, used only when no token or basic auth is available.
+func WithCookieProvider(p CookieProvider) AuthRoundTripperOption {
+	return func(rt *AuthRoundTripper) { rt.cookies = p }
 }
 
 func (rt *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	clonedReq := req.Clone(req.Context())
 
 	accessToken, idToken, apiKey, basicAuth := rt.accessToken, rt.idToken, rt.apiKey, rt.basicAuth
+	cookies := rt.cookies
 	cfg := GrafanaConfigFromContext(req.Context())
 	if cfg.AccessToken != "" {
 		accessToken = cfg.AccessToken
@@ -584,31 +609,47 @@ func (rt *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	if cfg.BasicAuth != nil {
 		basicAuth = cfg.BasicAuth
 	}
+	if cfg.CookieProvider != nil {
+		cookies = cfg.CookieProvider
+	}
 
-	if accessToken != "" && idToken != "" {
+	switch {
+	case accessToken != "" && idToken != "":
 		clonedReq.Header.Set("X-Access-Token", accessToken)
 		clonedReq.Header.Set("X-Grafana-Id", idToken)
-	} else if apiKey != "" {
+	case apiKey != "":
 		clonedReq.Header.Set("Authorization", "Bearer "+apiKey)
-	} else if basicAuth != nil {
+	case basicAuth != nil:
 		password, _ := basicAuth.Password()
 		clonedReq.SetBasicAuth(basicAuth.Username(), password)
+	case cookies != nil:
+		// AddCookie appends rather than replacing, so a Cookie header already
+		// set by an outer layer (GRAFANA_EXTRA_HEADERS, GRAFANA_FORWARD_HEADERS)
+		// survives alongside the session cookie. This layer is innermost, so a
+		// Header.Set here would silently discard it.
+		for _, c := range cookies.Cookies(req.Context()) {
+			clonedReq.AddCookie(c)
+		}
 	}
 
 	return rt.underlying.RoundTrip(clonedReq)
 }
 
-func NewAuthRoundTripper(rt http.RoundTripper, accessToken, idToken, apiKey string, basicAuth *url.Userinfo) *AuthRoundTripper {
+func NewAuthRoundTripper(rt http.RoundTripper, accessToken, idToken, apiKey string, basicAuth *url.Userinfo, opts ...AuthRoundTripperOption) *AuthRoundTripper {
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
-	return &AuthRoundTripper{
+	art := &AuthRoundTripper{
 		accessToken: accessToken,
 		idToken:     idToken,
 		apiKey:      apiKey,
 		basicAuth:   basicAuth,
 		underlying:  rt,
 	}
+	for _, o := range opts {
+		o(art)
+	}
+	return art
 }
 
 // sensitiveHeaders lists HTTP header names whose values must be redacted in
@@ -696,10 +737,14 @@ func WithoutUserAgent() TransportOption {
 // BuildTransport constructs an http.RoundTripper with the standard middleware
 // chain derived from cfg. The default chain (innermost to outermost) is:
 //
-//	base → TLS → debugLogging → Auth → ExtraHeaders → OrgID → UserAgent → otelhttp
+//	base → TLS → debugLogging → Auth → SessionRefresh → ExtraHeaders → OrgID → UserAgent → otelhttp
 //
 // Auth is innermost among the header-setting layers so that credentials take
 // precedence over any forwarded/extra headers with the same keys.
+//
+// SessionRefresh wraps Auth (and is a no-op unless cfg.CookieProvider is set)
+// so that when Grafana rejects a rotated browser session cookie, the replayed
+// request re-enters Auth and is signed with the refreshed cookie.
 //
 // When cfg.Debug is true a debug-logging layer is added just above the base
 // transport. It sees the fully-decorated request (all headers set by outer
@@ -742,8 +787,14 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 
 	// Auth (innermost header layer — wins on conflicts with ExtraHeaders)
 	if !options.withoutAuth {
-		transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+		transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth,
+			WithCookieProvider(cfg.CookieProvider))
 	}
+
+	// Session refresh sits just outside the auth layer so that a replayed
+	// request passes back through it and picks up the refreshed cookie.
+	// It is a no-op when no CookieProvider is configured.
+	transport = NewSessionRefreshRoundTripper(transport, cfg.CookieProvider, cfg.LoggerOrDefault())
 
 	// Extra headers (always included so per-request context overrides work)
 	transport = NewExtraHeadersRoundTripper(transport, cfg.ExtraHeaders)
@@ -852,7 +903,7 @@ var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context
 
 	extraHeaders := extraHeadersFromEnv(logger)
 
-	logger.Info("Using Grafana configuration", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil, "org_id", orgID, "extra_headers_count", len(extraHeaders))
+	logger.Info("Using Grafana configuration", "url", parsedURL.Redacted(), "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil, "cookie_auth_set", config.CookieProvider != nil, "org_id", orgID, "extra_headers_count", len(extraHeaders))
 	config.URL = u
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
@@ -881,6 +932,13 @@ var ExtractGrafanaInfoFromHeaders httpContextFunc = func(ctx context.Context, re
 	config.APIKey = apiKey
 	config.BasicAuth = basicAuth
 	config.OrgID = orgID
+
+	// Browser session cookies belong to whoever started the process, so they
+	// must never be attached to a request that arrived over the network — that
+	// would authenticate every caller as the operator. cmd/mcp-grafana already
+	// refuses to enable cookie auth on the HTTP transports; this clear makes the
+	// guarantee hold for library embedders that build their own config too.
+	config.CookieProvider = nil
 
 	// Environment extra headers may carry credentials (e.g. an Authorization
 	// header), so they are bound to the environment-configured URL just like the
@@ -1240,14 +1298,19 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 					// (handled by the OpenAPI client). OBO tokens still need
 					// transport-level injection since the OpenAPI client
 					// doesn't support them natively.
+					// CookieProvider must be carried here too: the OpenAPI
+					// client knows nothing about session cookies, so without it
+					// every call made through this client — the bulk of the
+					// tool surface — would go out unauthenticated.
 					oboConfig := GrafanaConfig{
-						AccessToken:  config.AccessToken,
-						IDToken:      config.IDToken,
-						OrgID:        config.OrgID,
-						TLSConfig:    config.TLSConfig,
-						ExtraHeaders: config.ExtraHeaders,
-						Debug:        config.Debug,
-						Logger:       config.Logger,
+						AccessToken:    config.AccessToken,
+						IDToken:        config.IDToken,
+						OrgID:          config.OrgID,
+						TLSConfig:      config.TLSConfig,
+						ExtraHeaders:   config.ExtraHeaders,
+						CookieProvider: config.CookieProvider,
+						Debug:          config.Debug,
+						Logger:         config.Logger,
 					}
 					// Panic matches the existing TLS error handling above
 					// (line ~887). The only realistic failure is a TLS
@@ -1266,14 +1329,15 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 
 	// Fetch the public URL from Grafana's frontend settings.
 	fetchCfg := &GrafanaConfig{
-		URL:          grafanaURL,
-		APIKey:       apiKey,
-		BasicAuth:    auth,
-		AccessToken:  config.AccessToken,
-		IDToken:      config.IDToken,
-		TLSConfig:    config.TLSConfig,
-		ExtraHeaders: config.ExtraHeaders,
-		Logger:       config.Logger,
+		URL:            grafanaURL,
+		APIKey:         apiKey,
+		BasicAuth:      auth,
+		AccessToken:    config.AccessToken,
+		IDToken:        config.IDToken,
+		TLSConfig:      config.TLSConfig,
+		ExtraHeaders:   config.ExtraHeaders,
+		CookieProvider: config.CookieProvider,
+		Logger:         config.Logger,
 	}
 	publicURL := fetchPublicURL(ctx, fetchCfg)
 

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -232,6 +232,11 @@ func parseProxiedToolName(toolName string) (string, string, error) {
 // http.RoundTripper (an interface value that is not reliably comparable) and is
 // process-constant (set once at server construction, never per request/session),
 // so it cannot differ between two sessions and needs no differentiation.
+//
+// GrafanaConfig.CookieProvider is omitted for the same two reasons, plus a
+// third: it is only ever set on the stdio transport, which has a single session
+// and no cross-tenant sharing to guard against. ExtractGrafanaInfoFromHeaders
+// clears it, so a session built from an HTTP request never carries one.
 type proxiedToolSetKey struct {
 	url           string
 	apiKey        string


### PR DESCRIPTION
Adds a browser session cookie as a first-class auth mode, for SSO-only Grafana instances where minting a service account token is impractical.

Previously every credential had to be handed to the server (env var, header, or mounted file). The nearest workaround was pasting a cookie into GRAFANA_EXTRA_HEADERS, which goes stale within hours because Grafana rotates grafana_session server-side.

The server now resolves a session from a saved file, then from the grafana_session cookie held by installed browsers (via kooky), and re-acquires it automatically when Grafana rejects a request with 401/403 -- so the session survives rotation without a restart.

Notable details:

- Candidates are validated against /api/user, never /api/health. /api/health is unauthenticated, so a dead cookie passes it and then fails every real call. Redirects are not followed, so a 302 to a login page is not mistaken for success.
- Cookies rank last in AuthRoundTripper (after OBO, API key, basic auth) so they can never shadow an explicit credential, and are attached with AddCookie so a Cookie header set by ExtraHeaders survives alongside them.
- CookieProvider is carried into the stripped GrafanaConfig copies in NewGrafanaClient. Without that the OpenAPI client -- most of the tool surface -- would send no cookie while still compiling.
- Refresh is singleflighted: a burst of concurrent 401s triggers one browser scrape, not one per request.
- Only ever enabled on stdio. On a shared HTTP server the operator's personal cookie would authenticate every client as the operator, so the flag combination is refused at startup and ExtractGrafanaInfoFromHeaders clears the provider defensively.

Verified end to end against Grafana 13.0.2: a real grafana_session cookie authenticates a live list_datasources call, and --debug output shows the cookie redacted. The successful 401 -> refresh -> replay cycle has unit coverage only; proving it live needs a browser rotating a cookie mid-session.