### PR TITLE
fix(metrics): make client cache and session OTel meters injectable

### DIFF
--- a/client_cache.go
+++ b/client_cache.go
@@ -77,8 +77,32 @@ type clientCacheMetrics struct {
 	size    metric.Int64Gauge   // Current number of cached clients
 }
 
-func newClientCacheMetrics() clientCacheMetrics {
-	meter := otel.GetMeterProvider().Meter(clientCacheMeterName)
+// clientCacheConfig holds configuration gathered from ClientCacheOptions.
+type clientCacheConfig struct {
+	meterProvider metric.MeterProvider
+}
+
+// ClientCacheOption configures a ClientCache created via NewClientCache.
+type ClientCacheOption func(*clientCacheConfig)
+
+// WithClientCacheMeterProvider sets the metric.MeterProvider used to create
+// the client cache's OTel instruments. If unset (or passed as nil), the
+// cache falls back to otel.GetMeterProvider(), matching the pre-existing
+// behavior. Callers embedding mcp-grafana as a library and running with a
+// non-global MeterProvider (e.g. because the process resets the global
+// provider to a noop for unrelated reasons) should pass their own provider
+// here so these metrics actually reach a scrapeable registry.
+func WithClientCacheMeterProvider(mp metric.MeterProvider) ClientCacheOption {
+	return func(c *clientCacheConfig) {
+		c.meterProvider = mp
+	}
+}
+
+func newClientCacheMetrics(mp metric.MeterProvider) clientCacheMetrics {
+	if mp == nil {
+		mp = otel.GetMeterProvider()
+	}
+	meter := mp.Meter(clientCacheMeterName)
 
 	lookups, _ := meter.Int64Counter("mcp.client_cache.lookups",
 		metric.WithDescription("Total number of client cache lookups"),
@@ -127,15 +151,19 @@ type ClientCache struct {
 }
 
 // NewClientCache creates a new client cache.
-func NewClientCache(logger *slog.Logger) *ClientCache {
+func NewClientCache(logger *slog.Logger, opts ...ClientCacheOption) *ClientCache {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	var cfg clientCacheConfig
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 	return &ClientCache{
 		grafanaClients:  make(map[clientCacheKey]*GrafanaClient),
 		incidentClients: make(map[clientCacheKey]*incident.Client),
 		k8sClients:      make(map[clientCacheKey]*KubernetesClient),
-		metrics:         newClientCacheMetrics(),
+		metrics:         newClientCacheMetrics(cfg.meterProvider),
 		logger:          logger,
 	}
 }

--- a/client_cache_test.go
+++ b/client_cache_test.go
@@ -1,6 +1,7 @@
 package mcpgrafana
 
 import (
+	"context"
 	"net/url"
 	"sync"
 	"testing"
@@ -8,6 +9,8 @@ import (
 	"github.com/grafana/incident-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestClientCache_GrafanaClient(t *testing.T) {
@@ -171,4 +174,39 @@ func TestClientCache_Close(t *testing.T) {
 	g, i, _ = cache.Size()
 	assert.Equal(t, 0, g)
 	assert.Equal(t, 0, i)
+}
+
+// TestClientCache_MetricsUseInjectedMeterProvider verifies that
+// WithClientCacheMeterProvider routes the cache's instruments to the given
+// provider instead of the (possibly noop) global one, so metrics reach a
+// scrapeable registry in deployments that reset otel.GetMeterProvider() for
+// reasons unrelated to mcp-grafana (see issue #1072).
+func TestClientCache_MetricsUseInjectedMeterProvider(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	cache := NewClientCache(nil, WithClientCacheMeterProvider(provider))
+	defer cache.Close()
+
+	key := clientCacheKey{url: "http://localhost:3000", apiKey: "key", orgID: 1}
+	cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {
+		return &GrafanaClient{}
+	})
+	// Second lookup for the same key should record a hit.
+	cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {
+		return &GrafanaClient{}
+	})
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+	require.Len(t, data.ScopeMetrics, 1)
+
+	names := make(map[string]bool)
+	for _, m := range data.ScopeMetrics[0].Metrics {
+		names[m.Name] = true
+	}
+	assert.True(t, names["mcp.client_cache.lookups"])
+	assert.True(t, names["mcp.client_cache.hits"])
+	assert.True(t, names["mcp.client_cache.misses"])
+	assert.True(t, names["mcp.client_cache.size"])
 }

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -301,7 +301,8 @@ func (dt *disabledTools) buildInstructions() string {
 
 func newServer(serverName, transport string, dt disabledTools, obs *observability.Observability, sessionIdleTimeoutMinutes int) (*server.MCPServer, *mcpgrafana.ToolManager, *mcpgrafana.SessionManager) {
 	sm := mcpgrafana.NewSessionManager(
-		mcpgrafana.WithSessionTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute),
+		mcpgrafana.WithSessionTTL(time.Duration(sessionIdleTimeoutMinutes)*time.Minute),
+		mcpgrafana.WithSessionMeterProvider(obs.MeterProvider()),
 	)
 
 	// Declare variables that will be initialized after server creation.
@@ -615,7 +616,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 	// transport allocation (see https://github.com/grafana/mcp-grafana/issues/682).
 	var clientCache *mcpgrafana.ClientCache
 	if transport != "stdio" {
-		clientCache = mcpgrafana.NewClientCache(nil)
+		clientCache = mcpgrafana.NewClientCache(nil, mcpgrafana.WithClientCacheMeterProvider(o.MeterProvider()))
 		defer clientCache.Close()
 	}
 

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
@@ -812,4 +813,20 @@ func (o *Observability) LoggerProvider() *sdklog.LoggerProvider {
 // not set).
 func (o *Observability) TracerProvider() *sdktrace.TracerProvider {
 	return o.tracerProvider
+}
+
+// MeterProvider returns the metric.MeterProvider backing this Observability
+// instance's metrics, or nil if metrics are not enabled (Config.MetricsEnabled
+// was false). Pass the result into mcp-grafana constructors that accept a
+// meter provider (e.g. NewClientCache's WithClientCacheMeterProvider,
+// NewSessionManager's WithSessionMeterProvider) so their metrics are recorded
+// against this provider explicitly, rather than relying on those constructors
+// reading otel.GetMeterProvider() at construction time — which silently
+// becomes a no-op in any process that installs its own global provider (e.g.
+// a noop one) for reasons unrelated to mcp-grafana.
+func (o *Observability) MeterProvider() metric.MeterProvider {
+	if o.meterProvider == nil {
+		return nil
+	}
+	return o.meterProvider
 }

--- a/session.go
+++ b/session.go
@@ -26,8 +26,11 @@ type sessionMetrics struct {
 	sessionsReaped metric.Int64Counter // Total sessions removed by the reaper
 }
 
-func newSessionMetrics() sessionMetrics {
-	meter := otel.GetMeterProvider().Meter(sessionMeterName)
+func newSessionMetrics(mp metric.MeterProvider) sessionMetrics {
+	if mp == nil {
+		mp = otel.GetMeterProvider()
+	}
+	meter := mp.Meter(sessionMeterName)
 
 	active, _ := meter.Int64Gauge("mcp.sessions.active",
 		metric.WithDescription("Current number of active MCP sessions"),
@@ -100,16 +103,30 @@ func WithSessionLogger(logger *slog.Logger) SessionManagerOption {
 	}
 }
 
+// WithSessionMeterProvider sets the metric.MeterProvider used to create the
+// SessionManager's OTel instruments. If unset (or passed as nil), the
+// SessionManager falls back to otel.GetMeterProvider(), matching the
+// pre-existing behavior. Callers embedding mcp-grafana as a library and
+// running with a non-global MeterProvider (e.g. because the process resets
+// the global provider to a noop for unrelated reasons) should pass their own
+// provider here so these metrics actually reach a scrapeable registry.
+func WithSessionMeterProvider(mp metric.MeterProvider) SessionManagerOption {
+	return func(sm *SessionManager) {
+		sm.meterProvider = mp
+	}
+}
+
 // SessionManager manages client sessions and their state
 type SessionManager struct {
-	sessions   map[string]*SessionState
-	mutex      sync.RWMutex
-	sessionTTL time.Duration
-	stopReaper chan struct{}
-	reaperDone chan struct{}
-	closeOnce  sync.Once
-	metrics    sessionMetrics
-	logger     *slog.Logger
+	sessions      map[string]*SessionState
+	mutex         sync.RWMutex
+	sessionTTL    time.Duration
+	stopReaper    chan struct{}
+	reaperDone    chan struct{}
+	closeOnce     sync.Once
+	metrics       sessionMetrics
+	meterProvider metric.MeterProvider
+	logger        *slog.Logger
 
 	// mcpServer is an optional reference to the MCP server, used to unregister
 	// sessions from the SDK's internal session map when they are reaped. This
@@ -148,11 +165,11 @@ func NewSessionManager(opts ...SessionManagerOption) *SessionManager {
 		sessionTTL: DefaultSessionTTL,
 		stopReaper: make(chan struct{}),
 		reaperDone: make(chan struct{}),
-		metrics:    newSessionMetrics(),
 	}
 	for _, opt := range opts {
 		opt(sm)
 	}
+	sm.metrics = newSessionMetrics(sm.meterProvider)
 	if sm.logger == nil {
 		sm.logger = slog.Default()
 	}

--- a/session_reaper_test.go
+++ b/session_reaper_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // testClientSession implements server.ClientSession for unit tests.
@@ -126,6 +128,34 @@ func TestSessionManager_CloseIsIdempotent(t *testing.T) {
 	sm := NewSessionManager(WithSessionTTL(100 * time.Millisecond))
 	sm.Close()
 	sm.Close() // Should not panic
+}
+
+// TestSessionManager_MetricsUseInjectedMeterProvider verifies that
+// WithSessionMeterProvider routes the manager's instruments to the given
+// provider instead of the (possibly noop) global one, so metrics reach a
+// scrapeable registry in deployments that reset otel.GetMeterProvider() for
+// reasons unrelated to mcp-grafana (see issue #1072).
+func TestSessionManager_MetricsUseInjectedMeterProvider(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	sm := NewSessionManager(WithSessionTTL(time.Hour), WithSessionMeterProvider(provider))
+	defer sm.Close()
+
+	sm.CreateSession(context.Background(), &testClientSession{id: "session-1"})
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+	require.Len(t, data.ScopeMetrics, 1)
+
+	names := make(map[string]bool)
+	for _, m := range data.ScopeMetrics[0].Metrics {
+		names[m.Name] = true
+	}
+	// mcp.sessions.reaped is omitted from the collected data until Add is
+	// called at least once (no reap happened here), so only assert on the
+	// gauge that CreateSession always records.
+	assert.True(t, names["mcp.sessions.active"])
 }
 
 func TestSessionManager_DisabledReaper(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #1072.

- `clientCacheMetrics` (`client_cache.go`) and `sessionMetrics` (`session.go`) previously built their OTel instruments via `otel.GetMeterProvider().Meter(...)`, reading whatever the *global* MeterProvider happens to be at construction time.
- In the hosted deployment (grafana-assistant-app), the global MeterProvider is deliberately reset to a noop (to dodge an [otelhttp memory-leak bug](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5190)) before mcp-grafana code runs, so these metrics were silently discarded there.
- Adds `WithClientCacheMeterProvider` and `WithSessionMeterProvider` functional options so a caller can inject an explicit `metric.MeterProvider`. Both default to `otel.GetMeterProvider()` when unset, so existing behavior is unchanged for callers that don't opt in.
- Adds `Observability.MeterProvider()` so the standalone CLI (and other embedders) can pass the provider from `observability.Setup` through explicitly, rather than relying on the implicit global. Wired into `cmd/mcp-grafana/main.go`.

## Out of scope

`proxied_tools.go`'s `discoveryMetrics`, mentioned in #1072, was added in #1071, which is still an unmerged draft PR — it doesn't exist on `main` yet, so there's nothing to fix there right now. It should adopt the same `WithXxxMeterProvider` pattern once #1071 lands.

The grafana-assistant-app side (constructing a private `sdkmetric.MeterProvider` wired to `prometheus.DefaultRegisterer` and passing it into `NewMCPServer`) lives in a separate repo and is not part of this PR.

## Testing

- Added `TestClientCache_MetricsUseInjectedMeterProvider` and `TestSessionManager_MetricsUseInjectedMeterProvider`, each using an `sdkmetric.ManualReader`-backed provider to assert the injected provider (not the global one) actually receives the recorded instruments.
- `go build ./...`, `go vet ./...`, `make test-unit`, and `make lint` all pass.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (doc comments on new exported options/getter)
- [x] Linting passes