### PR TITLE
feat: migrate tool registration to official go-sdk (mark3labs -> modelcontextprotocol/go-sdk)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/itchyny/gojq v0.12.19
 	github.com/mark3labs/mcp-go v0.55.0
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/prometheus/alertmanager v0.31.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
@@ -99,7 +100,7 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
@@ -142,6 +143,8 @@ require (
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/prometheus/sigv4 v0.4.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
@@ -165,6 +168,7 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
 	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,12 +104,8 @@ github.com/go-openapi/analysis v0.24.3 h1:a1hrvMr8X0Xt69KP5uVTu5jH62DscmDifrLzNg
 github.com/go-openapi/analysis v0.24.3/go.mod h1:Nc+dWJ/FxZbhSow5Yh3ozg5CLJioB+XXT6MdLvJUsUw=
 github.com/go-openapi/errors v0.22.7 h1:JLFBGC0Apwdzw3484MmBqspjPbwa2SHvpDm0u5aGhUA=
 github.com/go-openapi/errors v0.22.7/go.mod h1://QW6SD9OsWtH6gHllUCddOXDL0tk0ZGNYHwsw4sW3w=
-github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
-github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxgL3h1H8s=
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
-github.com/go-openapi/jsonreference v0.21.5 h1:6uCGVXU/aNF13AQNggxfysJ+5ZcU4nEAe+pJyVWRdiE=
-github.com/go-openapi/jsonreference v0.21.5/go.mod h1:u25Bw85sX4E2jzFodh1FOKMTZLcfifd1Q+iKKOUxExw=
 github.com/go-openapi/jsonreference v1.0.0 h1:jlmTr6torcd1YgDQvSfNmRtKzYDO4FGBkrAdlAVWnpY=
 github.com/go-openapi/jsonreference v1.0.0/go.mod h1:jtwdyGbJk0Xhe5Y+rwtglQP6Sb1WZST4rT32LWB+sv0=
 github.com/go-openapi/loads v0.23.3 h1:g5Xap1JfwKkUnZdn+S0L3SzBDpcTIYzZ5Qaag0YDkKQ=
@@ -148,8 +144,8 @@ github.com/go-openapi/swag/yamlutils v0.25.5 h1:kASCIS+oIeoc55j28T4o8KwlV2S4ZLPT
 github.com/go-openapi/swag/yamlutils v0.25.5/go.mod h1:Gek1/SjjfbYvM+Iq4QGwa/2lEXde9n2j4a3wI3pNuOQ=
 github.com/go-openapi/testify/enable/yaml/v2 v2.4.1 h1:NZOrZmIb6PTv5LTFxr5/mKV/FjbUzGE7E6gLz7vFoOQ=
 github.com/go-openapi/testify/enable/yaml/v2 v2.4.1/go.mod h1:r7dwsujEHawapMsxA69i+XMGZrQ5tRauhLAjV/sxg3Q=
-github.com/go-openapi/testify/v2 v2.4.1 h1:zB34HDKj4tHwyUQHrUkpV0Q0iXQ6dUCOQtIqn8hE6Iw=
-github.com/go-openapi/testify/v2 v2.4.1/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
+github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
+github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
 github.com/go-openapi/validate v0.25.2 h1:12NsfLAwGegqbGWr2CnvT65X/Q2USJipmJ9b7xDJZz0=
 github.com/go-openapi/validate v0.25.2/go.mod h1:Pgl1LpPPGFnZ+ys4/hTlDiRYQdI1ocKypgE+8Q8BLfY=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
@@ -178,8 +174,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -276,6 +272,8 @@ github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8D
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -330,6 +328,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=

--- a/tools.go
+++ b/tools.go
@@ -10,8 +10,7 @@ import (
 	"strings"
 
 	"github.com/invopop/jsonschema"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -25,8 +24,8 @@ import (
 // The simplest way to create a Tool is to use MustTool for compile-time tool creation,
 // or ConvertTool if you need runtime tool creation with proper error handling.
 type Tool struct {
-	Tool    mcp.Tool
-	Handler server.ToolHandlerFunc
+	Tool    *mcp.Tool
+	Handler mcp.ToolHandler
 }
 
 // HardError wraps an error to indicate it should propagate as a JSON-RPC protocol
@@ -44,13 +43,52 @@ func (e *HardError) Unwrap() error {
 	return e.Err
 }
 
-// Register adds the Tool to the given MCPServer.
-// It is a convenience method that calls server.MCPServer.AddTool with the Tool's metadata and handler,
+// Register adds the Tool to the given Server.
+// It is a convenience method that calls Server.AddTool with the Tool's metadata and handler,
 // allowing fluent tool registration in a single statement:
 //
 //	mcpgrafana.MustTool(name, description, toolHandler).Register(server)
-func (t *Tool) Register(mcp *server.MCPServer) {
-	mcp.AddTool(t.Tool, t.Handler)
+func (t *Tool) Register(s *mcp.Server) {
+	s.AddTool(t.Tool, t.Handler)
+}
+
+// ToolOption configures optional metadata (annotations) on a Tool. It mirrors
+// the small subset of mark3labs' mcp.ToolOption surface this codebase used,
+// since the official SDK exposes annotations as plain struct fields rather
+// than functional options.
+type ToolOption func(*mcp.Tool)
+
+// ensureAnnotations returns t.Annotations, allocating it if necessary.
+func ensureAnnotations(t *mcp.Tool) *mcp.ToolAnnotations {
+	if t.Annotations == nil {
+		t.Annotations = &mcp.ToolAnnotations{}
+	}
+	return t.Annotations
+}
+
+// WithTitleAnnotation sets the tool's human-readable title annotation.
+func WithTitleAnnotation(title string) ToolOption {
+	return func(t *mcp.Tool) { ensureAnnotations(t).Title = title }
+}
+
+// WithReadOnlyHintAnnotation sets whether the tool does not modify its environment.
+func WithReadOnlyHintAnnotation(value bool) ToolOption {
+	return func(t *mcp.Tool) { ensureAnnotations(t).ReadOnlyHint = value }
+}
+
+// WithDestructiveHintAnnotation sets whether the tool may perform destructive updates.
+func WithDestructiveHintAnnotation(value bool) ToolOption {
+	return func(t *mcp.Tool) { ensureAnnotations(t).DestructiveHint = &value }
+}
+
+// WithIdempotentHintAnnotation sets whether repeated calls with the same arguments are a no-op.
+func WithIdempotentHintAnnotation(value bool) ToolOption {
+	return func(t *mcp.Tool) { ensureAnnotations(t).IdempotentHint = value }
+}
+
+// WithOpenWorldHintAnnotation sets whether the tool interacts with an open world of external entities.
+func WithOpenWorldHintAnnotation(value bool) ToolOption {
+	return func(t *mcp.Tool) { ensureAnnotations(t).OpenWorldHint = &value }
 }
 
 // MustTool creates a new Tool from the given name, description, and toolHandler.
@@ -58,7 +96,7 @@ func (t *Tool) Register(mcp *server.MCPServer) {
 func MustTool[T any, R any](
 	name, description string,
 	toolHandler ToolHandlerFunc[T, R],
-	options ...mcp.ToolOption,
+	options ...ToolOption,
 ) Tool {
 	tool, handler, err := ConvertTool(name, description, toolHandler, options...)
 	if err != nil {
@@ -197,34 +235,59 @@ func collectStringSliceFieldNames(structType reflect.Type) map[string]bool {
 	return fields
 }
 
-// ConvertTool converts a toolHandler function to an MCP Tool and ToolHandlerFunc.
+// toolArgumentsSchema mirrors the shape mark3labs' mcp.ToolArgumentsSchema
+// marshaled to, so that existing tool schemas (and their tests) are
+// unaffected by the SDK migration. Required is omitted when empty, matching
+// the previous behaviour.
+type toolArgumentsSchema struct {
+	Type                 string         `json:"type"`
+	Properties           map[string]any `json:"properties"`
+	Required             []string       `json:"required,omitempty"`
+	AdditionalProperties any            `json:"additionalProperties,omitempty"`
+}
+
+// NewToolResultText builds a *mcp.CallToolResult carrying a single text content item.
+func NewToolResultText(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}
+}
+
+// NewToolResultError builds a *mcp.CallToolResult carrying a single text content
+// item and IsError set, i.e. a tool-level error surfaced to the model rather
+// than a JSON-RPC protocol error.
+func NewToolResultError(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: text}},
+		IsError: true,
+	}
+}
+
+// ConvertTool converts a toolHandler function to an MCP Tool and mcp.ToolHandler.
 // The toolHandler must accept a context.Context and a struct with jsonschema tags for parameter documentation.
 // The struct fields define the tool's input schema, while the return value can be a string, struct, or *mcp.CallToolResult.
 // This function automatically generates JSON schema from the struct type and wraps the handler with OpenTelemetry instrumentation.
-func ConvertTool[T any, R any](name, description string, toolHandler ToolHandlerFunc[T, R], options ...mcp.ToolOption) (mcp.Tool, server.ToolHandlerFunc, error) {
-	zero := mcp.Tool{}
+func ConvertTool[T any, R any](name, description string, toolHandler ToolHandlerFunc[T, R], options ...ToolOption) (*mcp.Tool, mcp.ToolHandler, error) {
 	handlerValue := reflect.ValueOf(toolHandler)
 	handlerType := handlerValue.Type()
 	if handlerType.Kind() != reflect.Func {
-		return zero, nil, errors.New("tool handler must be a function")
+		return nil, nil, errors.New("tool handler must be a function")
 	}
 	if handlerType.NumIn() != 2 {
-		return zero, nil, errors.New("tool handler must have 2 arguments")
+		return nil, nil, errors.New("tool handler must have 2 arguments")
 	}
 	if handlerType.NumOut() != 2 {
-		return zero, nil, errors.New("tool handler must return 2 values")
+		return nil, nil, errors.New("tool handler must return 2 values")
 	}
 	if handlerType.In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
-		return zero, nil, errors.New("tool handler first argument must be context.Context")
+		return nil, nil, errors.New("tool handler first argument must be context.Context")
 	}
 	// We no longer check the type of the first return value
 	if handlerType.Out(1).Kind() != reflect.Interface {
-		return zero, nil, errors.New("tool handler second return value must be error")
+		return nil, nil, errors.New("tool handler second return value must be error")
 	}
 
 	argType := handlerType.In(1)
 	if argType.Kind() != reflect.Struct {
-		return zero, nil, errors.New("tool handler second argument must be a struct")
+		return nil, nil, errors.New("tool handler second argument must be a struct")
 	}
 
 	// Built before the handler closure so it can validate incoming argument
@@ -235,7 +298,7 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 		properties[pair.Key] = pair.Value
 	}
 
-	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	handler := func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		config := GrafanaConfigFromContext(ctx)
 
 		// Extract W3C trace context from request _meta if present
@@ -253,15 +316,18 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 			semconv.GenAIToolName(name),
 			attribute.String("mcp.method.name", "tools/call"),
 		)
-		if session := server.ClientSessionFromContext(ctx); session != nil {
-			span.SetAttributes(semconv.McpSessionID(session.SessionID()))
+		if request.Session != nil {
+			span.SetAttributes(semconv.McpSessionID(request.Session.ID()))
 		}
 
-		argBytes, err := json.Marshal(request.Params.Arguments)
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to marshal arguments")
-			return nil, fmt.Errorf("marshal args: %w", err)
+		// Arguments arrive as raw wire bytes; unmarshaling/validating them is
+		// this wrapper's responsibility (see mcp.AddTool's documentation).
+		var argBytes json.RawMessage
+		if request.Params != nil {
+			argBytes = request.Params.Arguments
+		}
+		if len(argBytes) == 0 {
+			argBytes = json.RawMessage("{}")
 		}
 
 		// Add arguments as span attribute only if adding args to trace attributes is enabled
@@ -269,14 +335,20 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 			span.SetAttributes(attribute.String("gen_ai.tool.call.arguments", string(argBytes)))
 		}
 
+		var rawArgs map[string]any
+		if err := json.Unmarshal(argBytes, &rawArgs); err != nil {
+			// Non-object argument shapes are left to the decode path below to report.
+			rawArgs = nil
+		}
+
 		// Reject unknown argument keys instead of silently dropping them: a typo'd
 		// optional argument (e.g. "start_rfc3339" for "start_rfc_3339") would
 		// otherwise leave the field zero-valued and the tool would answer a
 		// different question than the caller asked. The error is returned as a
 		// tool result (not a protocol error) so LLM callers can see it and retry.
-		if unknown := unknownArguments(request.Params.Arguments, properties); len(unknown) > 0 {
+		if unknown := unknownArguments(rawArgs, properties); len(unknown) > 0 {
 			span.SetStatus(codes.Error, "unknown arguments")
-			return mcp.NewToolResultError(unknownArgumentsError(unknown, properties)), nil
+			return NewToolResultError(unknownArgumentsError(unknown, properties)), nil
 		}
 
 		unmarshaledArgs := reflect.New(argType).Interface()
@@ -334,15 +406,7 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 			if errors.As(handlerErr, &hardErr) {
 				return nil, hardErr.Err
 			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					mcp.TextContent{
-						Type: "text",
-						Text: handlerErr.Error(),
-					},
-				},
-				IsError: true,
-			}, nil
+			return NewToolResultError(handlerErr.Error()), nil
 		}
 
 		// Tool execution completed successfully
@@ -357,10 +421,9 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 			output[0].Kind() == reflect.Func
 
 		if isNilable && output[0].IsNil() {
-			// Return an empty text result instead of nil to avoid a nil pointer
-			// dereference in mcp-go's request_handler.go when it dereferences
-			// the *CallToolResult. A nil slice/map is a valid "no results" response.
-			return mcp.NewToolResultText("null"), nil
+			// Return an empty text result instead of nil. A nil slice/map is a
+			// valid "no results" response.
+			return NewToolResultText("null"), nil
 		}
 
 		returnVal := output[0].Interface()
@@ -379,14 +442,14 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 
 		// Case 3: String or *string
 		if str, ok := returnVal.(string); ok {
-			return mcp.NewToolResultText(str), nil
+			return NewToolResultText(str), nil
 		}
 
 		if strPtr, ok := returnVal.(*string); ok {
 			if strPtr == nil {
-				return mcp.NewToolResultText(""), nil
+				return NewToolResultText(""), nil
 			}
-			return mcp.NewToolResultText(*strPtr), nil
+			return NewToolResultText(*strPtr), nil
 		}
 
 		// Case 4: Any other type - marshal to JSON
@@ -395,25 +458,23 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 			return nil, fmt.Errorf("failed to marshal return value: %s", err)
 		}
 
-		return mcp.NewToolResultText(string(returnBytes)), nil
+		return NewToolResultText(string(returnBytes)), nil
 	}
 
-	// Use RawInputSchema with ToolArgumentsSchema to work around a Go limitation where type aliases
-	// don't inherit custom MarshalJSON methods. This ensures empty properties are included in the schema.
-	// additionalProperties: false advertises the strictness enforced above, so
-	// schema-validating clients (and providers with strict function calling)
-	// catch unknown arguments before the call reaches the server.
-	argumentsSchema := mcp.ToolArgumentsSchema{
+	// Marshal the schema ourselves (rather than relying on the SDK's own
+	// jsonschema-go-based inference) so we keep invopop/jsonschema and this
+	// package's existing validation/coercion behaviour unchanged.
+	// Tool.InputSchema accepts any value that marshals to valid JSON Schema.
+	argumentsSchema := toolArgumentsSchema{
 		Type:                 jsonSchema.Type,
 		Properties:           properties,
 		Required:             jsonSchema.Required,
 		AdditionalProperties: false,
 	}
 
-	// Marshal the schema to preserve empty properties
 	schemaBytes, err := json.Marshal(argumentsSchema)
 	if err != nil {
-		return zero, nil, fmt.Errorf("failed to marshal input schema: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal input schema: %w", err)
 	}
 
 	// Validate that no bare boolean schemas slipped through. The Mapper on the
@@ -421,16 +482,16 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 	// misses and prevents future regressions. MustTool will panic at init time
 	// if this fails, making it impossible to register a tool with bare booleans.
 	if err := validateNoBooleanSchemas(name, schemaBytes); err != nil {
-		return zero, nil, err
+		return nil, nil, err
 	}
 
-	t := mcp.Tool{
-		Name:           name,
-		Description:    description,
-		RawInputSchema: schemaBytes,
+	t := &mcp.Tool{
+		Name:        name,
+		Description: description,
+		InputSchema: json.RawMessage(schemaBytes),
 	}
 	for _, option := range options {
-		option(&t)
+		option(t)
 	}
 	return t, handler, nil
 }
@@ -438,11 +499,11 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 // extractTraceContext checks the request's _meta for W3C trace context headers
 // (traceparent/tracestate) and returns a context with the extracted span context
 // so that the tool span becomes a child of the caller's trace.
-func extractTraceContext(ctx context.Context, request mcp.CallToolRequest) context.Context {
-	if request.Params.Meta == nil {
+func extractTraceContext(ctx context.Context, request *mcp.CallToolRequest) context.Context {
+	if request.Params == nil {
 		return ctx
 	}
-	fields := request.Params.Meta.AdditionalFields
+	fields := request.Params.Meta
 	if len(fields) == 0 {
 		return ctx
 	}

--- a/tools/admin.go
+++ b/tools/admin.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	"github.com/grafana/grafana-openapi-client-go/client/access_control"
 	"github.com/grafana/grafana-openapi-client-go/client/org"
 	"github.com/grafana/grafana-openapi-client-go/client/teams"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type ListTeamsParams struct {
@@ -35,11 +33,11 @@ var ListTeams = mcpgrafana.MustTool(
 	"list_teams",
 	"Search for Grafana teams by a query string. Returns a list of matching teams with details like name, ID, and URL.",
 	listTeams,
-	mcp.WithTitleAnnotation("List teams"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List teams"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListUsersByOrgParams struct{}
@@ -59,11 +57,11 @@ var ListUsersByOrg = mcpgrafana.MustTool(
 	"list_users_by_org",
 	"List users in the Grafana organization. Returns a list of organization users with details like userid, email, role etc.",
 	listUsersByOrg,
-	mcp.WithTitleAnnotation("List users by org"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List users by org"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListAllRolesParams struct {
@@ -90,11 +88,11 @@ var ListAllRoles = mcpgrafana.MustTool(
 	"list_all_roles",
 	"List all roles in Grafana. Optionally filter to show only roles that can be delegated by the current user. Returns role details including UID, name, permissions, and metadata.",
 	listAllRoles,
-	mcp.WithTitleAnnotation("List all roles"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List all roles"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type GetRoleDetailsParams struct {
@@ -116,11 +114,11 @@ var GetRoleDetails = mcpgrafana.MustTool(
 	"get_role_details",
 	"Get detailed information about a specific Grafana role by its UID, including permissions, metadata, and configuration.",
 	getRoleDetails,
-	mcp.WithTitleAnnotation("Get role details"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get role details"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type GetRoleAssignmentsParams struct {
@@ -142,11 +140,11 @@ var GetRoleAssignments = mcpgrafana.MustTool(
 	"get_role_assignments",
 	"List all assignments for a specific role, showing which users, teams, and service accounts have been assigned this role.",
 	getRoleAssignments,
-	mcp.WithTitleAnnotation("Get role assignments"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get role assignments"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListUserRolesParams struct {
@@ -169,11 +167,11 @@ var ListUserRoles = mcpgrafana.MustTool(
 	"list_user_roles",
 	"List all roles assigned to one or more users. Returns a map of user IDs to their assigned roles, excluding built-in roles and team-inherited roles.",
 	listUserRoles,
-	mcp.WithTitleAnnotation("List user roles"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List user roles"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListTeamRolesParams struct {
@@ -196,11 +194,11 @@ var ListTeamRoles = mcpgrafana.MustTool(
 	"list_team_roles",
 	"List all roles assigned to one or more teams. Returns a map of team IDs to their assigned roles.",
 	listTeamRoles,
-	mcp.WithTitleAnnotation("List team roles"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List team roles"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type GetResourcePermissionsParams struct {
@@ -223,11 +221,11 @@ var GetResourcePermissions = mcpgrafana.MustTool(
 	"get_resource_permissions",
 	"List all permissions set on a specific Grafana resource (e.g., dashboard, datasource, folder) by its type and ID.",
 	getResourcePermissions,
-	mcp.WithTitleAnnotation("Get resource permissions"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get resource permissions"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type GetResourceDescriptionParams struct {
@@ -252,14 +250,14 @@ var GetResourceDescription = mcpgrafana.MustTool(
 	"get_resource_description",
 	"List available permissions and assignment capabilities for a Grafana resource type.",
 	getResourceDescription,
-	mcp.WithTitleAnnotation("Get resource description"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get resource description"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddAdminTools(mcp *server.MCPServer) {
+func AddAdminTools(mcp *mcp.Server) {
 	ListTeams.Register(mcp)
 	ListUsersByOrg.Register(mcp)
 	ListAllRoles.Register(mcp)

--- a/tools/agento11y.go
+++ b/tools/agento11y.go
@@ -12,8 +12,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -466,11 +465,11 @@ When to use:
 When NOT to use:
 - Fetching a single generation or its evaluation scores (use agento11y_manage_generations)`,
 	manageAgento11yConversations,
-	mcp.WithTitleAnnotation("Manage Agent Observability conversations"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability conversations"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yGenerations = mcpgrafana.MustTool(
@@ -488,11 +487,11 @@ When to use:
 When NOT to use:
 - Searching or listing conversations (use agento11y_manage_conversations)`,
 	manageAgento11yGenerations,
-	mcp.WithTitleAnnotation("Manage Agent Observability generations"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability generations"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 const manageAgento11yEvaluatorsDescriptionFmt = `%s
@@ -762,108 +761,108 @@ var ManageAgento11yEvaluatorsRead = mcpgrafana.MustTool(
 	"agento11y_manage_evaluators",
 	manageAgento11yEvaluatorsDescription(true),
 	manageAgento11yEvaluatorsRead,
-	mcp.WithTitleAnnotation("Manage Agent Observability evaluators"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability evaluators"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalRulesRead = mcpgrafana.MustTool(
 	"agento11y_manage_eval_rules",
 	manageAgento11yEvalRulesDescription(true),
 	manageAgento11yEvalRulesRead,
-	mcp.WithTitleAnnotation("Manage Agent Observability eval rules and guards"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability eval rules and guards"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalCollectionsRead = mcpgrafana.MustTool(
 	"agento11y_manage_eval_collections",
 	manageAgento11yEvalCollectionsDescription(true),
 	manageAgento11yEvalCollectionsRead,
-	mcp.WithTitleAnnotation("Manage Agent Observability saved conversations and collections"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability saved conversations and collections"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yExperimentsRead = mcpgrafana.MustTool(
 	"agento11y_manage_experiments",
 	manageAgento11yExperimentsDescription(true),
 	manageAgento11yExperimentsRead,
-	mcp.WithTitleAnnotation("Manage Agent Observability experiments"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability experiments"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yTestSuitesRead = mcpgrafana.MustTool(
 	"agento11y_manage_test_suites",
 	manageAgento11yTestSuitesDescription(true),
 	manageAgento11yTestSuitesRead,
-	mcp.WithTitleAnnotation("Manage Agent Observability test suites"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability test suites"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvaluatorsReadWrite = mcpgrafana.MustTool(
 	"agento11y_manage_evaluators",
 	manageAgento11yEvaluatorsDescription(false),
 	manageAgento11yEvaluatorsReadWrite,
-	mcp.WithTitleAnnotation("Manage Agent Observability evaluators"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability evaluators"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalRulesReadWrite = mcpgrafana.MustTool(
 	"agento11y_manage_eval_rules",
 	manageAgento11yEvalRulesDescription(false),
 	manageAgento11yEvalRulesReadWrite,
-	mcp.WithTitleAnnotation("Manage Agent Observability eval rules and guards"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability eval rules and guards"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yEvalCollectionsReadWrite = mcpgrafana.MustTool(
 	"agento11y_manage_eval_collections",
 	manageAgento11yEvalCollectionsDescription(false),
 	manageAgento11yEvalCollectionsReadWrite,
-	mcp.WithTitleAnnotation("Manage Agent Observability saved conversations and collections"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability saved conversations and collections"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yExperimentsReadWrite = mcpgrafana.MustTool(
 	"agento11y_manage_experiments",
 	manageAgento11yExperimentsDescription(false),
 	manageAgento11yExperimentsReadWrite,
-	mcp.WithTitleAnnotation("Manage Agent Observability experiments"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability experiments"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageAgento11yTestSuitesReadWrite = mcpgrafana.MustTool(
 	"agento11y_manage_test_suites",
 	manageAgento11yTestSuitesDescription(false),
 	manageAgento11yTestSuitesReadWrite,
-	mcp.WithTitleAnnotation("Manage Agent Observability test suites"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability test suites"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddAgento11yTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddAgento11yTools(mcp *mcp.Server, enableWriteTools bool) {
 	ManageAgento11yConversations.Register(mcp)
 	ManageAgento11yGenerations.Register(mcp)
 	ManageAgento11yAgents.Register(mcp)

--- a/tools/agento11y_agents.go
+++ b/tools/agento11y_agents.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // Agent catalog of Agent Observability (/query/agents on the
@@ -326,9 +325,9 @@ When NOT to use:
 - Reading individual conversations, generations, or their scores (use agento11y_manage_conversations and agento11y_manage_generations)
 - Inspecting evaluators or the rules that schedule them (use agento11y_manage_evaluators and agento11y_manage_eval_rules)`,
 	manageAgento11yAgents,
-	mcp.WithTitleAnnotation("Manage Agent Observability agents"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage Agent Observability agents"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/alerting.go
+++ b/tools/alerting.go
@@ -3,10 +3,8 @@ package tools
 import (
 	"fmt"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -43,24 +41,24 @@ var ManageRulesRead = mcpgrafana.MustTool(
 	"alerting_manage_rules",
 	manageAlertRulesDescription(true),
 	manageRulesRead,
-	mcp.WithTitleAnnotation("Manage alert rules"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage alert rules"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var ManageRulesReadWrite = mcpgrafana.MustTool(
 	"alerting_manage_rules",
 	manageAlertRulesDescription(false),
 	manageRulesReadWrite,
-	mcp.WithTitleAnnotation("Manage alert rules"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage alert rules"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddAlertingTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddAlertingTools(mcp *mcp.Server, enableWriteTools bool) {
 	if enableWriteTools {
 		ManageRulesReadWrite.Register(mcp)
 	} else {

--- a/tools/alerting_routing.go
+++ b/tools/alerting_routing.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/mark3labs/mcp-go/mcp"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
@@ -157,9 +156,9 @@ var ManageRouting = mcpgrafana.MustTool(
 	"alerting_manage_routing",
 	manageRoutingDescription,
 	manageRouting,
-	mcp.WithTitleAnnotation("Manage alerting routing"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Manage alerting routing"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/annotations.go
+++ b/tools/annotations.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/grafana/grafana-openapi-client-go/client/annotations"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -58,11 +56,11 @@ var GetAnnotationsTool = mcpgrafana.MustTool(
 	"get_annotations",
 	"Fetch Grafana annotations using filters such as dashboard UID, time range and tags.",
 	getAnnotations,
-	mcp.WithTitleAnnotation("Get Annotations"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get Annotations"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // CreateAnnotationInput creates a new annotation, optionally in Graphite format.
@@ -134,11 +132,11 @@ var CreateAnnotationTool = mcpgrafana.MustTool(
 	"create_annotation",
 	"Create a new annotation on a dashboard or panel. Set format to 'graphite' and provide 'what' for Graphite-format annotations.",
 	createAnnotation,
-	mcp.WithTitleAnnotation("Create Annotation"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Create Annotation"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // UpdateAnnotationInput updates only the provided fields of an annotation (PATCH semantics).
@@ -187,11 +185,11 @@ var UpdateAnnotationTool = mcpgrafana.MustTool(
 	"update_annotation",
 	"Updates the provided properties of an annotation by ID. Only fields included in the request are modified; omitted fields are left unchanged.",
 	updateAnnotation,
-	mcp.WithTitleAnnotation("Update Annotation"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Update Annotation"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // GetAnnotationTagsInput defines filters for retrieving annotation tags.
@@ -221,14 +219,14 @@ var GetAnnotationTagsTool = mcpgrafana.MustTool(
 	"get_annotation_tags",
 	"Returns annotation tags with optional filtering by tag name. Only the provided filters are applied.",
 	getAnnotationTags,
-	mcp.WithTitleAnnotation("Get Annotation Tags"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get Annotation Tags"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddAnnotationTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddAnnotationTools(mcp *mcp.Server, enableWriteTools bool) {
 	GetAnnotationsTool.Register(mcp)
 	if enableWriteTools {
 		CreateAnnotationTool.Register(mcp)

--- a/tools/api.go
+++ b/tools/api.go
@@ -9,8 +9,7 @@ import (
 	"strings"
 
 	"github.com/itchyny/gojq"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
@@ -176,10 +175,10 @@ var APIRequest = mcpgrafana.MustTool(
 		"Supports any Grafana API endpoint with optional jq-style response filtering. "+
 		"Use this for API endpoints that don't have a dedicated tool.",
 	apiRequest,
-	mcp.WithTitleAnnotation("Grafana API request"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Grafana API request"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var APIRequestReadOnly = mcpgrafana.MustTool(
@@ -189,14 +188,14 @@ var APIRequestReadOnly = mcpgrafana.MustTool(
 		"Use this for API endpoints that don't have a dedicated tool. "+
 		"Only GET requests are allowed.",
 	apiRequestReadOnly,
-	mcp.WithTitleAnnotation("Grafana API request"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Grafana API request"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddAPITools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddAPITools(mcp *mcp.Server, enableWriteTools bool) {
 	if enableWriteTools {
 		APIRequest.Register(mcp)
 	} else {

--- a/tools/asserts.go
+++ b/tools/asserts.go
@@ -8,8 +8,7 @@ import (
 	"net/http"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func newAssertsClient(ctx context.Context) (*Client, error) {
@@ -145,13 +144,13 @@ var GetAssertions = mcpgrafana.MustTool(
 	"get_assertions",
 	"Get assertion summary for a given entity with its type, name, env, site, namespace, and a time range",
 	getAssertions,
-	mcp.WithTitleAnnotation("Get assertions summary"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get assertions summary"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddAssertsTools(mcp *server.MCPServer) {
+func AddAssertsTools(mcp *mcp.Server) {
 	GetAssertions.Register(mcp)
 }

--- a/tools/assistant.go
+++ b/tools/assistant.go
@@ -25,8 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -178,16 +177,16 @@ var AskAssistant = mcpgrafana.MustTool(
 	"ask_assistant",
 	askAssistantDescription,
 	askAssistant,
-	mcp.WithTitleAnnotation("Ask Grafana Assistant"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Ask Grafana Assistant"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddAssistantTools registers the assistant tools with the MCP server. The
 // assistant may perform write operations, so it is gated behind enableWriteTools.
-func AddAssistantTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddAssistantTools(mcp *mcp.Server, enableWriteTools bool) {
 	if enableWriteTools {
 		AskAssistant.Register(mcp)
 	}

--- a/tools/athena.go
+++ b/tools/athena.go
@@ -13,8 +13,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -238,11 +237,11 @@ var ListAthenaCatalogs = mcpgrafana.MustTool(
 	"list_athena_catalogs",
 	"START HERE for Athena: List available data catalogs (e.g. AwsDataCatalog, Iceberg connectors). NEXT: Use list_athena_databases with a catalog.",
 	listAthenaCatalogs,
-	mcp.WithTitleAnnotation("List Athena catalogs"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Athena catalogs"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListAthenaDatabasesParams struct {
@@ -281,11 +280,11 @@ var ListAthenaDatabases = mcpgrafana.MustTool(
 	"list_athena_databases",
 	"List databases in an Athena catalog. Use after list_athena_catalogs. NEXT: Use list_athena_tables with a database.",
 	listAthenaDatabases,
-	mcp.WithTitleAnnotation("List Athena databases"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Athena databases"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListAthenaTablesParams struct {
@@ -328,11 +327,11 @@ var ListAthenaTables = mcpgrafana.MustTool(
 	"list_athena_tables",
 	"List tables in an Athena database. Use after list_athena_databases. NEXT: Use describe_athena_table to see column schemas before querying.",
 	listAthenaTables,
-	mcp.WithTitleAnnotation("List Athena tables"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Athena tables"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type DescribeAthenaTableParams struct {
@@ -382,11 +381,11 @@ var DescribeAthenaTable = mcpgrafana.MustTool(
 	"describe_athena_table",
 	"Get column names for an Athena table. Use after list_athena_tables. NEXT: Use query_athena with discovered column names.",
 	describeAthenaTable,
-	mcp.WithTitleAnnotation("Describe Athena table"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Describe Athena table"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type AthenaQueryParams struct {
@@ -524,18 +523,18 @@ Athena queries are async — Grafana handles polling. Use LIMIT and partition-aw
 
 Example: SELECT request_time, status FROM my_table WHERE $__timeFilter(request_time) LIMIT 100`,
 	queryAthena,
-	mcp.WithTitleAnnotation("Query Athena"),
-	mcp.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Athena"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
 	// The raw SQL is passed through unfiltered, so DML/DDL (INSERT, DROP,
 	// CREATE TABLE AS) executes if the datasource credentials permit it —
 	// not read-only, potentially destructive.
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddAthenaTools registers all Athena tools with the MCP server.
-func AddAthenaTools(s *server.MCPServer) {
+func AddAthenaTools(s *mcp.Server) {
 	ListAthenaCatalogs.Register(s)
 	ListAthenaDatabases.Register(s)
 	ListAthenaTables.Register(s)

--- a/tools/clickhouse.go
+++ b/tools/clickhouse.go
@@ -9,8 +9,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -237,14 +236,14 @@ Time formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)
 
 Example: SELECT Timestamp, Body FROM otel_logs WHERE $__timeFilter(Timestamp)`,
 	queryClickHouse,
-	mcp.WithTitleAnnotation("Query ClickHouse"),
-	mcp.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query ClickHouse"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
 	// The raw SQL is passed through unfiltered, so a DELETE/DROP executes if
 	// the datasource credentials permit it — not read-only, potentially
 	// destructive.
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListClickHouseTablesParams defines the parameters for listing ClickHouse tables
@@ -308,11 +307,11 @@ var ListClickHouseTables = mcpgrafana.MustTool(
 	"list_clickhouse_tables",
 	"START HERE for ClickHouse: List available tables (name, database, engine, row count, size). NEXT: Use describe_clickhouse_table to see column schemas.",
 	listClickHouseTables,
-	mcp.WithTitleAnnotation("List ClickHouse tables"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List ClickHouse tables"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // DescribeClickHouseTableParams defines the parameters for describing a ClickHouse table
@@ -387,15 +386,15 @@ var DescribeClickHouseTable = mcpgrafana.MustTool(
 	"describe_clickhouse_table",
 	"Get column schema for a ClickHouse table. Pass the database from list_clickhouse_tables results. NEXT: Use query_clickhouse with discovered column names.",
 	describeClickHouseTable,
-	mcp.WithTitleAnnotation("Describe ClickHouse table"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Describe ClickHouse table"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddClickHouseTools registers all ClickHouse tools with the MCP server
-func AddClickHouseTools(mcp *server.MCPServer) {
+func AddClickHouseTools(mcp *mcp.Server) {
 	QueryClickHouse.Register(mcp)
 	ListClickHouseTables.Register(mcp)
 	DescribeClickHouseTable.Register(mcp)

--- a/tools/cloudwatch.go
+++ b/tools/cloudwatch.go
@@ -13,8 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -315,11 +314,11 @@ Example dimensions: ECS: {ClusterName, ServiceName}, EC2: {InstanceId}
 
 Cross-account monitoring: Use accountId to query metrics from a specific source account (e.g. '123456789012') or 'all' to query all linked accounts. Only applicable when using a CloudWatch monitoring account datasource.`,
 	queryCloudWatch,
-	mcp.WithTitleAnnotation("Query CloudWatch"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query CloudWatch"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListCloudWatchNamespacesParams defines the parameters for listing CloudWatch namespaces
@@ -422,11 +421,11 @@ var ListCloudWatchNamespaces = mcpgrafana.MustTool(
 	"list_cloudwatch_namespaces",
 	"START HERE for CloudWatch: List available namespaces (AWS/EC2, AWS/ECS, AWS/RDS, etc.). Requires region. Supports cross-account monitoring via optional accountId parameter. NEXT: Use list_cloudwatch_metrics with a namespace.",
 	listCloudWatchNamespaces,
-	mcp.WithTitleAnnotation("List CloudWatch namespaces"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List CloudWatch namespaces"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListCloudWatchMetricsParams defines the parameters for listing CloudWatch metrics
@@ -484,11 +483,11 @@ var ListCloudWatchMetrics = mcpgrafana.MustTool(
 	"list_cloudwatch_metrics",
 	"List metrics for a CloudWatch namespace. Requires region. Supports cross-account monitoring via optional accountId parameter. Use after list_cloudwatch_namespaces. NEXT: Use list_cloudwatch_dimensions\\, then query_cloudwatch.",
 	listCloudWatchMetrics,
-	mcp.WithTitleAnnotation("List CloudWatch metrics"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List CloudWatch metrics"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListCloudWatchDimensionsParams defines the parameters for listing CloudWatch dimensions
@@ -548,15 +547,15 @@ var ListCloudWatchDimensions = mcpgrafana.MustTool(
 	"list_cloudwatch_dimensions",
 	"List dimension keys for a CloudWatch metric. Requires region. Supports cross-account monitoring via optional accountId parameter. Use after list_cloudwatch_metrics. NEXT: Use query_cloudwatch with discovered dimensions.",
 	listCloudWatchDimensions,
-	mcp.WithTitleAnnotation("List CloudWatch dimensions"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List CloudWatch dimensions"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddCloudWatchTools registers all CloudWatch tools with the MCP server
-func AddCloudWatchTools(mcp *server.MCPServer) {
+func AddCloudWatchTools(mcp *mcp.Server) {
 	QueryCloudWatch.Register(mcp)
 	ListCloudWatchNamespaces.Register(mcp)
 	ListCloudWatchMetrics.Register(mcp)

--- a/tools/config.go
+++ b/tools/config.go
@@ -7,8 +7,7 @@ import (
 	"strings"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // This file hosts config-generation tools — outputs that operators paste
@@ -117,14 +116,14 @@ var SuggestLokiAlloyLabelConfig = mcpgrafana.MustTool(
 	"suggest_loki_alloy_label_config",
 	"Generates an Alloy loki.process snippet enforcing an approved label set via stage.label_keep, with optional log-level normalisation and soft-enforcement placeholders.",
 	suggestLokiAlloyLabelConfig,
-	mcp.WithTitleAnnotation("Suggest Alloy label enforcement config"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Suggest Alloy label enforcement config"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddConfigTools registers the config-generation tool set.
-func AddConfigTools(s *server.MCPServer) {
+func AddConfigTools(s *mcp.Server) {
 	SuggestLokiAlloyLabelConfig.Register(s)
 }

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -14,8 +14,7 @@ import (
 
 	"github.com/PaesslerAG/gval"
 	"github.com/PaesslerAG/jsonpath"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -671,21 +670,21 @@ var GetDashboardByUID = mcpgrafana.MustTool(
 	"get_dashboard_by_uid",
 	"Retrieves the complete dashboard, including panels, variables, and settings, for a specific dashboard identified by its UID. The response includes 'apiVersion' and 'isV2': when 'isV2' is true the dashboard uses the v2 schema (panels live under 'elements' keyed by name, arranged by 'layout'; variables under 'variables'), otherwise it is classic v1 ('panels[]' with 'templating.list'). WARNING: Large dashboards can consume significant context window space. Consider using get_dashboard_summary for overview or get_dashboard_property for specific data instead.",
 	getDashboardByUID,
-	mcp.WithTitleAnnotation("Get dashboard details"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get dashboard details"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var UpdateDashboard = mcpgrafana.MustTool(
 	"update_dashboard",
 	"Create or update a dashboard. Two modes: (1) Full JSON — provide 'dashboard' for new dashboards or complete replacements. (2) Patch — provide 'uid' + 'operations' to make targeted changes to an existing dashboard. One of these two modes is required; 'folderUid'\\, 'message'\\, and 'overwrite' are supplementary and do nothing on their own. Dashboard authoring guidance: if a saved query must support one\\, many\\, or All values from a multi-select variable inside a regex expression or matcher\\, save '${var:regex}' rather than plain '$var'. Saved dashboard annotation queries/definitions must be written into dashboard JSON under 'annotations.list'; the create_annotation tool creates annotation events and does not add a reusable dashboard annotation query/definition to the saved dashboard. For stat panels over the current dashboard range\\, make the query return the range-level result the stat should display; panel-side reduction only reduces returned series and does not compute peak-over-range or ratio-of-peaks semantics for you. Patch operations support JSONPaths like '$.panels[0].targets[0].expr'\\, '$.panels[1].title'\\, '$.panels[2].targets[0].datasource'\\, '$.templating.list/-'\\, and '$.annotations.list/-'. Append to arrays with '/- ' syntax: '$.panels/- '. Remove by index: {\"op\": \"remove\"\\, \"path\": \"$.panels[2]\"}. Multiple removes on the same array are automatically reordered to avoid index-shifting issues. Note: only numeric array indices are supported in patch paths; filter expressions like [?(@.id==2)] and wildcards like [*] are not supported. v2 dashboards (check 'isV2' from get_dashboard_by_uid) use a different shape: patch '$.elements.<name>.spec.title' or '$.elements.<name>.spec.data.spec.queries[0].spec' and edit '$.variables'/'$.layout' rather than '$.panels'/'$.templating.list'. Full-JSON saves containing top-level 'elements'/'layout' are written as v2 and require a Kubernetes-capable Grafana. After creating or updating a dashboard\\, verify that panel queries return data by using `run_panel_query` or the appropriate query tool (`query_prometheus`\\, `query_loki_logs`\\, etc.) to validate expressions before considering the task complete.",
 	updateDashboard,
-	mcp.WithTitleAnnotation("Create or update dashboard"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Create or update dashboard"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type DashboardPanelQueriesParams struct {
@@ -754,11 +753,11 @@ var GetDashboardPanelQueries = mcpgrafana.MustTool(
 	"get_dashboard_panel_queries",
 	"Retrieve panel queries from a Grafana dashboard. Supports all datasource types (Prometheus, Loki, CloudWatch, SQL, etc.) and row-nested panels. Optionally filter to a specific panel by ID with `panelId`. Optionally provide `variables` for template variable substitution, which populates `processedQuery` and `requiredVariables` fields. Returns an array of objects with fields: title, query (raw expression), datasource (object with uid and type), and optionally processedQuery, refId, and requiredVariables.",
 	GetDashboardPanelQueriesTool,
-	mcp.WithTitleAnnotation("Get dashboard panel queries"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get dashboard panel queries"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // GetDashboardPropertyParams defines parameters for getting specific dashboard properties
@@ -806,11 +805,11 @@ var GetDashboardProperty = mcpgrafana.MustTool(
 	"get_dashboard_property",
 	"Get specific parts of a dashboard using JSONPath expressions to minimize context window usage. JSONPath targets the dashboard's native schema. Classic v1 paths: '$.title' (title)\\, '$.panels[*].title' (all panel titles)\\, '$.panels[0]' (first panel)\\, '$.templating.list' (variables)\\, '$.annotations.list' (saved dashboard annotation queries/definitions)\\, '$.tags' (tags)\\, '$.panels[*].targets[*].expr' (all queries). v2 dashboards (see isV2 from get_dashboard_by_uid) use different paths: '$.title'\\, '$.elements' (panels\\, keyed by name)\\, '$.variables' (variables)\\, '$.annotations'. Use this instead of get_dashboard_by_uid when you only need specific dashboard properties.",
 	getDashboardProperty,
-	mcp.WithTitleAnnotation("Get dashboard property"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get dashboard property"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // GetDashboardSummaryParams defines parameters for getting a dashboard summary
@@ -921,11 +920,11 @@ var GetDashboardSummary = mcpgrafana.MustTool(
 	"get_dashboard_summary",
 	"Get a compact summary of a dashboard including title\\, panel count\\, panel types\\, variables\\, and other metadata without the full JSON. Use this for dashboard overview and planning modifications without consuming large context windows.",
 	getDashboardSummary,
-	mcp.WithTitleAnnotation("Get dashboard summary"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get dashboard summary"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // applyJSONPath applies a value to a JSONPath or removes it if remove=true
@@ -1216,7 +1215,7 @@ func extractVariableSummary(variable map[string]interface{}) VariableSummary {
 	}
 }
 
-func AddDashboardTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddDashboardTools(mcp *mcp.Server, enableWriteTools bool) {
 	GetDashboardByUID.Register(mcp)
 	if enableWriteTools {
 		UpdateDashboard.Register(mcp)

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -9,14 +9,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/grafana/mcp-grafana/observability"
 	datasourceschemas "github.com/grafana/mcp-grafana/tools/datasource_schemas"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -39,12 +37,9 @@ const (
 // data (see observability.ToolPhaseMetaKey).
 func withToolPhase(r *mcp.CallToolResult, phase string) *mcp.CallToolResult {
 	if r.Meta == nil {
-		r.Meta = &mcp.Meta{}
+		r.Meta = mcp.Meta{}
 	}
-	if r.Meta.AdditionalFields == nil {
-		r.Meta.AdditionalFields = map[string]any{}
-	}
-	r.Meta.AdditionalFields[observability.ToolPhaseMetaKey] = phase
+	r.Meta[observability.ToolPhaseMetaKey] = phase
 	return r
 }
 
@@ -310,11 +305,11 @@ func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.Ca
 	// directly.
 	if schema != nil && (!args.SchemaReviewed || args.Name == "") {
 		text, _ := json.Marshal(datasourceschemas.BuildSchemaGuidance(schema, "create_datasource"))
-		return withToolPhase(mcp.NewToolResultText(string(text)), dsPhaseSchema), nil
+		return withToolPhase(mcpgrafana.NewToolResultText(string(text)), dsPhaseSchema), nil
 	}
 	if schema == nil && args.Name == "" {
 		text, _ := json.Marshal(noSchemaGuidance(args.Type))
-		return withToolPhase(mcp.NewToolResultText(string(text)), dsPhaseSchema), nil
+		return withToolPhase(mcpgrafana.NewToolResultText(string(text)), dsPhaseSchema), nil
 	}
 
 	dsAccess := args.Access
@@ -378,9 +373,8 @@ func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.Ca
 		if err != nil {
 			return nil, fmt.Errorf("marshal result: %w", err)
 		}
-		toolResult := mcp.NewToolResultText(string(b))
-		toolResult.Content = append(toolResult.Content, mcp.ResourceLink{
-			Type:        "resource_link",
+		toolResult := mcpgrafana.NewToolResultText(string(b))
+		toolResult.Content = append(toolResult.Content, &mcp.ResourceLink{
 			URI:         configPageURL,
 			Name:        result.Name,
 			Description: "Datasource configuration page",
@@ -391,7 +385,7 @@ func createDatasource(ctx context.Context, args CreateDatasourceParams) (*mcp.Ca
 	if err != nil {
 		return nil, fmt.Errorf("marshal result: %w", err)
 	}
-	return withToolPhase(mcp.NewToolResultText(string(b)), dsPhaseCreated), nil
+	return withToolPhase(mcpgrafana.NewToolResultText(string(b)), dsPhaseCreated), nil
 }
 
 // filterDatasources returns only datasources whose type contains `t` and
@@ -434,33 +428,33 @@ var ListDatasources = mcpgrafana.MustTool(
 	"list_datasources",
 	"List all configured datasources in Grafana. Use this to discover available datasources and their UIDs. Supports filtering by type and/or name (case-insensitive substring match) and pagination.",
 	listDatasources,
-	mcp.WithTitleAnnotation("List datasources"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List datasources"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var CreateDatasource = mcpgrafana.MustTool(
 	"create_datasource",
 	"Create a datasource. If type is ambiguous, call search_plugin_information first; install the plugin if needed. IMPORTANT: always call this tool twice. First call: provide only the type — the tool returns a field schema. After receiving the schema, you MUST ask the user for every required field value explicitly; do not infer or use defaults without user confirmation. Second call: provide the type, the display name in the top-level name argument, schemaReviewed=true, and the fields map populated with values confirmed by the user. Never handle credentials — remind the user to rotate any detected. Returns UID, health check, and a config page link. ",
 	createDatasource,
-	mcp.WithTitleAnnotation("Create datasource"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Create datasource"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var UpdateDatasource = mcpgrafana.MustTool(
 	"update_datasource",
 	"Update non-secret datasource fields by UID. Omitted fields are preserved. IMPORTANT: always call this tool twice. First call: provide only the uid — the tool returns the datasource's field schema. After receiving the schema, ask the user which fields they want to change and confirm each new value; do not infer or reset fields the user did not mention. Second call: provide the uid, schemaReviewed=true, and the changed values in the fields map. Returns an update message and a health check. For secrets, direct the user to the Grafana UI.",
 	updateDatasource,
-	mcp.WithTitleAnnotation("Update datasource"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Update datasource"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type GetDatasourceByUIDParams struct {
@@ -517,11 +511,11 @@ var GetDatasource = mcpgrafana.MustTool(
 	"get_datasource",
 	"Retrieves detailed information about a specific datasource by UID or name. Returns the full datasource model, including name, type, URL, access settings, JSON data, and secure JSON field status. Provide either uid or name; uid takes priority if both are given.",
 	getDatasource,
-	mcp.WithTitleAnnotation("Get datasource"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get datasource"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type UpdateDatasourceParams struct {
@@ -573,7 +567,7 @@ func updateDatasource(ctx context.Context, args UpdateDatasourceParams) (*mcp.Ca
 			guidance = noUpdateSchemaGuidance(ds.Type)
 		}
 		text, _ := json.Marshal(guidance)
-		return mcp.NewToolResultText(string(text)), nil
+		return mcpgrafana.NewToolResultText(string(text)), nil
 	}
 
 	cmd := &models.UpdateDataSourceCommand{
@@ -646,7 +640,7 @@ func updateDatasource(ctx context.Context, args UpdateDatasourceParams) (*mcp.Ca
 	if err != nil {
 		return nil, fmt.Errorf("marshal result: %w", err)
 	}
-	return mcp.NewToolResultText(string(b)), nil
+	return mcpgrafana.NewToolResultText(string(b)), nil
 }
 
 type CheckDatasourceHealthParams struct {
@@ -821,15 +815,15 @@ var CheckDatasourcesHealth = mcpgrafana.MustTool(
 	"check_datasources_health",
 	"Check datasource health. Filter by type or UIDs; omit both to check all.",
 	checkDatasourcesHealth,
-	mcp.WithTitleAnnotation("Check datasources health"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Check datasources health"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddDatasourceTools registers the datasource tools on the MCP server; write tools are registered only when enableWriteTools is true.
-func AddDatasourceTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddDatasourceTools(mcp *mcp.Server, enableWriteTools bool) {
 	ListDatasources.Register(mcp)
 	GetDatasource.Register(mcp)
 	CheckDatasourcesHealth.Register(mcp)

--- a/tools/elasticsearch.go
+++ b/tools/elasticsearch.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // QueryElasticsearchParams defines the parameters for querying Elasticsearch or OpenSearch
@@ -53,14 +52,14 @@ var QueryElasticsearch = mcpgrafana.MustTool(
 	"query_elasticsearch",
 	"Executes a search query against an Elasticsearch or OpenSearch datasource and retrieves matching documents. Supports Lucene query syntax (e.g., 'status:200 AND host:server1') for both Elasticsearch and OpenSearch. Elasticsearch Query DSL JSON is also supported for Elasticsearch datasources only (not OpenSearch). Returns a list of documents with their index, ID, source fields, and optional score. Use this to search logs, metrics, or any indexed data stored in Elasticsearch or OpenSearch. Defaults to 10 results and sorts by @timestamp in descending order (newest first).",
 	queryElasticsearch,
-	mcp.WithTitleAnnotation("Query Elasticsearch"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Elasticsearch"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddElasticsearchTools registers all Elasticsearch and OpenSearch tools with the MCP server
-func AddElasticsearchTools(mcp *server.MCPServer) {
+func AddElasticsearchTools(mcp *mcp.Server) {
 	QueryElasticsearch.Register(mcp)
 }

--- a/tools/examples.go
+++ b/tools/examples.go
@@ -6,8 +6,7 @@ import (
 	"strings"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // GetQueryExamplesParams defines the parameters for the get_query_examples tool.
@@ -291,14 +290,14 @@ var GetQueryExamples = mcpgrafana.MustTool(
 	"get_query_examples",
 	"Get example queries for a specific datasource type. Provides sample queries with descriptions for Prometheus (PromQL), Loki (LogQL), ClickHouse (SQL with Grafana macros), CloudWatch (metric configurations), and InfluxDB (Flux and InfluxQL). Use this to understand query syntax and common patterns for each datasource. TIP: Use list_datasources to find datasource UIDs, or get_datasource if you know the exact name.",
 	getQueryExamples,
-	mcp.WithTitleAnnotation("Get query examples"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get query examples"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddExamplesTools registers all example-related tools to the MCP server.
-func AddExamplesTools(mcp *server.MCPServer) {
+func AddExamplesTools(mcp *mcp.Server) {
 	GetQueryExamples.Register(mcp)
 }

--- a/tools/folder.go
+++ b/tools/folder.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type CreateFolderParams struct {
@@ -45,14 +43,14 @@ var CreateFolder = mcpgrafana.MustTool(
 	"create_folder",
 	"Create a Grafana folder. Provide a title and optional UID. Returns the created folder.",
 	createFolder,
-	mcp.WithTitleAnnotation("Create folder"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Create folder"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddFolderTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddFolderTools(mcp *mcp.Server, enableWriteTools bool) {
 	if enableWriteTools {
 		CreateFolder.Register(mcp)
 	}

--- a/tools/graphite.go
+++ b/tools/graphite.go
@@ -12,8 +12,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -230,11 +229,11 @@ var QueryGraphite = mcpgrafana.MustTool(
 	"query_graphite",
 	"WORKFLOW: list_graphite_metrics -> query_graphite.\n\nExecutes a Graphite render API query against a Graphite datasource and returns matching metric series with their datapoints. Supports the full Graphite target expression language including wildcard patterns (e.g. 'servers.web*.cpu.load5'), aggregation functions (e.g. 'sumSeries(app.*.requests)'), and tag-based queries (e.g. 'seriesByTag(\\'name=cpu.load\\')'). Datapoints with no recorded value are returned with a null value field. Time range defaults to the last hour if not specified.",
 	queryGraphite,
-	mcp.WithTitleAnnotation("Query Graphite metrics"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Graphite metrics"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // GraphiteMetricNode is a node in the Graphite metric hierarchy as returned
@@ -307,11 +306,11 @@ var ListGraphiteMetrics = mcpgrafana.MustTool(
 	"list_graphite_metrics",
 	"Discover available metric paths in a Graphite datasource by browsing the metric tree. Returns nodes matching the query pattern\\, each indicating whether it is a leaf metric (has data) or an expandable branch (has children). Use '*' as a wildcard at any level to enumerate the tree (e.g. '*' → top-level nodes\\, 'servers.*' → all second-level nodes under 'servers'). Drill down progressively to find the full metric path before querying with query_graphite.",
 	listGraphiteMetrics,
-	mcp.WithTitleAnnotation("List Graphite metrics"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Graphite metrics"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListGraphiteTagsParams defines the parameters for the list_graphite_tags tool.
@@ -356,11 +355,11 @@ var ListGraphiteTags = mcpgrafana.MustTool(
 	"list_graphite_tags",
 	"List available tag names in a Graphite datasource that uses tag-based metrics. Returns a list of tag name strings (e.g. [\"name\"\\, \"env\"\\, \"region\"]). These tags can be used to build tag-based target expressions for query_graphite (e.g. seriesByTag('name=cpu.load\\,env=prod')). Optionally filter by a prefix. Requires Graphite to be configured with tag support.",
 	listGraphiteTags,
-	mcp.WithTitleAnnotation("List Graphite tags"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Graphite tags"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // computeSeriesDensity derives data-density statistics from the parsed
@@ -502,15 +501,15 @@ var QueryGraphiteDensity = mcpgrafana.MustTool(
 		"Supports wildcard targets (e.g. 'obox-cl*.sys.sessions') to diagnose stale, sparse, or dead metrics across a cluster. "+
 		"A fillRatio of 0 with lastSeen null means the series reported no data in the requested window.",
 	queryGraphiteDensity,
-	mcp.WithTitleAnnotation("Query Graphite metric density"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Graphite metric density"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddGraphiteTools registers all Graphite tools with the MCP server.
-func AddGraphiteTools(mcp *server.MCPServer) {
+func AddGraphiteTools(mcp *mcp.Server) {
 	QueryGraphite.Register(mcp)
 	ListGraphiteMetrics.Register(mcp)
 	ListGraphiteTags.Register(mcp)

--- a/tools/incident.go
+++ b/tools/incident.go
@@ -6,8 +6,7 @@ import (
 
 	"github.com/grafana/incident-go"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type ListIncidentsParams struct {
@@ -86,11 +85,11 @@ var ListIncidents = mcpgrafana.MustTool(
 	"list_incidents",
 	"List Grafana incidents. Allows filtering by status ('active', 'resolved') and optionally including drill incidents. Returns a preview list with basic details.",
 	listIncidents,
-	mcp.WithTitleAnnotation("List incidents"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List incidents"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type CreateIncidentParams struct {
@@ -127,10 +126,10 @@ var CreateIncident = mcpgrafana.MustTool(
 	"create_incident",
 	"Create a new Grafana incident. Requires title, severity, and room prefix. Allows setting status and labels. This tool should be used judiciously and sparingly, and only after confirmation from the user, as it may notify or alarm lots of people.",
 	createIncident,
-	mcp.WithTitleAnnotation("Create incident"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Create incident"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type AddActivityToIncidentParams struct {
@@ -158,13 +157,13 @@ var AddActivityToIncident = mcpgrafana.MustTool(
 	"add_activity_to_incident",
 	"Add a note (userNote activity) to an existing incident's timeline using its ID. The note body can include URLs which will be attached as context. Use this to add context to an incident.",
 	addActivityToIncident,
-	mcp.WithTitleAnnotation("Add activity to incident"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Add activity to incident"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddIncidentTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddIncidentTools(mcp *mcp.Server, enableWriteTools bool) {
 	ListIncidents.Register(mcp)
 	if enableWriteTools {
 		CreateIncident.Register(mcp)
@@ -195,9 +194,9 @@ var GetIncident = mcpgrafana.MustTool(
 	"get_incident",
 	"Get a single incident by ID. Returns the full incident details including title, status, severity, labels, timestamps, and other metadata.",
 	getIncident,
-	mcp.WithTitleAnnotation("Get incident details"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get incident details"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/influxdb.go
+++ b/tools/influxdb.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -215,17 +214,17 @@ Time formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)
 InfluxQL example: SELECT mean("value") FROM "cpu" WHERE time > now() - 1h GROUP BY time(1m)
 Flux example:    from(bucket: "metrics") |> range(start: -1h) |> filter(fn: (r) => r._measurement == "cpu")`,
 	queryInfluxDB,
-	mcp.WithTitleAnnotation("Query InfluxDB"),
-	mcp.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query InfluxDB"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
 	// The query is passed through unfiltered: InfluxQL supports DELETE/DROP
 	// and Flux can write via to(), so this executes writes if the datasource
 	// credentials permit it — not read-only, potentially destructive.
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddInfluxDBTools registers all InfluxDB tools with the MCP server.
-func AddInfluxDBTools(mcp *server.MCPServer) {
+func AddInfluxDBTools(mcp *mcp.Server) {
 	QueryInfluxDB.Register(mcp)
 }

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -13,8 +13,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -219,11 +218,11 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 	"list_loki_label_names",
 	"Lists all available label/field names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
 	listLokiLabelNames,
-	mcp.WithTitleAnnotation("List Loki label names"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Loki label names"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListLokiLabelValuesParams defines the parameters for listing Loki label values
@@ -268,11 +267,11 @@ var ListLokiLabelValues = mcpgrafana.MustTool(
 	"list_loki_label_values",
 	"Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
 	listLokiLabelValues,
-	mcp.WithTitleAnnotation("List Loki label values"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Loki label values"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // LokiLogStream represents a stream of log entries from Loki (resultType: "streams")
@@ -748,11 +747,11 @@ var QueryLokiLogs = mcpgrafana.MustTool(
 	"query_loki_logs",
 	"Executes a log query against a Loki or VictoriaLogs datasource and returns matching log entries (or metric samples on Loki). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). The `logql` parameter takes LogQL on Loki and LogsQL on VictoriaLogs (e.g., Loki: `{app=\"foo\"} |= \"error\"`; VictoriaLogs: `{app=\"foo\"} \"error\"`). To count matching log lines precisely, use a `count_over_time()` metric query with queryType='instant'. Prefer using `query_loki_stats` first to cheaply check whether a stream contains data (avoiding expensive queries against empty streams) and `list_loki_label_names` / `list_loki_label_values` to verify labels exist before querying. Note: `query_loki_stats` returns approximate storage-level counts, not exact log line counts.",
 	queryLokiLogs,
-	mcp.WithTitleAnnotation("Query Loki logs"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Loki logs"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // fetchStats is a method to fetch stats data from Loki API
@@ -862,11 +861,11 @@ var QueryLokiStats = mcpgrafana.MustTool(
 	"query_loki_stats",
 	"Retrieves index-level statistics about log streams matching a given selector within a Loki or VictoriaLogs datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{\"streams\": 5, \"chunks\": 50, \"entries\": 10000, \"bytes\": 512000}`). **Important**: the `entries` count reflects storage-level index entries (chunk metadata), NOT the number of individual log lines matching the selector. To count actual matching log lines, use `query_loki_logs` with a `count_over_time()` metric query instead. On VictoriaLogs only `entries` is populated; the other fields remain zero. The `logql` parameter **must** be a simple label selector (e.g., `{app=\"nginx\", env=\"prod\"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.",
 	queryLokiStats,
-	mcp.WithTitleAnnotation("Get Loki log statistics"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get Loki log statistics"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // QueryLokiPatternsParams defines the parameters for querying Loki patterns
@@ -905,17 +904,17 @@ var QueryLokiPatterns = mcpgrafana.MustTool(
 	"query_loki_patterns",
 	"Retrieves detected log patterns from a Loki datasource for a given stream selector and time range. Returns a list of patterns, each containing a pattern string and a total count of occurrences. Patterns help identify common log structures and anomalies. The `logql` parameter must be a stream selector (e.g., `{job=\"nginx\"}`) and does not support line filters or aggregations. Defaults to the last hour if the time range is omitted. **Not supported on VictoriaLogs** datasources - use a `| stats` pipeline instead.",
 	queryLokiPatterns,
-	mcp.WithTitleAnnotation("Query Loki patterns"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Loki patterns"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddLokiTools registers all Loki tools with the MCP server.
 // Config-generation tools (e.g. suggest_loki_alloy_label_config) live in
 // the separate "config" category — see tools.AddConfigTools.
-func AddLokiTools(mcp *server.MCPServer) {
+func AddLokiTools(mcp *mcp.Server) {
 	ListLokiLabelNames.Register(mcp)
 	ListLokiLabelValues.Register(mcp)
 	QueryLokiStats.Register(mcp)

--- a/tools/loki_label_analyzer.go
+++ b/tools/loki_label_analyzer.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // The functions in this file translate the Grafana Professional Services
@@ -926,7 +925,7 @@ func buildPerfSummary(findings []QueryPerfFinding, stats *Stats) string {
 
 // AddLokiLabelAnalyzerTools registers the label-analyzer tool set.
 // AddLokiTools calls this so the standard Loki bundle includes them.
-func AddLokiLabelAnalyzerTools(s *server.MCPServer) {
+func AddLokiLabelAnalyzerTools(s *mcp.Server) {
 	AnalyzeLokiLabels.Register(s)
 }
 
@@ -1008,9 +1007,9 @@ var AnalyzeLokiLabels = mcpgrafana.MustTool(
 	"analyze_loki_labels",
 	"Audits a Loki label strategy and optionally diagnoses query performance. Returns per-label verdicts, missing base labels, normalisation issues, and a recommended set. Pass datasourceUid for live cardinality or labels for static scoring; both may be combined.",
 	analyzeLokiLabels,
-	mcp.WithTitleAnnotation("Analyze Loki label strategy"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Analyze Loki label strategy"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -11,10 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type GenerateDeeplinkParams struct {
@@ -315,25 +313,25 @@ var GenerateDeeplink = mcpgrafana.MustTool(
 	"generate_deeplink",
 	"Generate deeplink URLs for Grafana resources. Supports dashboards (requires dashboardUid or provisioningPreview), panels (requires dashboardUid or provisioningPreview, plus panelId), and Explore queries (requires datasourceUid and optionally queries). For dashboard and panel links, provisioningPreview points at a dashboard staged on a provisioning repository branch (e.g. a git-sync PR preview). For explore links, the time range and queries are embedded inside the Grafana explore state. Set shorten=true to also attempt a /goto/<uid> short URL; if shortening fails, the full deeplink is returned.",
 	generateDeeplink,
-	mcp.WithTitleAnnotation("Generate navigation deeplink"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Generate navigation deeplink"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var GenerateDeeplinkReadOnly = mcpgrafana.MustTool(
 	"generate_deeplink",
 	"Generate deeplink URLs for Grafana resources. Supports dashboards (requires dashboardUid or provisioningPreview), panels (requires dashboardUid or provisioningPreview, plus panelId), and Explore queries (requires datasourceUid and optionally queries). For dashboard and panel links, provisioningPreview points at a dashboard staged on a provisioning repository branch (e.g. a git-sync PR preview). In read-only mode, shorten=true is accepted but ignored and the full deeplink is returned.",
 	generateDeeplinkReadOnly,
-	mcp.WithTitleAnnotation("Generate navigation deeplink"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Generate navigation deeplink"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddNavigationTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddNavigationTools(mcp *mcp.Server, enableWriteTools bool) {
 	if enableWriteTools {
 		GenerateDeeplink.Register(mcp)
 		return

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -10,8 +10,7 @@ import (
 
 	aapi "github.com/grafana/amixr-api-go-client"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // getOnCallURLFromSettings retrieves the OnCall API URL from the Grafana settings endpoint.
@@ -189,11 +188,11 @@ var ListOnCallSchedules = mcpgrafana.MustTool(
 	"list_oncall_schedules",
 	"List Grafana OnCall schedules, optionally filtering by team ID. If a specific schedule ID is provided, retrieves details for only that schedule. Returns a list of schedule summaries including ID, name, team ID, timezone, and shift IDs. Supports pagination.",
 	listOnCallSchedules,
-	mcp.WithTitleAnnotation("List OnCall schedules"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List OnCall schedules"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Shifts ---
@@ -241,11 +240,11 @@ var GetOnCallShift = mcpgrafana.MustTool(
 	"get_oncall_shift",
 	"Get detailed information for a specific Grafana OnCall shift using its ID. A shift represents a designated time period within a schedule when users are actively on-call. Returns the full shift details.",
 	getOnCallShift,
-	mcp.WithTitleAnnotation("Get OnCall shift"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get OnCall shift"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Current On-Call Users ---
@@ -311,11 +310,11 @@ var GetCurrentOnCallUsers = mcpgrafana.MustTool(
 	"get_current_oncall_users",
 	"Get the list of users currently on-call for a specific Grafana OnCall schedule ID. Returns the schedule ID, name, and a list of detailed user objects for those currently on call.",
 	getCurrentOnCallUsers,
-	mcp.WithTitleAnnotation("Get current on-call users"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get current on-call users"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Teams ---
@@ -364,11 +363,11 @@ var ListOnCallTeams = mcpgrafana.MustTool(
 	"list_oncall_teams",
 	"List teams configured in Grafana OnCall. Returns a list of team objects with their details. Supports pagination.",
 	listOnCallTeams,
-	mcp.WithTitleAnnotation("List OnCall teams"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List OnCall teams"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Users ---
@@ -436,11 +435,11 @@ var ListOnCallUsers = mcpgrafana.MustTool(
 	"list_oncall_users",
 	"List users from Grafana OnCall. These are OnCall users (separate from Grafana users). Can retrieve all users in the OnCall directory, a specific user by ID, or filter by username. Returns a list of user objects with their details. Supports pagination.",
 	listOnCallUsers,
-	mcp.WithTitleAnnotation("List OnCall users"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List OnCall users"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // --- Alert Groups ---
@@ -527,11 +526,11 @@ var ListAlertGroups = mcpgrafana.MustTool(
 	"list_alert_groups",
 	"List alert groups from Grafana OnCall with filtering options. Supports filtering by alert group ID, route ID, integration ID, state (new, acknowledged, resolved, silenced), team ID, time range, labels, and name. For time ranges, use format '{start}_{end}' ISO 8601 timestamp range (e.g., '2025-01-19T00:00:00_2025-01-19T23:59:59' for a specific day). For labels, use format 'key:value' (e.g., ['env:prod', 'severity:high']). Returns a list of alert group objects with their details. Supports pagination.",
 	listAlertGroups,
-	mcp.WithTitleAnnotation("List IRM alert groups"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List IRM alert groups"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type GetAlertGroupParams struct {
@@ -574,14 +573,14 @@ var GetAlertGroup = mcpgrafana.MustTool(
 	"get_alert_group",
 	"Get a specific alert group from Grafana OnCall by its ID. Returns the full alert group details.",
 	getAlertGroup,
-	mcp.WithTitleAnnotation("Get IRM alert group"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get IRM alert group"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddOnCallTools(mcp *server.MCPServer) {
+func AddOnCallTools(mcp *mcp.Server) {
 	ListOnCallSchedules.Register(mcp)
 	GetOnCallShift.Register(mcp)
 	GetCurrentOnCallUsers.Register(mcp)

--- a/tools/plugins.go
+++ b/tools/plugins.go
@@ -11,10 +11,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type GetPluginParams struct {
@@ -126,11 +124,11 @@ var GetPlugin = mcpgrafana.MustTool(
 	"get_plugin",
 	"Check whether a Grafana plugin is installed and retrieve its details (name, version, type, enabled status). Returns installed=false when the plugin is not found. Use install_plugin when a plugin is not installed to install plugin after confirming this action with the user.",
 	getPlugin,
-	mcp.WithTitleAnnotation("Get plugin"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get plugin"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type InstallPluginParams struct {
@@ -231,11 +229,11 @@ var InstallPlugin = mcpgrafana.MustTool(
 	"install_plugin",
 	"Install a Grafana plugin by its plugin ID. If the version is not already confirmed with the user, omit it — the tool will look up the latest version and return it for confirmation before installing.",
 	installPlugin,
-	mcp.WithTitleAnnotation("Install plugin"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(true),
+	mcpgrafana.WithTitleAnnotation("Install plugin"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(true),
 )
 
 // catalogPlugin mirrors the relevant fields from the Grafana plugin catalog list API.
@@ -398,14 +396,14 @@ var SearchPlugins = mcpgrafana.MustTool(
 		"it returns the exact pluginId to pass to get_plugin or install_plugin. "+
 		"Results include warnings for enterprise-only or Angular-based plugins.",
 	searchPlugins,
-	mcp.WithTitleAnnotation("Search plugins"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(true),
+	mcpgrafana.WithTitleAnnotation("Search plugins"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(true),
 )
 
-func AddPluginTools(s *server.MCPServer, enableWrite bool) {
+func AddPluginTools(s *mcp.Server, enableWrite bool) {
 	SearchPlugins.Register(s)
 	GetPlugin.Register(s)
 	if enableWrite {

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -10,8 +10,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -57,11 +56,11 @@ var ListPrometheusMetricMetadata = mcpgrafana.MustTool(
 	"list_prometheus_metric_metadata",
 	"List Prometheus metric metadata. Returns metadata about metrics currently scraped from targets. Note: This endpoint is experimental.",
 	listPrometheusMetricMetadata,
-	mcp.WithTitleAnnotation("List Prometheus metric metadata"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Prometheus metric metadata"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type QueryPrometheusParams struct {
@@ -181,11 +180,11 @@ var QueryPrometheus = mcpgrafana.MustTool(
 	"query_prometheus",
 	"WORKFLOW: list_prometheus_metric_names -> list_prometheus_label_values -> query_prometheus. Query a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.) using a PromQL expression. Supports instant queries (single point) and range queries (time range). Time: RFC3339 or relative expressions like 'now'\\, 'now-1h'.",
 	queryPrometheusWithHints,
-	mcp.WithTitleAnnotation("Query Prometheus metrics"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Prometheus metrics"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPrometheusMetricNamesParams struct {
@@ -263,11 +262,11 @@ var ListPrometheusMetricNames = mcpgrafana.MustTool(
 	"list_prometheus_metric_names",
 	"DISCOVERY: Call this first to find available metrics before querying. Lists metric names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Retrieves all metric names and filters them using the provided regex. Supports pagination and an optional time range to restrict results to metrics active within that window.",
 	listPrometheusMetricNames,
-	mcp.WithTitleAnnotation("List Prometheus metric names"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Prometheus metric names"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type LabelMatcher struct {
@@ -368,11 +367,11 @@ var ListPrometheusLabelNames = mcpgrafana.MustTool(
 	"list_prometheus_label_names",
 	"List label names in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Allows filtering by series selectors and time range.",
 	listPrometheusLabelNames,
-	mcp.WithTitleAnnotation("List Prometheus label names"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Prometheus label names"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPrometheusLabelValuesParams struct {
@@ -427,11 +426,11 @@ var ListPrometheusLabelValues = mcpgrafana.MustTool(
 	"list_prometheus_label_values",
 	"Use after list_prometheus_metric_names to find label values for filtering queries. Gets the values for a specific label name in a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.). Allows filtering by series selectors and time range.",
 	listPrometheusLabelValues,
-	mcp.WithTitleAnnotation("List Prometheus label values"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Prometheus label values"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // PrometheusHistogramResult wraps histogram query results with debugging info
@@ -583,14 +582,14 @@ Generates histogram_quantile PromQL. Example: metric='http_duration', percentile
 
 Time formats: 'now-1h', '2026-02-02T19:00:00Z', '1738519200000' (Unix ms)`,
 	queryPrometheusHistogram,
-	mcp.WithTitleAnnotation("Query Prometheus histogram percentile"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Prometheus histogram percentile"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddPrometheusTools(mcp *server.MCPServer) {
+func AddPrometheusTools(mcp *mcp.Server) {
 	ListPrometheusMetricMetadata.Register(mcp)
 	QueryPrometheus.Register(mcp)
 	QueryPrometheusHistogram.Register(mcp)

--- a/tools/provisioning.go
+++ b/tools/provisioning.go
@@ -9,10 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // ListProvisioningRepositoriesParams accepts an optional namespace.
@@ -158,11 +156,11 @@ var ListProvisioningRepositories = mcpgrafana.MustTool(
 		"Returns each repository's slug along with its source URL, branch, path, sync state, and health. "+
 		"Use the returned `name` as the `repo` argument when rendering a not-yet-applied dashboard preview via get_panel_image's provisioningPreview parameter.",
 	listProvisioningRepositories,
-	mcp.WithTitleAnnotation("List provisioning repositories"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List provisioning repositories"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ValidateProvisioningFileParams identifies a single file to validate inside
@@ -378,14 +376,14 @@ var ValidateProvisioningFile = mcpgrafana.MustTool(
 		"Returns whether the file would be accepted (valid)\\, what resource action would result (create/update)\\, the target resource type\\, and any structured validation errors. "+
 		"Use to confirm a draft dashboard or other resource will be accepted before merging or applying a PR — this is the same validation surface that Grafana's PR commenter reports.",
 	validateProvisioningFile,
-	mcp.WithTitleAnnotation("Validate provisioning file"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Validate provisioning file"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddProvisioningTools(s *server.MCPServer) {
+func AddProvisioningTools(s *mcp.Server) {
 	ListProvisioningRepositories.Register(s)
 	ValidateProvisioningFile.Register(s)
 }

--- a/tools/pyroscope.go
+++ b/tools/pyroscope.go
@@ -19,11 +19,10 @@ import (
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func AddPyroscopeTools(mcp *server.MCPServer) {
+func AddPyroscopeTools(mcp *mcp.Server) {
 	ListPyroscopeLabelNames.Register(mcp)
 	ListPyroscopeLabelValues.Register(mcp)
 	ListPyroscopeProfileTypes.Register(mcp)
@@ -41,11 +40,11 @@ var ListPyroscopeLabelNames = mcpgrafana.MustTool(
 	"list_pyroscope_label_names",
 	listPyroscopeLabelNamesToolPrompt,
 	listPyroscopeLabelNames,
-	mcp.WithTitleAnnotation("List Pyroscope label names"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Pyroscope label names"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPyroscopeLabelNamesParams struct {
@@ -102,11 +101,11 @@ var ListPyroscopeLabelValues = mcpgrafana.MustTool(
 	"list_pyroscope_label_values",
 	listPyroscopeLabelValuesToolPrompt,
 	listPyroscopeLabelValues,
-	mcp.WithTitleAnnotation("List Pyroscope label values"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Pyroscope label values"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPyroscopeLabelValuesParams struct {
@@ -170,11 +169,11 @@ var ListPyroscopeProfileTypes = mcpgrafana.MustTool(
 	"list_pyroscope_profile_types",
 	listPyroscopeProfileTypesToolPrompt,
 	listPyroscopeProfileTypes,
-	mcp.WithTitleAnnotation("List Pyroscope profile types"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Pyroscope profile types"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type ListPyroscopeProfileTypesParams struct {
@@ -625,11 +624,11 @@ var QueryPyroscope = mcpgrafana.MustTool(
 	"query_pyroscope",
 	queryPyroscopeToolPrompt,
 	queryPyroscope,
-	mcp.WithTitleAnnotation("Query Pyroscope"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Pyroscope"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type QueryPyroscopeParams struct {

--- a/tools/quickwit.go
+++ b/tools/quickwit.go
@@ -12,8 +12,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const quickwitDatasourceType = "quickwit-quickwit-datasource"
@@ -259,14 +258,14 @@ var QueryQuickwit = mcpgrafana.MustTool(
 	"query_quickwit",
 	"Executes a search query against a Quickwit datasource and retrieves matching documents. Supports Lucene query syntax (e.g., 'severity_text:ERROR AND service_name:api') and partial Elasticsearch-compatible Query DSL JSON. The timestamp field is resolved from Quickwit index metadata (not jsonData.timeField). Returns a list of documents with their index, ID, source fields, and optional score. Use this to search logs or other indexed data stored in Quickwit. Defaults to 10 results and sorts by the index timestamp field in descending order (newest first).",
 	queryQuickwit,
-	mcp.WithTitleAnnotation("Query Quickwit"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Quickwit"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddQuickwitTools registers all Quickwit tools with the MCP server.
-func AddQuickwitTools(mcp *server.MCPServer) {
+func AddQuickwitTools(mcp *mcp.Server) {
 	QueryQuickwit.Register(mcp)
 }

--- a/tools/rendering.go
+++ b/tools/rendering.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,8 +12,7 @@ import (
 	"time"
 
 	"github.com/invopop/jsonschema"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 )
@@ -160,15 +158,11 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 		return nil, fmt.Errorf("failed to read image data: %w", err)
 	}
 
-	// Return the image as base64 encoded data using MCP's image content type
-	base64Data := base64.StdEncoding.EncodeToString(imageData)
-
-	// Rendering succeeded, so always return the image. The deeplink is
-	// best-effort metadata added only if it builds successfully.
+	// Return the image using MCP's image content type. Data is raw bytes -
+	// the SDK base64-encodes []byte fields automatically when marshaling.
 	content := []mcp.Content{
-		mcp.ImageContent{
-			Type:     "image",
-			Data:     base64Data,
+		&mcp.ImageContent{
+			Data:     imageData,
 			MIMEType: "image/png",
 		},
 	}
@@ -177,9 +171,8 @@ func getPanelImage(ctx context.Context, args GetPanelImageParams) (*mcp.CallTool
 	// endpoint the browser can't reach.
 	if deeplinkBase, err := grafanaBaseURLFromContext(ctx); err == nil {
 		if deeplink, err := buildDashboardDeeplink(deeplinkBase, args); err == nil {
-			content = append(content, mcp.TextContent{
+			content = append(content, &mcp.TextContent{
 				Meta: mcpgrafana.NewUIContentMeta(mcpgrafana.UIContentKindDeeplink),
-				Type: "text",
 				Text: deeplink,
 			})
 		}
@@ -357,14 +350,14 @@ var GetPanelImage = mcpgrafana.MustTool(
 		"Either dashboardUid (for stored dashboards) or provisioningPreview (for dashboards staged on a provisioning repository branch, e.g. a git-sync PR) must be supplied. "+
 		"Use this for generating visual snapshots of dashboards for reports, alerts, or presentations.",
 	getPanelImage,
-	mcp.WithTitleAnnotation("Get panel or dashboard image"),
-	mcp.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithTitleAnnotation("Get panel or dashboard image"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
 	mcpgrafana.WithUIResource(mcpgrafana.PanelViewerResourceURI),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddRenderingTools(mcp *server.MCPServer) {
+func AddRenderingTools(mcp *mcp.Server) {
 	GetPanelImage.Register(mcp)
 }

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -10,8 +10,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/prometheus/common/model"
 )
 
@@ -840,14 +839,14 @@ var RunPanelQuery = mcpgrafana.MustTool(
 	"run_panel_query",
 	"Executes one or more dashboard panel queries with optional time range and variable overrides. Accepts an array of panel IDs to query in a single call. Fetches the dashboard\\, extracts queries from the specified panels\\, substitutes template variables and Grafana macros ($__range\\, $__rate_interval\\, $__interval)\\, and routes to the appropriate datasource (Prometheus\\, Loki\\, ClickHouse\\, CloudWatch\\, InfluxDB\\, or BigQuery). Returns results keyed by panel ID - partial failures are allowed (some panels can succeed while others fail). Use get_dashboard_summary first to find panel IDs. If a panel uses a template variable datasource you cannot access\\, provide datasourceUid and datasourceType to override.",
 	runPanelQuery,
-	mcp.WithTitleAnnotation("Run panel query"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Run panel query"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddRunPanelQueryTools registers run panel query tools with the MCP server
-func AddRunPanelQueryTools(mcp *server.MCPServer) {
+func AddRunPanelQueryTools(mcp *mcp.Server) {
 	RunPanelQuery.Register(mcp)
 }

--- a/tools/search.go
+++ b/tools/search.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	"github.com/grafana/grafana-openapi-client-go/client/search"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 var dashboardTypeStr = "dash-db"
@@ -104,11 +102,11 @@ var SearchDashboards = mcpgrafana.MustTool(
 	"search_dashboards",
 	"Search for Grafana dashboards by a query string. Returns a list of matching dashboards with details like title, UID, folder, tags, and URL.",
 	searchDashboards,
-	mcp.WithTitleAnnotation("Search dashboards"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Search dashboards"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 type SearchFoldersParams struct {
@@ -136,14 +134,14 @@ var SearchFolders = mcpgrafana.MustTool(
 	"search_folders",
 	"Search for Grafana folders by a query string. Returns matching folders with details like title, UID, and URL.",
 	searchFolders,
-	mcp.WithTitleAnnotation("Search folders"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Search folders"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddSearchTools(mcp *server.MCPServer) {
+func AddSearchTools(mcp *mcp.Server) {
 	SearchDashboards.Register(mcp)
 	SearchFolders.Register(mcp)
 }

--- a/tools/sift.go
+++ b/tools/sift.go
@@ -12,8 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type investigationStatus string
@@ -174,11 +173,11 @@ var GetSiftInvestigation = mcpgrafana.MustTool(
 	"get_sift_investigation",
 	"Retrieves an existing Sift investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').",
 	getSiftInvestigation,
-	mcp.WithTitleAnnotation("Get Sift investigation"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get Sift investigation"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // GetSiftAnalysisParams defines the parameters for retrieving a specific analysis
@@ -218,11 +217,11 @@ var GetSiftAnalysis = mcpgrafana.MustTool(
 	"get_sift_analysis",
 	"Retrieves a specific analysis from an investigation by its UUID. The investigation ID and analysis ID should be provided as strings in UUID format.",
 	getSiftAnalysis,
-	mcp.WithTitleAnnotation("Get Sift analysis"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get Sift analysis"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListSiftInvestigationsParams defines the parameters for retrieving investigations
@@ -255,11 +254,11 @@ var ListSiftInvestigations = mcpgrafana.MustTool(
 	"list_sift_investigations",
 	"Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.",
 	listSiftInvestigations,
-	mcp.WithTitleAnnotation("List Sift investigations"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Sift investigations"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // FindErrorPatternLogsParams defines the parameters for running an ErrorPatternLogs check
@@ -350,10 +349,10 @@ var FindErrorPatternLogs = mcpgrafana.MustTool(
 	"find_error_pattern_logs",
 	"Searches Loki logs for elevated error patterns compared to the last day's average, waits for the analysis to complete, and returns the results including any patterns found.",
 	findErrorPatternLogs,
-	mcp.WithTitleAnnotation("Find error patterns in logs"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Find error patterns in logs"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // FindSlowRequestsParams defines the parameters for running an SlowRequests check
@@ -419,14 +418,14 @@ var FindSlowRequests = mcpgrafana.MustTool(
 	"find_slow_requests",
 	"Searches relevant Tempo datasources for slow requests, waits for the analysis to complete, and returns the results.",
 	findSlowRequests,
-	mcp.WithTitleAnnotation("Find slow requests"),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Find slow requests"),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddSiftTools registers all Sift tools with the MCP server
-func AddSiftTools(mcp *server.MCPServer, enableWriteTools bool) {
+func AddSiftTools(mcp *mcp.Server, enableWriteTools bool) {
 	GetSiftInvestigation.Register(mcp)
 	GetSiftAnalysis.Register(mcp)
 	ListSiftInvestigations.Register(mcp)

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -9,10 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-
 	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type ListSnapshotsParams struct {
@@ -228,47 +226,47 @@ var ListSnapshotsTool = mcpgrafana.MustTool(
 	"list_snapshots",
 	"List Grafana dashboard snapshots with optional query and result limit filters.",
 	listSnapshots,
-	mcp.WithTitleAnnotation("List snapshots"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List snapshots"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var GetSnapshotTool = mcpgrafana.MustTool(
 	"get_snapshot",
 	"Get a Grafana snapshot by key, including snapshot metadata and dashboard payload.",
 	getSnapshot,
-	mcp.WithTitleAnnotation("Get snapshot"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Get snapshot"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var CreateSnapshotTool = mcpgrafana.MustTool(
 	"create_snapshot",
 	"Create a Grafana snapshot from a full dashboard payload. Supports optional expiration and external snapshot fields.",
 	createSnapshot,
-	mcp.WithTitleAnnotation("Create snapshot"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Create snapshot"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 var DeleteSnapshotTool = mcpgrafana.MustTool(
 	"delete_snapshot",
 	"Delete a Grafana snapshot by snapshot key.",
 	deleteSnapshot,
-	mcp.WithTitleAnnotation("Delete snapshot"),
-	mcp.WithIdempotentHintAnnotation(false),
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Delete snapshot"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
-func AddSnapshotTools(s *server.MCPServer, enableWriteTools bool) {
+func AddSnapshotTools(s *mcp.Server, enableWriteTools bool) {
 	ListSnapshotsTool.Register(s)
 	GetSnapshotTool.Register(s)
 	if enableWriteTools {

--- a/tools/snowflake.go
+++ b/tools/snowflake.go
@@ -9,8 +9,7 @@ import (
 	"time"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -238,14 +237,14 @@ Snowflake event tables (telemetry from logging APIs/auto-instrumentation) live i
 
 Example: SELECT TIMESTAMP, RECORD['severity_text']::STRING AS LEVEL, VALUE FROM SNOWFLAKE.TELEMETRY.EVENTS WHERE $__timeFilter(TIMESTAMP) AND RECORD_TYPE = 'LOG'`,
 	querySnowflake,
-	mcp.WithTitleAnnotation("Query Snowflake"),
-	mcp.WithIdempotentHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Query Snowflake"),
+	mcpgrafana.WithIdempotentHintAnnotation(false),
 	// The raw SQL is passed through unfiltered, so a DELETE/DROP executes if
 	// the datasource credentials permit it — not read-only, potentially
 	// destructive.
-	mcp.WithReadOnlyHintAnnotation(false),
-	mcp.WithDestructiveHintAnnotation(true),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithReadOnlyHintAnnotation(false),
+	mcpgrafana.WithDestructiveHintAnnotation(true),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // ListSnowflakeTablesParams defines the parameters for listing Snowflake tables
@@ -321,11 +320,11 @@ var ListSnowflakeTables = mcpgrafana.MustTool(
 	"list_snowflake_tables",
 	"START HERE for Snowflake: List available tables (database, schema, name, kind, row count, size) via INFORMATION_SCHEMA. NEXT: Use describe_snowflake_table to see column schemas.",
 	listSnowflakeTables,
-	mcp.WithTitleAnnotation("List Snowflake tables"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("List Snowflake tables"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // DescribeSnowflakeTableParams defines the parameters for describing a Snowflake table
@@ -405,15 +404,15 @@ var DescribeSnowflakeTable = mcpgrafana.MustTool(
 	"describe_snowflake_table",
 	"Get column schema for a Snowflake table. Pass the database/schema from list_snowflake_tables results. NEXT: Use query_snowflake with discovered column names.",
 	describeSnowflakeTable,
-	mcp.WithTitleAnnotation("Describe Snowflake table"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
-	mcp.WithOpenWorldHintAnnotation(false),
+	mcpgrafana.WithTitleAnnotation("Describe Snowflake table"),
+	mcpgrafana.WithIdempotentHintAnnotation(true),
+	mcpgrafana.WithReadOnlyHintAnnotation(true),
+	mcpgrafana.WithDestructiveHintAnnotation(false),
+	mcpgrafana.WithOpenWorldHintAnnotation(false),
 )
 
 // AddSnowflakeTools registers all Snowflake tools with the MCP server
-func AddSnowflakeTools(mcp *server.MCPServer) {
+func AddSnowflakeTools(mcp *mcp.Server) {
 	QuerySnowflake.Register(mcp)
 	ListSnowflakeTables.Register(mcp)
 	DescribeSnowflakeTable.Register(mcp)

--- a/ui_apps.go
+++ b/ui_apps.go
@@ -3,8 +3,7 @@ package mcpgrafana
 import (
 	"context"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -17,47 +16,44 @@ const (
 
 // WithUIResource attaches a _meta.ui.resourceUri to a tool definition,
 // linking it to an MCP App HTML resource for inline rendering.
-func WithUIResource(resourceURI string) mcp.ToolOption {
+func WithUIResource(resourceURI string) ToolOption {
 	return func(t *mcp.Tool) {
 		if t.Meta == nil {
-			t.Meta = &mcp.Meta{}
+			t.Meta = mcp.Meta{}
 		}
-		if t.Meta.AdditionalFields == nil {
-			t.Meta.AdditionalFields = make(map[string]any)
-		}
-		t.Meta.AdditionalFields["ui"] = map[string]any{
+		t.Meta["ui"] = map[string]any{
 			"resourceUri": resourceURI,
 		}
 	}
 }
 
-// NewUIContentMeta builds an *mcp.Meta that sets `_meta.ui.kind = kind`
+// NewUIContentMeta builds an mcp.Meta that sets `_meta.ui.kind = kind`
 // on a tool-result content item. Use the UIContentKind* constants.
-func NewUIContentMeta(kind string) *mcp.Meta {
-	return &mcp.Meta{
-		AdditionalFields: map[string]any{
-			"ui": map[string]any{
-				"kind": kind,
-			},
+func NewUIContentMeta(kind string) mcp.Meta {
+	return mcp.Meta{
+		"ui": map[string]any{
+			"kind": kind,
 		},
 	}
 }
 
 // RegisterAppResources registers MCP App UI resources with the server.
-func RegisterAppResources(s *server.MCPServer) {
+func RegisterAppResources(s *mcp.Server) {
 	s.AddResource(
-		mcp.NewResource(
-			PanelViewerResourceURI,
-			"Panel Viewer",
-			mcp.WithResourceDescription("Interactive HTML viewer for Grafana panel images"),
-			mcp.WithMIMEType(appMIMEType),
-		),
-		func(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-			return []mcp.ResourceContents{
-				mcp.TextResourceContents{
-					URI:      PanelViewerResourceURI,
-					MIMEType: appMIMEType,
-					Text:     panelViewerAppHTML,
+		&mcp.Resource{
+			URI:         PanelViewerResourceURI,
+			Name:        "Panel Viewer",
+			Description: "Interactive HTML viewer for Grafana panel images",
+			MIMEType:    appMIMEType,
+		},
+		func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{
+					{
+						URI:      PanelViewerResourceURI,
+						MIMEType: appMIMEType,
+						Text:     panelViewerAppHTML,
+					},
 				},
 			}, nil
 		},


### PR DESCRIPTION
Rewrites tools.go's Tool/MustTool/ConvertTool machinery to build
*mcp.Server-compatible tools via github.com/modelcontextprotocol/go-sdk
instead of mark3labs/mcp-go, keeping invopop/jsonschema and this
package's existing arg validation/coercion behaviour unchanged.
Mechanically updates all AddXTools registrars and mcp.With*Annotation
call sites across tools/*.go to the new API, and ports ui_apps.go's
resource registration and _meta.ui.* helpers.

Session ID for tracing now comes directly off request.Session.ID()
rather than a separate context lookup, since CallToolRequest carries
the session.

Not yet migrated (tracked as follow-up): cmd/mcp-grafana/main.go,
session.go, proxied_*.go (server construction, context propagation,
session management), and all *_test.go files, which still reference
mark3labs types directly. `go build ./tools/... .` is green; full
`go build ./...` and lint will not pass until those land.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>