### PR TITLE
docs: add contributing guide, PR template and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Something isn't working as documented
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this. The version and client fields below are the ones that most often decide whether we can reproduce a problem — several past reports turned out to be already fixed in a later release, so they're worth filling in accurately.
+
+        **Security issues:** please don't report suspected vulnerabilities here. Follow Grafana's [security disclosure process](https://github.com/grafana/mcp-grafana/security/policy) instead.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What you expected, and what happened instead. Paste the full error if there is one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Include the tool call or prompt if the problem is with a specific tool.
+      placeholder: |
+        1. Start the server with `--transport streamable-http`
+        2. Ask the assistant to ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: mcp-grafana version
+      description: |
+        The output of `mcp-grafana --version`, or the Docker image tag. Please check against the [latest release](https://github.com/grafana/mcp-grafana/releases) before filing — if you're several versions behind, it's worth trying a newer one first.
+      placeholder: "v1.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: grafana
+    attributes:
+      label: Grafana version
+      description: And whether it's Grafana Cloud or self-hosted.
+      placeholder: "12.0.1, self-hosted"
+    validations:
+      required: true
+
+  - type: input
+    id: client
+    attributes:
+      label: MCP client
+      description: |
+        Which client you're using, and its version. Some client-side limitations look like server bugs — for example, a client whose proxy rejects a particular schema shape can make tools appear to vanish entirely.
+      placeholder: "Claude Desktop 1.2.3 / Claude Code / custom SDK client"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - stdio
+        - streamable-http
+        - sse
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install it?
+      options:
+        - Docker image
+        - Binary from a GitHub release
+        - Desktop extension (.mcpb / .dxt)
+        - Built from source with `go build` or `make build`
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Operating system and CPU architecture
+      description: Please include the architecture — `arm64` vs `x86_64` matters for the prebuilt binaries and the desktop extension.
+      placeholder: "macOS 15, x86_64 (Intel) / Linux, arm64"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Run with `--debug` if you can. Please redact tokens, URLs and anything else sensitive.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Troubleshooting guide
+    url: https://github.com/grafana/mcp-grafana/blob/main/docs/troubleshooting.md
+    about: Common setup and connection problems — worth checking before filing a bug.
+  - name: Security vulnerability
+    url: https://github.com/grafana/mcp-grafana/security/policy
+    about: Please report suspected vulnerabilities through Grafana's disclosure process, not as a public issue.
+  - name: Grafana documentation
+    url: https://grafana.com/docs/
+    about: For questions about Grafana itself rather than this MCP server.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest an improvement that isn't a new tool
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for CLI flags, auth methods, transports, output formats, performance, docs and anything else that isn't a new MCP tool.
+
+        **Proposing a new tool?** Please use the **New tool proposal** template instead — it asks a few extra questions about naming and cost that we need in order to give you an answer.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Please describe the situation rather than the solution — it often turns out there's an easier way in, or that something already supports it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: How are you working around it today?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you be willing to implement this?
+      description: No obligation at all — it just helps us prioritise, and we'll offer pointers if you'd like to try.
+      options:
+        - "Yes, with some guidance"
+        - "Yes"
+        - "No"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-tool-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/new-tool-proposal.yml
@@ -1,0 +1,99 @@
+name: New tool proposal
+description: Propose a new MCP tool, or a change to an existing tool's name or input/output shape
+title: "[Tool proposal]: "
+labels: ["tool proposal", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a tool.
+
+        **Please open this before writing the code.** Every default-on tool is sent to the model on every request by every user, so adding one is a shared cost we have to weigh. We would much rather discuss the idea here than decline a finished pull request — see [CONTRIBUTING.md](https://github.com/grafana/mcp-grafana/blob/main/CONTRIBUTING.md).
+
+        If you've already written it, that's fine — link the PR at the bottom and we'll review the idea first.
+
+        Not proposing a new tool? Use the **Bug report** or **Feature request** templates instead. Bug fixes, docs, tests and new parameters on existing tools don't need a proposal at all.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What question should this tool let a user answer?
+      description: Phrase it as something a person would ask their assistant, not as an API endpoint.
+      placeholder: "Which of my alert rules fired most often last week?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: existing
+    attributes:
+      label: Why can't an existing tool do this?
+      description: |
+        Please check the [tool table in the README](https://github.com/grafana/mcp-grafana#tools) first. If an existing tool is close, could it take one more optional parameter instead? Extending a tool is far cheaper than adding one, so this is the question most likely to change our answer.
+      placeholder: "`list_alert_groups` returns groups but has no way to filter by ..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Which tier are you proposing?
+      description: |
+        **Default-on** means every user pays for it in every request, so the bar is "useful to most people using Grafana through an MCP client". **Opt-in** means it ships behind `--enabled-tools` and costs nothing to anyone who doesn't enable it — the bar is much lower, and most new tools belong here.
+
+        Niche, datasource-specific, Cloud-only, plugin-dependent or administrative tools should be opt-in. Proposing opt-in yourself makes this much easier to say yes to.
+      options:
+        - Opt-in category (behind --enabled-tools)
+        - Default-on (part of the default tool set)
+        - Not sure — happy to be advised
+    validations:
+      required: true
+
+  - type: input
+    id: category
+    attributes:
+      label: Which category would it live in?
+      description: An existing category from the README table, or a new one if you're proposing a new opt-in group.
+      placeholder: "loki, or a new `tempo` category"
+    validations:
+      required: true
+
+  - type: textarea
+    id: shape
+    attributes:
+      label: Proposed name, inputs and outputs
+      description: |
+        A rough sketch is fine. Names are permanent once shipped, so it's worth getting right here rather than in review. Keep descriptions and schemas as small as they can be while still being usable — that's the token cost.
+      placeholder: |
+        Name: list_tempo_services
+        Inputs: datasourceUid (required), start/end (optional)
+        Output: array of service names
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: writes
+    attributes:
+      label: Does it modify anything in Grafana?
+      description: Anything that creates, updates or deletes must be gated behind `--disable-write`.
+      options:
+        - "No — read-only"
+        - "Yes — it creates, updates or deletes something"
+    validations:
+      required: true
+
+  - type: input
+    id: rbac
+    attributes:
+      label: Required RBAC permissions and scopes
+      description: Needed for the README tool table. Leave blank if you're not sure and we'll help.
+      placeholder: "`alert.rules:read`, scope `folders:*`"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: |
+        Who asked for this, whether you're willing to implement it, a link to an existing PR or prototype, or how you're working around it today. If you used an AI assistant to explore this, that's completely fine — please just say so, and make sure you've read what it produced.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Fixes #
 | --- | --- | --- |
 | `` | new / changed | default-on / opt-in category |
 
-**Token cost:** <!-- The Token Analysis check will comment this automatically — no need to fill it in unless you want to explain a large delta. -->
+**Token cost:** <!-- From the Token Analysis check's run summary, or `make token-check` locally. Please paste the change if this adds a default-on tool — it's the most useful number for reviewing the proposal. -->
 
 **Why not extend an existing tool?** <!-- Only needed for new tools. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!--
+Thanks for contributing! A few notes before you submit:
+
+  - Adding a new tool, or changing a tool's name or input/output shape?
+    Please open a new tool proposal issue first and link it below.
+    See CONTRIBUTING.md — we'd rather discuss the idea than decline a finished PR.
+
+  - Bug fix, docs, tests, or a new parameter on an existing tool?
+    No issue needed. Delete the "New or changed tools" section and send it.
+-->
+
+## What this changes
+
+<!-- One or two sentences. What problem does this solve, and for whom? -->
+
+Fixes #
+
+## New or changed tools
+
+<!-- Delete this whole section if you aren't adding or changing a tool. -->
+
+**Proposal issue:** #
+
+| Tool name | New or changed | Proposed tier |
+| --- | --- | --- |
+| `` | new / changed | default-on / opt-in category |
+
+**Token cost:** <!-- The Token Analysis check will comment this automatically — no need to fill it in unless you want to explain a large delta. -->
+
+**Why not extend an existing tool?** <!-- Only needed for new tools. -->
+
+**Read-only safety:** <!-- If this tool writes anything, confirm it's gated behind `--disable-write`. -->
+
+## How you tested it
+
+<!--
+What did you actually run this against? A real Grafana instance, the docker-compose
+test stack, unit tests only? Reviewers here often test against a live instance,
+so anything that helps them reproduce your setup is genuinely useful.
+-->
+
+## Checklist
+
+- [ ] `make lint` and `make test-unit` pass locally
+- [ ] Commits are signed (required to merge — see CONTRIBUTING.md)
+- [ ] CLA signed (required to merge)
+- [ ] README tool table updated, with RBAC permissions and scopes, if this adds a tool
+- [ ] Any write operation respects `--disable-write`
+
+<!--
+Note on CI: workflow runs on fork PRs need manual maintainer approval, on every
+push. If your checks look stuck, they're waiting on us, not on you.
+`Test Cloud` and the Python E2E suites are informational and cannot pass from a
+fork — a red mark there is expected and won't block your merge.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,9 @@ A PR that is easy to generate can still be expensive to review. The proposal ste
 
 ## Measuring the token cost
 
-CI runs a **Token Analysis** check on every pull request. It compares your branch against the current baseline, comments the difference, and fails above a 5% increase. You don't need to do anything to get this — it runs on fork pull requests too.
+CI runs a **Token Analysis** check on every pull request, including from forks. It compares your branch against the current baseline and fails above a 5% increase.
+
+To see the numbers, open that check's run and read its summary — you'll get the baseline, the new total, the change, and a per-tool breakdown of what was added or modified. It isn't posted as a comment, so it's worth knowing where to look.
 
 If you want the number before you push, or you're weighing two designs against each other:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to the Grafana MCP server
+
+Thanks for wanting to contribute. This document covers **what belongs in this server and how to propose it**. For build, test and lint mechanics, see [DEVELOPING.md](DEVELOPING.md).
+
+Please read the section below before writing a new tool. It will save you time, and it means we can say yes faster.
+
+## The one thing to understand first
+
+Every tool in the default set is sent to the model on **every request, by every user, forever**. A tool's name, description and JSON schema are spent out of a context budget that users also want to spend on their actual data.
+
+That makes a new tool different from most contributions: it isn't free to add and then ignore. A tool nobody uses still costs everybody. This is a real, measured constraint, not a stylistic preference — CI reports the token cost of every PR, and shrinking the server is an [open request from users](https://github.com/grafana/mcp-grafana/issues/569).
+
+So the interesting question is never only "does this work?" It's "**should everyone pay for this?**" — and there are three possible answers.
+
+## New tools need an issue first
+
+**Before you write a new tool, please [open a new tool proposal](https://github.com/grafana/mcp-grafana/issues/new?template=new-tool-proposal.yml) and wait for a maintainer to agree with the approach.**
+
+We know this is friction, and we're asking for it anyway for one reason: **we would much rather say "not like this" to a three-paragraph issue than to your finished pull request.** Declining completed work is a bad outcome for everyone, and it has happened here more than once.
+
+This applies to:
+
+- net-new tools, and
+- changes to a tool's name, or to the shape of its inputs or outputs.
+
+It does **not** apply to (please just send a PR):
+
+- bug fixes
+- documentation
+- tests
+- performance and reliability work
+- adding a parameter to an existing tool, where the tool's purpose doesn't change
+
+If you have already written the code, that's fine — open the proposal anyway and link it. We'll review the idea before the diff.
+
+## The three tiers
+
+Not every good idea has to be in everyone's context window. The server already supports shipping a tool that costs nothing to people who don't want it, and **that is where most new tools should land**.
+
+| Tier | How it ships | The bar | Cost to other users |
+| --- | --- | --- | --- |
+| **Default-on** | Registered in the default category set | Useful to *most* people using Grafana through an MCP client | Everyone pays, every request |
+| **Opt-in category** | Behind `--enabled-tools` | Coherent, with a real audience | **Zero** |
+| **Not in this server** | — | — | — |
+
+The default-on bar is deliberately high, because it is the only tier that spends a shared budget. The opt-in bar is much lower: if your tool is genuinely useful to a subset of users, it can almost certainly ship as an opt-in category. That is not a consolation prize — 12 of the server's 33 categories already work this way, including `admin`, `cloudwatch`, `clickhouse`, `athena`, `snowflake`, `graphite`, `elasticsearch`, `quickwit`, `examples`, `runpanelquery`, `agento11y` and `assistant`.
+
+Good reasons for a tool to be opt-in rather than default-on:
+
+- it targets one datasource type that most users don't have
+- it only works on Grafana Cloud, or only with a plugin installed
+- it's for operators or administrators rather than everyday querying
+- it's powerful enough that some users will want it off
+
+If you're proposing something niche, **propose it as opt-in yourself**. It makes the decision much easier to say yes to.
+
+## Prefer extending a tool over adding one
+
+Each tool carries fixed overhead: a name, a description, and a schema, all of them permanent. An extra optional parameter on a tool that already exists carries almost none.
+
+Before adding a tool, please check whether an existing one could answer the same question with one more argument, or whether several related operations could be a single tool with a `action`-style parameter. `alerting_manage_rules` and `alerting_manage_routing` are examples of the latter in this repo.
+
+If two open PRs would add overlapping tools, we'd rather consolidate them before merging than ship both and deprecate one later. Searching [open pull requests](https://github.com/grafana/mcp-grafana/pulls) for your tool's area before you start is genuinely worth the two minutes — it has saved contributors here from duplicating each other's work.
+
+## A note on AI-assisted contributions
+
+These are welcome, and plenty of good contributions to this repo were written with an agent's help. Two requests:
+
+1. **Please read and understand the diff before you send it.** We will ask questions about design decisions, and "the agent chose that" is a difficult place to review from.
+2. **The tiering question above is the part an agent is least likely to get right.** An agent asked to add a feature will add a feature. Whether *everyone* should pay for it is a judgement about this project's users, and it needs a human — which is exactly why we ask for the issue first.
+
+A PR that is easy to generate can still be expensive to review. The proposal step is how we keep that cost from landing on you as a rejection.
+
+## Measuring the token cost
+
+CI runs a **Token Analysis** check on every pull request. It compares your branch against the current baseline, comments the difference, and fails above a 5% increase. You don't need to do anything to get this — it runs on fork pull requests too.
+
+If you want the number before you push, or you're weighing two designs against each other:
+
+```bash
+make token-baseline   # once, on main
+make token-check      # on your branch
+```
+
+A tool's cost is almost entirely its description and its JSON schema. If your delta looks larger than you expected, that's usually where to trim — long parameter descriptions and deeply nested schemas are the expensive parts.
+
+## Conventions that CI enforces
+
+Run `make lint` and `make test-unit` before pushing. The specifics:
+
+- **Signed commits are required.** Every commit must have a verified signature — this is [an organisation-wide Grafana policy](https://community.grafana.com/t/action-required-signed-commits-mandatory-for-all-grafana-repositories/163404). Setting this up once saves a round trip later; it is the most common reason a finished PR sits unmerged here.
+- **The CLA must be signed.** It's a required check, so nothing can merge without it, however good the code is.
+- **Conventional commit messages** — `feat(tools):`, `fix(loki):`, `docs:` and so on.
+- **Commas inside `jsonschema` struct tags must be escaped.** There's a dedicated linter because it's easy to get wrong: `make lint-jsonschema-fix` will fix it for you.
+- **No bare boolean sub-schemas.** An `any` or `interface{}` field makes the schema reflector emit `true`, which breaks some MCP clients outright. Tool creation panics if this happens; add the type to the reflector's `Mapper` in `tools.go`.
+- **Pass `context.Context` through Grafana API client calls** — enforced by `make lint-openapi`.
+- **Write tools must respect `--disable-write`.** Any tool that creates, updates or deletes anything must be registered so that it disappears when the server runs read-only. Take the `enableWriteTools` parameter in your category's `Add*Tools` function.
+- **New tools need a row in the README's tool table**, including the category and the required RBAC permissions and scopes.
+
+The checks that must pass to merge are `license/cla`, `Test Unit`, `Test Integration`, `Lint Go`, `Lint JSON Schemas`, `docker` and `docker-alpine`. `Test Cloud` and the Python E2E suites are informational — `Test Cloud` cannot pass from a fork at all, because it needs credentials, so please don't worry about it being red.
+
+## What you can expect from us
+
+- **Your CI will not start on its own.** For security reasons, workflow runs on pull requests from forks require manual maintainer approval — and that applies to *every push*, not just your first. If your checks show as pending or never seem to start, you are not being ignored; it needs one of us to click. Feel free to comment if it's been a while.
+- **We'll tell you the tier.** If we ask for your tool to be opt-in rather than default-on, that's a yes with a placement, not a rejection.
+- **If we're going to say no, we'll try to say it on the issue, not on your PR.** That's the whole point of proposing first.
+
+Thanks — the constraint this document describes exists because people rely on this server being fast and cheap to load, and that's worth protecting.

--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,9 @@ This typically indicates that you are using a Grafana version earlier than 9.0. 
 
 ## Development
 
-Contributions are welcome! Please open an issue or submit a pull request if you have any suggestions or improvements.
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first — it covers what belongs in this server and how to propose it.
+
+If you're **adding a new tool**, please [open a tool proposal](https://github.com/grafana/mcp-grafana/issues/new?template=new-tool-proposal.yml) before writing the code. Every default-on tool is sent to the model on every request by every user, so we'd rather discuss the idea than decline a finished pull request. Bug fixes, docs, tests and new parameters on existing tools need no proposal — just send a PR.
 
 This project is written in Go. Install Go following the instructions for your platform.
 


### PR DESCRIPTION
## What this changes

Documents what belongs in this server and how to propose it. There is currently no `CONTRIBUTING.md`, no PR template and no issue templates, so the criteria for "should this tool exist" live only in maintainers' heads and get applied at review time — after a contributor has finished the work.

## Why

Every default-on tool is sent to the model on every request, by every user. That makes a new tool unlike most contributions: it isn't free to add and then ignore. Generating a plausible tool PR has also become very cheap, while evaluating one has not — so the queue fills faster than taste can be applied one diff at a time.

Rather than invent a policy, this leans on a mechanism the server already has: **12 of its 33 tool categories ship disabled by default**. So the question isn't yes/no, it's which of three tiers a tool belongs in:

| Tier | Bar | Cost to other users |
| --- | --- | --- |
| Default-on | useful to *most* users | everyone pays, every request |
| Opt-in via `--enabled-tools` | coherent, real audience | **zero** |
| Not in this server | — | — |

The opt-in tier is the important one. It turns "no, that's too niche and too expensive" into "yes, as an opt-in category" — same outcome for the default token budget, much better outcome for the contributor. The guide says explicitly that opt-in is not a consolation prize, and encourages contributors to propose it themselves.

The other substantive ask: **new tools need a proposal issue before the code**. We would much rather decline a three-paragraph issue than a finished PR.

## What's in it

- **`CONTRIBUTING.md`** — the tiering decision, the proposal-first requirement, prefer-extending-over-adding, a short note on AI-assisted contributions, and the conventions CI enforces (signed commits, CLA, `jsonschema` comma escaping, no bare boolean sub-schemas, `--disable-write` gating, README tool table).
- **`new-tool-proposal.yml`** — asks what question the tool answers, why an existing tool can't be extended, the proposed tier, and whether it writes.
- **`bug-report.yml`** — requires the fields our reports most often lack: mcp-grafana version, Grafana version, MCP client + version, transport, install method, and OS/CPU architecture. Two of those are chosen deliberately: architecture would have identified #1070 immediately, and client version would have identified #1054 as already fixed.
- **`feature-request.yml`** — for non-tool changes, so the proposal template stays specific.
- **`PULL_REQUEST_TEMPLATE.md`** — links the proposal, asks for the tier and how it was tested, with a merge checklist.
- **`config.yml`** — points at the troubleshooting guide and the security disclosure process. Note Discussions is not enabled on this repo, so there's no link to it.

## Expectations we had left implicit

Two things contributors have reasonably read as being ignored, now written down:

- Fork CI requires maintainer approval **on every push**, not just the first.
- `Test Cloud` and the Python E2E suites are informational, and `Test Cloud` cannot pass from a fork at all.

## Notes for review

- Docs only — no Go changes.
- The token-cost section assumes the Token Analysis bot can comment on fork PRs, which needs the `workflow_run` split in the follow-up PR. Worth landing that one first, or merging them together.
- Deliberately no review-time commitments: any number there becomes a promise, and this seemed like the wrong moment to make one.
- Open question for you: whether `asserts` should be reclassified as opt-in. It's default-on today, and #607 proposes adding 12 tools to it at a measured +18% of the token budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)