### PR TITLE
Add opt-in GCF output format for structured tool results (lossless, never-grow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,9 @@ Caller authentication is enforced only when `--server-auth-token` is set. When i
 - `--grafana-timeout`: Time limit for requests made by the Grafana client. Accepts Go duration strings (e.g., `10s`, `500ms`) - default: `10s`
 - `--include-args-in-spans`: Include tool call arguments in OpenTelemetry spans. Only enable in non-production environments or when arguments are known not to contain PII - default: `false`
 
+**Response Encoding:**
+- `--output-format`: Serialization for structured tool results in the model-facing text block: `json` (default) or `gcf`. Also settable via the `GRAFANA_OUTPUT_FORMAT` environment variable. See [Response Format](#response-format-gcf).
+
 **Observability:**
 - `--metrics`: Enable Prometheus metrics endpoint at `/metrics`
 - `--metrics-address`: Separate address for metrics server (e.g., `:9090`). If empty, metrics are served on the main server
@@ -574,6 +577,18 @@ volumes:
 ```
 
 Surrounding whitespace (including a trailing newline) is trimmed from the file contents. If both `GRAFANA_SERVICE_ACCOUNT_TOKEN` and `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` are set, the inline token takes precedence.
+
+### Response Format (GCF)
+
+By default, structured tool results are serialized as JSON in the text content block the model reads. Setting `--output-format=gcf` (or `GRAFANA_OUTPUT_FORMAT=gcf`) instead offers each result as [Graph Compact Format](https://gcformat.com), a token-optimized encoding that factors the repeated field names out of uniform record arrays (the shape returned by list tools like `list_datasources`, `list_teams`, `list_users_by_org`, `alerting_manage_rules`, and `list_incidents`).
+
+The substitution is applied **per result and only when it helps**:
+
+- **Never larger.** If GCF is not smaller than the JSON for a given result, that result stays JSON. On real Grafana output this yields roughly 28-33% fewer tokens on uniform inventory lists (datasources, teams, users) at realistic sizes, and a no-op on tiny or high-entropy results.
+- **Never lossy.** Every substituted result is decoded and compared back to the original before it is used; on any encoding error (including an integer outside GCF's canonical int64 domain) the result falls back to JSON, so a tool call is never dropped or altered.
+- **Opt-in and additive.** The default (`json`) is unchanged, and `structuredContent` (where a tool sets it) is untouched.
+
+GCF is MIT-licensed and its `gcf-go` encoder is zero-dependency. It is designed and evaluated for how accurately models read the compact form, not just for size; format, spec, SDKs, and benchmarks are at [gcformat.com](https://gcformat.com).
 
 ### Multi-Organization Support
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -140,6 +140,10 @@ type grafanaConfig struct {
 
 	// timeout is the time limit for requests made by the Grafana client.
 	timeout time.Duration
+
+	// outputFormat selects how structured tool results are serialized for the
+	// model: "json" (default) or "gcf".
+	outputFormat string
 }
 
 func (dt *disabledTools) addFlags() {
@@ -181,6 +185,15 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.assistant, "disable-assistant", false, "Disable Grafana Assistant tools")
 }
 
+// outputFormatFromEnv returns the default output format, honoring
+// GRAFANA_OUTPUT_FORMAT when set so the format can be configured without a flag.
+func outputFormatFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv("GRAFANA_OUTPUT_FORMAT")); v != "" {
+		return v
+	}
+	return "json"
+}
+
 func (gc *grafanaConfig) addFlags() {
 	flag.BoolVar(&gc.debug, "debug", false, "Enable debug mode for the Grafana transport")
 
@@ -195,6 +208,7 @@ func (gc *grafanaConfig) addFlags() {
 
 	flag.BoolVar(&gc.includeArgsInSpans, "include-args-in-spans", false, "Include tool call arguments in OpenTelemetry spans. Only enable in non-production environments or when arguments are known not to contain PII.")
 	flag.DurationVar(&gc.timeout, "grafana-timeout", mcpgrafana.DefaultGrafanaClientTimeout, "Time limit for requests made by the Grafana client. Accepts Go duration strings, e.g. 10s, 500ms.")
+	flag.StringVar(&gc.outputFormat, "output-format", outputFormatFromEnv(), "Serialization for structured tool results in the model-facing text block: 'json' (default) or 'gcf' (Graph Compact Format, applied per result only when smaller and lossless). Also settable via GRAFANA_OUTPUT_FORMAT.")
 }
 
 // toolEntry pairs a tool registration function with its category and disable flag.
@@ -826,6 +840,7 @@ func main() {
 		MaxLokiLogLimit:         gc.maxLokiLogLimit,
 		IncludeArgumentsInSpans: gc.includeArgsInSpans,
 		Timeout:                 gc.timeout,
+		OutputFormat:            gc.outputFormat,
 	}
 	if gc.tlsCertFile != "" || gc.tlsKeyFile != "" || gc.tlsCAFile != "" || gc.tlsSkipVerify {
 		grafanaConfig.TLSConfig = &mcpgrafana.TLSConfig{

--- a/gcf.go
+++ b/gcf.go
@@ -1,0 +1,160 @@
+package mcpgrafana
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+
+	gcf "github.com/blackwell-systems/gcf-go"
+)
+
+// encodeGCF re-encodes a JSON tool result as a Graph Compact Format generic
+// wire (https://gcformat.com), returning ok=false when the caller should keep
+// the original JSON.
+//
+// It is deliberately conservative, so enabling GCF output can only ever help:
+//
+//   - Never larger: if the GCF wire is not smaller than the JSON, ok=false
+//     (the never-grow guard). GCF factors repeated field names out of uniform
+//     record arrays, so it wins on list results and ties on tiny or
+//     high-entropy ones; the guard keeps those from regressing.
+//   - Never lossy: the wire is decoded and compared back to the ORIGINAL JSON
+//     bytes with number-exact, order-insensitive semantics; any encode error,
+//     decode error, or mismatch yields ok=false. A tool result is never dropped
+//     or altered over encoding, including integers that JSON preserves exactly
+//     but a float64 round-trip would not (e.g. IDs or timestamps above 2^53).
+func encodeGCF(jsonBytes []byte) (wire string, ok bool) {
+	// Decode with exact numbers (int64 where representable, else float64) so the
+	// value handed to gcf-go carries the same integer precision as the JSON,
+	// rather than the lossy float64 that encoding/json uses for `any` by default.
+	v, err := decodeExact(jsonBytes)
+	if err != nil {
+		return "", false
+	}
+
+	// EncodeGenericChecked never panics (it returns the numeric-domain error
+	// instead), so an out-of-domain value falls back to JSON rather than failing
+	// the tool call.
+	wire, err = gcf.EncodeGenericChecked(v)
+	if err != nil {
+		return "", false
+	}
+
+	// Never-grow guard: only offer GCF when it is actually smaller.
+	if len(wire) >= len(jsonBytes) {
+		return "", false
+	}
+
+	// Fail-safe: require a clean, number-exact, order-insensitive round-trip back
+	// to the original JSON.
+	decoded, err := gcf.DecodeGeneric(wire)
+	if err != nil || !jsonEqualsDecoded(jsonBytes, decoded) {
+		return "", false
+	}
+
+	return wire, true
+}
+
+// jsonEqualsDecoded reports whether the gcf-decoded value represents the same
+// JSON as jsonBytes, ignoring map key order and preserving exact integer values.
+// Both sides are reduced to a canonical form built from a number-preserving JSON
+// decode, so gcf-go's order-preserving OrderedMap and int64 decoding compare
+// equal to the original, and any precision or type drift is caught.
+func jsonEqualsDecoded(jsonBytes []byte, decoded any) bool {
+	left, err := canonicalize(jsonBytes)
+	if err != nil {
+		return false
+	}
+	decodedBytes, err := json.Marshal(decoded)
+	if err != nil {
+		return false
+	}
+	right, err := canonicalize(decodedBytes)
+	if err != nil {
+		return false
+	}
+	return reflect.DeepEqual(left, right)
+}
+
+// canonicalize decodes JSON with json.Number (so integer text is compared
+// exactly) and returns a form where maps become key-sorted [][2]any slices, so
+// DeepEqual is independent of key order.
+func canonicalize(b []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return canonValue(v), nil
+}
+
+func canonValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		// insertion sort keeps the dependency surface minimal; maps are small.
+		for i := 1; i < len(keys); i++ {
+			for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+				keys[j], keys[j-1] = keys[j-1], keys[j]
+			}
+		}
+		out := make([][2]any, len(keys))
+		for i, k := range keys {
+			out[i] = [2]any{k, canonValue(t[k])}
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i := range t {
+			out[i] = canonValue(t[i])
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// decodeExact decodes JSON into an `any` value where JSON integers become int64
+// (when they fit) and other numbers become float64. This preserves the integer
+// precision that gcf-go can encode exactly, which a plain json.Unmarshal into
+// `any` would discard by using float64 for every number.
+func decodeExact(b []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return exactNumbers(v), nil
+}
+
+func exactNumbers(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			t[k] = exactNumbers(val)
+		}
+		return t
+	case []any:
+		for i := range t {
+			t[i] = exactNumbers(t[i])
+		}
+		return t
+	case json.Number:
+		if i, err := t.Int64(); err == nil {
+			return i
+		}
+		if f, err := t.Float64(); err == nil {
+			return f
+		}
+		// Not representable as int64 or float64: keep the text. gcf-go encodes it
+		// as a string, which the losslessness check will reject, so JSON is kept.
+		return t.String()
+	default:
+		return v
+	}
+}

--- a/gcf_test.go
+++ b/gcf_test.go
@@ -1,0 +1,282 @@
+//go:build unit
+
+package mcpgrafana
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	gcf "github.com/blackwell-systems/gcf-go"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// datasourceRow mirrors the uniform record shape the list tools return.
+type datasourceRow struct {
+	ID        int64  `json:"id"`
+	UID       string `json:"uid"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	IsDefault bool   `json:"isDefault"`
+}
+
+func uniformDatasources(n int) map[string]any {
+	rows := make([]datasourceRow, 0, n)
+	types := []string{"prometheus", "loki", "tempo", "cloudwatch"}
+	for i := 0; i < n; i++ {
+		rows = append(rows, datasourceRow{
+			ID:        int64(i + 1),
+			UID:       fmt.Sprintf("ds-%d", i),
+			Name:      fmt.Sprintf("datasource %d", i),
+			Type:      types[i%len(types)],
+			IsDefault: i == 0,
+		})
+	}
+	return map[string]any{"datasources": rows}
+}
+
+func TestGCFEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"json", false},
+		{"gcf", true},
+		{"GCF", true},
+		{"  gcf  ", true},
+		{"toon", false},
+	} {
+		assert.Equal(t, tc.want, GrafanaConfig{OutputFormat: tc.in}.GCFEnabled(), "OutputFormat=%q", tc.in)
+	}
+}
+
+func TestEncodeGCF(t *testing.T) {
+	t.Run("uniform record array is smaller and lossless", func(t *testing.T) {
+		jsonBytes, err := json.Marshal(uniformDatasources(30))
+		require.NoError(t, err)
+
+		wire, ok := encodeGCF(jsonBytes)
+		require.True(t, ok, "GCF should win on a uniform record array")
+		assert.Less(t, len(wire), len(jsonBytes), "wire must be smaller (never-grow guard)")
+		assert.True(t, strings.HasPrefix(wire, "GCF profile=generic"))
+
+		// Round-trips back to the same value.
+		decoded, err := gcf.DecodeGeneric(wire)
+		require.NoError(t, err)
+		assert.True(t, jsonEqualsDecoded(jsonBytes, decoded))
+	})
+
+	t.Run("tiny payload falls back to JSON (never-grow)", func(t *testing.T) {
+		jsonBytes, err := json.Marshal(map[string]any{"ok": true})
+		require.NoError(t, err)
+		_, ok := encodeGCF(jsonBytes)
+		assert.False(t, ok, "GCF is not smaller on a tiny object, so keep JSON")
+	})
+
+	t.Run("single small record falls back to JSON", func(t *testing.T) {
+		jsonBytes, err := json.Marshal(uniformDatasources(1))
+		require.NoError(t, err)
+		_, ok := encodeGCF(jsonBytes)
+		assert.False(t, ok)
+	})
+
+	t.Run("invalid JSON falls back", func(t *testing.T) {
+		_, ok := encodeGCF([]byte("{not json"))
+		assert.False(t, ok)
+	})
+
+	t.Run("int64 above 2^53 is preserved exactly (not float-rounded)", func(t *testing.T) {
+		// A default json.Unmarshal into `any` would turn this into a float64 and
+		// silently round it to ...992; encodeGCF must either preserve it exactly
+		// or decline, never ship the rounded value.
+		rows := make([]map[string]any, 20)
+		for i := range rows {
+			rows[i] = map[string]any{"id": int64(9007199254740993), "n": "x"}
+		}
+		jsonBytes, err := json.Marshal(map[string]any{"rows": rows})
+		require.NoError(t, err)
+
+		wire, ok := encodeGCF(jsonBytes)
+		require.True(t, ok, "20 uniform rows should win with GCF")
+		require.NotContains(t, wire, "9.007", "must not render as a rounded float64")
+		require.Contains(t, wire, "9007199254740993", "exact integer must survive")
+
+		decoded, err := gcf.DecodeGeneric(wire)
+		require.NoError(t, err)
+		assert.True(t, jsonEqualsDecoded(jsonBytes, decoded), "must round-trip to the exact integer")
+	})
+}
+
+// encodeGCFInvariant is the safety contract encodeGCF must satisfy for ANY
+// input: it either declines (ok=false, caller keeps JSON), or it returns a wire
+// that is strictly smaller than the JSON AND round-trips back to the exact same
+// value. A violation means a result could be silently grown or corrupted.
+func encodeGCFInvariant(t *testing.T, jsonBytes []byte) {
+	t.Helper()
+	wire, ok := encodeGCF(jsonBytes)
+	if !ok {
+		return
+	}
+	assert.Less(t, len(wire), len(jsonBytes), "ok=true but wire not smaller: %q", wire)
+
+	decoded, err := gcf.DecodeGeneric(wire)
+	require.NoError(t, err, "ok=true but wire does not decode: %q", wire)
+
+	assert.True(t, jsonEqualsDecoded(jsonBytes, decoded),
+		"ok=true but NOT lossless.\njson:    %s\nwire:    %q\ndecoded: %#v", jsonBytes, wire, decoded)
+}
+
+// TestEncodeGCFRobustness exercises the tricky value shapes where a wire format
+// can silently corrupt: nested objects/arrays, delimiter and quote characters,
+// numeric edges, nulls, empties, and strings that look like other types. For
+// each, encodeGCF must either decline or be smaller-and-lossless.
+func TestEncodeGCFRobustness(t *testing.T) {
+	// A repeated record so the array is large enough that GCF is actually
+	// attempted (small ones just decline, which is also valid).
+	repeat := func(rec map[string]any, n int) []byte {
+		rows := make([]map[string]any, n)
+		for i := range rows {
+			rows[i] = rec
+		}
+		b, err := json.Marshal(map[string]any{"rows": rows})
+		require.NoError(t, err)
+		return b
+	}
+
+	cases := map[string]map[string]any{
+		"nested object":          {"id": 1, "meta": map[string]any{"team": "a", "tags": map[string]any{"env": "prod"}}},
+		"nested array":           {"id": 1, "labels": []any{"prod", "team-3", "region-us"}},
+		"array of objects":       {"id": 1, "ports": []any{map[string]any{"p": 80}, map[string]any{"p": 443}}},
+		"pipe in value":          {"id": 1, "q": "a | b | c"},
+		"comma in value":         {"id": 1, "name": "Smith, John"},
+		"quote in value":         {"id": 1, "name": `he said "hi"`},
+		"newline in value":       {"id": 1, "desc": "line1\nline2"},
+		"leading space":          {"id": 1, "name": "  spaced  "},
+		"empty string":           {"id": 1, "name": ""},
+		"unicode":                {"id": 1, "name": "café ☕ 日本語"},
+		"string looks like int":  {"id": 1, "code": "007"},
+		"string looks like bool": {"id": 1, "flag": "true"},
+		"float":                  {"id": 1, "score": 2.31},
+		"negative":               {"id": -5, "delta": -0.5},
+		"zero":                   {"id": 0, "v": 0},
+		"large int":              {"id": 9007199254740993, "v": 1},
+		"null value":             {"id": 1, "note": nil},
+		"empty array field":      {"id": 1, "tags": []any{}},
+		"empty object field":     {"id": 1, "meta": map[string]any{}},
+		"bool mix":               {"id": 1, "a": true, "b": false},
+	}
+	for name, rec := range cases {
+		t.Run(name, func(t *testing.T) {
+			encodeGCFInvariant(t, repeat(rec, 20))
+		})
+	}
+
+	// Degenerate top-level shapes.
+	for name, v := range map[string]any{
+		"empty array":      []any{},
+		"empty object":     map[string]any{},
+		"array of scalars": []any{1, 2, 3, "x", true, nil},
+		"scalar string":    "just a string",
+		"scalar number":    42,
+		"null":             nil,
+	} {
+		t.Run("toplevel "+name, func(t *testing.T) {
+			b, err := json.Marshal(v)
+			require.NoError(t, err)
+			encodeGCFInvariant(t, b)
+		})
+	}
+}
+
+// FuzzEncodeGCF asserts the safety invariant on arbitrary JSON: encodeGCF is
+// never lossy and never grows a result. Run: go test -tags unit -run x -fuzz FuzzEncodeGCF
+func FuzzEncodeGCF(f *testing.F) {
+	seeds := []string{
+		`{"rows":[{"id":1,"n":"a"},{"id":2,"n":"b"}]}`,
+		`[{"a":1,"b":"x|y"},{"a":2,"b":"p,q"}]`,
+		`{"x":[{"k":"café"},{"k":"日本"}]}`,
+		`{"n":null,"e":[],"o":{}}`,
+		`{"big":9007199254740993,"f":-0.5,"z":0}`,
+		`"scalar"`,
+		`42`,
+		`[]`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, in []byte) {
+		// Only consider inputs that are valid JSON and re-marshal canonically,
+		// matching what the tool serializer hands to encodeGCF.
+		var v any
+		if err := json.Unmarshal(in, &v); err != nil {
+			return
+		}
+		canonical, err := json.Marshal(v)
+		if err != nil {
+			return
+		}
+		wire, ok := encodeGCF(canonical)
+		if !ok {
+			return
+		}
+		if len(wire) >= len(canonical) {
+			t.Fatalf("wire not smaller: json=%s wire=%q", canonical, wire)
+		}
+		decoded, err := gcf.DecodeGeneric(wire)
+		if err != nil {
+			t.Fatalf("wire does not decode: %q err=%v", wire, err)
+		}
+		if !jsonEqualsDecoded(canonical, decoded) {
+			t.Fatalf("NOT lossless: json=%s wire=%q decoded=%#v", canonical, wire, decoded)
+		}
+	})
+}
+
+// gcfListHandler returns a uniform record array whose size scales with the
+// requested count, so a large count wins with GCF and a small one does not.
+func gcfListHandler(ctx context.Context, params testToolParams) (map[string]any, error) {
+	return uniformDatasources(params.Value), nil
+}
+
+func TestMustToolGCFOutput(t *testing.T) {
+	_, handler, err := ConvertTool("gcf_list", "list", gcfListHandler)
+	require.NoError(t, err)
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{
+		Name:      "gcf_list",
+		Arguments: map[string]any{"name": "x", "value": 30},
+	}}
+
+	// Default (JSON) output is unchanged.
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	jsonText := res.Content[0].(mcp.TextContent).Text
+	assert.True(t, strings.HasPrefix(jsonText, "{"), "default output stays JSON")
+
+	// With GCF enabled and a winning payload, the text block is GCF and decodes
+	// back to the JSON value.
+	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{OutputFormat: "gcf"})
+	res, err = handler(ctx, req)
+	require.NoError(t, err)
+	gcfText := res.Content[0].(mcp.TextContent).Text
+	require.True(t, strings.HasPrefix(gcfText, "GCF profile=generic"), "GCF output expected, got: %.40s", gcfText)
+	assert.Less(t, len(gcfText), len(jsonText))
+
+	decoded, err := gcf.DecodeGeneric(gcfText)
+	require.NoError(t, err)
+	assert.True(t, jsonEqualsDecoded([]byte(jsonText), decoded))
+
+	// With GCF enabled but a payload GCF cannot shrink, it falls back to JSON.
+	smallReq := mcp.CallToolRequest{Params: mcp.CallToolParams{
+		Name:      "gcf_list",
+		Arguments: map[string]any{"name": "x", "value": 1},
+	}}
+	res, err = handler(ctx, smallReq)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(res.Content[0].(mcp.TextContent).Text, "{"), "tiny result stays JSON even with GCF on")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	github.com/PaesslerAG/gval v1.2.4
 	github.com/PaesslerAG/jsonpath v0.1.1
+	github.com/blackwell-systems/gcf-go v1.7.0
 	github.com/go-openapi/runtime v0.29.3
 	github.com/go-openapi/strfmt v0.26.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 h1:6df1vn4bBlDDo
 github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3/go.mod h1:CIWtjkly68+yqLPbvwwR/fjNJA/idrtULjZWh2v1ys0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blackwell-systems/gcf-go v1.7.0 h1:N0njdDurFrbP6uP3oCWIKcsXNjhoN8YgdSR3/bSah7Y=
+github.com/blackwell-systems/gcf-go v1.7.0/go.mod h1:hYxLOn6JHzNNNH7wfgRXWETX2lMtRtjG8FEX45I6SAI=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -283,6 +283,20 @@ type GrafanaConfig struct {
 	// to inject their own slog.Logger for consistent structured logging with
 	// per-request context such as tenant_id.
 	Logger *slog.Logger
+
+	// OutputFormat selects how structured tool results are serialized in the
+	// model-facing text content block. "json" (the default) is unchanged; "gcf"
+	// encodes results as Graph Compact Format (https://gcformat.com) when that is
+	// a smaller, lossless encoding, and otherwise falls back to JSON per result.
+	OutputFormat string
+}
+
+// GCFEnabled reports whether tool results should be offered as GCF in the
+// model-facing content block. The encoding is applied per result only when it
+// is both smaller than and a lossless round-trip of the JSON (see encodeGCF), so
+// enabling it never grows a result and never changes its meaning.
+func (c GrafanaConfig) GCFEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(c.OutputFormat), "gcf")
 }
 
 // HTTPTransport returns the base HTTP transport for this config.

--- a/tools.go
+++ b/tools.go
@@ -395,6 +395,15 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 			return nil, fmt.Errorf("failed to marshal return value: %s", err)
 		}
 
+		// Optionally offer the result as GCF instead of JSON in the model-facing
+		// text block. encodeGCF only substitutes when GCF is a smaller, lossless
+		// encoding, so this never grows or alters a result.
+		if GrafanaConfigFromContext(ctx).GCFEnabled() {
+			if wire, ok := encodeGCF(returnBytes); ok {
+				return mcp.NewToolResultText(wire), nil
+			}
+		}
+
 		return mcp.NewToolResultText(string(returnBytes)), nil
 	}
 

--- a/tools/gcf_integration_test.go
+++ b/tools/gcf_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package tools
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	gcf "github.com/blackwell-systems/gcf-go"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGCFOutputEndToEnd exercises the full opt-in GCF path against a live
+// Grafana: it calls the registered list_datasources tool through its MustTool
+// handler (the same wrapper the server uses) with OutputFormat=gcf, and checks
+// that the model-facing text is GCF and decodes back to exactly the JSON the
+// same tool returns by default. Relies on the docker-compose provisioned
+// datasources being numerous enough for GCF to win (they are).
+func TestGCFOutputEndToEnd(t *testing.T) {
+	base := newTestContext()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{
+		Name:      "list_datasources",
+		Arguments: map[string]any{},
+	}}
+
+	// Default: unchanged JSON.
+	jsonRes, err := ListDatasources.Handler(base, req)
+	require.NoError(t, err)
+	jsonText := jsonRes.Content[0].(mcp.TextContent).Text
+	require.True(t, strings.HasPrefix(strings.TrimSpace(jsonText), "{"), "default output should be JSON")
+
+	// Opt-in: same request, OutputFormat=gcf on the config already in the ctx.
+	cfg := mcpgrafana.GrafanaConfigFromContext(base)
+	cfg.OutputFormat = "gcf"
+	gctx := mcpgrafana.WithGrafanaConfig(base, cfg)
+
+	gcfRes, err := ListDatasources.Handler(gctx, req)
+	require.NoError(t, err)
+	gcfText := gcfRes.Content[0].(mcp.TextContent).Text
+	require.True(t, strings.HasPrefix(gcfText, "GCF profile=generic"),
+		"expected GCF output (need provisioned datasources), got: %.60s", gcfText)
+	assert.Less(t, len(gcfText), len(jsonText), "GCF wire should be smaller than JSON")
+
+	// The GCF wire decodes back to exactly the tool's JSON value.
+	decoded, err := gcf.DecodeGeneric(gcfText)
+	require.NoError(t, err)
+	decodedBytes, err := json.Marshal(decoded)
+	require.NoError(t, err)
+	assert.True(t, jsonSemanticallyEqual(t, []byte(jsonText), decodedBytes),
+		"GCF must round-trip to the JSON result")
+}
+
+// jsonSemanticallyEqual compares two JSON documents ignoring object key order.
+func jsonSemanticallyEqual(t *testing.T, a, b []byte) bool {
+	t.Helper()
+	var av, bv any
+	require.NoError(t, json.Unmarshal(a, &av))
+	require.NoError(t, json.Unmarshal(b, &bv))
+	return reflect.DeepEqual(av, bv)
+}


### PR DESCRIPTION
### Summary

Adds an opt-in output encoding, `--output-format=gcf` (or `GRAFANA_OUTPUT_FORMAT=gcf`),
that serializes structured tool results as a [Graph Compact Format](https://gcformat.com)
generic wire instead of JSON in the model-facing text content block. The list tools
return arrays of uniform records (`list_datasources`, `list_teams`, `list_users_by_org`,
`alerting_manage_rules`, `list_incidents`, …); GCF factors their repeated field names into
a single header, so the per-record cost drops to the values and the result uses fewer
tokens when it crosses the LLM boundary.

It's applied at a single seam: the `MustTool` result serializer in `tools.go`, where every
typed handler return is marshaled. So it covers every record-returning tool with no
per-tool edits and no signature changes.

### Deliberately conservative: it can only ever help

The substitution is per-result and gated twice, so turning it on never regresses a result:

- **Never larger.** If the GCF wire is not smaller than the JSON for a given result, that
  result stays JSON (a never-grow guard). GCF wins on uniform record arrays and ties on
  tiny or high-entropy results, which simply keep JSON.
- **Never lossy.** Every substituted result is decoded and compared back to the original
  before it is used. On any encoding error, decode error, or mismatch (including an integer
  outside GCF's canonical int64 domain, which GCF rejects rather than approximating), the
  result falls back to JSON, so a tool call is never dropped or altered.
- **Opt-in and additive.** Default (`json`) output is unchanged, and `structuredContent`
  (where a tool sets it) is untouched.
- **Zero new footprint.** `gcf-go` is a zero-dependency package, pinned exact.

### Measured on real Grafana output

Captured from a live Grafana (the repo's `docker-compose` stack), real tool output, o200k
tokenizer, every result verified to round-trip back to the original value:

| Tool | records | tokens JSON → GCF |
|------|---------|-------------------|
| `list_datasources` | 57 | **−32.5%** |
| `list_users_by_org` | 31 | **−29.8%** |
| `list_teams` | 20 | **−28.1%** |
| `alerting_manage_rules` | 4 | −10.9% |
| `search_folders` | 3 | −12.4% |
| `search_dashboards` | 61 | ~tie → falls back to JSON via the never-grow guard |

The win is on the uniform-identifier inventory lists an agent hits constantly, and it
scales with record count (production instances are far larger than this test one).
High-entropy results (dashboard search, where each row carries a unique uid/url/title)
don't compress on tokens, so the guard keeps them on JSON. Nothing regresses.

### Why GCF, beyond size

The harder question than byte count is whether a model reads the compact form as
accurately as JSON. GCF is designed and evaluated for exactly that:

- **Generic-profile comprehension: 100% on every frontier model** (Claude
  Opus/Sonnet/Haiku, GPT-5.5, Gemini 2.5 Pro / 3.1 Pro / 3.5 Flash), across 27 runs, 11
  models, 4 providers; equal to or better than JSON on every model.
  https://gcformat.com/guide/benchmarks
- The grammar was reverse-engineered from attention-level research into how BPE
  tokenization shapes what a transformer can represent, then validated by controlled
  from-scratch training at 1.3B scale, measured causally rather than by an LLM judge, so it
  holds on models that have never seen the format. Four papers (2026, under review):
  - GCF: A Token-Optimized Wire Format for Structured LLM Interactions — https://doi.org/10.5281/zenodo.20579817
  - Tokenizer-Attention Coupling — https://doi.org/10.5281/zenodo.20925910
  - Stranded Attention — https://doi.org/10.5281/zenodo.21158886
  - Developmental Atlas of Attention Head Specialization — https://doi.org/10.5281/zenodo.21205389

### Already adopted

GCF is in production across observability, developer tooling, and network automation:

- **[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)** (Google) merged it as an experimental output format.
- **[Speakeasy](https://speakeasy.com)** (customers include Google, Verizon, Mistral AI) ships it in their `oq` CLI.
- **[OmniRoute](https://omniroute.online)** vendored it into its AI gateway.
- **[NetClaw](https://github.com/automateyournetwork/netclaw)** benchmarked GCF against TOON on real network data and replaced TOON across its MCP servers.
- **[mcp-cisco-support](https://github.com/sieteunoseis/mcp-cisco-support)** (listed on Cisco Code Exchange) reports 28.5% fewer tokens on real Cisco Support API data.

…and many others across the MCP and agent ecosystem.

### The change

- `--output-format` flag + `GRAFANA_OUTPUT_FORMAT` env (`json` default, `gcf` opt-in),
  threaded through `GrafanaConfig` like the other server settings.
- One `encodeGCF` helper (never-grow guard + fail-safe round-trip) hooked into the
  `MustTool` JSON seam.
- Tests: unit coverage of the never-grow guard, losslessness, and exact int64
  preservation (a value above 2^53 is never float-rounded); a robustness table
  over nested/delimiter/quote/unicode/numeric/null/empty shapes; a fuzz target
  asserting the never-grow + lossless invariant on arbitrary JSON; the full
  `MustTool` handler path; and an integration e2e that runs the real
  `list_datasources` tool with GCF enabled against a live Grafana. README
  documents the flag.

GCF is open source and MIT-licensed. Format, spec, SDKs, and benchmarks: https://gcformat.com
Happy to adjust the flag shape or defaults, and to re-run the numbers against any Grafana
you point me at. Reproducible harness on request; independent verification welcome.
