### PR TITLE
fix(test): drop stale X-Grafana-URL assumptions from URL normalization tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proxied-tools memory scaling with session count and unbounded per-session tool-store growth ([#1001](https://github.com/grafana/mcp-grafana/pull/1001))
 - Restrict the Prometheus backend to known Prometheus-compatible datasource types ([#1006](https://github.com/grafana/mcp-grafana/pull/1006))
 - Respect `OTEL_LOGS_EXPORTER=none` to disable OTLP log export ([#1012](https://github.com/grafana/mcp-grafana/pull/1012))
-
-### Fixed
-
 - A `GRAFANA_URL` without a scheme is normalized where it enters the process, so the API client and the client cache resolve the same instance as the rest of the server. `GRAFANA_URL=127.0.0.1:3000` used to panic at startup, and a schemeless hostname produced requests with no host while tools built from `GrafanaConfig.URL` kept working ([#1034](https://github.com/grafana/mcp-grafana/pull/1034))
 
 ### Changed

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -2311,34 +2311,22 @@ func TestBlankEnvURLFallsBackToDefault(t *testing.T) {
 	}
 }
 
-// Normalizing the environment URL must not move the boundary that binds
-// environment credentials to the environment instance.
-func TestSchemelessEnvURLKeepsCredentialBinding(t *testing.T) {
+// A schemeless GRAFANA_URL must still reach the header path as the one
+// environment URL. X-Grafana-URL cannot name another instance since #1052, so
+// the env token always applies; TestExtractGrafanaInfoFromHeadersIgnoresURLHeader
+// pins that.
+func TestSchemelessEnvURLReachesHeaderPath(t *testing.T) {
 	const envToken = "env-service-account-token"
 
-	t.Run("same instance spelled with a scheme still receives env credentials", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", "grafana.example.com")
-		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
+	t.Setenv("GRAFANA_URL", "grafana.example.com")
+	t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
 
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		req.Header.Set(grafanaURLHeader, "https://grafana.example.com")
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
 
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Equal(t, envToken, config.APIKey)
-	})
-
-	t.Run("foreign URL still has env credentials withheld", func(t *testing.T) {
-		t.Setenv("GRAFANA_URL", "grafana.example.com")
-		t.Setenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", envToken)
-
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		require.NoError(t, err)
-		req.Header.Set(grafanaURLHeader, "https://attacker.example.com")
-
-		config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
-		assert.Empty(t, config.APIKey, "env token must not be sent to a caller-specified URL")
-	})
+	config := GrafanaConfigFromContext(ExtractGrafanaInfoFromHeaders(context.Background(), req))
+	assert.Equal(t, "https://grafana.example.com", config.URL)
+	assert.Equal(t, envToken, config.APIKey)
 }
 
 // The cached client extractors derive their cache key from the URL the request
@@ -2358,7 +2346,7 @@ func TestEnvURLSpellingsResolveToOneValue(t *testing.T) {
 	} {
 		t.Run(spelling, func(t *testing.T) {
 			t.Setenv("GRAFANA_URL", spelling)
-			resolvedURL, _, _, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
+			resolvedURL, _, _, _ := extractKeyGrafanaInfoFromReq(req, logger)
 			assert.Equal(t, canonical, resolvedURL)
 		})
 	}


### PR DESCRIPTION
The tests added in #1034 were written against the tree before #1052, which removed the X-Grafana-URL header support and it broke [tests](https://github.com/grafana/mcp-grafana/actions/runs/31382299741/job/93434952372) on main.