### PR TITLE
fix(proxied-tools): retry transient discovery/connect failures, parallelize connects

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -375,7 +375,11 @@ func newServer(serverName, transport string, dt disabledTools, obs *observabilit
 	)
 
 	// Initialize ToolManager now that server is created
-	stm = mcpgrafana.NewToolManager(sm, s, mcpgrafana.WithProxiedTools(!dt.proxied), mcpgrafana.WithToolManagerLogger(slog.Default()))
+	stm = mcpgrafana.NewToolManager(sm, s,
+		mcpgrafana.WithProxiedTools(!dt.proxied),
+		mcpgrafana.WithToolManagerLogger(slog.Default()),
+		mcpgrafana.WithToolManagerMeterProvider(obs.MeterProvider()),
+	)
 
 	// Give the SessionManager a reference to the MCPServer so the reaper can
 	// unregister sessions from the SDK's internal session map.

--- a/proxied_client.go
+++ b/proxied_client.go
@@ -2,6 +2,7 @@ package mcpgrafana
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -17,7 +18,108 @@ const (
 	// (connecting, handshaking, and listing tools). Kept short to avoid blocking
 	// server startup when a datasource's MCP endpoint is slow or unreachable.
 	mcpClientInitTimeout = 30 * time.Second
+
+	// mcpRetryMaxAttempts is the total number of attempts (including the first)
+	// made for a probe or connect operation before giving up on a candidate.
+	mcpRetryMaxAttempts = 2
+	// mcpRetryBackoff is the base backoff between retry attempts; attempt N
+	// waits N*mcpRetryBackoff before retrying.
+	mcpRetryBackoff = 250 * time.Millisecond
 )
+
+// retryPolicy configures withRetry.
+type retryPolicy struct {
+	maxAttempts int
+	backoff     time.Duration
+}
+
+// defaultRetryPolicy is used for both MCP-support probes and client connects.
+var defaultRetryPolicy = retryPolicy{maxAttempts: mcpRetryMaxAttempts, backoff: mcpRetryBackoff}
+
+// transientError marks a failure as retryable (a timeout, network/dial error,
+// or server error that may well succeed on a subsequent attempt). Any error
+// NOT wrapped as a transientError is treated as deterministic by withRetry and
+// is never retried.
+type transientError struct{ err error }
+
+// newTransientError wraps err as transient. Returns nil if err is nil, so it
+// can be used directly as a return value: `return result, newTransientError(err)`.
+func newTransientError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &transientError{err: err}
+}
+
+func (e *transientError) Error() string { return e.err.Error() }
+func (e *transientError) Unwrap() error { return e.err }
+
+// isTransient reports whether err (or anything it wraps) is a transientError.
+func isTransient(err error) bool {
+	var te *transientError
+	return errors.As(err, &te)
+}
+
+// withRetry runs attempt up to policy.maxAttempts times. attempt receives the
+// 1-based attempt number, so callers can distinguish first tries from retries
+// (e.g. for metrics) or build a fresh per-attempt timeout context.
+//
+//   - attempt returns (result, nil): success, returned immediately.
+//   - attempt returns a transientError (see newTransientError): retried after
+//     waiting attemptNum*policy.backoff, unless attempts are exhausted or ctx
+//     is done first.
+//   - attempt returns any other non-nil error: deterministic, returned
+//     immediately with no retry.
+//
+// On exhaustion, the returned error wraps the last attempt's error with the
+// attempt count, and still satisfies isTransient, so a caller's final log
+// message is self-describing (e.g. "... failed after 2 attempts: <err>").
+func withRetry[T any](ctx context.Context, policy retryPolicy, description string, attempt func(attemptNum int) (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+	for n := 1; n <= policy.maxAttempts; n++ {
+		result, err := attempt(n)
+		if err == nil {
+			return result, nil
+		}
+		if !isTransient(err) {
+			return zero, err
+		}
+		lastErr = err
+		if n == policy.maxAttempts {
+			break
+		}
+
+		select {
+		case <-time.After(time.Duration(n) * policy.backoff):
+		case <-ctx.Done():
+			return zero, newTransientError(contextCauseOrErr(ctx, ctx.Err()))
+		}
+	}
+	return zero, newTransientError(fmt.Errorf("%s failed after %d attempts: %w", description, policy.maxAttempts, lastErr))
+}
+
+// classifyConnectError decides whether a NewProxiedClient failure is worth
+// retrying. Auth rejections are deterministic: retrying with the same
+// credentials cannot help. Everything else (handshake timeout, dial/network
+// error, or any other Initialize/ListTools failure) is treated as transient.
+//
+// This deliberately over-retries a few genuinely deterministic failures we
+// can't cheaply classify (e.g. a persistently-misconfigured endpoint), at the
+// cost of one extra mcpClientInitTimeout-bounded attempt per candidate. That
+// trade-off favors fixing the under-retry of transient failures that caused
+// production flapping over precisely classifying every failure mode.
+func classifyConnectError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var authErr *transport.AuthorizationRequiredError
+	var oauthErr *transport.OAuthAuthorizationRequiredError
+	if errors.As(err, &authErr) || errors.As(err, &oauthErr) {
+		return err
+	}
+	return newTransientError(err)
+}
 
 // ProxiedClient represents a connection to a remote MCP server (e.g., Tempo datasource)
 type ProxiedClient struct {

--- a/proxied_client_test.go
+++ b/proxied_client_test.go
@@ -1,0 +1,137 @@
+package mcpgrafana
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithRetry(t *testing.T) {
+	t.Run("succeeds on first attempt without retrying", func(t *testing.T) {
+		calls := 0
+		result, err := withRetry(context.Background(), retryPolicy{maxAttempts: 3, backoff: time.Millisecond}, "test",
+			func(attemptNum int) (int, error) {
+				calls++
+				return 42, nil
+			})
+
+		require.NoError(t, err)
+		assert.Equal(t, 42, result)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("deterministic error is not retried", func(t *testing.T) {
+		calls := 0
+		wantErr := errors.New("deterministic boom")
+		_, err := withRetry(context.Background(), retryPolicy{maxAttempts: 3, backoff: time.Millisecond}, "test",
+			func(attemptNum int) (int, error) {
+				calls++
+				return 0, wantErr
+			})
+
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
+		assert.Same(t, wantErr, err)
+		assert.False(t, isTransient(err))
+	})
+
+	t.Run("transient error is retried then succeeds", func(t *testing.T) {
+		calls := 0
+		result, err := withRetry(context.Background(), retryPolicy{maxAttempts: 2, backoff: time.Millisecond}, "test",
+			func(attemptNum int) (int, error) {
+				calls++
+				if attemptNum == 1 {
+					return 0, newTransientError(errors.New("flaky"))
+				}
+				return 7, nil
+			})
+
+		require.NoError(t, err)
+		assert.Equal(t, 7, result)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("exhausts retries on persistent transient error", func(t *testing.T) {
+		calls := 0
+		_, err := withRetry(context.Background(), retryPolicy{maxAttempts: 3, backoff: time.Millisecond}, "probe X",
+			func(attemptNum int) (int, error) {
+				calls++
+				return 0, newTransientError(errors.New("always flaky"))
+			})
+
+		require.Error(t, err)
+		assert.Equal(t, 3, calls)
+		assert.True(t, isTransient(err))
+		assert.Contains(t, err.Error(), "probe X")
+		assert.Contains(t, err.Error(), "failed after 3 attempts")
+		assert.Contains(t, err.Error(), "always flaky")
+	})
+
+	t.Run("context cancellation during backoff aborts early", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		_, err := withRetry(ctx, retryPolicy{maxAttempts: 3, backoff: time.Hour}, "test",
+			func(attemptNum int) (int, error) {
+				calls++
+				cancel() // cancel immediately after the first attempt so the backoff wait aborts
+				return 0, newTransientError(errors.New("flaky"))
+			})
+
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
+		assert.True(t, isTransient(err))
+	})
+}
+
+func TestClassifyConnectError(t *testing.T) {
+	t.Run("nil error stays nil", func(t *testing.T) {
+		assert.NoError(t, classifyConnectError(nil))
+	})
+
+	t.Run("auth error is deterministic", func(t *testing.T) {
+		err := fmt.Errorf("failed to initialize MCP client: %w", &transport.AuthorizationRequiredError{})
+		got := classifyConnectError(err)
+		assert.False(t, isTransient(got))
+		assert.Same(t, err, got)
+	})
+
+	t.Run("oauth error is deterministic", func(t *testing.T) {
+		err := fmt.Errorf("failed to initialize MCP client: %w", &transport.OAuthAuthorizationRequiredError{
+			AuthorizationRequiredError: transport.AuthorizationRequiredError{},
+		})
+		got := classifyConnectError(err)
+		assert.False(t, isTransient(got))
+	})
+
+	t.Run("generic error is transient", func(t *testing.T) {
+		err := errors.New("connection reset")
+		got := classifyConnectError(err)
+		assert.True(t, isTransient(got))
+	})
+}
+
+func TestIsTransient(t *testing.T) {
+	t.Run("unwraps through fmt.Errorf wrapping", func(t *testing.T) {
+		err := fmt.Errorf("outer: %w", newTransientError(errors.New("inner")))
+		assert.True(t, isTransient(err))
+	})
+
+	t.Run("plain error is not transient", func(t *testing.T) {
+		assert.False(t, isTransient(errors.New("plain")))
+	})
+
+	t.Run("nil is not transient", func(t *testing.T) {
+		assert.False(t, isTransient(nil))
+	})
+
+	t.Run("error message does not leak wrapper type name", func(t *testing.T) {
+		err := newTransientError(errors.New("inner message"))
+		assert.Equal(t, "inner message", err.Error())
+	})
+}

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -45,8 +45,11 @@ type discoveryMetrics struct {
 	connectRetries              metric.Int64Counter // Connect attempts issued as a retry (attempts beyond the first)
 }
 
-func newDiscoveryMetrics() discoveryMetrics {
-	meter := otel.GetMeterProvider().Meter(proxiedToolsMeterName)
+func newDiscoveryMetrics(mp metric.MeterProvider) discoveryMetrics {
+	if mp == nil {
+		mp = otel.GetMeterProvider()
+	}
+	meter := mp.Meter(proxiedToolsMeterName)
 
 	probeSuccess, _ := meter.Int64Counter("mcp.discovery.probe_success",
 		metric.WithDescription("Number of MCP-support probes that found a datasource is MCP-enabled"),
@@ -518,6 +521,9 @@ type ToolManager struct {
 
 	// metrics holds OTel instruments for discovery/connect observability.
 	metrics discoveryMetrics
+	// meterProvider is the metric.MeterProvider used to build metrics, set via
+	// WithToolManagerMeterProvider.
+	meterProvider metric.MeterProvider
 }
 
 // NewToolManager creates a new ToolManager
@@ -527,11 +533,11 @@ func NewToolManager(sm *SessionManager, mcpServer *server.MCPServer, opts ...too
 		server:        mcpServer,
 		serverClients: make(map[string]*ProxiedClient),
 		proxiedSets:   make(map[proxiedToolSetKey]*proxiedToolSet),
-		metrics:       newDiscoveryMetrics(),
 	}
 	for _, opt := range opts {
 		opt(tm)
 	}
+	tm.metrics = newDiscoveryMetrics(tm.meterProvider)
 	if tm.logger == nil {
 		tm.logger = slog.Default()
 	}
@@ -557,6 +563,19 @@ func WithProxiedTools(enabled bool) toolManagerOption {
 func WithToolManagerLogger(logger *slog.Logger) toolManagerOption {
 	return func(tm *ToolManager) {
 		tm.logger = logger
+	}
+}
+
+// WithToolManagerMeterProvider sets the metric.MeterProvider used to create
+// the ToolManager's discovery/connect OTel instruments. If unset (or passed
+// as nil), the ToolManager falls back to otel.GetMeterProvider(), matching
+// the pre-existing behavior. Callers embedding mcp-grafana as a library and
+// running with a non-global MeterProvider (e.g. because the process resets
+// the global provider to a noop for unrelated reasons) should pass their own
+// provider here so these metrics actually reach a scrapeable registry.
+func WithToolManagerMeterProvider(mp metric.MeterProvider) toolManagerOption {
+	return func(tm *ToolManager) {
+		tm.meterProvider = mp
 	}
 }
 

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -249,8 +249,14 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger, metrics di
 					"datasource", c.uid, "name", c.name, "type", c.dsType, "error", probeErr)
 				results <- probeResult{}
 			default:
+				// A clean non-OK response (typically 404) just means this
+				// datasource instance doesn't have MCP enabled, which is a
+				// routine, expected outcome for many Tempo datasources, not a
+				// failure. Debug (not Warn) keeps that from drowning out the
+				// transient case above, which is the one worth an operator's
+				// attention.
 				metrics.probeDeterministicFailure.Add(ctx, 1, typeAttr)
-				logger.WarnContext(ctx, "MCP probe determined datasource does not support MCP; excluding it",
+				logger.DebugContext(ctx, "MCP probe determined datasource does not support MCP; excluding it",
 					"datasource", c.uid, "name", c.name, "type", c.dsType, "error", probeErr)
 				results <- probeResult{}
 			}
@@ -702,7 +708,30 @@ func (tm *ToolManager) buildProxiedToolSet(ctx context.Context, logger *slog.Log
 			typeAttr := metric.WithAttributes(attribute.String("datasource.type", ds.Type))
 			description := fmt.Sprintf("connect to MCP server for datasource %s (%s)", ds.Name, ds.UID)
 
-			client, connectErr := withRetry(ctx, defaultRetryPolicy, description,
+			// Connect work now runs in its own goroutine (parallelized, unlike
+			// the sequential loop this replaced), so a panic here would
+			// otherwise crash the whole process instead of being turned into
+			// an error by buildProxiedToolSet's top-level recover, which only
+			// guards its own goroutine. Recover here too, closing any client
+			// that connected before the panic so it isn't leaked, and report
+			// this candidate as failed rather than letting the panic escape.
+			var client *ProxiedClient
+			defer func() {
+				if r := recover(); r != nil {
+					logger.ErrorContext(ctx, "panic connecting to proxied MCP client; excluding datasource",
+						"datasource", ds.UID, "name", ds.Name, "type", ds.Type, "panic", r)
+					tm.metrics.connectDeterministicFailure.Add(ctx, 1, typeAttr)
+					if client != nil {
+						if err := client.Close(); err != nil {
+							logger.ErrorContext(ctx, "failed to close proxied client after panic", "datasource", ds.UID, "error", err)
+						}
+					}
+					connectResults <- connectResult{failed: true}
+				}
+			}()
+
+			var connectErr error
+			client, connectErr = withRetry(ctx, defaultRetryPolicy, description,
 				func(attemptNum int) (*ProxiedClient, error) {
 					if attemptNum > 1 {
 						tm.metrics.connectRetries.Add(ctx, 1, typeAttr)

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -11,6 +11,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -21,7 +25,73 @@ const (
 	// mcpProbeTimeout is the timeout for probing a single datasource's MCP endpoint.
 	// This is kept short to avoid slow startup when datasources are unreachable.
 	mcpProbeTimeout = 5 * time.Second
+
+	// proxiedToolsMeterName is the OTel meter name for discovery/connect metrics,
+	// matching the convention used by clientCacheMeterName/sessionMeterName.
+	proxiedToolsMeterName = "mcp-grafana"
 )
+
+// discoveryMetrics holds OTel instruments for MCP datasource discovery (probe)
+// and connection (buildProxiedToolSet) observability.
+type discoveryMetrics struct {
+	probeSuccess              metric.Int64Counter // Probes that found a datasource is MCP-enabled
+	probeDeterministicFailure metric.Int64Counter // Probes with a clean non-retryable response (e.g. 404): not MCP-enabled
+	probeTransientFailure     metric.Int64Counter // Probes that exhausted retries on a transient error (timeout/network/5xx)
+	probeRetries              metric.Int64Counter // Probe attempts issued as a retry (attempts beyond the first)
+
+	connectSuccess              metric.Int64Counter // Proxied client connections established
+	connectDeterministicFailure metric.Int64Counter // Connections that failed for a non-retryable reason (e.g. auth)
+	connectTransientFailure     metric.Int64Counter // Connections that exhausted retries on a transient error
+	connectRetries              metric.Int64Counter // Connect attempts issued as a retry (attempts beyond the first)
+}
+
+func newDiscoveryMetrics() discoveryMetrics {
+	meter := otel.GetMeterProvider().Meter(proxiedToolsMeterName)
+
+	probeSuccess, _ := meter.Int64Counter("mcp.discovery.probe_success",
+		metric.WithDescription("Number of MCP-support probes that found a datasource is MCP-enabled"),
+		metric.WithUnit("{probe}"),
+	)
+	probeDeterministicFailure, _ := meter.Int64Counter("mcp.discovery.probe_deterministic_failure",
+		metric.WithDescription("Number of MCP-support probes that got a clean non-retryable response (e.g. 404)"),
+		metric.WithUnit("{probe}"),
+	)
+	probeTransientFailure, _ := meter.Int64Counter("mcp.discovery.probe_transient_failure",
+		metric.WithDescription("Number of MCP-support probes that exhausted retries on a transient error"),
+		metric.WithUnit("{probe}"),
+	)
+	probeRetries, _ := meter.Int64Counter("mcp.discovery.probe_retries",
+		metric.WithDescription("Number of MCP-support probe attempts issued as a retry"),
+		metric.WithUnit("{attempt}"),
+	)
+	connectSuccess, _ := meter.Int64Counter("mcp.discovery.connect_success",
+		metric.WithDescription("Number of proxied MCP client connections established"),
+		metric.WithUnit("{connection}"),
+	)
+	connectDeterministicFailure, _ := meter.Int64Counter("mcp.discovery.connect_deterministic_failure",
+		metric.WithDescription("Number of proxied MCP client connections that failed for a non-retryable reason"),
+		metric.WithUnit("{connection}"),
+	)
+	connectTransientFailure, _ := meter.Int64Counter("mcp.discovery.connect_transient_failure",
+		metric.WithDescription("Number of proxied MCP client connections that exhausted retries on a transient error"),
+		metric.WithUnit("{connection}"),
+	)
+	connectRetries, _ := meter.Int64Counter("mcp.discovery.connect_retries",
+		metric.WithDescription("Number of proxied MCP client connect attempts issued as a retry"),
+		metric.WithUnit("{attempt}"),
+	)
+
+	return discoveryMetrics{
+		probeSuccess:                probeSuccess,
+		probeDeterministicFailure:   probeDeterministicFailure,
+		probeTransientFailure:       probeTransientFailure,
+		probeRetries:                probeRetries,
+		connectSuccess:              connectSuccess,
+		connectDeterministicFailure: connectDeterministicFailure,
+		connectTransientFailure:     connectTransientFailure,
+		connectRetries:              connectRetries,
+	}
+}
 
 // MCPDatasourceConfig defines configuration for a datasource type that supports MCP
 type MCPDatasourceConfig struct {
@@ -43,12 +113,13 @@ type DiscoveredDatasource struct {
 	MCPURL string // The MCP endpoint URL
 }
 
-// discoverMCPDatasources discovers datasources that support MCP
-// Returns a list of datasources with MCP endpoints
-func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]DiscoveredDatasource, error) {
+// discoverMCPDatasources discovers datasources that support MCP.
+// Returns the list of datasources with MCP endpoints and the number of
+// candidates considered (datasources of an MCP-enabled type, before probing).
+func discoverMCPDatasources(ctx context.Context, logger *slog.Logger, metrics discoveryMetrics) ([]DiscoveredDatasource, int, error) {
 	gc := GrafanaClientFromContext(ctx)
 	if gc == nil {
-		return nil, fmt.Errorf("grafana client not found in context")
+		return nil, 0, fmt.Errorf("grafana client not found in context")
 	}
 
 	var discovered []DiscoveredDatasource
@@ -58,13 +129,13 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 		datasources.NewGetDataSourcesParamsWithContext(ctx),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list datasources: %w", err)
+		return nil, 0, fmt.Errorf("failed to list datasources: %w", err)
 	}
 
 	// Get the Grafana base URL from context
 	config := GrafanaConfigFromContext(ctx)
 	if config.URL == "" {
-		return nil, fmt.Errorf("grafana url not found in context")
+		return nil, 0, fmt.Errorf("grafana url not found in context")
 	}
 	grafanaBaseURL := config.URL
 
@@ -92,12 +163,12 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 
 	if len(candidates) == 0 {
 		logger.DebugContext(ctx, "no candidate MCP datasources found")
-		return nil, nil
+		return nil, 0, nil
 	}
 
 	transport, err := BuildTransport(&config, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transport: %w", err)
+		return nil, len(candidates), fmt.Errorf("failed to create transport: %w", err)
 	}
 
 	httpClient := &http.Client{
@@ -105,7 +176,7 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 		Timeout:   mcpProbeTimeout,
 	}
 
-	// Probe candidates in parallel with timeout
+	// Probe candidates in parallel, retrying transient failures.
 	type probeResult struct {
 		ds      DiscoveredDatasource
 		enabled bool
@@ -119,43 +190,69 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 			defer wg.Done()
 
 			probeURL := fmt.Sprintf("%s/api/datasources/proxy/uid/%s%s", grafanaBaseURL, c.uid, c.dsConfig.EndpointPath)
+			typeAttr := metric.WithAttributes(attribute.String("datasource.type", c.dsType))
 
-			probeCtx, cancel := context.WithTimeoutCause(ctx, mcpProbeTimeout,
-				fmt.Errorf("timed out after %s probing MCP endpoint for datasource %s (%s) at %s", mcpProbeTimeout, c.name, c.uid, probeURL))
-			defer cancel()
+			doProbe := func(attemptNum int) (struct{}, error) {
+				if attemptNum > 1 {
+					metrics.probeRetries.Add(ctx, 1, typeAttr)
+				}
 
-			// Check if the datasource instance has MCP enabled
-			// We use a DELETE request to probe the MCP endpoint since:
-			// - GET would start an event stream and hang
-			// - POST doesn't work with the Grafana OpenAPI client
-			// - DELETE returns 200 if MCP is enabled, 404 if not
-			req, err := http.NewRequestWithContext(probeCtx, http.MethodDelete, probeURL, nil)
-			if err != nil {
-				logger.DebugContext(ctx, "failed to create probe request", "datasource", c.uid, "error", err)
-				return
+				probeCtx, cancel := context.WithTimeoutCause(ctx, mcpProbeTimeout,
+					fmt.Errorf("timed out after %s probing MCP endpoint for datasource %s (%s) at %s (attempt %d/%d)",
+						mcpProbeTimeout, c.name, c.uid, probeURL, attemptNum, mcpRetryMaxAttempts))
+				defer cancel()
+
+				// Check if the datasource instance has MCP enabled
+				// We use a DELETE request to probe the MCP endpoint since:
+				// - GET would start an event stream and hang
+				// - POST doesn't work with the Grafana OpenAPI client
+				// - DELETE returns 200 if MCP is enabled, 404 if not
+				req, err := http.NewRequestWithContext(probeCtx, http.MethodDelete, probeURL, nil)
+				if err != nil {
+					return struct{}{}, fmt.Errorf("failed to create probe request: %w", err)
+				}
+
+				resp, err := httpClient.Do(req)
+				if err != nil {
+					return struct{}{}, newTransientError(contextCauseOrErr(probeCtx, err))
+				}
+				defer func() { _ = resp.Body.Close() }()
+
+				switch {
+				case resp.StatusCode == http.StatusOK:
+					return struct{}{}, nil
+				case resp.StatusCode >= 500:
+					return struct{}{}, newTransientError(fmt.Errorf("probe returned server error status %d", resp.StatusCode))
+				default:
+					return struct{}{}, fmt.Errorf("probe returned non-OK status %d", resp.StatusCode)
+				}
 			}
 
-			resp, err := httpClient.Do(req)
-			if err != nil {
-				logger.DebugContext(ctx, "MCP probe failed", "datasource", c.uid, "error", contextCauseOrErr(probeCtx, err))
-				return
-			}
-			defer func() { _ = resp.Body.Close() }()
+			_, probeErr := withRetry(ctx, defaultRetryPolicy,
+				fmt.Sprintf("MCP probe for datasource %s (%s)", c.name, c.uid), doProbe)
 
-			// MCP is enabled if we get a 200 response
-			if resp.StatusCode == http.StatusOK {
-				mcpURL := fmt.Sprintf("%s/api/datasources/proxy/uid/%s%s", grafanaBaseURL, c.uid, c.dsConfig.EndpointPath)
+			switch {
+			case probeErr == nil:
+				metrics.probeSuccess.Add(ctx, 1, typeAttr)
 				results <- probeResult{
 					ds: DiscoveredDatasource{
 						UID:    c.uid,
 						Name:   c.name,
 						Type:   c.dsType,
-						MCPURL: mcpURL,
+						MCPURL: probeURL,
 					},
 					enabled: true,
 				}
-			} else {
-				logger.DebugContext(ctx, "MCP probe returned non-OK status", "datasource", c.uid, "status", resp.StatusCode, "url", probeURL)
+			case isTransient(probeErr):
+				metrics.probeTransientFailure.Add(ctx, 1, typeAttr)
+				logger.WarnContext(ctx, "MCP probe failed after retries; excluding datasource from proxied tool set",
+					"datasource", c.uid, "name", c.name, "type", c.dsType, "error", probeErr)
+				results <- probeResult{}
+			default:
+				metrics.probeDeterministicFailure.Add(ctx, 1, typeAttr)
+				logger.WarnContext(ctx, "MCP probe determined datasource does not support MCP; excluding it",
+					"datasource", c.uid, "name", c.name, "type", c.dsType, "error", probeErr)
+				results <- probeResult{}
 			}
 		}(c)
 	}
@@ -174,7 +271,7 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 	}
 
 	logger.DebugContext(ctx, "discovered MCP datasources", "count", len(discovered), "candidates", len(candidates))
-	return discovered, nil
+	return discovered, len(candidates), nil
 }
 
 // addDatasourceUidParameter adds a required datasourceUid parameter to a tool's input schema
@@ -412,6 +509,9 @@ type ToolManager struct {
 	// defaults to buildProxiedToolSet and is a field only so tests can inject a
 	// fake builder that avoids real discovery/network I/O.
 	buildSet func(ctx context.Context, logger *slog.Logger) (builtProxiedTools, error)
+
+	// metrics holds OTel instruments for discovery/connect observability.
+	metrics discoveryMetrics
 }
 
 // NewToolManager creates a new ToolManager
@@ -421,6 +521,7 @@ func NewToolManager(sm *SessionManager, mcpServer *server.MCPServer, opts ...too
 		server:        mcpServer,
 		serverClients: make(map[string]*ProxiedClient),
 		proxiedSets:   make(map[proxiedToolSetKey]*proxiedToolSet),
+		metrics:       newDiscoveryMetrics(),
 	}
 	for _, opt := range opts {
 		opt(tm)
@@ -476,7 +577,7 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 	logger := tm.loggerFromCtx(ctx)
 
 	// Discover datasources with MCP support
-	discovered, err := discoverMCPDatasources(ctx, logger)
+	discovered, _, err := discoverMCPDatasources(ctx, logger, tm.metrics)
 	if err != nil {
 		return fmt.Errorf("failed to discover MCP datasources: %w", err)
 	}
@@ -531,6 +632,15 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 	return nil
 }
 
+// buildStats summarizes how a build's candidate datasources fared, for the
+// "built proxied tool set" summary log. Zero-value-safe: builders that don't
+// populate it (e.g. test seams) simply report zeros.
+type buildStats struct {
+	candidates    int // datasources of an MCP-enabled type, before probing
+	discovered    int // candidates that passed the MCP probe
+	connectFailed int // discovered datasources that failed to connect (after retries)
+}
+
 // builtProxiedTools is the result of a build, held in local variables while the
 // build runs so that nothing shared is mutated without the cache lock. It is
 // published into a proxiedToolSet in a single critical section.
@@ -538,6 +648,7 @@ type builtProxiedTools struct {
 	clients           map[string]*ProxiedClient
 	tools             []mcp.Tool
 	toolToDatasources map[string][]string
+	stats             buildStats
 }
 
 // buildProxiedToolSet discovers datasources, connects to them, and returns the
@@ -565,21 +676,79 @@ func (tm *ToolManager) buildProxiedToolSet(ctx context.Context, logger *slog.Log
 	}()
 
 	// Discover datasources with MCP support.
-	discovered, err := discoverMCPDatasources(ctx, logger)
+	discovered, candidateCount, err := discoverMCPDatasources(ctx, logger, tm.metrics)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to discover MCP datasources", "error", err)
 		return built, fmt.Errorf("failed to discover MCP datasources: %w", err)
 	}
 
-	// Connect to each discovered datasource.
+	// Connect to each discovered datasource in parallel, retrying transient
+	// failures, mirroring the probe step's concurrency pattern in
+	// discoverMCPDatasources. A failed connect is non-fatal to the overall
+	// build: it just excludes that datasource.
+	type connectResult struct {
+		key    string
+		client *ProxiedClient
+		failed bool
+	}
+	connectResults := make(chan connectResult, len(discovered))
+	var connectWg sync.WaitGroup
+
 	for _, ds := range discovered {
-		client, err := NewProxiedClient(ctx, ds.UID, ds.Name, ds.Type, ds.MCPURL)
-		if err != nil {
-			logger.ErrorContext(ctx, "failed to create proxied client", "datasource", ds.UID, "error", err)
+		connectWg.Add(1)
+		go func(ds DiscoveredDatasource) {
+			defer connectWg.Done()
+
+			typeAttr := metric.WithAttributes(attribute.String("datasource.type", ds.Type))
+			description := fmt.Sprintf("connect to MCP server for datasource %s (%s)", ds.Name, ds.UID)
+
+			client, connectErr := withRetry(ctx, defaultRetryPolicy, description,
+				func(attemptNum int) (*ProxiedClient, error) {
+					if attemptNum > 1 {
+						tm.metrics.connectRetries.Add(ctx, 1, typeAttr)
+					}
+					c, err := NewProxiedClient(ctx, ds.UID, ds.Name, ds.Type, ds.MCPURL)
+					if err != nil {
+						return nil, classifyConnectError(err)
+					}
+					return c, nil
+				})
+
+			if connectErr != nil {
+				if isTransient(connectErr) {
+					tm.metrics.connectTransientFailure.Add(ctx, 1, typeAttr)
+				} else {
+					tm.metrics.connectDeterministicFailure.Add(ctx, 1, typeAttr)
+				}
+				logger.WarnContext(ctx, "failed to create proxied client after retries; excluding datasource from proxied tool set",
+					"datasource", ds.UID, "name", ds.Name, "type", ds.Type, "error", connectErr)
+				connectResults <- connectResult{failed: true}
+				return
+			}
+
+			tm.metrics.connectSuccess.Add(ctx, 1, typeAttr)
+			connectResults <- connectResult{key: ds.Type + "_" + ds.UID, client: client}
+		}(ds)
+	}
+
+	go func() {
+		connectWg.Wait()
+		close(connectResults)
+	}()
+
+	connectFailed := 0
+	for r := range connectResults {
+		if r.failed {
+			connectFailed++
 			continue
 		}
-		key := ds.Type + "_" + ds.UID
-		built.clients[key] = client
+		built.clients[r.key] = r.client
+	}
+
+	built.stats = buildStats{
+		candidates:    candidateCount,
+		discovered:    len(discovered),
+		connectFailed: connectFailed,
 	}
 
 	// Collect unique tools and track which datasources support each one.
@@ -745,7 +914,9 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 		logger.InfoContext(ctx, "proxied tool set build failed; not caching", "key", set.key, "error", buildErr)
 		return
 	}
-	logger.InfoContext(ctx, "built proxied tool set", "key", set.key, "datasources", len(set.clients), "tools", len(set.tools), "cache_size", size)
+	logger.InfoContext(ctx, "built proxied tool set", "key", set.key,
+		"candidates", built.stats.candidates, "discovered", built.stats.discovered, "connect_failed", built.stats.connectFailed,
+		"datasources", len(set.clients), "tools", len(set.tools), "cache_size", size)
 }
 
 // releaseProxiedToolSet decrements a set's reference count and, once no session

--- a/proxied_tools_discovery_test.go
+++ b/proxied_tools_discovery_test.go
@@ -1,0 +1,209 @@
+package mcpgrafana
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	grafana_client "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDatasource describes one tempo-type datasource to serve from the fake
+// Grafana instance's /api/datasources list, along with the handler that
+// answers its /api/datasources/proxy/uid/<uid>/api/mcp endpoint (both the
+// probe DELETE and any real MCP traffic).
+type fakeDatasource struct {
+	uid     string
+	name    string
+	handler http.Handler
+}
+
+// newFakeGrafana serves a minimal /api/datasources list (one entry per ds,
+// all type "tempo") and routes /api/datasources/proxy/uid/<uid>/api/mcp to
+// that datasource's handler, mirroring the real Grafana datasource proxy path
+// discoverMCPDatasources/NewProxiedClient talk to. Returns a context carrying
+// a GrafanaConfig/GrafanaClient pointed at the returned server, matching
+// newProxiedToolsTestContext's shape in session_test.go.
+func newFakeGrafana(t *testing.T, dss ...fakeDatasource) (*httptest.Server, context.Context) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/datasources", func(w http.ResponseWriter, r *http.Request) {
+		type dsListItem struct {
+			UID  string `json:"uid"`
+			Name string `json:"name"`
+			Type string `json:"type"`
+		}
+		list := make([]dsListItem, 0, len(dss))
+		for _, ds := range dss {
+			list = append(list, dsListItem{UID: ds.uid, Name: ds.name, Type: "tempo"})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(list))
+	})
+	for _, ds := range dss {
+		path := fmt.Sprintf("/api/datasources/proxy/uid/%s/api/mcp", ds.uid)
+		mux.Handle(path, ds.handler)
+	}
+
+	httpServer := httptest.NewServer(mux)
+	t.Cleanup(httpServer.Close)
+
+	parsed, err := url.Parse(httpServer.URL)
+	require.NoError(t, err)
+
+	cfg := grafana_client.DefaultTransportConfig()
+	cfg.Host = parsed.Host
+	cfg.Schemes = []string{"http"}
+	grafanaClient := grafana_client.NewHTTPClientWithConfig(strfmt.Default, cfg)
+
+	grafanaCfg := GrafanaConfig{URL: httpServer.URL}
+	ctx := WithGrafanaConfig(context.Background(), grafanaCfg)
+	ctx = WithGrafanaClient(ctx, &GrafanaClient{GrafanaHTTPAPI: grafanaClient})
+	return httpServer, ctx
+}
+
+// scriptedHandler answers with the status codes in sequence (one per call,
+// repeating the last for any call beyond the sequence's length), regardless
+// of HTTP method. It's used to simulate a datasource's probe endpoint
+// behaving transiently or deterministically across retry attempts.
+func scriptedHandler(t *testing.T, statuses ...int) (http.HandlerFunc, func() int32) {
+	t.Helper()
+	var calls int32
+	return func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		idx := int(n) - 1
+		if idx >= len(statuses) {
+			idx = len(statuses) - 1
+		}
+		w.WriteHeader(statuses[idx])
+	}, func() int32 { return atomic.LoadInt32(&calls) }
+}
+
+func TestDiscoverMCPDatasources_ProbeRetry(t *testing.T) {
+	t.Run("transient failure then success is retried and included", func(t *testing.T) {
+		handler, callCount := scriptedHandler(t, http.StatusServiceUnavailable, http.StatusOK)
+		_, ctx := newFakeGrafana(t, fakeDatasource{uid: "flaky", name: "Flaky Tempo", handler: handler})
+
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, candidateCount)
+		require.Len(t, discovered, 1)
+		assert.Equal(t, "flaky", discovered[0].UID)
+		assert.Equal(t, int32(2), callCount(), "probe should be retried exactly once after the transient 503")
+	})
+
+	t.Run("deterministic 404 is excluded without retry", func(t *testing.T) {
+		handler, callCount := scriptedHandler(t, http.StatusNotFound)
+		_, ctx := newFakeGrafana(t, fakeDatasource{uid: "unsupported", name: "Not MCP", handler: handler})
+
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, candidateCount)
+		assert.Empty(t, discovered)
+		assert.Equal(t, int32(1), callCount(), "a clean 404 must not be retried")
+	})
+
+	t.Run("persistent transient failure exhausts retries and is excluded", func(t *testing.T) {
+		handler, callCount := scriptedHandler(t, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable)
+		_, ctx := newFakeGrafana(t, fakeDatasource{uid: "down", name: "Down Tempo", handler: handler})
+
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, candidateCount)
+		assert.Empty(t, discovered)
+		assert.Equal(t, int32(mcpRetryMaxAttempts), callCount(), "probe should stop retrying at mcpRetryMaxAttempts")
+	})
+
+	t.Run("independent candidates succeed and fail independently", func(t *testing.T) {
+		goodHandler, goodCalls := scriptedHandler(t, http.StatusOK)
+		badHandler, badCalls := scriptedHandler(t, http.StatusNotFound)
+		_, ctx := newFakeGrafana(t,
+			fakeDatasource{uid: "good", name: "Good Tempo", handler: goodHandler},
+			fakeDatasource{uid: "bad", name: "Bad Tempo", handler: badHandler},
+		)
+
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, candidateCount)
+		require.Len(t, discovered, 1)
+		assert.Equal(t, "good", discovered[0].UID)
+		assert.Equal(t, int32(1), goodCalls())
+		assert.Equal(t, int32(1), badCalls())
+	})
+}
+
+func TestBuildProxiedToolSet_ConnectFailureExcludedOthersSucceed(t *testing.T) {
+	// "good" is a real, working MCP server: probing and connecting to it must
+	// succeed. Each "bad-N" answers the probe (200, so it's discovered) but
+	// always fails the connect handshake (503) after a delay, so each must be
+	// retried then excluded without blocking "good" or each other.
+	goodMCPServer := server.NewMCPServer("good-tempo", "0.0.0")
+	goodMCPServer.AddTool(mcp.NewTool("example"), func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return nil, nil
+	})
+	goodStreamable := server.NewStreamableHTTPServer(goodMCPServer, server.WithStateLess(true))
+
+	const (
+		badCount = 4
+		badDelay = 400 * time.Millisecond
+	)
+	slowFailingHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			// Answer the discovery probe successfully so this candidate is
+			// discovered and buildProxiedToolSet actually attempts to connect.
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		time.Sleep(badDelay)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	dss := []fakeDatasource{{uid: "good", name: "Good Tempo", handler: goodStreamable}}
+	for i := 0; i < badCount; i++ {
+		dss = append(dss, fakeDatasource{
+			uid:     fmt.Sprintf("bad-%d", i),
+			name:    fmt.Sprintf("Bad Tempo %d", i),
+			handler: http.HandlerFunc(slowFailingHandler),
+		})
+	}
+	_, ctx := newFakeGrafana(t, dss...)
+
+	sm := NewSessionManager()
+	t.Cleanup(sm.Close)
+	tm := NewToolManager(sm, server.NewMCPServer("test", "0.0.0"), WithProxiedTools(true))
+
+	start := time.Now()
+	built, err := tm.buildProxiedToolSet(ctx, slog.Default())
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+
+	assert.Equal(t, buildStats{candidates: badCount + 1, discovered: badCount + 1, connectFailed: badCount}, built.stats)
+	require.Len(t, built.clients, 1)
+	_, hasGood := built.clients["tempo_good"]
+	assert.True(t, hasGood, "the working datasource must still be connected")
+
+	// Each bad candidate takes mcpRetryMaxAttempts*badDelay to exhaust its
+	// retries (~800ms here). Sequentially, badCount of them would compound to
+	// ~badCount*mcpRetryMaxAttempts*badDelay (~3.2s); concurrently, they all
+	// exhaust their retries in parallel, so total time stays close to a
+	// single candidate's worst case regardless of badCount.
+	assert.Less(t, elapsed, time.Duration(badCount)*time.Duration(mcpRetryMaxAttempts)*badDelay,
+		"connecting to datasources must happen concurrently, not sequentially")
+}

--- a/proxied_tools_discovery_test.go
+++ b/proxied_tools_discovery_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // fakeDatasource describes one tempo-type datasource to serve from the fake
@@ -97,7 +99,7 @@ func TestDiscoverMCPDatasources_ProbeRetry(t *testing.T) {
 		handler, callCount := scriptedHandler(t, http.StatusServiceUnavailable, http.StatusOK)
 		_, ctx := newFakeGrafana(t, fakeDatasource{uid: "flaky", name: "Flaky Tempo", handler: handler})
 
-		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, candidateCount)
@@ -110,7 +112,7 @@ func TestDiscoverMCPDatasources_ProbeRetry(t *testing.T) {
 		handler, callCount := scriptedHandler(t, http.StatusNotFound)
 		_, ctx := newFakeGrafana(t, fakeDatasource{uid: "unsupported", name: "Not MCP", handler: handler})
 
-		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, candidateCount)
@@ -122,7 +124,7 @@ func TestDiscoverMCPDatasources_ProbeRetry(t *testing.T) {
 		handler, callCount := scriptedHandler(t, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable)
 		_, ctx := newFakeGrafana(t, fakeDatasource{uid: "down", name: "Down Tempo", handler: handler})
 
-		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, candidateCount)
@@ -138,7 +140,7 @@ func TestDiscoverMCPDatasources_ProbeRetry(t *testing.T) {
 			fakeDatasource{uid: "bad", name: "Bad Tempo", handler: badHandler},
 		)
 
-		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, candidateCount, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, candidateCount)
@@ -147,6 +149,33 @@ func TestDiscoverMCPDatasources_ProbeRetry(t *testing.T) {
 		assert.Equal(t, int32(1), goodCalls())
 		assert.Equal(t, int32(1), badCalls())
 	})
+}
+
+// TestDiscoverMCPDatasources_MetricsUseInjectedMeterProvider verifies that
+// newDiscoveryMetrics routes its instruments to an explicitly given provider
+// instead of the (possibly noop) global one, so discovery/connect metrics
+// reach a scrapeable registry in deployments that reset
+// otel.GetMeterProvider() for reasons unrelated to mcp-grafana (see issue
+// #1072).
+func TestDiscoverMCPDatasources_MetricsUseInjectedMeterProvider(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	handler, _ := scriptedHandler(t, http.StatusOK)
+	_, ctx := newFakeGrafana(t, fakeDatasource{uid: "good", name: "Good Tempo", handler: handler})
+
+	_, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(provider))
+	require.NoError(t, err)
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+	require.Len(t, data.ScopeMetrics, 1)
+
+	names := make(map[string]bool)
+	for _, m := range data.ScopeMetrics[0].Metrics {
+		names[m.Name] = true
+	}
+	assert.True(t, names["mcp.discovery.probe_success"])
 }
 
 func TestBuildProxiedToolSet_ConnectFailureExcludedOthersSucceed(t *testing.T) {

--- a/session_test.go
+++ b/session_test.go
@@ -67,7 +67,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 	ctx := newProxiedToolsTestContext(t)
 
 	t.Run("discovers tempo datasources", func(t *testing.T) {
-		discovered, err := discoverMCPDatasources(ctx, slog.Default())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
 		require.NoError(t, err)
 
 		// Should find two Tempo datasources from docker-compose
@@ -93,7 +93,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 
 	t.Run("returns error when grafana client not in context", func(t *testing.T) {
 		emptyCtx := context.Background()
-		discovered, err := discoverMCPDatasources(emptyCtx, slog.Default())
+		discovered, _, err := discoverMCPDatasources(emptyCtx, slog.Default(), newDiscoveryMetrics())
 		assert.Error(t, err)
 		assert.Nil(t, discovered)
 		assert.Contains(t, err.Error(), "grafana client not found in context")
@@ -113,7 +113,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), grafanaCfg)
 		ctx = WithGrafanaClient(ctx, &GrafanaClient{GrafanaHTTPAPI: grafanaClient})
 
-		discovered, err := discoverMCPDatasources(ctx, slog.Default())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
 		assert.Error(t, err)
 		assert.Nil(t, discovered)
 		assert.Contains(t, err.Error(), "Unauthorized")
@@ -228,7 +228,7 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 
 	t.Run("full flow from discovery to tool call", func(t *testing.T) {
 		// Step 1: Discover MCP datasources
-		discovered, err := discoverMCPDatasources(ctx, slog.Default())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(discovered), 1, "Should discover at least one Tempo datasource")
 
@@ -298,7 +298,7 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 	})
 
 	t.Run("multiple datasources in single session", func(t *testing.T) {
-		discovered, err := discoverMCPDatasources(ctx, slog.Default())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
 		require.NoError(t, err)
 
 		if len(discovered) < 2 {

--- a/session_test.go
+++ b/session_test.go
@@ -67,7 +67,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 	ctx := newProxiedToolsTestContext(t)
 
 	t.Run("discovers tempo datasources", func(t *testing.T) {
-		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		require.NoError(t, err)
 
 		// Should find two Tempo datasources from docker-compose
@@ -93,7 +93,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 
 	t.Run("returns error when grafana client not in context", func(t *testing.T) {
 		emptyCtx := context.Background()
-		discovered, _, err := discoverMCPDatasources(emptyCtx, slog.Default(), newDiscoveryMetrics())
+		discovered, _, err := discoverMCPDatasources(emptyCtx, slog.Default(), newDiscoveryMetrics(nil))
 		assert.Error(t, err)
 		assert.Nil(t, discovered)
 		assert.Contains(t, err.Error(), "grafana client not found in context")
@@ -113,7 +113,7 @@ func TestDiscoverMCPDatasources(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), grafanaCfg)
 		ctx = WithGrafanaClient(ctx, &GrafanaClient{GrafanaHTTPAPI: grafanaClient})
 
-		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		assert.Error(t, err)
 		assert.Nil(t, discovered)
 		assert.Contains(t, err.Error(), "Unauthorized")
@@ -228,7 +228,7 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 
 	t.Run("full flow from discovery to tool call", func(t *testing.T) {
 		// Step 1: Discover MCP datasources
-		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(discovered), 1, "Should discover at least one Tempo datasource")
 
@@ -298,7 +298,7 @@ func TestEndToEndProxiedToolsFlow(t *testing.T) {
 	})
 
 	t.Run("multiple datasources in single session", func(t *testing.T) {
-		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics())
+		discovered, _, err := discoverMCPDatasources(ctx, slog.Default(), newDiscoveryMetrics(nil))
 		require.NoError(t, err)
 
 		if len(discovered) < 2 {


### PR DESCRIPTION
## Summary
- Production traces/logs showed the hosted MCP server intermittently exposing only a fraction of a customer's Tempo datasources — the per-candidate MCP-support probe and client-connect steps each got exactly one attempt, so a single timeout/transient error silently excluded a datasource while the overall build was still reported as fully successful.
- Add a shared `withRetry`/`transientError` primitive; retry transient probe (timeout/network/5xx) and connect failures, but not deterministic ones (a clean 404, or an auth rejection).
- Parallelize `buildProxiedToolSet`'s connect loop (previously sequential), mirroring the concurrency pattern the probe step already used in the same file.
- Add OTel counters for probe/connect outcomes, plus `candidates`/`discovered`/`connect_failed` fields on the existing `"built proxied tool set"` summary log — these failures were previously only visible via Debug-level logs or by pulling a trace.

Scope is deliberately narrow: no changes to the `proxiedToolSet` cache itself, session affinity, the mark3labs→official-SDK migration, or the stdio-path (`InitializeAndRegisterServerTools`) connect loop, which has the same gap but isn't on the path the reported bug goes through — flagging that as a follow-up.

**Known limitation:** the new `discoveryMetrics` OTel counters follow the exact same pattern as the existing `clientCacheMetrics`/`sessionMetrics` (read the *global* `otel.GetMeterProvider()`), which turns out to be a silent no-op in the hosted deployment — grafana-assistant-app installs a `noop.MeterProvider` globally on purpose (to dodge an otelhttp memory-leak bug) before mcp-grafana code runs, and does its own metrics via `prometheus/client_golang` instead. The `candidates`/`discovered`/`connect_failed` log fields work unconditionally and are the actual observability win here; the metrics are correctly structured and will start working once the meter is made injectable. Tracked as a follow-up in #1072 (covers all three metric groups, not just this PR's addition).

## Test plan
- [x] `proxied_client_test.go` — pure unit tests for `withRetry`/`classifyConnectError`/`isTransient` (success-first-try, deterministic-no-retry, transient-then-success, exhausts-retries, context-cancelled-during-backoff, auth-error classification)
- [x] `proxied_tools_discovery_test.go` — httptest-based tests: probe retries transient (503) but not deterministic (404) failures; `buildProxiedToolSet` connects to a working datasource while several slow-failing ones are retried-then-excluded concurrently (asserts wall-clock time rules out a sequential regression)
- [x] `session_test.go` integration call sites updated for the new `discoverMCPDatasources` signature
- [x] `go build`/`go vet` clean (default and `-tags integration`)
- [x] `go test ./... -race` passes
- [x] `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)