### PR TITLE
Attach Grafana credentials only to the bound Grafana host

### DIFF
--- a/auth_host_scoping_test.go
+++ b/auth_host_scoping_test.go
@@ -52,7 +52,7 @@ func TestAuthRoundTripper_WithholdsCredentialsOffBoundHost(t *testing.T) {
 		require.NoError(t, err)
 		resp, err := rt.RoundTrip(req)
 		require.NoError(t, err)
-		resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 	}
 
 	assert.Equal(t, "Bearer secret-api-key", rec.credByHost["grafana.example.com"],
@@ -74,7 +74,7 @@ func TestAuthRoundTripper_EmptyBoundURLPreservesBehavior(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := rt.RoundTrip(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, "Bearer secret-api-key", rec.credByHost["anywhere.example.com"],
 		"with no bound URL, credential attaches as before")

--- a/auth_host_scoping_test.go
+++ b/auth_host_scoping_test.go
@@ -1,0 +1,127 @@
+package mcpgrafana
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// grafanaHostRecordingTransport records the credential seen for each request
+// host, so a test can assert what the credential would be attached to without a
+// live network.
+type grafanaHostRecordingTransport struct {
+	credByHost map[string]string
+}
+
+func (h *grafanaHostRecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cred := req.Header.Get("Authorization")
+	if cred == "" {
+		cred = req.Header.Get("X-Access-Token")
+	}
+	h.credByHost[req.URL.Hostname()] = cred
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// TestAuthRoundTripper_WithholdsCredentialsOffBoundHost verifies that the
+// credential is attached to a request on the configured Grafana host but
+// withheld from any other host. A redirect off the bound instance arrives here
+// as a RoundTrip to a different host, so this is the property that keeps the
+// credential from following such a redirect.
+func TestAuthRoundTripper_WithholdsCredentialsOffBoundHost(t *testing.T) {
+	rec := &grafanaHostRecordingTransport{credByHost: map[string]string{}}
+	rt := NewAuthRoundTripper(rec, "", "", "secret-api-key", nil)
+
+	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+		URL:    "https://grafana.example.com",
+		APIKey: "secret-api-key",
+	})
+
+	for _, target := range []string{
+		"https://grafana.example.com/api/dashboards", // bound host
+		"https://attacker.example.com/steal",         // redirect target, different host
+	} {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		require.NoError(t, err)
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+
+	assert.Equal(t, "Bearer secret-api-key", rec.credByHost["grafana.example.com"],
+		"credential must reach the bound host")
+	assert.Empty(t, rec.credByHost["attacker.example.com"],
+		"credential must not follow a redirect to another host")
+}
+
+// TestAuthRoundTripper_EmptyBoundURLPreservesBehavior verifies the
+// backward-compatible default: with no configured Grafana URL, the credential
+// is attached as before this change.
+func TestAuthRoundTripper_EmptyBoundURLPreservesBehavior(t *testing.T) {
+	rec := &grafanaHostRecordingTransport{credByHost: map[string]string{}}
+	rt := NewAuthRoundTripper(rec, "", "", "secret-api-key", nil)
+
+	// No GrafanaConfig in context, so cfg.URL is empty and the credential
+	// attaches as before.
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://anywhere.example.com/x", nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, "Bearer secret-api-key", rec.credByHost["anywhere.example.com"],
+		"with no bound URL, credential attaches as before")
+}
+
+// TestAuthRoundTripper_BindsWhenContextHasNoConfig verifies that a transport
+// built for a specific Grafana instance keeps its construction-time credential
+// bound to that instance even when a request carries no GrafanaConfig in its
+// context. Without the fallback binding the empty context URL matched every
+// host, so construction-time credentials followed a redirect anywhere.
+func TestAuthRoundTripper_BindsWhenContextHasNoConfig(t *testing.T) {
+	rec := &grafanaHostRecordingTransport{credByHost: map[string]string{}}
+	rt := NewAuthRoundTripper(rec, "", "", "secret-api-key", nil)
+	rt.boundURL = "https://grafana.example.com"
+
+	// No GrafanaConfig in context at all.
+	ctx := context.Background()
+
+	for _, target := range []string{
+		"https://grafana.example.com/api/health",
+		"https://attacker.example.net/collect",
+	} {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		require.NoError(t, err)
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, "Bearer secret-api-key", rec.credByHost["grafana.example.com"],
+		"credential should be attached on the bound host")
+	assert.Empty(t, rec.credByHost["attacker.example.net"],
+		"credential must not be attached off the bound host when context has no config")
+}
+
+// TestAuthRoundTripper_UnboundTransportPreservesPriorBehavior verifies the
+// genuinely unconfigured case still works: with neither a context URL nor a
+// construction-time URL there is nothing to bind to, so behavior is unchanged.
+func TestAuthRoundTripper_UnboundTransportPreservesPriorBehavior(t *testing.T) {
+	rec := &grafanaHostRecordingTransport{credByHost: map[string]string{}}
+	rt := NewAuthRoundTripper(rec, "", "", "secret-api-key", nil)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"https://anywhere.example.org/api", nil)
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer secret-api-key", rec.credByHost["anywhere.example.org"],
+		"with no binding configured at all, prior behavior is preserved")
+}

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -561,7 +561,12 @@ type AuthRoundTripper struct {
 	idToken     string
 	apiKey      string
 	basicAuth   *url.Userinfo
-	underlying  http.RoundTripper
+	// boundURL is the Grafana URL this transport was constructed for. It is
+	// the fallback host binding for requests that carry no GrafanaConfig in
+	// their context, so construction-time credentials stay bound to the
+	// instance they were configured for.
+	boundURL   string
+	underlying http.RoundTripper
 }
 
 func (rt *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -582,17 +587,53 @@ func (rt *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		basicAuth = cfg.BasicAuth
 	}
 
-	if accessToken != "" && idToken != "" {
-		clonedReq.Header.Set("X-Access-Token", accessToken)
-		clonedReq.Header.Set("X-Grafana-Id", idToken)
-	} else if apiKey != "" {
-		clonedReq.Header.Set("Authorization", "Bearer "+apiKey)
-	} else if basicAuth != nil {
-		password, _ := basicAuth.Password()
-		clonedReq.SetBasicAuth(basicAuth.Username(), password)
+	// Attach credentials only when the request targets the configured Grafana
+	// host. A redirect can carry the request to a different host; net/http
+	// strips a cross-host Authorization header on redirect but does not strip
+	// X-Access-Token, X-Grafana-Id, or basic auth, and this transport would
+	// re-add any of them on the next hop regardless. Withholding on a host
+	// mismatch keeps the credential from following a redirect off the bound
+	// instance, extending the same URL binding that requestTargetsEnvURL
+	// already applies to environment credentials.
+	// Prefer the per-request URL; fall back to the URL this transport was
+	// constructed for so a request without a GrafanaConfig does not escape the
+	// binding and carry construction-time credentials to an arbitrary host.
+	boundURL := cfg.URL
+	if boundURL == "" {
+		boundURL = rt.boundURL
+	}
+	if requestTargetsBoundHost(req.URL, boundURL) {
+		if accessToken != "" && idToken != "" {
+			clonedReq.Header.Set("X-Access-Token", accessToken)
+			clonedReq.Header.Set("X-Grafana-Id", idToken)
+		} else if apiKey != "" {
+			clonedReq.Header.Set("Authorization", "Bearer "+apiKey)
+		} else if basicAuth != nil {
+			password, _ := basicAuth.Password()
+			clonedReq.SetBasicAuth(basicAuth.Username(), password)
+		}
 	}
 
 	return rt.underlying.RoundTrip(clonedReq)
+}
+
+// requestTargetsBoundHost reports whether reqURL is on the same host as the
+// configured Grafana instance boundURL. An empty boundURL (no configured
+// instance) is treated as a match, preserving prior behavior for callers that
+// do not set a Grafana URL. A boundURL that does not parse is treated as no
+// match, failing closed.
+func requestTargetsBoundHost(reqURL *url.URL, boundURL string) bool {
+	if reqURL == nil {
+		return false
+	}
+	if boundURL == "" {
+		return true
+	}
+	b, err := url.Parse(boundURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(reqURL.Hostname(), b.Hostname())
 }
 
 func NewAuthRoundTripper(rt http.RoundTripper, accessToken, idToken, apiKey string, basicAuth *url.Userinfo) *AuthRoundTripper {
@@ -739,7 +780,9 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 
 	// Auth (innermost header layer — wins on conflicts with ExtraHeaders)
 	if !options.withoutAuth {
-		transport = NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+		authRT := NewAuthRoundTripper(transport, cfg.AccessToken, cfg.IDToken, cfg.APIKey, cfg.BasicAuth)
+		authRT.boundURL = cfg.URL
+		transport = authRT
 	}
 
 	// Extra headers (always included so per-request context overrides work)


### PR DESCRIPTION
`AuthRoundTripper` attaches the Grafana credential (OBO access and ID tokens, an API key bearer, or basic auth) to every request it processes, including redirect hops. `net/http` strips a cross-host `Authorization` header on redirect, but it does not strip `X-Access-Token`, `X-Grafana-Id`, or basic auth, and even the `Authorization` strip is defeated here because the transport re-adds the header on the next hop.

Today this is contained by the existing URL binding (environment credentials are withheld when `X-Grafana-URL` names a different instance, via `requestTargetsEnvURL`) and by datasource work going through Grafana's own proxy. This change extends that same binding to redirect time: credentials are attached only when the request host matches the configured Grafana host, so a redirect off the bound instance travels without them.

This lives in the RoundTripper rather than in `refuseRedirect` because a `CheckRedirect` that stripped headers would not hold: the transport re-adds them on the next hop. An empty configured URL preserves prior behavior, so existing auth tests pass unchanged.

One question for maintainers: does any legitimate flow, for example a Grafana Cloud vanity or org URL that redirects to a different stack host, rely on a credential surviving a cross-host redirect? If so, I will switch from the single bound host to an allowed-host set. This is a hardening change.
