### PR TITLE
Add optional caller authentication for HTTP transports, fail closed on exposed listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,15 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 - `--allowed-hosts`: Comma-separated allowlist of `Host` header values. Defaults to loopback variants of `--address` (e.g. `localhost:8000,127.0.0.1:8000,[::1]:8000`). A value that parses to empty (unset, `,`, ` , `, etc.) also falls back to the defaults so a typo cannot silently disable the check. Requests with a `Host` header outside the allowlist are rejected with `403`. Pass `*` to disable the check — only safe when running behind a trusted reverse proxy that rewrites `Host`, or in an isolated network. K8s `httpGet` probes and external `/metrics` scrapes will need either an explicit hostname in this list, `*`, or a `tcpSocket` probe / a separate metrics port (`--metrics-address`).
 - `--allowed-origins`: Comma-separated allowlist of `Origin` header values. Empty by default — any request that carries an `Origin` header is rejected (browsers always send one for cross-origin requests, and no browser should be calling this server directly). Set to an explicit list to permit browser-based clients, or `*` to disable the check.
 
+**Caller Authentication (SSE / streamable-http only):**
+
+Optionally require MCP clients to authenticate *to the server*. This is separate from the credentials the server uses to reach Grafana. Stdio is unaffected.
+
+- `--server-auth-token`: Bearer token callers must send as `Authorization: Bearer <token>`. Falls back to the `MCP_GRAFANA_SERVER_TOKEN` environment variable. When set, requests without a valid token are rejected with `401` before any tool runs. Prefer the env var so the secret isn't visible in the process arguments.
+- `--allow-unauthenticated`: Allow binding to a non-loopback address *without* `--server-auth-token`. Insecure on its own — only for deployments behind a trusted proxy that authenticates callers.
+
+By default the SSE/streamable-http server **refuses to start** on a non-loopback address unless one of the above is set (loopback and stdio are unaffected). Use TLS (or TLS termination) whenever caller auth is enabled on a non-loopback address. When caller auth is enabled, the validated `Authorization` header is stripped before requests reach Grafana; combining `--server-auth-token` with `GRAFANA_FORWARD_HEADERS=Authorization` is rejected at startup.
+
 **Debug and Logging:**
 - `--debug`: Enable debug mode for detailed HTTP request/response logging
 - `--log-level`: Log level (`debug`, `info`, `warn`, `error`) - default: `info`
@@ -658,18 +667,20 @@ Forwarded headers are merged with any headers defined in `GRAFANA_EXTRA_HEADERS`
      docker run --rm -i -e GRAFANA_URL=https://myinstance.grafana.net -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> grafana/mcp-grafana -t stdio
      ```
 
+     > **Note — caller authentication required for networked modes:** In SSE and streamable-http modes the container binds a non-loopback address (`0.0.0.0:8000`), so the server **requires caller authentication and refuses to start without it**. Set `MCP_GRAFANA_SERVER_TOKEN` to require an `Authorization: Bearer <token>` from clients (recommended), or pass `--allow-unauthenticated` if a trusted proxy in front of the server authenticates callers. STDIO mode is unaffected. See [Caller Authentication](#cli-flags-reference).
+
      2. **SSE Mode**: In this mode, the server runs as an HTTP server that clients connect to. You must expose port 8000 using the `-p` flag:
 
      ```bash
      docker pull grafana/mcp-grafana
-     docker run --rm -p 8000:8000 -e GRAFANA_URL=http://localhost:3000 -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> grafana/mcp-grafana
+     docker run --rm -p 8000:8000 -e GRAFANA_URL=http://localhost:3000 -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> -e MCP_GRAFANA_SERVER_TOKEN=<caller auth token> grafana/mcp-grafana
      ```
 
      3. **Streamable HTTP Mode**: In this mode, the server operates as an independent process that can handle multiple client connections. You must expose port 8000 using the `-p` flag: For this mode you must explicitly override the default with `-t streamable-http`
 
      ```bash
      docker pull grafana/mcp-grafana
-     docker run --rm -p 8000:8000 -e GRAFANA_URL=http://localhost:3000 -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> grafana/mcp-grafana -t streamable-http
+     docker run --rm -p 8000:8000 -e GRAFANA_URL=http://localhost:3000 -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> -e MCP_GRAFANA_SERVER_TOKEN=<caller auth token> grafana/mcp-grafana -t streamable-http
      ```
 
      For HTTPS streamable HTTP mode with server TLS certificates:
@@ -680,6 +691,7 @@ Forwarded headers are merged with any headers defined in `GRAFANA_EXTRA_HEADERS`
        -v /path/to/certs:/certs:ro \
        -e GRAFANA_URL=http://localhost:3000 \
        -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> \
+       -e MCP_GRAFANA_SERVER_TOKEN=<caller auth token> \
        grafana/mcp-grafana \
        -t streamable-http \
        -addr :8443 \

--- a/caller_auth.go
+++ b/caller_auth.go
@@ -1,0 +1,126 @@
+package mcpgrafana
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// RequireBearerToken returns middleware that authenticates the *caller* of the
+// MCP server (not the credentials the server uses to reach Grafana). Requests
+// must carry "Authorization: Bearer <token>" matching expected, or they are
+// rejected with 401 before reaching the MCP handler.
+//
+// Both sides are SHA-256 hashed and compared in constant time, so neither the
+// token's value nor its length leaks via timing. On success the Authorization
+// header is stripped so the caller token can never be forwarded to Grafana or
+// folded into a cache key (Grafana auth uses its own X-Grafana-* headers).
+//
+// CORS preflight (OPTIONS) passes through unauthenticated (no credentials, no
+// MCP operation). If expected is empty the middleware fails closed and rejects
+// every request. Rejections are logged at WARN with request metadata only,
+// never the token. A nil logger falls back to slog.Default().
+func RequireBearerToken(expected string, logger *slog.Logger) func(http.Handler) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	expectedHash := sha256.Sum256([]byte(expected))
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Let CORS preflight through unauthenticated — it carries no bearer
+			// token and triggers no MCP operation.
+			if r.Method == http.MethodOptions {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if expected == "" {
+				rejectUnauthorized(w, r, logger, "server misconfigured: empty auth token")
+				return
+			}
+			token := bearerTokenFromRequest(r)
+			if token == "" {
+				rejectUnauthorized(w, r, logger, "missing bearer token")
+				return
+			}
+			presentedHash := sha256.Sum256([]byte(token))
+			if subtle.ConstantTimeCompare(presentedHash[:], expectedHash[:]) != 1 {
+				rejectUnauthorized(w, r, logger, "invalid bearer token")
+				return
+			}
+			// Authentication succeeded. Strip the caller credential so it can
+			// never reach Grafana or a cache key downstream.
+			r.Header.Del("Authorization")
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// rejectUnauthorized logs a blocked request (metadata and reason only, never the
+// token) and writes a 401.
+func rejectUnauthorized(w http.ResponseWriter, r *http.Request, logger *slog.Logger, reason string) {
+	logger.Warn("Rejected unauthenticated request to MCP endpoint",
+		"remote_addr", r.RemoteAddr,
+		"method", r.Method,
+		"path", r.URL.Path,
+		"reason", reason,
+	)
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	http.Error(w, "unauthorized: "+reason, http.StatusUnauthorized)
+}
+
+// bearerTokenFromRequest extracts the token from an "Authorization: Bearer ..."
+// header. It returns an empty string when the header is absent or not a bearer
+// credential. The scheme match is case-insensitive per RFC 7235.
+func bearerTokenFromRequest(r *http.Request) string {
+	const prefix = "bearer "
+	h := r.Header.Get("Authorization")
+	if len(h) < len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return ""
+	}
+	return strings.TrimSpace(h[len(prefix):])
+}
+
+// IsLoopbackOnlyBind reports whether a bind address is reachable only from the
+// local host. Wildcard binds ("", "0.0.0.0", "::") and bare hostnames are
+// treated as public, since they may accept remote connections.
+func IsLoopbackOnlyBind(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		// No port (or malformed); treat the whole value as the host.
+		host = address
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.Trim(host, "[]")
+
+	switch host {
+	case "", "0.0.0.0", "::":
+		// Wildcard binds listen on all interfaces — public.
+		return false
+	case "localhost":
+		return true
+	}
+	if strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	// A non-loopback hostname may resolve to a routable address; be safe.
+	return false
+}
+
+// ForwardsAuthorizationHeader reports whether GRAFANA_FORWARD_HEADERS copies the
+// incoming Authorization header to Grafana. That conflicts with built-in caller
+// auth (which reserves Authorization for the caller token), so the server refuses
+// to start when both are set. Proxy mode (no caller token) may keep forwarding it.
+func ForwardsAuthorizationHeader() bool {
+	for _, name := range forwardHeaderNamesFromEnv() {
+		if strings.EqualFold(name, "Authorization") {
+			return true
+		}
+	}
+	return false
+}

--- a/caller_auth_integration_test.go
+++ b/caller_auth_integration_test.go
@@ -1,0 +1,134 @@
+package mcpgrafana
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testCallerToken = "integration-caller-token"
+
+// initializeBody is a minimal, well-formed MCP initialize request. It only needs
+// to be valid enough to pass the transport layer; these tests assert the
+// authentication boundary, not full protocol semantics.
+const initializeBody = `{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}`
+
+// TestCallerAuth_StreamableHTTP_EndToEnd drives the real streamable-HTTP handler
+// behind the RequireBearerToken middleware — the same wrapping cmd/mcp-grafana
+// applies — and asserts the full caller-auth contract end to end.
+func TestCallerAuth_StreamableHTTP_EndToEnd(t *testing.T) {
+	var capturedAuth string
+	var capturedAuthSet bool
+	mcpServer := server.NewMCPServer("test", "0")
+	srv := server.NewStreamableHTTPServer(mcpServer,
+		server.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
+			// Runs only after the middleware has authenticated (and stripped).
+			capturedAuth = r.Header.Get("Authorization")
+			capturedAuthSet = true
+			return ctx
+		}),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", RequireBearerToken(testCallerToken, slog.Default())(srv))
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	post := func(t *testing.T, authHeader, sessionID string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewBufferString(initializeBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		if sessionID != "" {
+			req.Header.Set("Mcp-Session-Id", sessionID)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		return resp
+	}
+
+	t.Run("no token cannot call tools -> 401", func(t *testing.T) {
+		resp := post(t, "", "")
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("wrong token -> 401", func(t *testing.T) {
+		resp := post(t, "Bearer nope", "")
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("self-minted session id does not bypass auth -> 401", func(t *testing.T) {
+		resp := post(t, "", "made-up-session-id")
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("valid token initializes and Authorization never reaches backend", func(t *testing.T) {
+		capturedAuthSet = false
+		capturedAuth = "unset"
+		resp := post(t, "Bearer "+testCallerToken, "")
+		assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+		require.True(t, capturedAuthSet, "authenticated request should reach the streamable handler")
+		assert.Empty(t, capturedAuth, "caller token must be stripped before the Grafana-facing handler")
+	})
+
+	t.Run("OPTIONS preflight passes without a token", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodOptions, ts.URL+"/mcp", nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+// TestCallerAuth_SSE_EndToEnd asserts the same boundary for the SSE transport.
+func TestCallerAuth_SSE_EndToEnd(t *testing.T) {
+	mcpServer := server.NewMCPServer("test", "0")
+	sse := server.NewSSEServer(mcpServer)
+	ts := httptest.NewServer(RequireBearerToken(testCallerToken, slog.Default())(sse))
+	t.Cleanup(ts.Close)
+
+	get := func(t *testing.T, authHeader string) (*http.Response, error) {
+		t.Helper()
+		// The SSE stream stays open; abort via context deadline once we have headers.
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		t.Cleanup(cancel)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/sse", nil)
+		require.NoError(t, err)
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		return http.DefaultClient.Do(req)
+	}
+
+	t.Run("no token -> 401", func(t *testing.T) {
+		resp, err := get(t, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("valid token opens the stream (not 401)", func(t *testing.T) {
+		resp, err := get(t, "Bearer "+testCallerToken)
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			require.NoError(t, err)
+		}
+		require.NotNil(t, resp)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}

--- a/caller_auth_test.go
+++ b/caller_auth_test.go
@@ -1,0 +1,213 @@
+package mcpgrafana
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireBearerToken(t *testing.T) {
+	const token = "s3cret-caller-token"
+
+	// Downstream handler records whether it was reached.
+	var reached bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequireBearerToken(token, slog.Default())(next)
+
+	cases := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+		wantReach  bool
+	}{
+		{"missing header", "", http.StatusUnauthorized, false},
+		{"wrong token", "Bearer wrong", http.StatusUnauthorized, false},
+		{"not bearer scheme", "Basic " + token, http.StatusUnauthorized, false},
+		{"empty bearer", "Bearer ", http.StatusUnauthorized, false},
+		{"valid token", "Bearer " + token, http.StatusOK, true},
+		{"valid token lowercase scheme", "bearer " + token, http.StatusOK, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reached = false
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			assert.Equal(t, tc.wantReach, reached)
+			if tc.wantStatus == http.StatusUnauthorized {
+				assert.Equal(t, "Bearer", rec.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}
+
+// An accidentally-empty expected token must fail closed, never allow-all.
+func TestRequireBearerToken_EmptyExpectedFailsClosed(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be reached when expected token is empty")
+	})
+	handler := RequireBearerToken("", slog.Default())(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer anything")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// Rejections must be logged for audit, but the token value must never appear in
+// the logs.
+func TestRequireBearerToken_LogsRejectionWithoutLeakingToken(t *testing.T) {
+	const secret = "the-expected-secret-token"
+	const presented = "the-wrong-presented-token"
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be reached for a rejected request")
+	})
+	handler := RequireBearerToken(secret, logger)(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+presented)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	logs := buf.String()
+	assert.Contains(t, logs, "Rejected unauthenticated request")
+	assert.Contains(t, logs, "invalid bearer token")
+	assert.Contains(t, logs, "method=POST")
+	assert.Contains(t, logs, "path=/mcp")
+	// The secret and the presented token must never be written to logs.
+	assert.NotContains(t, logs, secret)
+	assert.NotContains(t, logs, presented)
+}
+
+// A successful (authenticated) request must not emit a rejection log line.
+func TestRequireBearerToken_NoLogOnSuccess(t *testing.T) {
+	const secret = "the-expected-secret-token"
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequireBearerToken(secret, logger)(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+secret)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, buf.String(), "authenticated request should not log a rejection")
+}
+
+// After successful authentication the caller's Authorization header must be
+// stripped so it can never be forwarded to Grafana or folded into a cache key.
+func TestRequireBearerToken_StripsAuthorizationAfterAuth(t *testing.T) {
+	const token = "s3cret-caller-token"
+
+	var seenAuth string
+	var reached bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		seenAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequireBearerToken(token, slog.Default())(next)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, reached)
+	assert.Empty(t, seenAuth, "Authorization header must be stripped before reaching the downstream handler")
+}
+
+// CORS preflight must be allowed through unauthenticated so browser clients can
+// negotiate; it carries no bearer token and performs no MCP operation.
+func TestRequireBearerToken_AllowsOPTIONSPreflight(t *testing.T) {
+	const token = "s3cret-caller-token"
+
+	var reached bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler := RequireBearerToken(token, slog.Default())(next)
+
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, reached, "OPTIONS preflight should reach the downstream CORS handler")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestForwardsAuthorizationHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"unset -> false", "", false},
+		{"unrelated headers -> false", "Cookie, X-Session-Id", false},
+		{"exact match -> true", "Authorization", true},
+		{"case-insensitive match -> true", " cookie , authorization ", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GRAFANA_FORWARD_HEADERS", tc.env)
+			assert.Equal(t, tc.want, ForwardsAuthorizationHeader())
+		})
+	}
+}
+
+func TestIsLoopbackOnlyBind(t *testing.T) {
+	cases := []struct {
+		address string
+		want    bool
+	}{
+		{"localhost:8000", true},
+		{"127.0.0.1:8000", true},
+		{"[::1]:8000", true},
+		{"foo.localhost:8000", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		// Public / wildcard binds.
+		{"0.0.0.0:8000", false},
+		{":8000", false},
+		{"[::]:8000", false},
+		{"192.168.1.10:8000", false},
+		{"10.0.0.5:8000", false},
+		{"example.com:8000", false},
+		{"grafana.example.com:8000", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.address, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsLoopbackOnlyBind(tc.address))
+		})
+	}
+}

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -383,6 +383,74 @@ func (hsc *httpSecurityConfig) addFlags() {
 	flag.StringVar(&hsc.allowedOrigins, "allowed-origins", "", "Comma-separated allowlist of Origin header values for the HTTP/SSE transports. Empty (the default) rejects any request that carries an Origin header — appropriate for non-browser MCP clients. Use \"*\" to disable validation.")
 }
 
+// serverAuthTokenEnvVar is the env fallback for --server-auth-token, so the
+// secret need not appear in the process arguments.
+const serverAuthTokenEnvVar = "MCP_GRAFANA_SERVER_TOKEN"
+
+// callerAuthConfig configures authentication of *callers* to the HTTP/SSE
+// transports — distinct from the credentials the server uses to reach Grafana.
+// It gates who may invoke the MCP server at all.
+type callerAuthConfig struct {
+	// token, when non-empty, is required as "Authorization: Bearer <token>" on
+	// every request to the MCP endpoint.
+	token string
+
+	// allowUnauthenticated permits a non-loopback bind without a caller token.
+	// INSECURE: only behind a trusted proxy that authenticates callers.
+	allowUnauthenticated bool
+}
+
+func (ca *callerAuthConfig) addFlags() {
+	flag.StringVar(&ca.token, "server-auth-token", "", "Bearer token that callers must present in the Authorization header to use the HTTP/SSE transports. Falls back to the "+serverAuthTokenEnvVar+" environment variable. When set, unauthenticated requests are rejected with 401. Has no effect on the stdio transport.")
+	flag.BoolVar(&ca.allowUnauthenticated, "allow-unauthenticated", false, "Allow the HTTP/SSE server to bind to a non-loopback address without --server-auth-token. INSECURE: only use behind a trusted proxy that authenticates callers. By default the server refuses to start unauthenticated on a public address.")
+}
+
+// resolveToken returns the caller token, falling back to the env var. It is
+// trimmed so whitespace from a secrets mount can't produce a never-matching token.
+func (ca callerAuthConfig) resolveToken() string {
+	if t := strings.TrimSpace(ca.token); t != "" {
+		return t
+	}
+	return strings.TrimSpace(os.Getenv(serverAuthTokenEnvVar))
+}
+
+// checkCallerAuthPolicy enforces the fail-closed bind rule for network
+// transports: an externally reachable listener must not accept unauthenticated
+// callers. Rules, in order:
+//
+//   - Caller token configured → authenticated; any bind is fine.
+//   - Loopback bind → only local processes can reach it; allowed.
+//   - --allow-unauthenticated → assume a trusted proxy in front; allowed (warns).
+//   - Otherwise (non-loopback, no token) → refused.
+//
+// It deliberately ignores which Grafana credentials are configured, so the safe
+// default doesn't hinge on an evolving inventory of credential sources.
+func checkCallerAuthPolicy(transport, address, token string, allowUnauthenticated bool) error {
+	if token != "" {
+		slog.Info("Caller authentication enabled: requests must present a valid bearer token", "transport", transport)
+		return nil
+	}
+	if mcpgrafana.IsLoopbackOnlyBind(address) {
+		slog.Warn("No caller authentication configured. The server is bound to a loopback address, so only local processes can reach it. Set --server-auth-token (or "+serverAuthTokenEnvVar+") to require authentication for non-local callers.", "address", address)
+		return nil
+	}
+	if allowUnauthenticated {
+		slog.Warn("SECURITY: serving on a non-loopback address with NO caller authentication because --allow-unauthenticated was set. Anyone who can reach this address can invoke MCP tools and use any Grafana credentials the server is configured with. Ensure a trusted proxy authenticates callers.", "address", address)
+		return nil
+	}
+	return fmt.Errorf("refusing to start %s transport on non-loopback address %q without caller authentication: set --server-auth-token (or %s) to require a bearer token, or pass --allow-unauthenticated if a trusted proxy in front of this server authenticates callers", transport, address, serverAuthTokenEnvVar)
+}
+
+// withCallerAuth wraps h with bearer-token authentication when a token is
+// configured, and returns it unchanged otherwise. Only the MCP endpoint is
+// wrapped; health/metrics endpoints stay open.
+func withCallerAuth(token string, h http.Handler) http.Handler {
+	if token == "" {
+		return h
+	}
+	return mcpgrafana.RequireBearerToken(token, slog.Default())(h)
+}
+
 // policy resolves the configured flags into a HostOriginPolicy. An
 // --allowed-hosts whose parsed form is empty (unset, "," " , ", etc.) falls
 // back to DefaultAllowedHosts so a malformed value cannot silently disable
@@ -486,7 +554,7 @@ func runMetricsServer(addr string, o *observability.Observability) {
 	}
 }
 
-func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, hsc httpSecurityConfig, obs observability.Config, sessionIdleTimeoutMinutes int) error {
+func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, hsc httpSecurityConfig, ca callerAuthConfig, obs observability.Config, sessionIdleTimeoutMinutes int) error {
 	stderrHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
 	slog.SetDefault(slog.New(stderrHandler))
 
@@ -551,6 +619,21 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		}
 	}()
 
+	// Resolve the caller-auth token once and enforce the fail-closed bind
+	// policy before we start listening. stdio is a local pipe, so it is exempt.
+	callerToken := ca.resolveToken()
+	if transport == "sse" || transport == "streamable-http" {
+		if err := checkCallerAuthPolicy(transport, addr, callerToken, ca.allowUnauthenticated); err != nil {
+			return err
+		}
+		// With caller auth active, Authorization holds the caller token (stripped
+		// after validation). Forwarding it to Grafana would leak it, so refuse the
+		// contradictory combination.
+		if callerToken != "" && mcpgrafana.ForwardsAuthorizationHeader() {
+			return fmt.Errorf("refusing to start: caller authentication is enabled (--server-auth-token / %s) while GRAFANA_FORWARD_HEADERS forwards the Authorization header. Authorization is reserved for MCP caller authentication and would leak to Grafana. Remove Authorization from GRAFANA_FORWARD_HEADERS, or unset the caller token to run in proxy-forwarding mode", serverAuthTokenEnvVar)
+		}
+	}
+
 	// Start the appropriate server based on transport
 	switch transport {
 	case "stdio":
@@ -586,10 +669,10 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		if basePath == "" {
 			basePath = "/"
 		}
-		mux.Handle(basePath, observability.WrapHandler(
+		mux.Handle(basePath, withCallerAuth(callerToken, observability.WrapHandler(
 			mcpgrafana.ValidateGrafanaURLMiddleware(srv),
 			basePath,
-		))
+		)))
 		mux.HandleFunc("/healthz", handleHealthz)
 		if obs.MetricsEnabled {
 			if obs.MetricsAddress == "" {
@@ -626,10 +709,10 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		}
 		srv := server.NewStreamableHTTPServer(s, opts...)
 		mux := http.NewServeMux()
-		mux.Handle(endpointPath, observability.WrapHandler(
+		mux.Handle(endpointPath, withCallerAuth(callerToken, observability.WrapHandler(
 			mcpgrafana.ValidateGrafanaURLMiddleware(srv),
 			endpointPath,
-		))
+		)))
 		mux.HandleFunc("/healthz", handleHealthz)
 		if obs.MetricsEnabled {
 			if obs.MetricsAddress == "" {
@@ -671,6 +754,8 @@ func main() {
 	tls.addFlags()
 	var hsc httpSecurityConfig
 	hsc.addFlags()
+	var ca callerAuthConfig
+	ca.addFlags()
 	var obs observability.Config
 	flag.BoolVar(&obs.MetricsEnabled, "metrics", false, "Enable Prometheus metrics endpoint")
 	flag.StringVar(&obs.MetricsAddress, "metrics-address", "", "Separate address for metrics server (e.g., :9090). If empty, metrics are served on the main server at /metrics")
@@ -728,7 +813,7 @@ func main() {
 		level = slog.LevelDebug
 	}
 
-	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, hsc, obs, *sessionIdleTimeoutMinutes); err != nil {
+	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, hsc, ca, obs, *sessionIdleTimeoutMinutes); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -531,3 +531,58 @@ func TestHTTPSecurityConfigCORSOrigins(t *testing.T) {
 		})
 	}
 }
+
+func TestCallerAuthConfigResolveToken(t *testing.T) {
+	t.Run("flag takes precedence and is trimmed", func(t *testing.T) {
+		t.Setenv(serverAuthTokenEnvVar, "from-env")
+		ca := callerAuthConfig{token: "  from-flag  "}
+		assert.Equal(t, "from-flag", ca.resolveToken())
+	})
+
+	t.Run("falls back to env when flag empty", func(t *testing.T) {
+		t.Setenv(serverAuthTokenEnvVar, "  from-env  ")
+		ca := callerAuthConfig{}
+		assert.Equal(t, "from-env", ca.resolveToken())
+	})
+
+	t.Run("empty when neither set", func(t *testing.T) {
+		t.Setenv(serverAuthTokenEnvVar, "")
+		ca := callerAuthConfig{}
+		assert.Empty(t, ca.resolveToken())
+	})
+}
+
+func TestCheckCallerAuthPolicy(t *testing.T) {
+	cases := []struct {
+		name                 string
+		address              string
+		token                string
+		allowUnauthenticated bool
+		wantErr              bool
+	}{
+		// A caller token authenticates every request, so any bind is fine.
+		{"token set, public bind is fine", "0.0.0.0:8000", "tok", false, false},
+		{"token set, loopback bind is fine", "localhost:8000", "tok", false, false},
+
+		// No caller token: loopback is fine (local only), non-loopback is refused
+		// regardless of what Grafana credentials happen to be configured.
+		{"no token, loopback allowed", "127.0.0.1:8000", "", false, false},
+		{"no token, public bind refused", "0.0.0.0:8000", "", false, true},
+		{"no token, wildcard port refused", ":8000", "", false, true},
+		{"no token, routable IP refused", "192.168.1.5:8000", "", false, true},
+
+		// The explicit escape hatch for a trusted authenticating proxy.
+		{"no token, public bind allowed with override", "0.0.0.0:8000", "", true, false},
+		{"no token, routable IP allowed with override", "192.168.1.5:8000", "", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkCallerAuthPolicy("streamable-http", tc.address, tc.token, tc.allowUnauthenticated)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -41,6 +41,27 @@ The SSE and streamable-http transports validate `Host` and `Origin` headers on e
 
 When deploying behind an ingress or reverse proxy that forwards the original `Host`, set `--allowed-hosts` to the expected hostname (or `*` if the proxy is fully trusted). Kubernetes `httpGet` liveness/readiness probes send `Host: <pod-ip>:<port>` by default — either set `--allowed-hosts '*'`, override the probe's `host:` field, or use a `tcpSocket` probe. External `/metrics` scrapes must add the scrape source's `Host` to the allowlist (or use `--metrics-address` to bind metrics on a separate port, which is unaffected).
 
+## Configure caller authentication
+
+The SSE and streamable-http transports can authenticate the **caller** (the MCP client connecting to `mcp-grafana`). This is separate from the credentials the server uses to reach Grafana: it controls _who may invoke the server_, so an unauthenticated client can't borrow the server's Grafana identity or run tools. Stdio is a local pipe and is never affected.
+
+- `--server-auth-token`: Bearer token that callers must present in the `Authorization: Bearer <token>` header. Falls back to the `MCP_GRAFANA_SERVER_TOKEN` environment variable. When set, requests without a valid token are rejected with `401` before any tool runs. Prefer the environment variable over the flag so the secret doesn't appear in the process argument list.
+- `--allow-unauthenticated`: Permit binding to a non-loopback address **without** a caller token. Insecure on its own — only use it when a trusted proxy in front of `mcp-grafana` authenticates callers.
+
+### Fail-closed bind policy
+
+To avoid accidentally exposing an unauthenticated server, the network transports refuse to start on an externally reachable address unless callers are authenticated:
+
+| Transport / bind | Behavior |
+| --- | --- |
+| `stdio` | No caller authentication (local pipe). |
+| SSE / streamable-http on a loopback address (`localhost`, `127.0.0.1`, `::1`) | Caller token optional. |
+| SSE / streamable-http on any other address | **Requires** `--server-auth-token`, or an explicit `--allow-unauthenticated`. Otherwise the server exits with an error. |
+
+Bearer authentication only protects the token in transit if the connection is encrypted. Terminate TLS in front of the server, or use [server TLS for streamable-http](../server-tls-streamable-http/), whenever you set `--server-auth-token` on a non-loopback address.
+
+When caller authentication is enabled, the `Authorization` header is reserved for the caller token and is stripped after validation, so it is never forwarded to Grafana. Setting `--server-auth-token` together with `GRAFANA_FORWARD_HEADERS=Authorization` is contradictory and the server refuses to start; remove `Authorization` from `GRAFANA_FORWARD_HEADERS`, or unset the caller token to run in proxy-forwarding mode.
+
 ## Configure debug and logging
 
 - `--debug`: Enable debug mode for detailed HTTP request and response logging to and from the Grafana API.


### PR DESCRIPTION
## Summary
Adds optional bearer-token authentication for the SSE and streamable-http transports via `--server-auth-token` / `MCP_GRAFANA_SERVER_TOKEN`. When set, callers must send `Authorization: Bearer <token>`; unauthenticated requests get `401` before any tool runs. The validated header is stripped before requests reach Grafana.

To avoid accidental exposure, networked transports now fail closed: binding a non-loopback address requires either a caller token or an explicit `--allow-unauthenticated` (for deployments behind a trusted authenticating proxy). `stdio` and loopback binds are unaffected.

## Breaking change
The SSE/streamable-http server refuses to start on a non-loopback address (e.g. the container's `0.0.0.0` bind) without `- server-auth-token` or `--allow-unauthenticated`. Set one of them to restore the previous behaviour.

## Notes
- Combining `--server-auth-token` with `GRAFANA_FORWARD_HEADERS=Authorization`  is rejected at startup (conflicting use of the `Authorization` header).
- Docs updated: README (Quick Start unaffected; networked Docker examples + CLI Flags Reference) and command-line-flags reference.
