### PR TITLE
feat(oncall): return the last alert payload from get_alert_group

### DIFF
--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -545,15 +546,40 @@ func getAlertGroup(ctx context.Context, args GetAlertGroupParams) (*OnCallAlertG
 	return amixrGetAlertGroup(ctx, args.AlertGroupID)
 }
 
+// oncallAlertGroupPublic mirrors the public OnCall API's alert group response.
+//
+// It exists because aapi.AlertGroup omits last_alert, and aapi.Alert types its
+// payload as a fixed struct that would discard integration-specific fields. The
+// request below therefore bypasses aapi.AlertGroupService and decodes into this
+// type instead.
+type oncallAlertGroupPublic struct {
+	ID             string            `json:"id"`
+	IntegrationID  string            `json:"integration_id"`
+	AlertsCount    int               `json:"alerts_count"`
+	State          string            `json:"state"`
+	CreatedAt      string            `json:"created_at"`
+	ResolvedAt     string            `json:"resolved_at"`
+	AcknowledgedAt string            `json:"acknowledged_at"`
+	Title          string            `json:"title"`
+	Permalinks     map[string]string `json:"permalinks"`
+	LastAlert      *OnCallLastAlert  `json:"last_alert"`
+}
+
 func amixrGetAlertGroup(ctx context.Context, alertGroupID string) (*OnCallAlertGroup, error) {
 	client, err := oncallClientFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting OnCall client: %w", err)
 	}
 
-	alertGroupService := aapi.NewAlertGroupService(client)
-	ag, _, err := alertGroupService.GetAlertGroup(alertGroupID)
+	// Mirrors aapi.AlertGroupService.GetAlertGroup's path construction.
+	path := fmt.Sprintf("alert_groups/%s/", url.PathEscape(alertGroupID))
+	req, err := client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
+		return nil, fmt.Errorf("creating OnCall alert group request %s: %w", alertGroupID, err)
+	}
+
+	var ag oncallAlertGroupPublic
+	if _, err := client.Do(req, &ag); err != nil {
 		return nil, fmt.Errorf("getting OnCall alert group %s: %w", alertGroupID, err)
 	}
 
@@ -567,12 +593,13 @@ func amixrGetAlertGroup(ctx context.Context, alertGroupID string) (*OnCallAlertG
 		AcknowledgedAt: ag.AcknowledgedAt,
 		Title:          ag.Title,
 		Permalinks:     ag.Permalinks,
+		LastAlert:      ag.LastAlert,
 	}, nil
 }
 
 var GetAlertGroup = mcpgrafana.MustTool(
 	"get_alert_group",
-	"Get a specific alert group from Grafana OnCall by its ID. Returns the full alert group details.",
+	"Get a specific alert group from Grafana OnCall by its ID. Returns the full alert group details, including the most recent alert and its raw payload when the OnCall API provides them. Alert payloads carry integration-specific fingerprints (for example Sentry's payload.data.event.hashes or Alertmanager's payload.alerts[].fingerprint) that identify recurring alerts across different alert groups.",
 	getAlertGroup,
 	mcp.WithTitleAnnotation("Get IRM alert group"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/oncall_types.go
+++ b/tools/oncall_types.go
@@ -18,6 +18,24 @@ type OnCallAlertGroup struct {
 	Permalinks     map[string]string `json:"permalinks,omitempty"`
 	Labels         any               `json:"labels,omitempty"`
 	Team           string            `json:"team,omitempty"`
+	// LastAlert is the most recent alert in the group, including its raw
+	// payload. Only populated by get_alert_group on the public OnCall API
+	// path; the IRM proxy's internal endpoint does not expose it.
+	LastAlert *OnCallLastAlert `json:"last_alert,omitempty"`
+}
+
+// OnCallLastAlert is the most recent alert in an alert group.
+//
+// Payload is decoded as an arbitrary JSON object rather than a typed struct
+// because its contents are entirely determined by the integration that sent
+// the alert. Keeping it untyped preserves source-specific fields an agent
+// needs to correlate recurring alerts, such as Sentry's
+// payload.data.event.hashes[0] or Alertmanager's payload.alerts[0].fingerprint.
+type OnCallLastAlert struct {
+	ID           string         `json:"id"`
+	AlertGroupID string         `json:"alert_group_id"`
+	CreatedAt    string         `json:"created_at"`
+	Payload      map[string]any `json:"payload,omitempty"`
 }
 
 // OnCallUser represents an OnCall user returned by MCP tools.

--- a/tools/oncall_unit_test.go
+++ b/tools/oncall_unit_test.go
@@ -1,0 +1,153 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newOnCallPublicAPIServer starts a test server that answers both the Grafana
+// IRM plugin settings lookup and the public OnCall API, pointing the former at
+// itself. It records the path of every request it serves.
+func newOnCallPublicAPIServer(t *testing.T, alertGroups map[string]any) (context.Context, *[]string) {
+	t.Helper()
+
+	var requests []string
+	mux := http.NewServeMux()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		mux.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	mux.HandleFunc("GET /api/plugins/grafana-irm-app/settings", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"jsonData": map[string]string{"onCallApiUrl": server.URL},
+		}))
+	})
+	for id, body := range alertGroups {
+		alertGroup := body
+		mux.HandleFunc("GET /api/v1/alert_groups/"+id+"/", func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(alertGroup))
+		})
+	}
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unexpected request: "+r.URL.Path, http.StatusNotFound)
+	})
+
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{
+		URL:    server.URL,
+		APIKey: "oncall-token",
+	})
+	return ctx, &requests
+}
+
+func TestGetAlertGroupIncludesLastAlertPayload(t *testing.T) {
+	ctx, requests := newOnCallPublicAPIServer(t, map[string]any{
+		"AG123": map[string]any{
+			"id":              "AG123",
+			"integration_id":  "INT123",
+			"route_id":        "ROUTE123",
+			"alerts_count":    1,
+			"state":           "new",
+			"created_at":      "2026-04-29T07:00:00Z",
+			"acknowledged_at": nil,
+			"resolved_at":     nil,
+			"title":           "Sentry issue",
+			"permalinks": map[string]string{
+				"web": "https://grafana.example/alert-groups/AG123",
+			},
+			"last_alert": map[string]any{
+				"id":             "A123",
+				"alert_group_id": "AG123",
+				"created_at":     "2026-04-29T07:01:00Z",
+				"payload": map[string]any{
+					"data": map[string]any{
+						"event": map[string]any{
+							"hashes": []string{"66b46acbdeae7d18599d803d44d7c10f"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	result, err := getAlertGroup(ctx, GetAlertGroupParams{AlertGroupID: "AG123"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "AG123", result.ID)
+	assert.Equal(t, "INT123", result.IntegrationID)
+	assert.Equal(t, 1, result.AlertsCount)
+	assert.Equal(t, "new", result.State)
+	assert.Equal(t, "Sentry issue", result.Title)
+	assert.Equal(t, "https://grafana.example/alert-groups/AG123", result.Permalinks["web"])
+
+	// The settings lookup resolves the public OnCall API URL, then the alert
+	// group is fetched directly rather than via aapi.AlertGroupService.
+	assert.Equal(t, []string{
+		"GET /api/plugins/grafana-irm-app/settings",
+		"GET /api/v1/alert_groups/AG123/",
+	}, *requests)
+
+	require.NotNil(t, result.LastAlert)
+	assert.Equal(t, "A123", result.LastAlert.ID)
+	assert.Equal(t, "AG123", result.LastAlert.AlertGroupID)
+	assert.Equal(t, "2026-04-29T07:01:00Z", result.LastAlert.CreatedAt)
+
+	// Integration-specific nesting survives the round trip: this is the
+	// Sentry fingerprint an agent uses to correlate recurring alerts.
+	data, ok := result.LastAlert.Payload["data"].(map[string]any)
+	require.True(t, ok)
+	event, ok := data["event"].(map[string]any)
+	require.True(t, ok)
+	hashes, ok := event["hashes"].([]any)
+	require.True(t, ok)
+	require.Len(t, hashes, 1)
+	assert.Equal(t, "66b46acbdeae7d18599d803d44d7c10f", hashes[0])
+}
+
+func TestGetAlertGroupWithoutLastAlert(t *testing.T) {
+	ctx, _ := newOnCallPublicAPIServer(t, map[string]any{
+		"AG456": map[string]any{
+			"id":           "AG456",
+			"alerts_count": 0,
+			"state":        "resolved",
+			"created_at":   "2026-04-29T07:00:00Z",
+		},
+	})
+
+	result, err := getAlertGroup(ctx, GetAlertGroupParams{AlertGroupID: "AG456"})
+	require.NoError(t, err)
+	assert.Equal(t, "AG456", result.ID)
+	assert.Nil(t, result.LastAlert)
+
+	// last_alert must be omitted rather than serialised as null, so alert
+	// groups without alerts do not add noise to the tool response.
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "last_alert")
+}
+
+func TestGetAlertGroupNotFound(t *testing.T) {
+	ctx, _ := newOnCallPublicAPIServer(t, nil)
+
+	_, err := getAlertGroup(ctx, GetAlertGroupParams{AlertGroupID: "missing"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting OnCall alert group missing")
+}
+
+func TestGetAlertGroupEscapesID(t *testing.T) {
+	ctx, requests := newOnCallPublicAPIServer(t, nil)
+
+	_, err := getAlertGroup(ctx, GetAlertGroupParams{AlertGroupID: "../alert_groups"})
+	require.Error(t, err)
+	assert.NotContains(t, *requests, "GET /api/v1/alert_groups/")
+}


### PR DESCRIPTION
`get_alert_group` now returns the group's most recent alert along with its raw payload. Alert payloads carry integration-specific fingerprints — Sentry's `payload.data.event.hashes[0]`, Alertmanager's `payload.alerts[0].fingerprint` — which let an agent recognise that an alert group is a recurrence of one it has already seen. Before this, the tool returned `alerts_count` and no way to reach the payload without another call.

Closes #814. Supersedes #828.

## Attribution

Requested in #814 by @OshriBay and first implemented in #828 by @Genmin — thanks to both. This is a reimplementation on a fresh branch rather than a rebase, because #828 is blocked on an unsigned CLA, which cannot be resolved in place. The code and tests here follow that PR closely; the differences are noted under Implementation.

## Implementation

`amixr-api-go-client`'s `AlertGroup` has no `LastAlert` field, and its `Alert` types the payload as a fixed `AlertPayload` struct that would discard exactly the source-specific keys this feature is for. The public API path therefore issues the `alert_groups/{id}/` request directly through `client.NewRequest`/`client.Do` instead of `aapi.AlertGroupService`, decoding into a local struct that mirrors the API response and holds the payload as `map[string]any`. Path construction, including `url.PathEscape`, mirrors what the library's own `GetAlertGroup` does, and the response is mapped field by field onto `OnCallAlertGroup` so everything the tool returned before is unchanged.

Two deliberate departures from #828:

- `LastAlert` hangs off the shared `OnCallAlertGroup` type in `oncall_types.go` rather than a new `GetAlertGroupResult` wrapper. The JSON on the wire is identical — the wrapper embedded `OnCallAlertGroup`, so its fields were inlined either way — but this keeps one alert-group type in the package and matches how that file already unifies the proxy and public API shapes. `list_alert_groups` is unaffected: it builds its results explicitly and `last_alert` is `omitempty`.
- The tool description now says what the payload is useful for, so an agent knows the fingerprints are there without having to fetch a group first.

There is no new parameter. #814 proposed an opt-in `includeLastAlertPayload` flag; per the review on #828, always returning the payload is better than paying for a flag and its description in every conversation, since a user asking about an alert group usually wants to see what fired. #828 was already updated to drop the flag before it stalled.

## Deliberate omissions

- **The IRM proxy path returns no `last_alert`.** When on-behalf-of tokens are present, `get_alert_group` goes through the IRM plugin proxy to the internal `alertgroups/{pk}/` endpoint, whose response (`onCallAlertGroupInternal`) has no `last_alert` field — so in Grafana Cloud this feature is currently a no-op and the tool returns the regular shape. Wiring it up needs confirmation of whether that internal endpoint exposes the payload at all, and under what shape; it is a follow-up, not something to guess at here. `last_alert` is `omitempty`, so the proxy response is byte-identical to today's.
- **No `list_alerts` tool.** #814 mentions one as a separate proposal for reaching a group's full alert history. Out of scope.

## Testing

- `make test-unit` — full unit suite green, including four new tests in `tools/oncall_unit_test.go`: nested payload survives the round trip (asserting the Sentry `hashes[0]` value specifically), `last_alert` absent means the key is omitted rather than `null`, the API error path is wrapped with the alert group ID, and the group ID is escaped into the path.
- `make lint-jsonschema`, `make lint-openapi`, `golangci-lint run`, `gofmt -l .` — all clean.
- Listed `tools/list` over stdio and inspected the registered `get_alert_group` definition: input schema is unchanged, so no caller sees a new or altered parameter.
- Not tested against a live OnCall instance. The integration suite runs against shared services with fixtures other tests assert on, and the cloud suite needs credentials; the payload shape is exercised through an `httptest` server that also stands in for the plugin settings lookup.

## Docs

The `get_alert_group` rows in `README.md` and `docs/sources/reference/mcp-tools-table.md` are unchanged — those tables carry a one-line summary and required scope, both still accurate, and the tables are column-aligned so widening one cell would rewrite every row.
