### PR TITLE
test: migrate tools.go/tools test suite to official go-sdk types

### DIFF
--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-openapi/runtime/client"
 	grafana_client "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -427,14 +427,9 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), config)
 
 		// Create a mock MCP request
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "test_tool",
-				Arguments: map[string]interface{}{
-					"message": "world",
-				},
-			},
-		}
+		request := newCallToolRequest("test_tool", map[string]interface{}{
+			"message": "world",
+		})
 
 		// Execute the tool
 		result, err := tool.Handler(ctx, request)
@@ -480,14 +475,9 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), config)
 
 		// Create a mock MCP request that will cause failure
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "failing_tool",
-				Arguments: map[string]interface{}{
-					"shouldFail": true,
-				},
-			},
-		}
+		request := newCallToolRequest("failing_tool", map[string]interface{}{
+			"shouldFail": true,
+		})
 
 		// Execute the tool (should fail)
 		result, err := tool.Handler(ctx, request)
@@ -537,14 +527,9 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), config)
 
 		// Create a mock MCP request
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "context_prop_tool",
-				Arguments: map[string]interface{}{
-					"message": "test",
-				},
-			},
-		}
+		request := newCallToolRequest("context_prop_tool", map[string]interface{}{
+			"message": "test",
+		})
 
 		// Execute the tool (should always create spans for context propagation)
 		result, err := tool.Handler(ctx, request)
@@ -583,14 +568,9 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), config)
 
 		// Create a mock MCP request with potentially sensitive data
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "sensitive_tool",
-				Arguments: map[string]interface{}{
-					"sensitiveData": "user@example.com",
-				},
-			},
-		}
+		request := newCallToolRequest("sensitive_tool", map[string]interface{}{
+			"sensitiveData": "user@example.com",
+		})
 
 		// Execute the tool (arguments should NOT be logged by default)
 		result, err := tool.Handler(ctx, request)
@@ -639,14 +619,9 @@ func TestToolTracingInstrumentation(t *testing.T) {
 		ctx := WithGrafanaConfig(context.Background(), config)
 
 		// Create a mock MCP request
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "debug_tool",
-				Arguments: map[string]interface{}{
-					"safeData": "debug-value",
-				},
-			},
-		}
+		request := newCallToolRequest("debug_tool", map[string]interface{}{
+			"safeData": "debug-value",
+		})
 
 		// Execute the tool (arguments SHOULD be logged when flag enabled)
 		result, err := tool.Handler(ctx, request)
@@ -762,27 +737,25 @@ func TestHTTPTracingConfiguration(t *testing.T) {
 func TestExtractTraceContext(t *testing.T) {
 	t.Run("no meta returns original context", func(t *testing.T) {
 		ctx := context.Background()
-		request := mcp.CallToolRequest{}
+		request := &mcp.CallToolRequest{}
 		result := extractTraceContext(ctx, request)
 		assert.Equal(t, ctx, result)
 	})
 
 	t.Run("empty meta returns original context", func(t *testing.T) {
 		ctx := context.Background()
-		request := mcp.CallToolRequest{}
-		request.Params.Meta = &mcp.Meta{}
+		request := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{}}
 		result := extractTraceContext(ctx, request)
 		assert.Equal(t, ctx, result)
 	})
 
 	t.Run("valid traceparent extracts span context", func(t *testing.T) {
 		ctx := context.Background()
-		request := mcp.CallToolRequest{}
-		request.Params.Meta = &mcp.Meta{
-			AdditionalFields: map[string]any{
+		request := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+			Meta: mcp.Meta{
 				"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 			},
-		}
+		}}
 		result := extractTraceContext(ctx, request)
 		// Should have extracted a span context
 		sc := trace.SpanContextFromContext(result)
@@ -793,12 +766,11 @@ func TestExtractTraceContext(t *testing.T) {
 
 	t.Run("invalid traceparent returns context unchanged", func(t *testing.T) {
 		ctx := context.Background()
-		request := mcp.CallToolRequest{}
-		request.Params.Meta = &mcp.Meta{
-			AdditionalFields: map[string]any{
+		request := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+			Meta: mcp.Meta{
 				"traceparent": "not-a-valid-traceparent",
 			},
-		}
+		}}
 		result := extractTraceContext(ctx, request)
 		sc := trace.SpanContextFromContext(result)
 		assert.False(t, sc.IsValid())

--- a/tools/agento11y_agents_test.go
+++ b/tools/agento11y_agents_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -600,10 +600,9 @@ func TestAgento11yManageAgents(t *testing.T) {
 func TestAgento11yManageAgentsToolContract(t *testing.T) {
 	tool := ManageAgento11yAgents.Tool
 
-	require.NotNil(t, tool.Annotations.ReadOnlyHint, "the tool should carry a read-only hint")
-	assert.True(t, *tool.Annotations.ReadOnlyHint)
-	require.NotNil(t, tool.Annotations.IdempotentHint, "the tool should carry an idempotent hint")
-	assert.True(t, *tool.Annotations.IdempotentHint)
+	require.NotNil(t, tool.Annotations, "the tool should carry annotations")
+	assert.True(t, tool.Annotations.ReadOnlyHint, "the tool should carry a read-only hint")
+	assert.True(t, tool.Annotations.IdempotentHint, "the tool should carry an idempotent hint")
 
 	for _, guidance := range []string{
 		// Which changes mint a new version is the least obvious thing about the
@@ -666,9 +665,7 @@ func TestAgento11yManageAgentsToolArgumentBinding(t *testing.T) {
 			})
 			defer server.Close()
 
-			result, err := ManageAgento11yAgents.Handler(ctx, mcp.CallToolRequest{
-				Params: mcp.CallToolParams{Name: "agento11y_manage_agents", Arguments: tc.arguments},
-			})
+			result, err := ManageAgento11yAgents.Handler(ctx, newCallToolRequest("agento11y_manage_agents", tc.arguments))
 			require.NoError(t, err, "the MCP handler reports tool failures in the result, not as a transport error")
 			require.NotNil(t, result)
 
@@ -688,7 +685,7 @@ func resultText(t *testing.T, result *mcp.CallToolResult) string {
 	t.Helper()
 	var parts []string
 	for _, content := range result.Content {
-		if text, ok := content.(mcp.TextContent); ok {
+		if text, ok := content.(*mcp.TextContent); ok {
 			parts = append(parts, text.Text)
 		}
 	}

--- a/tools/agento11y_eval_test.go
+++ b/tools/agento11y_eval_test.go
@@ -11,8 +11,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/server"
-
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1154,26 +1153,36 @@ type agento11yAdvertisedTool struct {
 func listAgento11yEvalTools(t *testing.T, enableWriteTools bool) map[string]agento11yAdvertisedTool {
 	t.Helper()
 
-	srv := server.NewMCPServer("test", "0")
+	ctx := context.Background()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 	AddAgento11yTools(srv, enableWriteTools)
 
-	response := srv.HandleMessage(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
-	raw, err := json.Marshal(response)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := srv.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer clientSession.Close()
+
+	toolsResult, err := clientSession.ListTools(ctx, nil)
+	require.NoError(t, err)
+	raw, err := json.Marshal(toolsResult)
 	require.NoError(t, err)
 
 	var listed struct {
-		Result struct {
-			Tools []struct {
-				Name        string          `json:"name"`
-				Description string          `json:"description"`
-				InputSchema json.RawMessage `json:"inputSchema"`
-			} `json:"tools"`
-		} `json:"result"`
+		Tools []struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			InputSchema json.RawMessage `json:"inputSchema"`
+		} `json:"tools"`
 	}
 	require.NoError(t, json.Unmarshal(raw, &listed))
 
 	tools := map[string]agento11yAdvertisedTool{}
-	for _, tool := range listed.Result.Tools {
+	for _, tool := range listed.Tools {
 		switch tool.Name {
 		case "agento11y_manage_evaluators", "agento11y_manage_eval_rules", "agento11y_manage_eval_collections", "agento11y_manage_experiments", "agento11y_manage_test_suites", "agento11y_manage_agents":
 		default:

--- a/tools/agento11y_experiments_test.go
+++ b/tools/agento11y_experiments_test.go
@@ -971,15 +971,15 @@ func TestAgento11yManageExperimentsGetReport(t *testing.T) {
 func TestAgento11yManageExperimentsToolContract(t *testing.T) {
 	read := ManageAgento11yExperimentsRead.Tool
 	require.NotNil(t, read.Annotations.ReadOnlyHint)
-	assert.True(t, *read.Annotations.ReadOnlyHint)
+	assert.True(t, read.Annotations.ReadOnlyHint)
 	require.NotNil(t, read.Annotations.IdempotentHint)
-	assert.True(t, *read.Annotations.IdempotentHint)
+	assert.True(t, read.Annotations.IdempotentHint)
 	require.NotNil(t, read.Annotations.DestructiveHint)
 	assert.False(t, *read.Annotations.DestructiveHint)
 
 	write := ManageAgento11yExperimentsReadWrite.Tool
 	require.NotNil(t, write.Annotations.ReadOnlyHint)
-	assert.False(t, *write.Annotations.ReadOnlyHint, "the write variant cancels experiments")
+	assert.False(t, write.Annotations.ReadOnlyHint, "the write variant cancels experiments")
 	require.NotNil(t, write.Annotations.DestructiveHint)
 	assert.True(t, *write.Annotations.DestructiveHint)
 

--- a/tools/agento11y_test_suites_test.go
+++ b/tools/agento11y_test_suites_test.go
@@ -679,15 +679,15 @@ func TestAgento11yTestSuiteRoutesAvoidTheStandaloneVersion(t *testing.T) {
 func TestAgento11yManageTestSuitesToolContract(t *testing.T) {
 	read := ManageAgento11yTestSuitesRead.Tool
 	require.NotNil(t, read.Annotations.ReadOnlyHint)
-	assert.True(t, *read.Annotations.ReadOnlyHint)
+	assert.True(t, read.Annotations.ReadOnlyHint)
 	require.NotNil(t, read.Annotations.IdempotentHint)
-	assert.True(t, *read.Annotations.IdempotentHint)
+	assert.True(t, read.Annotations.IdempotentHint)
 	require.NotNil(t, read.Annotations.DestructiveHint)
 	assert.False(t, *read.Annotations.DestructiveHint)
 
 	write := ManageAgento11yTestSuitesReadWrite.Tool
 	require.NotNil(t, write.Annotations.ReadOnlyHint)
-	assert.False(t, *write.Annotations.ReadOnlyHint, "the write variant deletes test cases and freezes versions")
+	assert.False(t, write.Annotations.ReadOnlyHint, "the write variant deletes test cases and freezes versions")
 	require.NotNil(t, write.Annotations.DestructiveHint)
 	assert.True(t, *write.Annotations.DestructiveHint)
 

--- a/tools/datasources_test.go
+++ b/tools/datasources_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,7 +126,7 @@ func TestCreateDatasourceTools(t *testing.T) {
 		assert.False(t, toolResult.IsError)
 
 		require.Len(t, toolResult.Content, 2)
-		text, ok := toolResult.Content[0].(mcp.TextContent)
+		text, ok := toolResult.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 
 		var result CreateDatasourceResult
@@ -137,7 +137,7 @@ func TestCreateDatasourceTools(t *testing.T) {
 		configPageURL := "http://localhost:3000/connections/datasources/edit/" + result.UID
 		assert.Contains(t, result.NextSteps, configPageURL)
 
-		link, ok := toolResult.Content[1].(mcp.ResourceLink)
+		link, ok := toolResult.Content[1].(*mcp.ResourceLink)
 		require.True(t, ok)
 		assert.Equal(t, configPageURL, link.URI)
 		assert.Equal(t, result.Name, link.Name)
@@ -162,7 +162,7 @@ func TestCreateDatasourceTools(t *testing.T) {
 		assert.False(t, toolResult.IsError)
 
 		require.Len(t, toolResult.Content, 2)
-		text, ok := toolResult.Content[0].(mcp.TextContent)
+		text, ok := toolResult.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 
 		var result CreateDatasourceResult
@@ -173,7 +173,7 @@ func TestCreateDatasourceTools(t *testing.T) {
 		configPageURL := "http://localhost:3000/connections/datasources/edit/" + result.UID
 		assert.Contains(t, result.NextSteps, configPageURL)
 
-		link, ok := toolResult.Content[1].(mcp.ResourceLink)
+		link, ok := toolResult.Content[1].(*mcp.ResourceLink)
 		require.True(t, ok)
 		assert.Equal(t, configPageURL, link.URI)
 		assert.Equal(t, result.Name, link.Name)
@@ -264,7 +264,7 @@ func TestUpdateDatasourceTool(t *testing.T) {
 		t.Helper()
 		require.NotNil(t, res)
 		require.Len(t, res.Content, 1)
-		text, ok := res.Content[0].(mcp.TextContent)
+		text, ok := res.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		var r UpdateDatasourceResult
 		require.NoError(t, json.Unmarshal([]byte(text.Text), &r))
@@ -275,7 +275,7 @@ func TestUpdateDatasourceTool(t *testing.T) {
 		res, err := updateDatasource(ctx, UpdateDatasourceParams{UID: testUID})
 		require.NoError(t, err)
 		require.Len(t, res.Content, 1)
-		text, ok := res.Content[0].(mcp.TextContent)
+		text, ok := res.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		var guidance map[string]any
 		require.NoError(t, json.Unmarshal([]byte(text.Text), &guidance))

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana-openapi-client-go/models"
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	datasourceschemas "github.com/grafana/mcp-grafana/tools/datasource_schemas"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -316,7 +316,7 @@ func TestCreateDatasource_NoSchemaGuidancePhase(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 
-	text, ok := result.Content[0].(mcp.TextContent)
+	text, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 
 	var guidance map[string]any
@@ -345,7 +345,7 @@ func TestCreateDatasource_SchemaGuidancePhase(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 
-	text, ok := result.Content[0].(mcp.TextContent)
+	text, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 
 	var guidance map[string]any
@@ -373,7 +373,7 @@ func TestCreateDatasource_EmptyFieldsMapStaysInGuidancePhase(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 
-	text, ok := result.Content[0].(mcp.TextContent)
+	text, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 
 	var guidance map[string]any
@@ -437,7 +437,7 @@ func TestCreateDatasource_SchemaReviewedWithoutNameReturnsGuidance(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 
-	text, ok := result.Content[0].(mcp.TextContent)
+	text, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 
 	var guidance map[string]any
@@ -532,7 +532,7 @@ func TestCreateDatasource_Success(t *testing.T) {
 	assert.False(t, toolResult.IsError)
 	require.Len(t, toolResult.Content, 2)
 
-	text, ok := toolResult.Content[0].(mcp.TextContent)
+	text, ok := toolResult.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 
 	var got CreateDatasourceResult
@@ -548,9 +548,8 @@ func TestCreateDatasource_Success(t *testing.T) {
 	configPageURL := "https://grafana.example.com/connections/datasources/edit/" + uid
 	assert.Contains(t, got.NextSteps, configPageURL)
 
-	link, ok := toolResult.Content[1].(mcp.ResourceLink)
+	link, ok := toolResult.Content[1].(*mcp.ResourceLink)
 	require.True(t, ok)
-	assert.Equal(t, "resource_link", link.Type)
 	assert.Equal(t, configPageURL, link.URI)
 	assert.Equal(t, name, link.Name)
 }
@@ -593,7 +592,7 @@ func parseUpdateResult(t *testing.T, res *mcp.CallToolResult) UpdateDatasourceRe
 	t.Helper()
 	require.NotNil(t, res)
 	require.Len(t, res.Content, 1)
-	text, ok := res.Content[0].(mcp.TextContent)
+	text, ok := res.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 	var r UpdateDatasourceResult
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &r))
@@ -641,7 +640,7 @@ func TestUpdateDatasource_SchemaGuidancePhase(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 
-	text, ok := result.Content[0].(mcp.TextContent)
+	text, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 
 	var guidance map[string]any
@@ -670,7 +669,7 @@ func TestUpdateDatasource_NoSchemaGuidancePhase(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 
-	text, ok := result.Content[0].(mcp.TextContent)
+	text, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 
 	var guidance map[string]any

--- a/tools/provisioning_integration_test.go
+++ b/tools/provisioning_integration_test.go
@@ -6,11 +6,10 @@
 package tools
 
 import (
-	"encoding/base64"
 	"net/url"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -119,19 +118,19 @@ func TestRenderProvisioningPreview_Integration(t *testing.T) {
 			require.False(t, result.IsError, "render returned an error result: %+v", result.Content)
 			require.Len(t, result.Content, 2)
 
-			img, ok := result.Content[0].(mcp.ImageContent)
+			img, ok := result.Content[0].(*mcp.ImageContent)
 			require.True(t, ok, "expected ImageContent at index 0, got %T", result.Content[0])
 			assert.Equal(t, "image/png", img.MIMEType)
 
-			data, err := base64.StdEncoding.DecodeString(img.Data)
-			require.NoError(t, err)
-			require.NotEmpty(t, data, "rendered PNG should not be empty")
+			// Data holds raw bytes - the SDK base64-encodes []byte fields
+			// automatically when marshaling to the wire.
+			require.NotEmpty(t, img.Data, "rendered PNG should not be empty")
 			// PNG magic number.
-			assert.Equal(t, []byte{0x89, 'P', 'N', 'G'}, data[:4], "rendered image should be a PNG")
+			assert.Equal(t, []byte{0x89, 'P', 'N', 'G'}, img.Data[:4], "rendered image should be a PNG")
 
 			// Provisioning previews must use the /dashboard/provisioning
 			// route, not the stored-dashboard /d/<uid> route.
-			deeplink, ok := result.Content[1].(mcp.TextContent)
+			deeplink, ok := result.Content[1].(*mcp.TextContent)
 			require.True(t, ok, "expected TextContent at index 1, got %T", result.Content[1])
 			require.NotEmpty(t, deeplink.Text, "deeplink text should not be empty")
 
@@ -147,8 +146,7 @@ func TestRenderProvisioningPreview_Integration(t *testing.T) {
 
 			// _meta.ui.kind marker that the panel viewer keys off.
 			require.NotNil(t, deeplink.Meta)
-			require.NotNil(t, deeplink.Meta.AdditionalFields)
-			ui, ok := deeplink.Meta.AdditionalFields["ui"].(map[string]any)
+			ui, ok := deeplink.Meta["ui"].(map[string]any)
 			require.True(t, ok, "expected _meta.ui to be a map")
 			assert.Equal(t, mcpgrafana.UIContentKindDeeplink, ui["kind"])
 		})

--- a/tools/rendering_test.go
+++ b/tools/rendering_test.go
@@ -4,7 +4,6 @@ package tools
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -518,16 +517,15 @@ func TestGetPanelImage(t *testing.T) {
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 2)
 
-		// Check image content
-		imageContent, ok := result.Content[0].(mcp.ImageContent)
+		// Check image content. Data holds raw bytes - the SDK base64-encodes
+		// []byte fields automatically when marshaling to the wire.
+		imageContent, ok := result.Content[0].(*mcp.ImageContent)
 		require.True(t, ok, "first content item should be ImageContent")
 		assert.Equal(t, "image/png", imageContent.MIMEType)
-		decoded, err := base64.StdEncoding.DecodeString(imageContent.Data)
-		require.NoError(t, err)
-		assert.Equal(t, testPNGData, decoded)
+		assert.Equal(t, testPNGData, imageContent.Data)
 
 		// Check deeplink content
-		textContent, ok := result.Content[1].(mcp.TextContent)
+		textContent, ok := result.Content[1].(*mcp.TextContent)
 		require.True(t, ok, "second content item should be TextContent")
 		assert.Equal(t, server.URL+"/d/test-dash", textContent.Text)
 		assertDeeplinkMeta(t, textContent)
@@ -560,7 +558,7 @@ func TestGetPanelImage(t *testing.T) {
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 2)
 
-		textContent, ok := result.Content[1].(mcp.TextContent)
+		textContent, ok := result.Content[1].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, server.URL+"/d/test-dash?viewPanel=5", textContent.Text)
 		assertDeeplinkMeta(t, textContent)
@@ -587,7 +585,7 @@ func TestGetPanelImage(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, result.Content, 2)
 
-			text, ok := result.Content[1].(mcp.TextContent)
+			text, ok := result.Content[1].(*mcp.TextContent)
 			require.True(t, ok)
 			assert.Equal(t,
 				server.URL+"/dashboard/provisioning/my-repo/preview/folder/dashboard.json",
@@ -609,7 +607,7 @@ func TestGetPanelImage(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, result.Content, 2)
 
-			text, ok := result.Content[1].(mcp.TextContent)
+			text, ok := result.Content[1].(*mcp.TextContent)
 			require.True(t, ok)
 			parsed, err := url.Parse(text.Text)
 			require.NoError(t, err)
@@ -643,7 +641,7 @@ func TestGetPanelImage(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Content, 2)
 
-		text, ok := result.Content[1].(mcp.TextContent)
+		text, ok := result.Content[1].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, publicURL+"/d/test-dash", text.Text)
 		assertDeeplinkMeta(t, text)
@@ -670,7 +668,7 @@ func TestGetPanelImage(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Content, 2)
 
-		text, ok := result.Content[1].(mcp.TextContent)
+		text, ok := result.Content[1].(*mcp.TextContent)
 		require.True(t, ok)
 		parsed, err := url.Parse(text.Text)
 		require.NoError(t, err)
@@ -707,7 +705,7 @@ func TestGetPanelImage(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Content, 2)
 
-		text, ok := result.Content[1].(mcp.TextContent)
+		text, ok := result.Content[1].(*mcp.TextContent)
 		require.True(t, ok)
 		parsed, err := url.Parse(text.Text)
 		require.NoError(t, err)
@@ -736,7 +734,7 @@ func TestGetPanelImage(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Content, 2)
 
-		text, ok := result.Content[1].(mcp.TextContent)
+		text, ok := result.Content[1].(*mcp.TextContent)
 		require.True(t, ok)
 		parsed, err := url.Parse(text.Text)
 		require.NoError(t, err)
@@ -988,20 +986,18 @@ func TestGetPanelImage(t *testing.T) {
 func TestGetPanelImageToolMeta(t *testing.T) {
 	tool := GetPanelImage.Tool
 	require.NotNil(t, tool.Meta, "get_panel_image should have _meta for MCP Apps")
-	require.NotNil(t, tool.Meta.AdditionalFields)
 
-	ui, ok := tool.Meta.AdditionalFields["ui"].(map[string]any)
+	ui, ok := tool.Meta["ui"].(map[string]any)
 	require.True(t, ok, "expected _meta.ui to be a map")
 	assert.Equal(t, mcpgrafana.PanelViewerResourceURI, ui["resourceUri"])
 }
 
 // assertDeeplinkMeta checks the `_meta.ui.kind = "deeplink"` marker the
 // panel viewer uses to detect the deeplink content item.
-func assertDeeplinkMeta(t *testing.T, c mcp.TextContent) {
+func assertDeeplinkMeta(t *testing.T, c *mcp.TextContent) {
 	t.Helper()
 	require.NotNil(t, c.Meta)
-	require.NotNil(t, c.Meta.AdditionalFields)
-	ui, ok := c.Meta.AdditionalFields["ui"].(map[string]any)
-	require.True(t, ok, "expected _meta.ui to be a map, got %T", c.Meta.AdditionalFields["ui"])
+	ui, ok := c.Meta["ui"].(map[string]any)
+	require.True(t, ok, "expected _meta.ui to be a map, got %T", c.Meta["ui"])
 	assert.Equal(t, mcpgrafana.UIContentKindDeeplink, ui["kind"])
 }

--- a/tools/testutil_helpers_test.go
+++ b/tools/testutil_helpers_test.go
@@ -1,0 +1,30 @@
+//go:build unit
+
+package tools
+
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newCallToolRequest builds a *mcp.CallToolRequest for tests, marshaling args
+// to the json.RawMessage the official SDK expects on the wire (mirroring what
+// a real client sends, rather than the map[string]any mark3labs let tests
+// construct directly).
+func newCallToolRequest(name string, args map[string]any) *mcp.CallToolRequest {
+	var raw json.RawMessage
+	if args != nil {
+		b, err := json.Marshal(args)
+		if err != nil {
+			panic(err)
+		}
+		raw = b
+	}
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      name,
+			Arguments: raw,
+		},
+	}
+}

--- a/tools_helpers_test.go
+++ b/tools_helpers_test.go
@@ -1,0 +1,28 @@
+package mcpgrafana
+
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newCallToolRequest builds a *mcp.CallToolRequest for tests, marshaling args
+// to the json.RawMessage the official SDK expects on the wire (mirroring what
+// a real client sends, rather than the map[string]any mark3labs let tests
+// construct directly).
+func newCallToolRequest(name string, args map[string]any) *mcp.CallToolRequest {
+	var raw json.RawMessage
+	if args != nil {
+		b, err := json.Marshal(args)
+		if err != nil {
+			panic(err)
+		}
+		raw = b
+	}
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      name,
+			Arguments: raw,
+		},
+	}
+}

--- a/tools_param_validation_test.go
+++ b/tools_param_validation_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,33 +59,23 @@ func TestConvertToolRejectsUnknownArguments(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("typo'd argument returns tool error listing valid arguments", func(t *testing.T) {
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "test_tool",
-				Arguments: map[string]any{
-					"name":    "test",
-					"value":   65,
-					"optionl": true,
-				},
-			},
-		}
+		request := newCallToolRequest("test_tool", map[string]any{
+			"name":    "test",
+			"value":   65,
+			"optionl": true,
+		})
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
-		text, ok := result.Content[0].(mcp.TextContent)
+		text, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, text.Text, `unknown argument "optionl"`)
 		assert.Contains(t, text.Text, "valid arguments: name, optional, value")
 	})
 
 	t.Run("valid arguments still succeed", func(t *testing.T) {
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name:      "test_tool",
-				Arguments: map[string]any{"name": "test", "value": 65},
-			},
-		}
+		request := newCallToolRequest("test_tool", map[string]any{"name": "test", "value": 65})
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
@@ -94,16 +84,11 @@ func TestConvertToolRejectsUnknownArguments(t *testing.T) {
 	t.Run("empty-params tool rejects any argument", func(t *testing.T) {
 		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
 		require.NoError(t, err)
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name:      "empty",
-				Arguments: map[string]any{"foo": "bar"},
-			},
-		}
+		request := newCallToolRequest("empty", map[string]any{"foo": "bar"})
 		result, err := emptyHandler(ctx, request)
 		require.NoError(t, err)
 		assert.True(t, result.IsError)
-		text, ok := result.Content[0].(mcp.TextContent)
+		text, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, text.Text, "this tool takes no arguments")
 	})
@@ -111,9 +96,7 @@ func TestConvertToolRejectsUnknownArguments(t *testing.T) {
 	t.Run("nil arguments succeed", func(t *testing.T) {
 		_, emptyHandler, err := ConvertTool("empty", "description", emptyToolHandler)
 		require.NoError(t, err)
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{Name: "empty"},
-		}
+		request := newCallToolRequest("empty", nil)
 		result, err := emptyHandler(ctx, request)
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
@@ -127,8 +110,10 @@ func TestConvertToolKnownArgumentsMatchSchema(t *testing.T) {
 	tool, handler, err := ConvertTool("embedded", "description", unknownArgsHandler)
 	require.NoError(t, err)
 
+	rawSchema, ok := tool.InputSchema.(json.RawMessage)
+	require.True(t, ok, "InputSchema should be json.RawMessage")
 	var schema map[string]any
-	require.NoError(t, json.Unmarshal(tool.RawInputSchema, &schema))
+	require.NoError(t, json.Unmarshal(rawSchema, &schema))
 	props, ok := schema["properties"].(map[string]any)
 	require.True(t, ok)
 	assert.Contains(t, props, "start_rfc_3339")
@@ -141,18 +126,11 @@ func TestConvertToolKnownArgumentsMatchSchema(t *testing.T) {
 	for name := range props {
 		args[name] = "y"
 	}
-	result, err := handler(ctx, mcp.CallToolRequest{
-		Params: mcp.CallToolParams{Name: "embedded", Arguments: args},
-	})
+	result, err := handler(ctx, newCallToolRequest("embedded", args))
 	require.NoError(t, err)
 	assert.False(t, result.IsError, "every schema-declared property must pass the unknown-args check")
 
-	result, err = handler(ctx, mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
-			Name:      "embedded",
-			Arguments: map[string]any{"data_source_uid": "x", "start_rfc3339": "now"},
-		},
-	})
+	result, err = handler(ctx, newCallToolRequest("embedded", map[string]any{"data_source_uid": "x", "start_rfc3339": "now"}))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.IsError)

--- a/tools_string_to_int_test.go
+++ b/tools_string_to_int_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -204,13 +204,8 @@ func TestConvertToolWithStringToIntConversion(t *testing.T) {
 	_, handler, err := ConvertTool("test_int_tool", "A test tool with int params", testIntHandler)
 	require.NoError(t, err)
 
-	makeRequest := func(args map[string]any) mcp.CallToolRequest {
-		return mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name:      "test_int_tool",
-				Arguments: args,
-			},
-		}
+	makeRequest := func(args map[string]any) *mcp.CallToolRequest {
+		return newCallToolRequest("test_int_tool", args)
 	}
 
 	tests := []struct {
@@ -550,13 +545,8 @@ func TestUnmarshalWithStringToSliceCoercion(t *testing.T) {
 		_, h, err := ConvertTool("test", "test", handler)
 		require.NoError(t, err)
 
-		result, err := h(context.Background(), mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name:      "test",
-				Arguments: map[string]any{"labels": "test"},
-			},
-		})
+		result, err := h(context.Background(), newCallToolRequest("test", map[string]any{"labels": "test"}))
 		require.NoError(t, err)
-		assert.Equal(t, "ok", result.Content[0].(mcp.TextContent).Text)
+		assert.Equal(t, "ok", result.Content[0].(*mcp.TextContent).Text)
 	})
 }

--- a/tools_test.go
+++ b/tools_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,13 +24,13 @@ func testToolHandler(ctx context.Context, params testToolParams) (*mcp.CallToolR
 	if params.Name == "error" {
 		return nil, errors.New("test error")
 	}
-	return mcp.NewToolResultText(params.Name + ": " + string(rune(params.Value))), nil
+	return NewToolResultText(params.Name + ": " + string(rune(params.Value))), nil
 }
 
 type emptyToolParams struct{}
 
 func emptyToolHandler(ctx context.Context, params emptyToolParams) (*mcp.CallToolResult, error) {
-	return mcp.NewToolResultText("empty"), nil
+	return NewToolResultText("empty"), nil
 }
 
 // New handlers for different return types
@@ -132,39 +132,29 @@ func TestConvertTool(t *testing.T) {
 
 		// Test handler execution
 		ctx := context.Background()
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "test_tool",
-				Arguments: map[string]any{
-					"name":  "test",
-					"value": 65, // ASCII 'A'
-				},
-			},
-		}
+		request := newCallToolRequest("test_tool", map[string]any{
+			"name":  "test",
+			"value": 65, // ASCII 'A'
+		})
 
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		require.Len(t, result.Content, 1)
-		resultString, ok := result.Content[0].(mcp.TextContent)
+		resultString, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test: A", resultString.Text)
 
 		// Test error handling
-		errorRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "test_tool",
-				Arguments: map[string]any{
-					"name":  "error",
-					"value": 66,
-				},
-			},
-		}
+		errorRequest := newCallToolRequest("test_tool", map[string]any{
+			"name":  "error",
+			"value": 66,
+		})
 
 		result, err = handler(ctx, errorRequest)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
-		resultString, ok = result.Content[0].(mcp.TextContent)
+		resultString, ok = result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test error", resultString.Text)
 	})
@@ -198,15 +188,11 @@ func TestConvertTool(t *testing.T) {
 
 		// Test handler execution
 		ctx := context.Background()
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "empty",
-			},
-		}
+		request := newCallToolRequest("empty", nil)
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		require.Len(t, result.Content, 1)
-		resultString, ok := result.Content[0].(mcp.TextContent)
+		resultString, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "empty", resultString.Text)
 	})
@@ -217,59 +203,44 @@ func TestConvertTool(t *testing.T) {
 
 		// Test normal string return
 		ctx := context.Background()
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "string_tool",
-				Arguments: map[string]any{
-					"name":  "test",
-					"value": 65, // ASCII 'A'
-				},
-			},
-		}
+		request := newCallToolRequest("string_tool", map[string]any{
+			"name":  "test",
+			"value": 65, // ASCII 'A'
+		})
 
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 1)
-		resultString, ok := result.Content[0].(mcp.TextContent)
+		resultString, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test: A", resultString.Text)
 
 		// Test empty string return
-		emptyRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "string_tool",
-				Arguments: map[string]any{
-					"name":  "empty",
-					"value": 65,
-				},
-			},
-		}
+		emptyRequest := newCallToolRequest("string_tool", map[string]any{
+			"name":  "empty",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, emptyRequest)
 		require.NoError(t, err)
 		require.NotNil(t, result, "empty string should return non-nil result to prevent mcp-go crash")
 		require.Len(t, result.Content, 1)
-		emptyText, ok := result.Content[0].(mcp.TextContent)
+		emptyText, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "", emptyText.Text)
 
 		// Test error return
-		errorRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "string_tool",
-				Arguments: map[string]any{
-					"name":  "error",
-					"value": 65,
-				},
-			},
-		}
+		errorRequest := newCallToolRequest("string_tool", map[string]any{
+			"name":  "error",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, errorRequest)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
-		resultString, ok = result.Content[0].(mcp.TextContent)
+		resultString, ok = result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test error", resultString.Text)
 	})
@@ -280,78 +251,58 @@ func TestConvertTool(t *testing.T) {
 
 		// Test normal string pointer return
 		ctx := context.Background()
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "string_ptr_tool",
-				Arguments: map[string]any{
-					"name":  "test",
-					"value": 65, // ASCII 'A'
-				},
-			},
-		}
+		request := newCallToolRequest("string_ptr_tool", map[string]any{
+			"name":  "test",
+			"value": 65, // ASCII 'A'
+		})
 
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 1)
-		resultString, ok := result.Content[0].(mcp.TextContent)
+		resultString, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test: A", resultString.Text)
 
 		// Test nil string pointer return
-		nilRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "string_ptr_tool",
-				Arguments: map[string]any{
-					"name":  "nil",
-					"value": 65,
-				},
-			},
-		}
+		nilRequest := newCallToolRequest("string_ptr_tool", map[string]any{
+			"name":  "nil",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, nilRequest)
 		require.NoError(t, err)
 		require.NotNil(t, result, "nil pointer should return a non-nil result to prevent mcp-go crash")
 		require.Len(t, result.Content, 1)
-		nullText, ok := result.Content[0].(mcp.TextContent)
+		nullText, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "null", nullText.Text)
 
 		// Test empty string pointer return
-		emptyRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "string_ptr_tool",
-				Arguments: map[string]any{
-					"name":  "empty",
-					"value": 65,
-				},
-			},
-		}
+		emptyRequest := newCallToolRequest("string_ptr_tool", map[string]any{
+			"name":  "empty",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, emptyRequest)
 		require.NoError(t, err)
 		require.NotNil(t, result, "empty *string should return non-nil result to prevent mcp-go crash")
 		require.Len(t, result.Content, 1)
-		emptyText, ok := result.Content[0].(mcp.TextContent)
+		emptyText, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "", emptyText.Text)
 
 		// Test error return
-		errorRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "string_ptr_tool",
-				Arguments: map[string]any{
-					"name":  "error",
-					"value": 65,
-				},
-			},
-		}
+		errorRequest := newCallToolRequest("string_ptr_tool", map[string]any{
+			"name":  "error",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, errorRequest)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
-		resultString, ok = result.Content[0].(mcp.TextContent)
+		resultString, ok = result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test error", resultString.Text)
 	})
@@ -362,41 +313,31 @@ func TestConvertTool(t *testing.T) {
 
 		// Test normal struct return
 		ctx := context.Background()
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "struct_tool",
-				Arguments: map[string]any{
-					"name":  "test",
-					"value": 65, // ASCII 'A'
-				},
-			},
-		}
+		request := newCallToolRequest("struct_tool", map[string]any{
+			"name":  "test",
+			"value": 65, // ASCII 'A'
+		})
 
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 1)
-		resultString, ok := result.Content[0].(mcp.TextContent)
+		resultString, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, resultString.Text, `"name":"test"`)
 		assert.Contains(t, resultString.Text, `"value":65`)
 
 		// Test error return
-		errorRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "struct_tool",
-				Arguments: map[string]any{
-					"name":  "error",
-					"value": 65,
-				},
-			},
-		}
+		errorRequest := newCallToolRequest("struct_tool", map[string]any{
+			"name":  "error",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, errorRequest)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
-		resultString, ok = result.Content[0].(mcp.TextContent)
+		resultString, ok = result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test error", resultString.Text)
 	})
@@ -407,60 +348,45 @@ func TestConvertTool(t *testing.T) {
 
 		// Test normal struct pointer return
 		ctx := context.Background()
-		request := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "struct_ptr_tool",
-				Arguments: map[string]any{
-					"name":  "test",
-					"value": 65, // ASCII 'A'
-				},
-			},
-		}
+		request := newCallToolRequest("struct_ptr_tool", map[string]any{
+			"name":  "test",
+			"value": 65, // ASCII 'A'
+		})
 
 		result, err := handler(ctx, request)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 1)
-		resultString, ok := result.Content[0].(mcp.TextContent)
+		resultString, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, resultString.Text, `"name":"test"`)
 		assert.Contains(t, resultString.Text, `"value":65`)
 
 		// Test nil struct pointer return
-		nilRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "struct_ptr_tool",
-				Arguments: map[string]any{
-					"name":  "nil",
-					"value": 65,
-				},
-			},
-		}
+		nilRequest := newCallToolRequest("struct_ptr_tool", map[string]any{
+			"name":  "nil",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, nilRequest)
 		require.NoError(t, err)
 		require.NotNil(t, result, "nil pointer should return a non-nil result to prevent mcp-go crash")
 		require.Len(t, result.Content, 1)
-		nullText, ok := result.Content[0].(mcp.TextContent)
+		nullText, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "null", nullText.Text)
 
 		// Test error return
-		errorRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "struct_ptr_tool",
-				Arguments: map[string]any{
-					"name":  "error",
-					"value": 65,
-				},
-			},
-		}
+		errorRequest := newCallToolRequest("struct_ptr_tool", map[string]any{
+			"name":  "error",
+			"value": 65,
+		})
 
 		result, err = handler(ctx, errorRequest)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
-		resultString, ok = result.Content[0].(mcp.TextContent)
+		resultString, ok = result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "test error", resultString.Text)
 	})
@@ -474,55 +400,40 @@ func TestConvertTool(t *testing.T) {
 		ctx := context.Background()
 
 		// Test nil slice return - must NOT return nil result (causes mcp-go crash)
-		nilRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "slice_tool",
-				Arguments: map[string]any{
-					"name":  "nil",
-					"value": 1,
-				},
-			},
-		}
+		nilRequest := newCallToolRequest("slice_tool", map[string]any{
+			"name":  "nil",
+			"value": 1,
+		})
 
 		result, err := handler(ctx, nilRequest)
 		require.NoError(t, err)
 		require.NotNil(t, result, "nil slice must return non-nil result to prevent mcp-go nil pointer dereference")
 
 		// Test empty slice return - should return valid JSON array
-		emptyRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "slice_tool",
-				Arguments: map[string]any{
-					"name":  "empty",
-					"value": 1,
-				},
-			},
-		}
+		emptyRequest := newCallToolRequest("slice_tool", map[string]any{
+			"name":  "empty",
+			"value": 1,
+		})
 
 		result, err = handler(ctx, emptyRequest)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 1)
-		resultString, ok := result.Content[0].(mcp.TextContent)
+		resultString, ok := result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Equal(t, "[]", resultString.Text)
 
 		// Test normal slice return
-		normalRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name: "slice_tool",
-				Arguments: map[string]any{
-					"name":  "test",
-					"value": 42,
-				},
-			},
-		}
+		normalRequest := newCallToolRequest("slice_tool", map[string]any{
+			"name":  "test",
+			"value": 42,
+		})
 
 		result, err = handler(ctx, normalRequest)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result.Content, 1)
-		resultString, ok = result.Content[0].(mcp.TextContent)
+		resultString, ok = result.Content[0].(*mcp.TextContent)
 		require.True(t, ok)
 		assert.Contains(t, resultString.Text, `"name":"test"`)
 		assert.Contains(t, resultString.Text, `"value":42`)
@@ -542,28 +453,22 @@ func TestConvertTool(t *testing.T) {
 		_, handler, err := ConvertTool("test_tool", "A test tool", testToolHandler)
 		require.NoError(t, err)
 
-		// Test with invalid JSON
-		invalidRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Arguments: map[string]any{
-					"name": make(chan int), // Channels can't be marshaled to JSON
-				},
-			},
-		}
+		// Test with malformed JSON on the wire. Arguments always arrive as
+		// json.RawMessage now, so there's no separate "marshal" step that can
+		// fail the way an unmarshalable Go value (e.g. a channel) used to.
+		invalidRequest := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(`{"name": `), // truncated JSON
+		}}
 
 		_, err = handler(context.Background(), invalidRequest)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "marshal args")
+		assert.Contains(t, err.Error(), "unmarshal args")
 
 		// Test with type mismatch
-		mismatchRequest := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Arguments: map[string]any{
-					"name":  123, // Should be a string
-					"value": "not an int",
-				},
-			},
-		}
+		mismatchRequest := newCallToolRequest("test_tool", map[string]any{
+			"name":  123, // Should be a string
+			"value": "not an int",
+		})
 
 		_, err = handler(context.Background(), mismatchRequest)
 		assert.Error(t, err)
@@ -741,7 +646,7 @@ func TestConvertToolHandlesInterfaceFields(t *testing.T) {
 
 	// Verify the schema contains an object for the model field, not bare true
 	var schema map[string]any
-	err = json.Unmarshal(tool.RawInputSchema, &schema)
+	err = json.Unmarshal(tool.InputSchema.(json.RawMessage), &schema)
 	require.NoError(t, err)
 
 	props := schema["properties"].(map[string]any)
@@ -756,7 +661,7 @@ func TestConvertToolSchemaDisallowsAdditionalProperties(t *testing.T) {
 	require.NoError(t, err)
 
 	var schema map[string]any
-	err = json.Unmarshal(tool.RawInputSchema, &schema)
+	err = json.Unmarshal(tool.InputSchema.(json.RawMessage), &schema)
 	require.NoError(t, err)
 	require.Contains(t, schema, "additionalProperties")
 	assert.Equal(t, false, schema["additionalProperties"])


### PR DESCRIPTION
Mechanically ports all test files exercising tools.go's ConvertTool
machinery and tools/*.go handlers from mark3labs' mcp.CallToolRequest
(value type, map[string]any arguments) to the official SDK's
*mcp.CallToolRequest (pointer, json.RawMessage arguments over the
wire). Adds a small newCallToolRequest test helper per package that
marshals args the way a real client would, replacing ad-hoc struct
literals across ~80 call sites.

Also fixes assertions that assumed mark3labs' shapes: ToolAnnotations'
ReadOnlyHint/IdempotentHint are plain bool (not *bool) in the official
SDK; Content items (TextContent/ImageContent/ResourceLink) are
returned as pointers; Meta is a plain map, not a struct with
AdditionalFields; ImageContent.Data is raw []byte (auto base64-encoded
on marshal), not a pre-encoded string. Replaces
agento11y_eval_test.go's raw HandleMessage JSON-RPC hack (a mark3labs
API with no equivalent) with a real client/server round trip over
mcp.NewInMemoryTransports().

`go test -tags unit ./tools/... .` and `golangci-lint run ./tools/... .`
are both green. Integration-tagged files were fixed to vet cleanly but
not run (require live infra).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>