### PR TITLE
Fix/caller auth non breaking default

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,9 +429,8 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 Optionally require MCP clients to authenticate *to the server*. This is separate from the credentials the server uses to reach Grafana. Stdio is unaffected.
 
 - `--server-auth-token`: Bearer token callers must send as `Authorization: Bearer <token>`. Falls back to the `MCP_GRAFANA_SERVER_TOKEN` environment variable. When set, requests without a valid token are rejected with `401` before any tool runs. Prefer the env var so the secret isn't visible in the process arguments.
-- `--allow-unauthenticated`: Allow binding to a non-loopback address *without* `--server-auth-token`. Insecure on its own — only for deployments behind a trusted proxy that authenticates callers.
 
-By default the SSE/streamable-http server **refuses to start** on a non-loopback address unless one of the above is set (loopback and stdio are unaffected). Use TLS (or TLS termination) whenever caller auth is enabled on a non-loopback address. When caller auth is enabled, the validated `Authorization` header is stripped before requests reach Grafana; combining `--server-auth-token` with `GRAFANA_FORWARD_HEADERS=Authorization` is rejected at startup.
+Caller authentication is enforced only when `--server-auth-token` is set. When it isn't and the server binds a non-loopback address, the server **starts but logs a loud security warning** (loopback and stdio are unaffected); a future major release will make that a startup error. Use TLS (or TLS termination) whenever caller auth is enabled on a non-loopback address. When caller auth is enabled, the validated `Authorization` header is stripped before requests reach Grafana; combining `--server-auth-token` with `GRAFANA_FORWARD_HEADERS=Authorization` is rejected at startup.
 
 **Debug and Logging:**
 - `--debug`: Enable debug mode for detailed HTTP request/response logging
@@ -667,7 +666,7 @@ Forwarded headers are merged with any headers defined in `GRAFANA_EXTRA_HEADERS`
      docker run --rm -i -e GRAFANA_URL=https://myinstance.grafana.net -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> grafana/mcp-grafana -t stdio
      ```
 
-     > **Note — caller authentication required for networked modes:** In SSE and streamable-http modes the container binds a non-loopback address (`0.0.0.0:8000`), so the server **requires caller authentication and refuses to start without it**. Set `MCP_GRAFANA_SERVER_TOKEN` to require an `Authorization: Bearer <token>` from clients (recommended), or pass `--allow-unauthenticated` if a trusted proxy in front of the server authenticates callers. STDIO mode is unaffected. See [Caller Authentication](#cli-flags-reference).
+     > **Note — secure the networked modes:** In SSE and streamable-http modes the container binds a non-loopback address (`0.0.0.0:8000`). Without a caller token the server **starts but logs a loud security warning** (and will refuse to start in a future major release). Set `MCP_GRAFANA_SERVER_TOKEN` to require an `Authorization: Bearer <token>` from clients (recommended). STDIO mode is unaffected. See [Caller Authentication](#cli-flags-reference).
 
      2. **SSE Mode**: In this mode, the server runs as an HTTP server that clients connect to. You must expose port 8000 using the `-p` flag:
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Optionally require MCP clients to authenticate *to the server*. This is separate
 
 - `--server-auth-token`: Bearer token callers must send as `Authorization: Bearer <token>`. Falls back to the `MCP_GRAFANA_SERVER_TOKEN` environment variable. When set, requests without a valid token are rejected with `401` before any tool runs. Prefer the env var so the secret isn't visible in the process arguments.
 
-Caller authentication is enforced only when `--server-auth-token` is set. When it isn't and the server binds a non-loopback address, the server **starts but logs a loud security warning** (loopback and stdio are unaffected); a future major release will make that a startup error. Use TLS (or TLS termination) whenever caller auth is enabled on a non-loopback address. When caller auth is enabled, the validated `Authorization` header is stripped before requests reach Grafana; combining `--server-auth-token` with `GRAFANA_FORWARD_HEADERS=Authorization` is rejected at startup.
+Caller authentication is enforced only when `--server-auth-token` is set. When it isn't and the server binds a non-loopback address, the server **starts but logs a security error** — emitted at the `error` log level so it isn't hidden by `--log-level` (loopback and stdio are unaffected); a future major release will make that a startup error. Use TLS (or TLS termination) whenever caller auth is enabled on a non-loopback address. When caller auth is enabled, the validated `Authorization` header is stripped before requests reach Grafana; combining `--server-auth-token` with `GRAFANA_FORWARD_HEADERS=Authorization` is rejected at startup.
 
 **Debug and Logging:**
 - `--debug`: Enable debug mode for detailed HTTP request/response logging
@@ -666,7 +666,7 @@ Forwarded headers are merged with any headers defined in `GRAFANA_EXTRA_HEADERS`
      docker run --rm -i -e GRAFANA_URL=https://myinstance.grafana.net -e GRAFANA_SERVICE_ACCOUNT_TOKEN=<your service account token> grafana/mcp-grafana -t stdio
      ```
 
-     > **Note — secure the networked modes:** In SSE and streamable-http modes the container binds a non-loopback address (`0.0.0.0:8000`). Without a caller token the server **starts but logs a loud security warning** (and will refuse to start in a future major release). Set `MCP_GRAFANA_SERVER_TOKEN` to require an `Authorization: Bearer <token>` from clients (recommended). STDIO mode is unaffected. See [Caller Authentication](#cli-flags-reference).
+     > **Note — secure the networked modes:** In SSE and streamable-http modes the container binds a non-loopback address (`0.0.0.0:8000`). Without a caller token the server **starts but logs a security error** (at the `error` log level, so it isn't hidden by `--log-level`; and it will refuse to start in a future major release). Set `MCP_GRAFANA_SERVER_TOKEN` to require an `Authorization: Bearer <token>` from clients (recommended). STDIO mode is unaffected. See [Caller Authentication](#cli-flags-reference).
 
      2. **SSE Mode**: In this mode, the server runs as an HTTP server that clients connect to. You must expose port 8000 using the `-p` flag:
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -415,8 +415,9 @@ func (ca callerAuthConfig) resolveToken() string {
 //
 //   - Token configured → callers are authenticated; logged at INFO.
 //   - Loopback bind → only local processes can connect; logged at WARN with a hint.
-//   - Non-loopback bind, no token → reachable and unauthenticated; logged at WARN.
-//     This will refuse to start in a future major release.
+//   - Non-loopback bind, no token → reachable and unauthenticated; logged at ERROR
+//     (the highest --log-level, so the exposure can't be filtered out) and will
+//     refuse to start in a future major release.
 //
 // A nil logger falls back to slog.Default().
 func checkCallerAuthPolicy(transport, address, token string, logger *slog.Logger) {
@@ -431,7 +432,9 @@ func checkCallerAuthPolicy(transport, address, token string, logger *slog.Logger
 		logger.Warn("No caller authentication configured. The server is bound to a loopback address, so only local processes can reach it. Set --server-auth-token (or "+serverAuthTokenEnvVar+") to require authentication for non-local callers.", "address", address)
 		return
 	}
-	logger.Warn("SECURITY: serving on a non-loopback address with NO caller authentication. Anyone who can reach this address can invoke MCP tools and use any Grafana credentials the server is configured with. This will become a startup error in a future release: set --server-auth-token (or "+serverAuthTokenEnvVar+") to require a bearer token.", "address", address)
+	// Logged at ERROR (not WARN) so the exposure is visible even under
+	// --log-level error; error is the highest configurable level.
+	logger.Error("SECURITY: serving on a non-loopback address with NO caller authentication. Anyone who can reach this address can invoke MCP tools and use any Grafana credentials the server is configured with. This will become a startup error in a future release: set --server-auth-token (or "+serverAuthTokenEnvVar+") to require a bearer token.", "address", address)
 }
 
 // withCallerAuth wraps h with bearer-token authentication when a token is

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -394,15 +394,10 @@ type callerAuthConfig struct {
 	// token, when non-empty, is required as "Authorization: Bearer <token>" on
 	// every request to the MCP endpoint.
 	token string
-
-	// allowUnauthenticated permits a non-loopback bind without a caller token.
-	// INSECURE: only behind a trusted proxy that authenticates callers.
-	allowUnauthenticated bool
 }
 
 func (ca *callerAuthConfig) addFlags() {
 	flag.StringVar(&ca.token, "server-auth-token", "", "Bearer token that callers must present in the Authorization header to use the HTTP/SSE transports. Falls back to the "+serverAuthTokenEnvVar+" environment variable. When set, unauthenticated requests are rejected with 401. Has no effect on the stdio transport.")
-	flag.BoolVar(&ca.allowUnauthenticated, "allow-unauthenticated", false, "Allow the HTTP/SSE server to bind to a non-loopback address without --server-auth-token. INSECURE: only use behind a trusted proxy that authenticates callers. By default the server refuses to start unauthenticated on a public address.")
 }
 
 // resolveToken returns the caller token, falling back to the env var. It is
@@ -414,31 +409,29 @@ func (ca callerAuthConfig) resolveToken() string {
 	return strings.TrimSpace(os.Getenv(serverAuthTokenEnvVar))
 }
 
-// checkCallerAuthPolicy enforces the fail-closed bind rule for network
-// transports: an externally reachable listener must not accept unauthenticated
-// callers. Rules, in order:
+// checkCallerAuthPolicy logs the caller-authentication posture of a network
+// transport at startup. Caller auth is enforced only when a token is configured
+// (see withCallerAuth); this surfaces the posture so it isn't silently exposed:
 //
-//   - Caller token configured → authenticated; any bind is fine.
-//   - Loopback bind → only local processes can reach it; allowed.
-//   - --allow-unauthenticated → assume a trusted proxy in front; allowed (warns).
-//   - Otherwise (non-loopback, no token) → refused.
+//   - Token configured → callers are authenticated; logged at INFO.
+//   - Loopback bind → only local processes can connect; logged at WARN with a hint.
+//   - Non-loopback bind, no token → reachable and unauthenticated; logged at WARN.
+//     This will refuse to start in a future major release.
 //
-// It deliberately ignores which Grafana credentials are configured, so the safe
-// default doesn't hinge on an evolving inventory of credential sources.
-func checkCallerAuthPolicy(transport, address, token string, allowUnauthenticated bool) error {
+// A nil logger falls back to slog.Default().
+func checkCallerAuthPolicy(transport, address, token string, logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	if token != "" {
-		slog.Info("Caller authentication enabled: requests must present a valid bearer token", "transport", transport)
-		return nil
+		logger.Info("Caller authentication enabled: requests must present a valid bearer token", "transport", transport)
+		return
 	}
 	if mcpgrafana.IsLoopbackOnlyBind(address) {
-		slog.Warn("No caller authentication configured. The server is bound to a loopback address, so only local processes can reach it. Set --server-auth-token (or "+serverAuthTokenEnvVar+") to require authentication for non-local callers.", "address", address)
-		return nil
+		logger.Warn("No caller authentication configured. The server is bound to a loopback address, so only local processes can reach it. Set --server-auth-token (or "+serverAuthTokenEnvVar+") to require authentication for non-local callers.", "address", address)
+		return
 	}
-	if allowUnauthenticated {
-		slog.Warn("SECURITY: serving on a non-loopback address with NO caller authentication because --allow-unauthenticated was set. Anyone who can reach this address can invoke MCP tools and use any Grafana credentials the server is configured with. Ensure a trusted proxy authenticates callers.", "address", address)
-		return nil
-	}
-	return fmt.Errorf("refusing to start %s transport on non-loopback address %q without caller authentication: set --server-auth-token (or %s) to require a bearer token, or pass --allow-unauthenticated if a trusted proxy in front of this server authenticates callers", transport, address, serverAuthTokenEnvVar)
+	logger.Warn("SECURITY: serving on a non-loopback address with NO caller authentication. Anyone who can reach this address can invoke MCP tools and use any Grafana credentials the server is configured with. This will become a startup error in a future release: set --server-auth-token (or "+serverAuthTokenEnvVar+") to require a bearer token.", "address", address)
 }
 
 // withCallerAuth wraps h with bearer-token authentication when a token is
@@ -619,13 +612,11 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		}
 	}()
 
-	// Resolve the caller-auth token once and enforce the fail-closed bind
-	// policy before we start listening. stdio is a local pipe, so it is exempt.
+	// Resolve the caller-auth token once and surface the auth posture before we
+	// start listening. stdio is a local pipe, so it is exempt.
 	callerToken := ca.resolveToken()
 	if transport == "sse" || transport == "streamable-http" {
-		if err := checkCallerAuthPolicy(transport, addr, callerToken, ca.allowUnauthenticated); err != nil {
-			return err
-		}
+		checkCallerAuthPolicy(transport, addr, callerToken, slog.Default())
 		// With caller auth active, Authorization holds the caller token (stripped
 		// after validation). Forwarding it to Grafana would leak it, so refuse the
 		// contradictory combination.

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -554,35 +555,34 @@ func TestCallerAuthConfigResolveToken(t *testing.T) {
 
 func TestCheckCallerAuthPolicy(t *testing.T) {
 	cases := []struct {
-		name                 string
-		address              string
-		token                string
-		allowUnauthenticated bool
-		wantErr              bool
+		name      string
+		address   string
+		token     string
+		wantLevel string // "INFO" or "WARN"
+		wantMsg   string // substring expected in the emitted log line
 	}{
 		// A caller token authenticates every request, so any bind is fine.
-		{"token set, public bind is fine", "0.0.0.0:8000", "tok", false, false},
-		{"token set, loopback bind is fine", "localhost:8000", "tok", false, false},
+		{"token set, public bind", "0.0.0.0:8000", "tok", "INFO", "Caller authentication enabled"},
+		{"token set, loopback bind", "localhost:8000", "tok", "INFO", "Caller authentication enabled"},
 
-		// No caller token: loopback is fine (local only), non-loopback is refused
-		// regardless of what Grafana credentials happen to be configured.
-		{"no token, loopback allowed", "127.0.0.1:8000", "", false, false},
-		{"no token, public bind refused", "0.0.0.0:8000", "", false, true},
-		{"no token, wildcard port refused", ":8000", "", false, true},
-		{"no token, routable IP refused", "192.168.1.5:8000", "", false, true},
+		// No token on a loopback bind: only local processes can connect, so this
+		// warns about the missing token rather than about public exposure.
+		{"no token, loopback", "127.0.0.1:8000", "", "WARN", "bound to a loopback address"},
 
-		// The explicit escape hatch for a trusted authenticating proxy.
-		{"no token, public bind allowed with override", "0.0.0.0:8000", "", true, false},
-		{"no token, routable IP allowed with override", "192.168.1.5:8000", "", true, false},
+		// No token on a reachable bind: warns that it will refuse to start in a
+		// future release, but starts today (backward compatible).
+		{"no token, public bind", "0.0.0.0:8000", "", "WARN", "startup error in a future release"},
+		{"no token, wildcard port", ":8000", "", "WARN", "startup error in a future release"},
+		{"no token, routable IP", "192.168.1.5:8000", "", "WARN", "startup error in a future release"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := checkCallerAuthPolicy("streamable-http", tc.address, tc.token, tc.allowUnauthenticated)
-			if tc.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			checkCallerAuthPolicy("streamable-http", tc.address, tc.token, logger)
+			out := buf.String()
+			assert.Contains(t, out, tc.wantMsg)
+			assert.Contains(t, out, `"level":"`+tc.wantLevel+`"`)
 		})
 	}
 }

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -569,11 +569,11 @@ func TestCheckCallerAuthPolicy(t *testing.T) {
 		// warns about the missing token rather than about public exposure.
 		{"no token, loopback", "127.0.0.1:8000", "", "WARN", "bound to a loopback address"},
 
-		// No token on a reachable bind: warns that it will refuse to start in a
-		// future release, but starts today (backward compatible).
-		{"no token, public bind", "0.0.0.0:8000", "", "WARN", "startup error in a future release"},
-		{"no token, wildcard port", ":8000", "", "WARN", "startup error in a future release"},
-		{"no token, routable IP", "192.168.1.5:8000", "", "WARN", "startup error in a future release"},
+		// No token on a reachable bind: logged at ERROR (highest --log-level, so
+		// the exposure can't be filtered out); starts today (backward compatible).
+		{"no token, public bind", "0.0.0.0:8000", "", "ERROR", "startup error in a future release"},
+		{"no token, wildcard port", ":8000", "", "ERROR", "startup error in a future release"},
+		{"no token, routable IP", "192.168.1.5:8000", "", "ERROR", "startup error in a future release"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -46,17 +46,20 @@ When deploying behind an ingress or reverse proxy that forwards the original `Ho
 The SSE and streamable-http transports can authenticate the **caller** (the MCP client connecting to `mcp-grafana`). This is separate from the credentials the server uses to reach Grafana: it controls _who may invoke the server_, so an unauthenticated client can't borrow the server's Grafana identity or run tools. Stdio is a local pipe and is never affected.
 
 - `--server-auth-token`: Bearer token that callers must present in the `Authorization: Bearer <token>` header. Falls back to the `MCP_GRAFANA_SERVER_TOKEN` environment variable. When set, requests without a valid token are rejected with `401` before any tool runs. Prefer the environment variable over the flag so the secret doesn't appear in the process argument list.
-- `--allow-unauthenticated`: Permit binding to a non-loopback address **without** a caller token. Insecure on its own — only use it when a trusted proxy in front of `mcp-grafana` authenticates callers.
 
-### Fail-closed bind policy
+### Bind policy
 
-To avoid accidentally exposing an unauthenticated server, the network transports refuse to start on an externally reachable address unless callers are authenticated:
+Caller authentication is enforced only when `--server-auth-token` is set. When it isn't, the network transports warn (but still start) on an externally reachable address:
 
 | Transport / bind | Behavior |
 | --- | --- |
 | `stdio` | No caller authentication (local pipe). |
 | SSE / streamable-http on a loopback address (`localhost`, `127.0.0.1`, `::1`) | Caller token optional. |
-| SSE / streamable-http on any other address | **Requires** `--server-auth-token`, or an explicit `--allow-unauthenticated`. Otherwise the server exits with an error. |
+| SSE / streamable-http on any other address | Starts and logs a **security warning** unless `--server-auth-token` is set. |
+
+{{< admonition type="note" >}}
+The permissive default preserves backward compatibility for existing deployments (such as the container's `0.0.0.0` bind). A future major release will make an unauthenticated non-loopback bind a startup error. Set `--server-auth-token` now to require caller authentication and prepare for that change.
+{{< /admonition >}}
 
 Bearer authentication only protects the token in transit if the connection is encrypted. Terminate TLS in front of the server, or use [server TLS for streamable-http](../server-tls-streamable-http/), whenever you set `--server-auth-token` on a non-loopback address.
 

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -55,7 +55,7 @@ Caller authentication is enforced only when `--server-auth-token` is set. When i
 | --- | --- |
 | `stdio` | No caller authentication (local pipe). |
 | SSE / streamable-http on a loopback address (`localhost`, `127.0.0.1`, `::1`) | Caller token optional. |
-| SSE / streamable-http on any other address | Starts and logs a **security warning** unless `--server-auth-token` is set. |
+| SSE / streamable-http on any other address | Starts and logs a **security error** (at the `error` log level, so it isn't suppressed by `--log-level`) unless `--server-auth-token` is set. |
 
 {{< admonition type="note" >}}
 The permissive default preserves backward compatibility for existing deployments (such as the container's `0.0.0.0` bind). A future major release will make an unauthenticated non-loopback bind a startup error. Set `--server-auth-token` now to require caller authentication and prepare for that change.


### PR DESCRIPTION
## Summary
Caller authentication on the HTTP/SSE transports is enforced only when `--server-auth-token` (or `MCP_GRAFANA_SERVER_TOKEN`) is set. Without a token, a non-loopback bind now starts with a security warning instead of refusing; stdio is unaffected.