### PR TITLE
feat: migrate server construction, session mgmt, and proxied-tools client to official go-sdk

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -15,8 +15,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/grafana/mcp-grafana/observability"
@@ -52,7 +51,7 @@ func resolveServerName(flagValue string, flagExplicitlySet bool, envValue, defau
 	return defaultValue
 }
 
-func maybeAddTools(s *server.MCPServer, tf func(*server.MCPServer), enabledTools []string, disable bool, category string) {
+func maybeAddTools(s *mcp.Server, tf func(*mcp.Server), enabledTools []string, disable bool, category string) {
 	if !slices.Contains(enabledTools, category) {
 		slog.Debug("Not enabling tools", "category", category)
 		return
@@ -199,7 +198,7 @@ func (gc *grafanaConfig) addFlags() {
 
 // toolEntry pairs a tool registration function with its category and disable flag.
 type toolEntry struct {
-	adder    func(*server.MCPServer)
+	adder    func(*mcp.Server)
 	disabled bool
 	category string
 }
@@ -211,25 +210,25 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 	enableWriteTools := !dt.write
 	return []toolEntry{
 		{tools.AddSearchTools, dt.search, "search"},
-		{func(mcp *server.MCPServer) { tools.AddDatasourceTools(mcp, enableWriteTools) }, dt.datasource, "datasource"},
-		{func(mcp *server.MCPServer) { tools.AddIncidentTools(mcp, enableWriteTools) }, dt.incident, "incident"},
+		{func(mcp *mcp.Server) { tools.AddDatasourceTools(mcp, enableWriteTools) }, dt.datasource, "datasource"},
+		{func(mcp *mcp.Server) { tools.AddIncidentTools(mcp, enableWriteTools) }, dt.incident, "incident"},
 		{tools.AddPrometheusTools, dt.prometheus, "prometheus"},
 		{tools.AddLokiTools, dt.loki, "loki"},
 		{tools.AddElasticsearchTools, dt.elasticsearch, "elasticsearch"},
 		{tools.AddQuickwitTools, dt.quickwit, "quickwit"},
 		{tools.AddInfluxDBTools, dt.influxdb, "influxdb"},
-		{func(mcp *server.MCPServer) { tools.AddAlertingTools(mcp, enableWriteTools) }, dt.alerting, "alerting"},
-		{func(mcp *server.MCPServer) { tools.AddDashboardTools(mcp, enableWriteTools) }, dt.dashboard, "dashboard"},
-		{func(mcp *server.MCPServer) { tools.AddFolderTools(mcp, enableWriteTools) }, dt.folder, "folder"},
+		{func(mcp *mcp.Server) { tools.AddAlertingTools(mcp, enableWriteTools) }, dt.alerting, "alerting"},
+		{func(mcp *mcp.Server) { tools.AddDashboardTools(mcp, enableWriteTools) }, dt.dashboard, "dashboard"},
+		{func(mcp *mcp.Server) { tools.AddFolderTools(mcp, enableWriteTools) }, dt.folder, "folder"},
 		{tools.AddOnCallTools, dt.oncall, "oncall"},
 		{tools.AddAssertsTools, dt.asserts, "asserts"},
-		{func(mcp *server.MCPServer) { tools.AddSiftTools(mcp, enableWriteTools) }, dt.sift, "sift"},
+		{func(mcp *mcp.Server) { tools.AddSiftTools(mcp, enableWriteTools) }, dt.sift, "sift"},
 		{tools.AddAdminTools, dt.admin, "admin"},
 		{tools.AddPyroscopeTools, dt.pyroscope, "pyroscope"},
-		{func(mcp *server.MCPServer) { tools.AddNavigationTools(mcp, enableWriteTools) }, dt.navigation, "navigation"},
-		{func(mcp *server.MCPServer) { tools.AddAnnotationTools(mcp, enableWriteTools) }, dt.annotations, "annotations"},
+		{func(mcp *mcp.Server) { tools.AddNavigationTools(mcp, enableWriteTools) }, dt.navigation, "navigation"},
+		{func(mcp *mcp.Server) { tools.AddAnnotationTools(mcp, enableWriteTools) }, dt.annotations, "annotations"},
 		{tools.AddRenderingTools, dt.rendering, "rendering"},
-		{func(mcp *server.MCPServer) { tools.AddSnapshotTools(mcp, enableWriteTools) }, dt.snapshot, "snapshot"},
+		{func(mcp *mcp.Server) { tools.AddSnapshotTools(mcp, enableWriteTools) }, dt.snapshot, "snapshot"},
 		{tools.AddCloudWatchTools, dt.cloudwatch, "cloudwatch"},
 		{tools.AddExamplesTools, dt.examples, "examples"},
 		{tools.AddClickHouseTools, dt.clickhouse, "clickhouse"},
@@ -237,17 +236,17 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{tools.AddRunPanelQueryTools, dt.runpanelquery, "runpanelquery"},
 		{tools.AddGraphiteTools, dt.graphite, "graphite"},
 		{tools.AddAthenaTools, dt.athena, "athena"},
-		{func(mcp *server.MCPServer) { tools.AddPluginTools(mcp, enableWriteTools) }, dt.plugin, "plugin"},
-		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools) }, dt.api, "api"},
+		{func(mcp *mcp.Server) { tools.AddPluginTools(mcp, enableWriteTools) }, dt.plugin, "plugin"},
+		{func(mcp *mcp.Server) { tools.AddAPITools(mcp, enableWriteTools) }, dt.api, "api"},
 		{tools.AddConfigTools, dt.config, "config"},
 		{tools.AddProvisioningTools, dt.provisioning, "provisioning"},
-		{func(mcp *server.MCPServer) { tools.AddAgento11yTools(mcp, enableWriteTools) }, dt.agento11y, "agento11y"},
-		{func(mcp *server.MCPServer) { tools.AddAssistantTools(mcp, enableWriteTools) }, dt.assistant, "assistant"},
+		{func(mcp *mcp.Server) { tools.AddAgento11yTools(mcp, enableWriteTools) }, dt.agento11y, "agento11y"},
+		{func(mcp *mcp.Server) { tools.AddAssistantTools(mcp, enableWriteTools) }, dt.assistant, "assistant"},
 	}
 }
 
 // processTools registers enabled tool categories on the server.
-func (dt *disabledTools) processTools(s *server.MCPServer) {
+func (dt *disabledTools) processTools(s *mcp.Server) {
 	enabledTools := strings.Split(dt.enabledTools, ",")
 	for _, e := range dt.toolEntries() {
 		maybeAddTools(s, e.adder, enabledTools, e.disabled, e.category)
@@ -299,95 +298,94 @@ func (dt *disabledTools) buildInstructions() string {
 	return b.String()
 }
 
-func newServer(serverName, transport string, dt disabledTools, obs *observability.Observability, sessionIdleTimeoutMinutes int) (*server.MCPServer, *mcpgrafana.ToolManager, *mcpgrafana.SessionManager) {
-	sm := mcpgrafana.NewSessionManager(
-		mcpgrafana.WithSessionTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute),
-	)
-
-	// Declare variables that will be initialized after server creation.
-	// The hooks below capture these by pointer, so they must be declared first.
-	var stm *mcpgrafana.ToolManager
-	var s *server.MCPServer
-
-	// Create hooks
-	hooks := &server.Hooks{
-		OnRegisterSession:   []server.OnRegisterSessionHookFunc{sm.CreateSession},
-		OnUnregisterSession: []server.OnUnregisterSessionHookFunc{sm.RemoveSession},
-	}
-
-	// Add proxied tools hooks if enabled and we're not running in stdio mode.
-	// (stdio mode is handled by InitializeAndRegisterServerTools; per-session tools
-	// are not supported).
-	if transport != "stdio" && !dt.proxied {
-		// ensureSessionRegistered registers an ephemeral session in MCPServer.sessions
-		// if it's not already there. This is needed for horizontal scaling: when a
-		// request lands on a pod that didn't handle the initialize call, the SDK
-		// creates an ephemeral session that isn't registered, causing AddSessionTools
-		// to fail with ErrSessionNotFound. RegisterSession uses LoadOrStore
-		// internally, so this is a no-op for already-registered sessions.
-		ensureSessionRegistered := func(ctx context.Context) {
-			if s != nil {
-				if session := server.ClientSessionFromContext(ctx); session != nil {
-					_ = s.RegisterSession(ctx, session)
-				}
-			}
-		}
-
-		// OnBeforeListTools: Discover, connect, and register tools
-		hooks.OnBeforeListTools = []server.OnBeforeListToolsFunc{
-			func(ctx context.Context, id any, request *mcp.ListToolsRequest) {
-				ensureSessionRegistered(ctx)
-				if stm != nil {
-					if session := server.ClientSessionFromContext(ctx); session != nil {
-						stm.InitializeAndRegisterProxiedTools(ctx, session)
-					}
-				}
-			},
-		}
-
-		// OnBeforeCallTool: Fallback in case client calls tool without listing first
-		hooks.OnBeforeCallTool = []server.OnBeforeCallToolFunc{
-			func(ctx context.Context, id any, request *mcp.CallToolRequest) {
-				ensureSessionRegistered(ctx)
-				if stm != nil {
-					if session := server.ClientSessionFromContext(ctx); session != nil {
-						stm.InitializeAndRegisterProxiedTools(ctx, session)
-					}
-				}
-			},
-		}
-	}
-
-	// Merge observability hooks with existing hooks
-	hooks = observability.MergeHooks(hooks, obs.MCPHooks())
-
-	// Register tools and build the instruction string from enabled categories.
-	// processTools both registers tools on the server and collects descriptions
-	// of enabled categories, so we need a temporary nil server reference first.
-	// Instead, we split: compute instructions from flags, then create server,
-	// then register tools.
-	instructions := dt.buildInstructions()
-
-	s = server.NewMCPServer(serverName, mcpgrafana.Version(),
-		server.WithInstructions(instructions),
-		server.WithHooks(hooks),
-	)
-
-	// Initialize ToolManager now that server is created
-	stm = mcpgrafana.NewToolManager(sm, s, mcpgrafana.WithProxiedTools(!dt.proxied), mcpgrafana.WithToolManagerLogger(slog.Default()))
-
-	// Give the SessionManager a reference to the MCPServer so the reaper can
-	// unregister sessions from the SDK's internal session map.
-	sm.SetMCPServer(s)
-
-	// Give the SessionManager a reference to the ToolManager so tearing down a
-	// session releases its reference to the shared proxied tool set (closing the
-	// underlying clients only when the last session using them is gone).
-	sm.SetToolManager(stm)
-
+// newBaseServer constructs an *mcp.Server with tools/resources registered and
+// the observability middleware attached — common to every transport and,
+// under HTTP transports, to every session's own server instance (see
+// sessionServerFactory).
+func newBaseServer(serverName string, dt disabledTools, obs *observability.Observability, instructions string) *mcp.Server {
+	s := mcp.NewServer(&mcp.Implementation{Name: serverName, Version: mcpgrafana.Version()}, &mcp.ServerOptions{
+		Instructions: instructions,
+	})
 	dt.processTools(s)
 	mcpgrafana.RegisterAppResources(s)
-	return s, stm, sm
+	s.AddReceivingMiddleware(obs.MCPMiddleware())
+	return s
+}
+
+// newStdioServer builds the single, process-wide server used for the stdio
+// transport. stdio is inherently single-tenant (one session for the whole
+// process lifetime), so unlike HTTP transports there is no per-session server
+// factory: proxied tools, if enabled, are discovered and registered once at
+// startup via ToolManager.InitializeAndRegisterServerTools.
+func newStdioServer(serverName string, dt disabledTools, obs *observability.Observability) (*mcp.Server, *mcpgrafana.ToolManager) {
+	s := newBaseServer(serverName, dt, obs, dt.buildInstructions())
+	stm := mcpgrafana.NewToolManager(nil,
+		mcpgrafana.WithProxiedTools(!dt.proxied),
+		mcpgrafana.WithToolManagerLogger(slog.Default()),
+		mcpgrafana.WithServer(s),
+	)
+	return s, stm
+}
+
+// sessionServerFactory returns the getServer callback passed to
+// NewSSEHandler/NewStreamableHTTPHandler for HTTP-based transports. The
+// official SDK has no per-session tool registration API (mark3labs'
+// AddSessionTools), so each session gets its own *mcp.Server instance instead
+// of a shared one with a per-session tool overlay; InitializeAndRegisterProxiedTools
+// later finds a session's instance via ToolManager.RegisterSessionServer to
+// add its discovered proxied tools directly.
+//
+// When stateless (proxied tools disabled), every request is its own ephemeral
+// session and getServer is invoked per REQUEST, not per session — see
+// StreamableHTTPOptions.Stateless. There is no session-scoped state to
+// isolate in that case, so a single shared server is built once and reused,
+// avoiding re-registering all ~35 tool categories on every call.
+func sessionServerFactory(serverName string, dt disabledTools, obs *observability.Observability, sm *mcpgrafana.SessionManager, stm *mcpgrafana.ToolManager, httpFn httpContextFunc, stateless bool) func(*http.Request) *mcp.Server {
+	instructions := dt.buildInstructions()
+	proxiedEnabled := !dt.proxied
+
+	buildServer := func() *mcp.Server {
+		s := newBaseServer(serverName, dt, obs, instructions)
+		s.AddReceivingMiddleware(
+			mcpgrafana.GrafanaContextMiddleware(httpFn),
+			sessionTrackingMiddleware(s, sm, stm, proxiedEnabled),
+		)
+		return s
+	}
+
+	if stateless {
+		shared := buildServer()
+		return func(*http.Request) *mcp.Server { return shared }
+	}
+	return func(*http.Request) *mcp.Server { return buildServer() }
+}
+
+// httpContextFunc mirrors the unexported type of the same name in the root
+// package (mcpgrafana.ComposedHTTPContextFunc's return type) so it can be
+// named here without exporting it from that package.
+type httpContextFunc = func(ctx context.Context, req *http.Request) context.Context
+
+// sessionTrackingMiddleware records session activity and, for tools/list and
+// tools/call, attaches the session to its shared proxied tool set (mirroring
+// mark3labs' OnBeforeListTools/OnBeforeCallTool hooks). s is the specific
+// *mcp.Server this middleware is attached to: each session gets its own (see
+// sessionServerFactory), so closing over it is how a later
+// InitializeAndRegisterProxiedTools call finds the right instance to add
+// discovered tools to.
+func sessionTrackingMiddleware(s *mcp.Server, sm *mcpgrafana.SessionManager, stm *mcpgrafana.ToolManager, proxiedEnabled bool) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if session := req.GetSession(); session != nil {
+				sessionID := session.ID()
+				sm.TouchOrCreateSession(sessionID)
+				if proxiedEnabled && (method == "tools/list" || method == "tools/call") {
+					stm.RegisterSessionServer(sessionID, s)
+					stm.InitializeAndRegisterProxiedTools(ctx, sessionID)
+				}
+			}
+			return next(ctx, method, req)
+		}
+	}
 }
 
 type tlsConfig struct {
@@ -490,16 +488,54 @@ func (hsc httpSecurityConfig) policy(address string) mcpgrafana.HostOriginPolicy
 	}
 }
 
+// corsOrigins returns the configured allowed Origins, lowercased. Unlike
+// mark3labs (which defaulted SSE to a wildcard Access-Control-Allow-Origin
+// unless suppressed), the official SDK sets no CORS headers at all — see
+// corsMiddleware — so an empty result here already means "no CORS headers,
+// browsers blocked" with no sentinel needed to force that outcome.
 func (hsc httpSecurityConfig) corsOrigins() []string {
-	if origins := splitAndTrim(hsc.allowedOrigins); len(origins) > 0 {
-		for i, o := range origins {
-			origins[i] = strings.ToLower(o)
-		}
-		return origins
+	origins := splitAndTrim(hsc.allowedOrigins)
+	for i, o := range origins {
+		origins[i] = strings.ToLower(o)
 	}
-	// Sentinel keeps mcp-go's corsConfig.enabled() true so its SSE default
-	// of Access-Control-Allow-Origin: * is suppressed.
-	return []string{"https://mcp-grafana.invalid"}
+	return origins
+}
+
+// corsMiddleware sets CORS response headers for the configured allowed
+// origins. The official SDK has no built-in CORS handling at all (unlike
+// mark3labs' SSE/StreamableHTTP servers, which defaulted to a wildcard
+// Access-Control-Allow-Origin that mcp-grafana had to actively suppress). By
+// default (no --allowed-origins), this sets no headers, so browsers are
+// blocked and non-browser MCP clients are unaffected — matching the
+// secure-by-default posture documented on httpSecurityConfig.
+func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	allowed := make(map[string]bool, len(allowedOrigins))
+	allowAll := false
+	for _, o := range allowedOrigins {
+		if o == "*" {
+			allowAll = true
+		}
+		allowed[o] = true
+	}
+	return func(next http.Handler) http.Handler {
+		if !allowAll && len(allowed) == 0 {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin != "" && (allowAll || allowed[strings.ToLower(origin)]) {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Vary", "Origin")
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id, Authorization, Mcp-Protocol-Version, Last-Event-ID")
+				if r.Method == http.MethodOptions {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func splitAndTrim(s string) []string {
@@ -515,18 +551,35 @@ func splitAndTrim(s string) []string {
 	return out
 }
 
-// httpServer represents a server with Start and Shutdown methods
-type httpServer interface {
-	Start(addr string) error
-	Shutdown(ctx context.Context) error
+// isBenignStdioClose reports whether err represents the normal stdio
+// shutdown path: the client (or our own SIGINT/SIGTERM handler) closed
+// stdin, which Server.Run surfaces as an error wrapping the SDK's internal,
+// unexported jsonrpc2.ErrServerClosing sentinel (e.g. "server is closing:
+// EOF") rather than a clean nil or context.Canceled return. Since that
+// sentinel isn't importable, this matches on its stable error text; a
+// genuinely unexpected failure (bad handshake, protocol violation) has a
+// different message and is still treated as fatal.
+func isBenignStdioClose(err error) bool {
+	return strings.Contains(err.Error(), "server is closing")
 }
 
-// runHTTPServer handles the common logic for running HTTP-based servers
-func runHTTPServer(ctx context.Context, srv httpServer, addr, transportName string) error {
+// runHTTPServer handles the common logic for running HTTP-based servers. The
+// official SDK's transport handlers are plain http.Handlers with no owned
+// http.Server (unlike mark3labs' NewSSEServer/NewStreamableHTTPServer, which
+// wrapped their own); srv.Addr and srv.Handler must already be set, and
+// certFile/keyFile (both empty for plain HTTP) select ListenAndServeTLS vs
+// ListenAndServe.
+func runHTTPServer(ctx context.Context, srv *http.Server, certFile, keyFile, transportName string) error {
 	// Start server in a goroutine
 	serverErr := make(chan error, 1)
 	go func() {
-		if err := srv.Start(addr); err != nil {
+		var err error
+		if certFile != "" || keyFile != "" {
+			err = srv.ListenAndServeTLS(certFile, keyFile)
+		} else {
+			err = srv.ListenAndServe()
+		}
+		if err != nil {
 			serverErr <- err
 		}
 		close(serverErr)
@@ -619,9 +672,6 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		defer clientCache.Close()
 	}
 
-	s, tm, sm := newServer(obs.ServerName, transport, dt, o, sessionIdleTimeoutMinutes)
-	defer sm.Close()
-
 	// Create a context that will be cancelled on shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -659,13 +709,15 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 	// Start the appropriate server based on transport
 	switch transport {
 	case "stdio":
-		srv := server.NewStdioServer(s)
-		cf := mcpgrafana.ComposedStdioContextFunc(gc)
-		srv.SetContextFunc(cf)
+		s, tm := newStdioServer(obs.ServerName, dt, o)
+
+		// stdio is single-tenant: context is set up once for the whole process
+		// (there's no per-call HTTP request to derive it from), unlike HTTP
+		// transports where GrafanaContextMiddleware runs per call.
+		stdioCtx := mcpgrafana.ComposedStdioContextFunc(gc)(ctx)
 
 		// For stdio (single-tenant), initialize proxied tools on the server directly
 		if !dt.proxied {
-			stdioCtx := cf(ctx)
 			if err := tm.InitializeAndRegisterServerTools(stdioCtx); err != nil {
 				slog.Error("failed to initialize proxied tools for stdio", "error", err)
 			}
@@ -673,26 +725,29 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 
 		slog.Info("Starting Grafana MCP server using stdio transport", "version", mcpgrafana.Version())
 
-		err := srv.Listen(ctx, os.Stdin, os.Stdout)
-		if err != nil && err != context.Canceled {
+		err := s.Run(stdioCtx, &mcp.StdioTransport{})
+		if err != nil && !errors.Is(err, context.Canceled) && !isBenignStdioClose(err) {
 			return fmt.Errorf("server error: %v", err)
 		}
 		return nil
 
 	case "sse":
-		httpSrv := &http.Server{Addr: addr}
-		srv := server.NewSSEServer(s,
-			server.WithSSEContextFunc(mcpgrafana.ComposedSSEContextFunc(gc, clientCache)),
-			server.WithStaticBasePath(basePath),
-			server.WithHTTPServer(httpSrv),
-			server.WithSSECORS(server.WithCORSAllowedOrigins(hsc.corsOrigins()...)),
-		)
-		mux := http.NewServeMux()
+		sm := mcpgrafana.NewSessionManager(mcpgrafana.WithSessionTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute))
+		defer sm.Close()
+		stm := mcpgrafana.NewToolManager(sm, mcpgrafana.WithProxiedTools(!dt.proxied), mcpgrafana.WithToolManagerLogger(slog.Default()))
+		sm.SetToolManager(stm)
+
+		httpFn := mcpgrafana.ComposedHTTPContextFunc(gc, clientCache)
+		getServer := sessionServerFactory(obs.ServerName, dt, o, sm, stm, httpFn, false /* SSE is always stateful */)
+		sseHandler := mcp.NewSSEHandler(getServer, nil)
+
 		if basePath == "" {
 			basePath = "/"
 		}
+		mux := http.NewServeMux()
 		mux.Handle(basePath, withCallerAuth(callerToken, observability.WrapHandler(
-			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
+			corsMiddleware(hsc.corsOrigins())(
+				mcpgrafana.ValidateGrafanaURLMiddleware(sseHandler)), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			basePath,
 		)))
 		mux.HandleFunc("/healthz", handleHealthz)
@@ -704,35 +759,37 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			}
 		}
 		// Wrap the full mux so /healthz and /metrics are validated too.
-		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
+		httpSrv := &http.Server{
+			Addr:    addr,
+			Handler: mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux),
+		}
 		slog.Info("Starting Grafana MCP server using SSE transport",
 			"version", mcpgrafana.Version(), "address", addr, "basePath", basePath, "metrics", obs.MetricsEnabled)
-		return runHTTPServer(ctx, srv, addr, "SSE")
+		return runHTTPServer(ctx, httpSrv, "", "", "SSE")
 	case "streamable-http":
-		httpSrv := &http.Server{Addr: addr}
-		opts := []server.StreamableHTTPOption{
-			server.WithHTTPContextFunc(mcpgrafana.ComposedHTTPContextFunc(gc, clientCache)),
-			server.WithStateLess(dt.proxied), // Stateful when proxied tools enabled (requires sessions)
-			server.WithEndpointPath(endpointPath),
-			server.WithStreamableHTTPServer(httpSrv),
-			server.WithStreamableHTTPCORS(server.WithCORSAllowedOrigins(hsc.corsOrigins()...)),
-			// Enable the SDK's idle-session sweeper so per-session transport state
-			// (the tool/resource maps populated by AddSessionTools, keyed by
-			// session ID in the server's shared stores) is freed when a client
-			// disconnects without sending a DELETE. Without it, UnregisterSession
-			// only drops the session handle and those stores grow without bound,
-			// leaking a fixed amount of memory per session that is ever created.
-			// Use the same idle timeout as our own SessionManager reaper so the
-			// two teardown paths stay aligned; a zero value disables both.
-			server.WithSessionIdleTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute),
-		}
-		if tls.certFile != "" || tls.keyFile != "" {
-			opts = append(opts, server.WithTLSCert(tls.certFile, tls.keyFile))
-		}
-		srv := server.NewStreamableHTTPServer(s, opts...)
+		sm := mcpgrafana.NewSessionManager(mcpgrafana.WithSessionTTL(time.Duration(sessionIdleTimeoutMinutes) * time.Minute))
+		defer sm.Close()
+		stm := mcpgrafana.NewToolManager(sm, mcpgrafana.WithProxiedTools(!dt.proxied), mcpgrafana.WithToolManagerLogger(slog.Default()))
+		sm.SetToolManager(stm)
+
+		httpFn := mcpgrafana.ComposedHTTPContextFunc(gc, clientCache)
+		// Stateful when proxied tools are enabled (requires sessions); stateless
+		// otherwise, in which case getServer builds one shared server used for
+		// every (ephemeral, per-request) session - see sessionServerFactory.
+		getServer := sessionServerFactory(obs.ServerName, dt, o, sm, stm, httpFn, dt.proxied)
+		streamableHandler := mcp.NewStreamableHTTPHandler(getServer, &mcp.StreamableHTTPOptions{
+			Stateless: dt.proxied,
+			// Replaces mark3labs' WithSessionIdleTTL: per-session transport state is
+			// freed when a client goes idle for this long without a new request.
+			// Kept in sync with our own SessionManager reaper TTL so the two
+			// teardown paths stay aligned; a zero value disables both.
+			SessionTimeout: time.Duration(sessionIdleTimeoutMinutes) * time.Minute,
+		})
+
 		mux := http.NewServeMux()
 		mux.Handle(endpointPath, withCallerAuth(callerToken, observability.WrapHandler(
-			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
+			corsMiddleware(hsc.corsOrigins())(
+				mcpgrafana.ValidateGrafanaURLMiddleware(streamableHandler)), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			endpointPath,
 		)))
 		mux.HandleFunc("/healthz", handleHealthz)
@@ -744,10 +801,13 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			}
 		}
 		// Wrap the full mux so /healthz and /metrics are validated too.
-		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
+		httpSrv := &http.Server{
+			Addr:    addr,
+			Handler: mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux),
+		}
 		slog.Info("Starting Grafana MCP server using StreamableHTTP transport",
 			"version", mcpgrafana.Version(), "address", addr, "endpointPath", endpointPath, "metrics", obs.MetricsEnabled)
-		return runHTTPServer(ctx, srv, addr, "StreamableHTTP")
+		return runHTTPServer(ctx, httpSrv, tls.certFile, tls.keyFile, "StreamableHTTP")
 	default:
 		return fmt.Errorf("invalid transport type: %s. Must be 'stdio', 'sse' or 'streamable-http'", transport)
 	}

--- a/examples/tls_example.go
+++ b/examples/tls_example.go
@@ -9,7 +9,7 @@ import (
 
 	mcpgrafana "github.com/grafana/mcp-grafana"
 	"github.com/grafana/mcp-grafana/tools"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func main() {
@@ -84,15 +84,16 @@ func fullTLSExample() {
 	fmt.Printf("  - Skip verify: %v\n", tlsConfig.SkipVerify)
 	fmt.Printf("  - Debug mode: %v\n", grafanaConfig.Debug)
 
-	// Create context functions for different transport types
+	// Create context functions for different transport types. HTTP-based
+	// transports (SSE, streamable HTTP) share one context func, applied per
+	// call via mcpgrafana.GrafanaContextMiddleware rather than once per
+	// connection.
 	stdioFunc := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)
-	sseFunc := mcpgrafana.ComposedSSEContextFunc(grafanaConfig)
 	httpFunc := mcpgrafana.ComposedHTTPContextFunc(grafanaConfig)
 
 	fmt.Printf("✓ Context functions created for all transport types\n")
 
 	_ = stdioFunc
-	_ = sseFunc
 	_ = httpFunc
 }
 
@@ -112,19 +113,17 @@ grafanaConfig := mcpgrafana.GrafanaConfig{
 }
 
 // Create MCP server
-s := server.NewMCPServer("mcp-grafana", "1.0.0")
+s := mcp.NewServer(&mcp.Implementation{Name: "mcp-grafana", Version: "1.0.0"}, nil)
 
 // Add tools
 tools.AddSearchTools(s)
 tools.AddDatasourceTools(s, false)
 // ... add other tools as needed
 
-// Create stdio server with TLS support
-srv := server.NewStdioServer(s)
-srv.SetContextFunc(mcpgrafana.ComposedStdioContextFunc(grafanaConfig))
-
-// Start server
-srv.Listen(ctx, os.Stdin, os.Stdout)`)
+// Start the server over stdio, with the Grafana config applied once for the
+// whole process (stdio is single-tenant: one session for its lifetime).
+ctx := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)(context.Background())
+s.Run(ctx, &mcp.StdioTransport{})`)
 }
 
 func runServerWithTLS() {
@@ -152,24 +151,21 @@ func runServerWithTLS() {
 	}
 
 	// Create MCP server
-	s := server.NewMCPServer("mcp-grafana-tls-example", "1.0.0")
+	s := mcp.NewServer(&mcp.Implementation{Name: "mcp-grafana-tls-example", Version: "1.0.0"}, nil)
 
 	// Add some basic tools
 	tools.AddSearchTools(s)
 	tools.AddDatasourceTools(s, false) // Read-only mode (no write tools)
 	tools.AddDashboardTools(s, false)  // Read-only mode (no write tools)
 
-	// Create stdio server with TLS-enabled context function
-	srv := server.NewStdioServer(s)
-	srv.SetContextFunc(mcpgrafana.ComposedStdioContextFunc(grafanaConfig))
-
 	fmt.Printf("Starting MCP Grafana server with TLS support...\n")
 	fmt.Printf("Grafana URL: %s\n", os.Getenv("GRAFANA_URL"))
 	fmt.Printf("TLS Skip Verify: %v\n", tlsConfig.SkipVerify)
 
-	// Start the server
-	ctx := context.Background()
-	if err := srv.Listen(ctx, os.Stdin, os.Stdout); err != nil {
+	// Start the server over stdio, with the Grafana config applied once for
+	// the whole process (stdio is single-tenant: one session for its lifetime).
+	ctx := mcpgrafana.ComposedStdioContextFunc(grafanaConfig)(context.Background())
+	if err := s.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		log.Fatalf("Server error: %v", err)
 	}
 }

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/incident-go"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/sync/singleflight"
 )
@@ -805,9 +805,14 @@ func extractKeyGrafanaInfoFromReq(req *http.Request, logger *slog.Logger) (grafa
 	return
 }
 
+// StdioContextFunc extracts or modifies the context for the stdio transport.
+// Unlike httpContextFunc, it runs once at server startup rather than per call,
+// since a stdio process serves exactly one session for its whole lifetime.
+type StdioContextFunc func(ctx context.Context) context.Context
+
 // ExtractGrafanaInfoFromEnv is a StdioContextFunc that extracts Grafana configuration from environment variables.
 // It reads GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN (or deprecated GRAFANA_API_KEY) environment variables and adds the configuration to the context for use by Grafana clients.
-var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
+var ExtractGrafanaInfoFromEnv StdioContextFunc = func(ctx context.Context) context.Context {
 	// Get existing config or create a new one.
 	// This will respect the existing debug flag, if set.
 	config := GrafanaConfigFromContext(ctx)
@@ -830,9 +835,11 @@ var ExtractGrafanaInfoFromEnv server.StdioContextFunc = func(ctx context.Context
 	return WithGrafanaConfig(ctx, config)
 }
 
-// httpContextFunc is a function that can be used as a `server.HTTPContextFunc` or a
-// `server.SSEContextFunc`. It is necessary because, while the two types are functionally
-// identical, they have distinct types and cannot be passed around interchangeably.
+// httpContextFunc extracts or modifies the context for HTTP-based transports
+// (SSE and streamable HTTP). Unlike StdioContextFunc, it is invoked once per
+// JSON-RPC call (see GrafanaContextMiddleware), not once per connection, so
+// that request-scoped auth/org headers are honored even when multiple calls
+// share one underlying session.
 type httpContextFunc func(ctx context.Context, req *http.Request) context.Context
 
 // ExtractGrafanaInfoFromHeaders is a HTTPContextFunc that extracts request-scoped Grafana configuration from HTTP headers.
@@ -1247,7 +1254,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 // ExtractGrafanaClientFromEnv is a StdioContextFunc that creates and injects a Grafana client into the context.
 // It uses configuration from GRAFANA_URL, GRAFANA_SERVICE_ACCOUNT_TOKEN (or deprecated GRAFANA_API_KEY), GRAFANA_USERNAME/PASSWORD environment variables to initialize
 // the client with proper authentication.
-var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
+var ExtractGrafanaClientFromEnv StdioContextFunc = func(ctx context.Context) context.Context {
 	// Extract transport config from env vars
 	logger := LoggerFromContext(ctx)
 	grafanaURL, apiKey := urlAndAPIKeyFromEnv(logger)
@@ -1298,7 +1305,7 @@ type kubernetesClientKey struct{}
 // Kubernetes-style API client into the context, used by tools that talk to
 // Grafana's app-platform APIs (e.g. dashboard.grafana.app). On failure it injects
 // a nil client; callers fall back to the legacy API.
-var ExtractKubernetesClientFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
+var ExtractKubernetesClientFromEnv StdioContextFunc = func(ctx context.Context) context.Context {
 	logger := LoggerFromContext(ctx)
 	client, err := NewKubernetesClient(ctx)
 	if err != nil {
@@ -1341,7 +1348,7 @@ type incidentClientKey struct{}
 
 // ExtractIncidentClientFromEnv is a StdioContextFunc that creates and injects a Grafana Incident client into the context.
 // It configures the client using environment variables and applies any custom TLS settings from the context.
-var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Context) context.Context {
+var ExtractIncidentClientFromEnv StdioContextFunc = func(ctx context.Context) context.Context {
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
 	grafanaURL, apiKey := urlAndAPIKeyFromEnv(logger)
@@ -1406,7 +1413,7 @@ func IncidentClientFromContext(ctx context.Context) *incident.Client {
 
 // ComposeStdioContextFuncs composes multiple StdioContextFuncs into a single one.
 // Functions are applied in order, allowing each to modify the context before passing it to the next.
-func ComposeStdioContextFuncs(funcs ...server.StdioContextFunc) server.StdioContextFunc {
+func ComposeStdioContextFuncs(funcs ...StdioContextFunc) StdioContextFunc {
 	return func(ctx context.Context) context.Context {
 		for _, f := range funcs {
 			ctx = f(ctx)
@@ -1415,9 +1422,11 @@ func ComposeStdioContextFuncs(funcs ...server.StdioContextFunc) server.StdioCont
 	}
 }
 
-// ComposeSSEContextFuncs composes multiple SSEContextFuncs into a single one.
-// This enables chaining of context modifications for Server-Sent Events transport, such as extracting headers and setting up clients.
-func ComposeSSEContextFuncs(funcs ...httpContextFunc) server.SSEContextFunc {
+// ComposeHTTPContextFuncs composes multiple httpContextFuncs into a single one.
+// This enables chaining of context modifications for HTTP-based transports
+// (SSE and streamable HTTP), allowing modular setup of authentication,
+// clients, and configuration.
+func ComposeHTTPContextFuncs(funcs ...httpContextFunc) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		for _, f := range funcs {
 			ctx = f(ctx, req)
@@ -1426,20 +1435,39 @@ func ComposeSSEContextFuncs(funcs ...httpContextFunc) server.SSEContextFunc {
 	}
 }
 
-// ComposeHTTPContextFuncs composes multiple HTTPContextFuncs into a single one.
-// This enables chaining of context modifications for HTTP transport, allowing modular setup of authentication, clients, and configuration.
-func ComposeHTTPContextFuncs(funcs ...httpContextFunc) server.HTTPContextFunc {
-	return func(ctx context.Context, req *http.Request) context.Context {
-		for _, f := range funcs {
-			ctx = f(ctx, req)
+// GrafanaContextMiddleware returns an mcp.Middleware that runs httpFn on
+// every incoming JSON-RPC call carrying HTTP headers (streamable HTTP and
+// SSE), synthesizing a minimal *http.Request from the call's headers so the
+// existing httpContextFunc family (which only ever reads req.Header /
+// req.BasicAuth) is reused unchanged.
+//
+// This replaces mark3labs' per-transport context-func hooks
+// (StdioContextFunc/SSEContextFunc/HTTPContextFunc set once at connection
+// time via WithHTTPContextFunc) with a single hook that runs per call. That
+// distinction matters: the official SDK's getServer(*http.Request) callback
+// passed to NewStreamableHTTPHandler/NewSSEHandler only fires once, when a
+// session is established — but CallToolRequest.Extra.Header is populated
+// fresh on every call, including calls reusing an existing session. Reading
+// it here (rather than trying to replicate a per-connection hook) preserves
+// today's per-call auth/org-ID isolation: two calls on the same session with
+// different credentials get correctly separated Grafana clients.
+//
+// Calls with no HTTP headers (stdio) are left untouched; stdio's context is
+// set up once at server startup via ComposedStdioContextFunc instead.
+func GrafanaContextMiddleware(httpFn httpContextFunc) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if extra := req.GetExtra(); extra != nil && extra.Header != nil {
+				ctx = httpFn(ctx, &http.Request{Header: extra.Header})
+			}
+			return next(ctx, method, req)
 		}
-		return ctx
 	}
 }
 
 // ComposedStdioContextFunc returns a StdioContextFunc that comprises all predefined StdioContextFuncs.
 // It sets up the complete context for stdio transport including Grafana configuration, client initialization from environment variables, and incident management support.
-func ComposedStdioContextFunc(config GrafanaConfig) server.StdioContextFunc {
+func ComposedStdioContextFunc(config GrafanaConfig) StdioContextFunc {
 	return ComposeStdioContextFuncs(
 		func(ctx context.Context) context.Context {
 			return WithGrafanaConfig(ctx, config)
@@ -1451,26 +1479,13 @@ func ComposedStdioContextFunc(config GrafanaConfig) server.StdioContextFunc {
 	)
 }
 
-// ComposedSSEContextFunc returns a SSEContextFunc that comprises all predefined SSEContextFuncs.
-// It sets up the complete context for SSE transport, extracting configuration from HTTP headers with environment variable fallbacks.
-// If cache is non-nil, clients are cached by credentials to avoid per-request transport allocation.
-func ComposedSSEContextFunc(config GrafanaConfig, cache ...*ClientCache) server.SSEContextFunc {
-	grafanaExtractor, k8sExtractor, incidentExtractor := clientExtractors(cache)
-	return ComposeSSEContextFuncs(
-		func(ctx context.Context, req *http.Request) context.Context {
-			return WithGrafanaConfig(ctx, config)
-		},
-		ExtractGrafanaInfoFromHeaders,
-		grafanaExtractor,
-		k8sExtractor,
-		incidentExtractor,
-	)
-}
-
-// ComposedHTTPContextFunc returns a HTTPContextFunc that comprises all predefined HTTPContextFuncs.
-// It provides the complete context setup for HTTP transport, including header-based authentication and client configuration.
-// If cache is non-nil, clients are cached by credentials to avoid per-request transport allocation.
-func ComposedHTTPContextFunc(config GrafanaConfig, cache ...*ClientCache) server.HTTPContextFunc {
+// ComposedHTTPContextFunc returns an httpContextFunc that comprises all
+// predefined httpContextFuncs. It provides the complete context setup for
+// HTTP-based transports (SSE and streamable HTTP), including header-based
+// authentication and client configuration. If cache is non-nil, clients are
+// cached by credentials to avoid per-request transport allocation. Wrap the
+// result in GrafanaContextMiddleware to run it per call.
+func ComposedHTTPContextFunc(config GrafanaConfig, cache ...*ClientCache) httpContextFunc {
 	grafanaExtractor, k8sExtractor, incidentExtractor := clientExtractors(cache)
 	return ComposeHTTPContextFuncs(
 		func(ctx context.Context, req *http.Request) context.Context {

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -7,6 +7,7 @@ package observability
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -17,8 +18,7 @@ import (
 	"time"
 
 	datasourceschemas "github.com/grafana/mcp-grafana/tools/datasource_schemas"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -103,9 +103,6 @@ type Observability struct {
 
 	// Network transport for attribute enrichment
 	networkTransport mcpconv.NetworkTransportAttr
-
-	// Track request start times for duration calculation
-	requestStartTimes sync.Map // map[any]time.Time keyed by request ID
 
 	// Per-session metadata (protocol version, start time)
 	sessions sync.Map // map[string]*sessionMeta keyed by session ID
@@ -310,15 +307,30 @@ func (o *Observability) metricsEnabled() bool {
 	return o.operationDuration.Inst() != nil
 }
 
+// argsFromRequest best-effort unmarshals a CallToolRequest's raw wire
+// arguments into a map for telemetry dimension extraction. Returns nil on any
+// failure (non-object arguments, malformed JSON) - dimension extraction below
+// treats a nil map as "nothing to report," matching prior behaviour.
+func argsFromRequest(req *mcp.CallToolRequest) map[string]any {
+	if req == nil || req.Params == nil || len(req.Params.Arguments) == 0 {
+		return nil
+	}
+	var args map[string]any
+	if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+		return nil
+	}
+	return args
+}
+
 // buildOperationAttrs assembles semconv attributes for an operation duration recording.
-func (o *Observability) buildOperationAttrs(ctx context.Context, method mcp.MCPMethod, message any, result any, err error) []attribute.KeyValue {
+func (o *Observability) buildOperationAttrs(method string, req mcp.Request, result any, err error) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
 	// Centralised through toolNameFromMessage so metrics and slow-log share
 	// one definition of "tools/call request reached." The bool distinguishes
 	// "no valid request" (skip emission) from "valid request, empty Name"
 	// (emit ""), preserving pre-existing OTel attribute presence semantics.
-	name, ok := toolNameFromMessage(method, message)
+	name, ok := toolNameFromMessage(method, req)
 	if ok {
 		attrs = append(attrs, o.operationDuration.AttrGenAIToolName(name))
 	}
@@ -329,8 +341,8 @@ func (o *Observability) buildOperationAttrs(ctx context.Context, method mcp.MCPM
 	// labels, and only with allowlisted values (others collapse to "other"). The
 	// high-cardinality target is span-only (see enrichSpanWithToolDims).
 	var args map[string]any
-	if req, ok := message.(*mcp.CallToolRequest); ok && req != nil {
-		args = req.GetArguments()
+	if ctReq, ok := req.(*mcp.CallToolRequest); ok && ctReq != nil {
+		args = argsFromRequest(ctReq)
 	}
 	md := ToolMetricDimensions(name, args, result)
 	if md.Operation != "" {
@@ -353,10 +365,10 @@ func (o *Observability) buildOperationAttrs(ctx context.Context, method mcp.MCPM
 		attrs = append(attrs, o.operationDuration.AttrNetworkTransport(o.networkTransport))
 	}
 
-	// mcp.protocol.version from session context
+	// mcp.protocol.version from session metadata captured on initialize.
 	// Note: mcp.session.id is a span-only attribute (not on metrics) to avoid cardinality explosion.
-	if session := server.ClientSessionFromContext(ctx); session != nil {
-		if meta, ok := o.sessions.Load(session.SessionID()); ok {
+	if session := req.GetSession(); session != nil {
+		if meta, ok := o.sessions.Load(session.ID()); ok {
 			sm := meta.(*sessionMeta)
 			if pv, ok := sm.protocolVersion.Load().(string); ok && pv != "" {
 				attrs = append(attrs, o.operationDuration.AttrProtocolVersion(pv))
@@ -367,25 +379,25 @@ func (o *Observability) buildOperationAttrs(ctx context.Context, method mcp.MCPM
 	return attrs
 }
 
-// toolNameFromMessage extracts the tool name from an MCP hook's message
-// argument when the method is tools/call and the message is a non-nil
-// *mcp.CallToolRequest. Returns (name, true) when the assertion succeeds,
-// including when the name is the empty string. Returns ("", false) for
-// wrong method, nil message, or wrong-type message.
+// toolNameFromMessage extracts the tool name from an MCP request when the
+// method is tools/call and req is a non-nil *mcp.CallToolRequest. Returns
+// (name, true) when the assertion succeeds, including when the name is the
+// empty string. Returns ("", false) for wrong method, nil req, or wrong-type
+// req.
 //
 // The bool lets callers distinguish "no valid tools/call request reached"
 // (don't emit attributes) from "valid request reached, Name happens to be
 // empty" (emit with empty value). buildOperationAttrs uses the bool to
 // preserve pre-existing metric series identity for zero-value Params.Name.
-func toolNameFromMessage(method mcp.MCPMethod, message any) (string, bool) {
+func toolNameFromMessage(method string, req mcp.Request) (string, bool) {
 	if method != "tools/call" {
 		return "", false
 	}
-	req, ok := message.(*mcp.CallToolRequest)
-	if !ok || req == nil {
+	ctReq, ok := req.(*mcp.CallToolRequest)
+	if !ok || ctReq == nil || ctReq.Params == nil {
 		return "", false
 	}
-	return req.Params.Name, true
+	return ctReq.Params.Name, true
 }
 
 // Attribute keys for tool-argument-derived telemetry dimensions. operation and
@@ -502,15 +514,15 @@ type toolArgDims struct {
 // wrong-type message, or arguments that are not a JSON object — mirroring
 // toolNameFromMessage's gating so metrics and spans agree on when "a tool call
 // reached."
-func toolArgDimensions(method mcp.MCPMethod, message any) toolArgDims {
+func toolArgDimensions(method string, req mcp.Request) toolArgDims {
 	if method != "tools/call" {
 		return toolArgDims{}
 	}
-	req, ok := message.(*mcp.CallToolRequest)
-	if !ok || req == nil {
+	ctReq, ok := req.(*mcp.CallToolRequest)
+	if !ok || ctReq == nil {
 		return toolArgDims{}
 	}
-	args := req.GetArguments()
+	args := argsFromRequest(ctReq)
 	dims := toolArgDims{
 		operation:    stringArg(args, "operation"),
 		resourceType: stringArg(args, "type"),
@@ -540,7 +552,7 @@ func toolPhaseFromResult(result any) string {
 	if !ok || res == nil || res.Meta == nil {
 		return ""
 	}
-	if v, ok := res.Meta.AdditionalFields[ToolPhaseMetaKey].(string); ok {
+	if v, ok := res.Meta[ToolPhaseMetaKey].(string); ok {
 		return v
 	}
 	return ""
@@ -584,12 +596,12 @@ func ToolMetricDimensions(toolName string, args map[string]any, result any) Tool
 // request. Attributes land on whatever span is active for the request
 // (typically the otelhttp server span), enabling trace-level filtering and —
 // for calls that name an entity — task-span correlation by target.
-func (o *Observability) enrichSpanWithToolDims(ctx context.Context, method mcp.MCPMethod, message any, result any) {
+func (o *Observability) enrichSpanWithToolDims(ctx context.Context, method string, req mcp.Request, result any) {
 	span := trace.SpanFromContext(ctx)
 	if !span.IsRecording() {
 		return
 	}
-	dims := toolArgDimensions(method, message)
+	dims := toolArgDimensions(method, req)
 	var spanAttrs []attribute.KeyValue
 	if dims.operation != "" {
 		spanAttrs = append(spanAttrs, attribute.String(attrKeyToolOperation, dims.operation))
@@ -618,7 +630,7 @@ func (o *Observability) enrichSpanWithToolDims(ctx context.Context, method mcp.M
 // A nil ctx is defensively coerced to context.Background() because some MCP
 // transports (notably stdio) may invoke hooks without a request-scoped
 // context, and slog.LogAttrs on a nil ctx can panic.
-func (o *Observability) maybeLogSlowRequest(ctx context.Context, method mcp.MCPMethod, toolName string, duration time.Duration, err error) {
+func (o *Observability) maybeLogSlowRequest(ctx context.Context, method string, toolName string, duration time.Duration, err error) {
 	if o.slowRequestThreshold <= 0 || duration <= o.slowRequestThreshold {
 		return
 	}
@@ -626,7 +638,7 @@ func (o *Observability) maybeLogSlowRequest(ctx context.Context, method mcp.MCPM
 		ctx = context.Background()
 	}
 	attrs := []slog.Attr{
-		slog.String("mcp.method", string(method)),
+		slog.String("mcp.method", method),
 		slog.Duration("duration", duration),
 		slog.Duration("threshold", o.slowRequestThreshold),
 	}
@@ -657,147 +669,83 @@ func errorTypeName(err error) string {
 	return "_OTHER"
 }
 
-// MCPHooks returns server.Hooks that record MCP metrics, enrich the active trace
-// span with tool dimensions, and/or emit slow-request logs, per configuration.
-// Merge with existing hooks via MergeHooks.
+// MCPMiddleware returns an mcp.Middleware that records MCP metrics, enriches
+// the active trace span with tool dimensions, and/or emits slow-request logs,
+// per configuration. Register it via Server.AddReceivingMiddleware.
+//
+// This replaces the mark3labs OnBeforeAny/OnSuccess/OnError hook trio (three
+// separately-registered callbacks correlated by a requestStartTimes map keyed
+// on request ID) with a single middleware closure: start/duration/outcome are
+// all in one function's scope, so no correlation map is needed.
+//
+// Session-duration tracking is NOT ported: mark3labs' OnUnregisterSession
+// fired immediately on disconnect, but the official SDK exposes no
+// session-disconnect hook at all (see SessionManager's doc in the root
+// package), so there is no reliable moment to record a session's final
+// duration. Per-call protocol-version enrichment (captured on "initialize")
+// is preserved since it only needs a "session seen" moment, not a "session
+// ended" one.
 //
 // Gate (metrics, slow-log, tracing):
-//   - all off → empty hooks (zero-overhead path)
-//   - any on → request hooks registered; span enrichment runs whenever a span is
-//     recording, while metric recording and slow-log emission are each guarded
-//     in the hook body. Tracing must gate here too, else a tracing-only
-//     deployment (traces on, --metrics off, no slow-log) would register no hooks
-//     and never enrich its spans.
-//   - session hooks only when metrics are on (session duration is a metric).
-func (o *Observability) MCPHooks() *server.Hooks {
+//   - all off → a no-op middleware (zero-overhead path)
+//   - any on → span enrichment runs whenever a span is recording, while metric
+//     recording and slow-log emission are each guarded in the middleware body.
+//     Tracing must gate here too, else a tracing-only deployment (traces on,
+//     --metrics off, no slow-log) would register nothing and never enrich its
+//     spans.
+func (o *Observability) MCPMiddleware() mcp.Middleware {
 	metricsOn := o.metricsEnabled()
 	slowLogOn := o.slowRequestThreshold > 0
 	tracingOn := o.tracerProvider != nil
 
 	if !metricsOn && !slowLogOn && !tracingOn {
-		// Nothing to do, return empty hooks
-		return &server.Hooks{}
+		return func(next mcp.MethodHandler) mcp.MethodHandler { return next }
 	}
 
-	hooks := &server.Hooks{
-		OnBeforeAny: []server.BeforeAnyHookFunc{
-			func(ctx context.Context, id any, method mcp.MCPMethod, message any) {
-				o.requestStartTimes.Store(id, time.Now())
-			},
-		},
-		OnSuccess: []server.OnSuccessHookFunc{
-			func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
-				startTime, ok := o.requestStartTimes.LoadAndDelete(id)
-				if !ok {
-					return
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if metricsOn && method == "initialize" {
+				if session := req.GetSession(); session != nil {
+					o.sessions.LoadOrStore(session.ID(), &sessionMeta{startTime: time.Now()})
 				}
-				duration := time.Since(startTime.(time.Time))
-				o.enrichSpanWithToolDims(ctx, method, message, result)
-				if o.metricsEnabled() {
-					attrs := o.buildOperationAttrs(ctx, method, message, result, nil)
-					o.operationDuration.Record(ctx, duration.Seconds(), mcpconv.MethodNameAttr(method), attrs...)
-				}
-				toolName, _ := toolNameFromMessage(method, message)
-				o.maybeLogSlowRequest(ctx, method, toolName, duration, nil)
-			},
-		},
-		OnError: []server.OnErrorHookFunc{
-			func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
-				startTime, ok := o.requestStartTimes.LoadAndDelete(id)
-				if !ok {
-					return
-				}
-				duration := time.Since(startTime.(time.Time))
-				o.enrichSpanWithToolDims(ctx, method, message, nil)
-				if o.metricsEnabled() {
-					attrs := o.buildOperationAttrs(ctx, method, message, nil, err)
-					o.operationDuration.Record(ctx, duration.Seconds(), mcpconv.MethodNameAttr(method), attrs...)
-				}
-				toolName, _ := toolNameFromMessage(method, message)
-				o.maybeLogSlowRequest(ctx, method, toolName, duration, err)
-			},
-		},
-	}
+			}
 
-	// Session-tracking hooks only populate when metrics are enabled —
-	// slow-log does not need session metadata.
-	if metricsOn {
-		hooks.OnRegisterSession = []server.OnRegisterSessionHookFunc{
-			func(ctx context.Context, session server.ClientSession) {
-				o.sessions.Store(session.SessionID(), &sessionMeta{
-					startTime: time.Now(),
-				})
-			},
-		}
-		hooks.OnUnregisterSession = []server.OnUnregisterSessionHookFunc{
-			func(ctx context.Context, session server.ClientSession) {
-				sid := session.SessionID()
-				if meta, ok := o.sessions.LoadAndDelete(sid); ok {
-					sm := meta.(*sessionMeta)
-					duration := time.Since(sm.startTime).Seconds()
-					var attrs []attribute.KeyValue
-					if o.networkTransport != "" {
-						attrs = append(attrs, o.sessionDuration.AttrNetworkTransport(o.networkTransport))
-					}
-					if pv, ok := sm.protocolVersion.Load().(string); ok && pv != "" {
-						attrs = append(attrs, o.sessionDuration.AttrProtocolVersion(pv))
-					}
-					o.sessionDuration.Record(ctx, duration, attrs...)
+			start := time.Now()
+			result, err := next(ctx, method, req)
+			duration := time.Since(start)
+
+			if err != nil {
+				o.enrichSpanWithToolDims(ctx, method, req, nil)
+			} else {
+				o.enrichSpanWithToolDims(ctx, method, req, result)
+			}
+			if metricsOn {
+				var attrs []attribute.KeyValue
+				if err != nil {
+					attrs = o.buildOperationAttrs(method, req, nil, err)
+				} else {
+					attrs = o.buildOperationAttrs(method, req, result, nil)
 				}
-			},
-		}
-		hooks.OnAfterInitialize = []server.OnAfterInitializeFunc{
-			func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
-				if result == nil {
-					return
-				}
-				if session := server.ClientSessionFromContext(ctx); session != nil {
-					if meta, ok := o.sessions.Load(session.SessionID()); ok {
-						meta.(*sessionMeta).protocolVersion.Store(result.ProtocolVersion)
+				o.operationDuration.Record(ctx, duration.Seconds(), mcpconv.MethodNameAttr(method), attrs...)
+			}
+			toolName, _ := toolNameFromMessage(method, req)
+			o.maybeLogSlowRequest(ctx, method, toolName, duration, err)
+
+			// Capture the negotiated protocol version once initialize succeeds, for
+			// later per-call metric enrichment (buildOperationAttrs).
+			if metricsOn && method == "initialize" && err == nil {
+				if initResult, ok := result.(*mcp.InitializeResult); ok && initResult != nil {
+					if session := req.GetSession(); session != nil {
+						if meta, ok := o.sessions.Load(session.ID()); ok {
+							meta.(*sessionMeta).protocolVersion.Store(initResult.ProtocolVersion)
+						}
 					}
 				}
-			},
+			}
+
+			return result, err
 		}
 	}
-
-	return hooks
-}
-
-// MergeHooks combines multiple Hooks into one, preserving all hook functions.
-func MergeHooks(hooks ...*server.Hooks) *server.Hooks {
-	merged := &server.Hooks{}
-	for _, h := range hooks {
-		if h == nil {
-			continue
-		}
-		merged.OnRegisterSession = append(merged.OnRegisterSession, h.OnRegisterSession...)
-		merged.OnUnregisterSession = append(merged.OnUnregisterSession, h.OnUnregisterSession...)
-		merged.OnBeforeAny = append(merged.OnBeforeAny, h.OnBeforeAny...)
-		merged.OnSuccess = append(merged.OnSuccess, h.OnSuccess...)
-		merged.OnError = append(merged.OnError, h.OnError...)
-		merged.OnRequestInitialization = append(merged.OnRequestInitialization, h.OnRequestInitialization...)
-		merged.OnBeforeInitialize = append(merged.OnBeforeInitialize, h.OnBeforeInitialize...)
-		merged.OnAfterInitialize = append(merged.OnAfterInitialize, h.OnAfterInitialize...)
-		merged.OnBeforePing = append(merged.OnBeforePing, h.OnBeforePing...)
-		merged.OnAfterPing = append(merged.OnAfterPing, h.OnAfterPing...)
-		merged.OnBeforeSetLevel = append(merged.OnBeforeSetLevel, h.OnBeforeSetLevel...)
-		merged.OnAfterSetLevel = append(merged.OnAfterSetLevel, h.OnAfterSetLevel...)
-		merged.OnBeforeListResources = append(merged.OnBeforeListResources, h.OnBeforeListResources...)
-		merged.OnAfterListResources = append(merged.OnAfterListResources, h.OnAfterListResources...)
-		merged.OnBeforeListResourceTemplates = append(merged.OnBeforeListResourceTemplates, h.OnBeforeListResourceTemplates...)
-		merged.OnAfterListResourceTemplates = append(merged.OnAfterListResourceTemplates, h.OnAfterListResourceTemplates...)
-		merged.OnBeforeReadResource = append(merged.OnBeforeReadResource, h.OnBeforeReadResource...)
-		merged.OnAfterReadResource = append(merged.OnAfterReadResource, h.OnAfterReadResource...)
-		merged.OnBeforeListPrompts = append(merged.OnBeforeListPrompts, h.OnBeforeListPrompts...)
-		merged.OnAfterListPrompts = append(merged.OnAfterListPrompts, h.OnAfterListPrompts...)
-		merged.OnBeforeGetPrompt = append(merged.OnBeforeGetPrompt, h.OnBeforeGetPrompt...)
-		merged.OnAfterGetPrompt = append(merged.OnAfterGetPrompt, h.OnAfterGetPrompt...)
-		merged.OnBeforeListTools = append(merged.OnBeforeListTools, h.OnBeforeListTools...)
-		merged.OnAfterListTools = append(merged.OnAfterListTools, h.OnAfterListTools...)
-		merged.OnBeforeCallTool = append(merged.OnBeforeCallTool, h.OnBeforeCallTool...)
-		merged.OnAfterCallTool = append(merged.OnAfterCallTool, h.OnAfterCallTool...)
-	}
-	return merged
 }
 
 // LoggerProvider returns the OTLP log provider, or nil if OTLP logging is

--- a/proxied_client.go
+++ b/proxied_client.go
@@ -7,9 +7,7 @@ import (
 	"sync"
 	"time"
 
-	mcp_client "github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/client/transport"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -24,8 +22,8 @@ type ProxiedClient struct {
 	DatasourceUID  string
 	DatasourceName string
 	DatasourceType string
-	Client         *mcp_client.Client
-	Tools          []mcp.Tool
+	Session        *mcp.ClientSession
+	Tools          []*mcp.Tool
 	mutex          sync.RWMutex
 
 	// closeHook, when set, runs inside Close (under the client mutex). It is a
@@ -61,36 +59,26 @@ func NewProxiedClient(ctx context.Context, datasourceUID, datasourceName, dataso
 	}
 
 	logger.DebugContext(initCtx, "connecting to MCP server", "datasource", datasourceUID, "url", mcpEndpoint)
-	httpTransport, err := transport.NewStreamableHTTP(
-		mcpEndpoint,
-		transport.WithHTTPBasicClient(&http.Client{Transport: rt}),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP transport: %w", err)
+	clientTransport := &mcp.StreamableClientTransport{
+		Endpoint:   mcpEndpoint,
+		HTTPClient: &http.Client{Transport: rt},
 	}
 
-	// Create MCP client
-	mcpClient := mcp_client.NewClient(httpTransport)
-
-	// Initialize the connection
-	initReq := mcp.InitializeRequest{}
-	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-	initReq.Params.ClientInfo = mcp.Implementation{
+	client := mcp.NewClient(&mcp.Implementation{
 		Name:    "mcp-grafana-proxy",
 		Version: Version(),
-	}
+	}, nil)
 
-	_, err = mcpClient.Initialize(initCtx, initReq)
+	// Connect performs the initialize handshake.
+	session, err := client.Connect(initCtx, clientTransport, nil)
 	if err != nil {
-		_ = mcpClient.Close()
 		return nil, fmt.Errorf("failed to initialize MCP client: %w", contextCauseOrErr(initCtx, err))
 	}
 
 	// List available tools from the remote server
-	listReq := mcp.ListToolsRequest{}
-	toolsResult, err := mcpClient.ListTools(initCtx, listReq)
+	toolsResult, err := session.ListTools(initCtx, nil)
 	if err != nil {
-		_ = mcpClient.Close()
+		_ = session.Close()
 		return nil, fmt.Errorf("failed to list tools from remote MCP server: %w", contextCauseOrErr(initCtx, err))
 	}
 
@@ -103,7 +91,7 @@ func NewProxiedClient(ctx context.Context, datasourceUID, datasourceName, dataso
 		DatasourceUID:  datasourceUID,
 		DatasourceName: datasourceName,
 		DatasourceType: datasourceType,
-		Client:         mcpClient,
+		Session:        session,
 		Tools:          toolsResult.Tools,
 	}, nil
 }
@@ -125,13 +113,11 @@ func (pc *ProxiedClient) CallTool(ctx context.Context, toolName string, argument
 		return nil, fmt.Errorf("tool %s not found in remote MCP server", toolName)
 	}
 
-	// Create the call tool request
-	req := mcp.CallToolRequest{}
-	req.Params.Name = toolName
-	req.Params.Arguments = arguments
-
 	// Forward the call to the remote server
-	result, err := pc.Client.CallTool(ctx, req)
+	result, err := pc.Session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: arguments,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool on remote MCP server: %w", err)
 	}
@@ -141,12 +127,12 @@ func (pc *ProxiedClient) CallTool(ctx context.Context, toolName string, argument
 
 // ListTools returns the tools available from this remote server
 // Note: This method doesn't take a context parameter as the tools are cached locally
-func (pc *ProxiedClient) ListTools() []mcp.Tool {
+func (pc *ProxiedClient) ListTools() []*mcp.Tool {
 	pc.mutex.RLock()
 	defer pc.mutex.RUnlock()
 
 	// Return a copy to prevent external modification
-	result := make([]mcp.Tool, len(pc.Tools))
+	result := make([]*mcp.Tool, len(pc.Tools))
 	copy(result, pc.Tools)
 	return result
 }
@@ -160,8 +146,8 @@ func (pc *ProxiedClient) Close() error {
 		pc.closeHook()
 	}
 
-	if pc.Client != nil {
-		if err := pc.Client.Close(); err != nil {
+	if pc.Session != nil {
+		if err := pc.Session.Close(); err != nil {
 			return fmt.Errorf("failed to close MCP client: %w", err)
 		}
 	}

--- a/proxied_handler.go
+++ b/proxied_handler.go
@@ -2,10 +2,10 @@ package mcpgrafana
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // ProxiedToolHandler implements the CallToolHandler interface for proxied tools
@@ -25,17 +25,18 @@ func NewProxiedToolHandler(sm *SessionManager, tm *ToolManager, toolName string)
 }
 
 // Handle forwards the tool call to the appropriate remote MCP server
-func (h *ProxiedToolHandler) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	// Check if session is in context
-	session := server.ClientSessionFromContext(ctx)
-	if session == nil {
+func (h *ProxiedToolHandler) Handle(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Check if session is present on the request
+	if request.Session == nil {
 		return nil, fmt.Errorf("session not found in context")
 	}
 
 	// Extract arguments
-	args, ok := request.Params.Arguments.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("invalid arguments type")
+	var args map[string]any
+	if request.Params != nil && len(request.Params.Arguments) > 0 {
+		if err := json.Unmarshal(request.Params.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("invalid arguments type")
+		}
 	}
 
 	// Extract required datasourceUid parameter
@@ -69,7 +70,7 @@ func (h *ProxiedToolHandler) Handle(ctx context.Context, request mcp.CallToolReq
 		client, err = h.toolManager.GetServerClient(datasourceType, datasourceUID)
 	} else {
 		// Session mode (HTTP/SSE): clients live in the session's shared set.
-		client, release, err = h.sessionManager.GetProxiedClient(ctx, datasourceType, datasourceUID)
+		client, release, err = h.sessionManager.GetProxiedClient(request.Session.ID(), datasourceType, datasourceUID)
 		if err != nil {
 			// Fallback to server-level in case of mixed mode.
 			client, err = h.toolManager.GetServerClient(datasourceType, datasourceUID)

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -11,8 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 )
@@ -177,26 +176,48 @@ func discoverMCPDatasources(ctx context.Context, logger *slog.Logger) ([]Discove
 	return discovered, nil
 }
 
-// addDatasourceUidParameter adds a required datasourceUid parameter to a tool's input schema
-func addDatasourceUidParameter(tool mcp.Tool, datasourceType string) mcp.Tool {
-	modifiedTool := tool
+// addDatasourceUidParameter adds a required datasourceUid parameter to a
+// tool's input schema and returns a new *mcp.Tool with the modified name and
+// schema. tool.InputSchema is expected to be a map[string]any: that's what a
+// remote tool's schema decodes to on the client side after a wire round trip
+// (see mcp.Tool.InputSchema's doc).
+func addDatasourceUidParameter(tool *mcp.Tool, datasourceType string) *mcp.Tool {
+	modifiedTool := *tool
 	// Prefix tool name with datasource type (e.g., "tempo_traceql-search")
 	modifiedTool.Name = datasourceType + "_" + tool.Name
 
-	// Add datasourceUid to the input schema
-	if modifiedTool.InputSchema.Properties == nil {
-		modifiedTool.InputSchema.Properties = make(map[string]any)
+	schema, ok := modifiedTool.InputSchema.(map[string]any)
+	if !ok || schema == nil {
+		schema = map[string]any{"type": "object"}
 	}
 
-	modifiedTool.InputSchema.Properties["datasourceUid"] = map[string]any{
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok || properties == nil {
+		properties = make(map[string]any)
+	}
+	properties["datasourceUid"] = map[string]any{
 		"type":        "string",
 		"description": "UID of the " + datasourceType + " datasource to query",
 	}
+	schema["properties"] = properties
 
-	// Add to required fields
-	modifiedTool.InputSchema.Required = append(modifiedTool.InputSchema.Required, "datasourceUid")
+	// Add to required fields. The decoded value may be []any (from JSON) or,
+	// in the stdio in-process path, []string.
+	var required []string
+	switch existing := schema["required"].(type) {
+	case []any:
+		for _, r := range existing {
+			if s, ok := r.(string); ok {
+				required = append(required, s)
+			}
+		}
+	case []string:
+		required = append(required, existing...)
+	}
+	schema["required"] = append(required, "datasourceUid")
 
-	return modifiedTool
+	modifiedTool.InputSchema = schema
+	return &modifiedTool
 }
 
 // parseProxiedToolName extracts datasource type and original tool name from a proxied tool name
@@ -367,7 +388,7 @@ type proxiedToolSet struct {
 	clients map[string]*ProxiedClient
 	// tools is the deduplicated, schema-rewritten set of proxied tools. Empty
 	// until built is true; immutable afterwards.
-	tools []mcp.Tool
+	tools []*mcp.Tool
 	// toolToDatasources maps a proxied tool name to the datasource keys that
 	// support it. Empty until built is true; immutable afterwards.
 	toolToDatasources map[string][]string
@@ -385,17 +406,26 @@ type proxiedToolSet struct {
 // ToolManager manages proxied tools (either per-session or server-wide)
 type ToolManager struct {
 	sm     *SessionManager
-	server *server.MCPServer
 	logger *slog.Logger
 
 	// Whether to enable proxied tools.
 	enableProxiedTools bool
 
-	// For stdio transport: store clients at manager level (single-tenant).
-	// These will be unused for HTTP/SSE transports.
+	// For stdio transport: single-tenant, single *mcp.Server and store of
+	// clients at manager level. Unused for HTTP/SSE transports.
 	serverMode    bool // true if using server-wide tools (stdio), false for per-session (HTTP/SSE)
+	server        *mcp.Server
 	serverClients map[string]*ProxiedClient
 	clientsMutex  sync.RWMutex
+
+	// For HTTP/SSE transport: each session gets its own *mcp.Server (built by
+	// the caller inside its getServer callback and registered here via
+	// RegisterSessionServer), since the official SDK has no per-session tool
+	// registration API (mark3labs' AddSessionTools). InitializeAndRegisterProxiedTools
+	// looks a session's server up here to add its discovered tools directly.
+	// There is no SDK session-disconnect hook (see SessionManager's doc), so
+	// entries are removed only when SessionManager reaps the session.
+	sessionServers sync.Map // sessionID string -> *mcp.Server
 
 	// For HTTP/SSE transport: shared, credential-keyed proxied tool sets.
 	// Sessions with identical credentials share a single entry, so memory no
@@ -415,10 +445,9 @@ type ToolManager struct {
 }
 
 // NewToolManager creates a new ToolManager
-func NewToolManager(sm *SessionManager, mcpServer *server.MCPServer, opts ...toolManagerOption) *ToolManager {
+func NewToolManager(sm *SessionManager, opts ...toolManagerOption) *ToolManager {
 	tm := &ToolManager{
 		sm:            sm,
-		server:        mcpServer,
 		serverClients: make(map[string]*ProxiedClient),
 		proxiedSets:   make(map[proxiedToolSetKey]*proxiedToolSet),
 	}
@@ -451,6 +480,30 @@ func WithToolManagerLogger(logger *slog.Logger) toolManagerOption {
 	return func(tm *ToolManager) {
 		tm.logger = logger
 	}
+}
+
+// WithServer sets the single, process-wide *mcp.Server used for stdio's
+// server-wide tool registration (InitializeAndRegisterServerTools). It is
+// unused for HTTP/SSE transports, which register tools per session via
+// RegisterSessionServer instead.
+func WithServer(s *mcp.Server) toolManagerOption {
+	return func(tm *ToolManager) {
+		tm.server = s
+	}
+}
+
+// RegisterSessionServer associates a session's own *mcp.Server (built by the
+// caller's getServer callback) with its session ID, so
+// InitializeAndRegisterProxiedTools can find it later to add discovered
+// proxied tools directly onto that session's server.
+func (tm *ToolManager) RegisterSessionServer(sessionID string, s *mcp.Server) {
+	tm.sessionServers.Store(sessionID, s)
+}
+
+// UnregisterSessionServer removes a session's server mapping. Called when the
+// session is reaped, since there is no earlier SDK signal that it disconnected.
+func (tm *ToolManager) UnregisterSessionServer(sessionID string) {
+	tm.sessionServers.Delete(sessionID)
 }
 
 // loggerFromCtx returns the logger from the context's GrafanaConfig if available,
@@ -509,13 +562,12 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 
 	// Collect and register all unique tools
 	tm.clientsMutex.RLock()
-	toolMap := make(map[string]mcp.Tool)
+	toolMap := make(map[string]*mcp.Tool)
 	for _, client := range tm.serverClients {
 		for _, tool := range client.ListTools() {
 			toolName := client.DatasourceType + "_" + tool.Name
 			if _, exists := toolMap[toolName]; !exists {
-				modifiedTool := addDatasourceUidParameter(tool, client.DatasourceType)
-				toolMap[toolName] = modifiedTool
+				toolMap[toolName] = addDatasourceUidParameter(tool, client.DatasourceType)
 			}
 		}
 	}
@@ -536,7 +588,7 @@ func (tm *ToolManager) InitializeAndRegisterServerTools(ctx context.Context) err
 // published into a proxiedToolSet in a single critical section.
 type builtProxiedTools struct {
 	clients           map[string]*ProxiedClient
-	tools             []mcp.Tool
+	tools             []*mcp.Tool
 	toolToDatasources map[string][]string
 }
 
@@ -583,7 +635,7 @@ func (tm *ToolManager) buildProxiedToolSet(ctx context.Context, logger *slog.Log
 	}
 
 	// Collect unique tools and track which datasources support each one.
-	toolMap := make(map[string]mcp.Tool) // unique tools by name
+	toolMap := make(map[string]*mcp.Tool) // unique tools by name
 	for key, client := range built.clients {
 		for _, tool := range client.ListTools() {
 			// Tool name format: datasourceType_originalToolName (e.g., "tempo_traceql-search").
@@ -840,38 +892,31 @@ func (tm *ToolManager) acquireProxiedClientForCall(set *proxiedToolSet, datasour
 }
 
 // InitializeAndRegisterProxiedTools attaches the calling session to a shared,
-// credential-keyed proxied tool set and registers that set's tools on the
-// session. The shared set is discovered/connected/rewritten at most once per
-// distinct credential set, so multiple concurrent sessions with identical
-// credentials reuse a single set instead of each building their own. This is
-// called from OnBeforeListTools and OnBeforeCallTool hooks for HTTP/SSE
-// transports and is idempotent per session.
-func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, session server.ClientSession) {
+// credential-keyed proxied tool set and registers that set's tools directly on
+// the session's own *mcp.Server (found via RegisterSessionServer - the official
+// SDK has no per-session tool registration API, so each session gets its own
+// server instance rather than an overlay on a shared one). The shared set is
+// discovered/connected/rewritten at most once per distinct credential set, so
+// multiple concurrent sessions with identical credentials reuse a single set
+// instead of each building their own. This is called from
+// GrafanaContextMiddleware for HTTP/SSE transports and is idempotent per
+// session.
+func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, sessionID string) {
 	if !tm.enableProxiedTools {
 		return
 	}
 
 	logger := tm.loggerFromCtx(ctx)
 
-	sessionID := session.SessionID()
-	state, exists := tm.sm.GetSession(sessionID)
-	if !exists {
-		// Session exists in server context but not in our SessionManager yet.
-		tm.sm.CreateSession(ctx, session)
-		state, exists = tm.sm.GetSession(sessionID)
-		if !exists {
-			logger.ErrorContext(ctx, "failed to create session in SessionManager", "sessionID", sessionID)
-			return
-		}
-	}
+	state := tm.sm.TouchOrCreateSession(sessionID)
 
 	key := proxiedToolSetKeyFromContext(ctx)
 
 	// Serialize attach/build/register for this session and allow a later retry if
 	// this attempt does not end in a successful registration. proxiedInitMu is
-	// held for the whole attempt: concurrent hooks for the SAME session (e.g.
-	// OnBeforeListTools and OnBeforeCallTool) queue behind it, and the second one
-	// sees proxiedRegistered and returns, or retries if the first failed.
+	// held for the whole attempt: concurrent calls for the SAME session queue
+	// behind it, and a later one sees proxiedRegistered and returns, or retries
+	// if the first attempt failed.
 	state.proxiedInitMu.Lock()
 	defer state.proxiedInitMu.Unlock()
 
@@ -884,15 +929,15 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 	// exists that teardown cannot find and release.
 	set, needsBuild := tm.attachProxiedToolSet(state, key)
 
-	// Reconcile against a teardown that raced this attach. A session may have been
-	// removed from the SessionManager (client DELETE / idle sweeper / reaper)
-	// between GetSession/CreateSession above and the bind inside
-	// attachProxiedToolSet. If so, that RemoveSession saw proxiedSet==nil and did
-	// not release, and no future teardown will fire for this (now untracked)
-	// session, so the ref we just took would leak. Detect it and release exactly
-	// once (releaseSessionProxiedToolSet is idempotent, so a RemoveSession that
-	// instead ran AFTER our bind is handled too, with no double release). We still
-	// run/await the build below so any live waiter for the same key is served.
+	// Reconcile against a teardown (reap) that raced this attach. A session may
+	// have been removed from the SessionManager between TouchOrCreateSession
+	// above and the bind inside attachProxiedToolSet. If so, that reap saw
+	// proxiedSet==nil and did not release, and no future reap will fire for this
+	// (now untracked) session, so the ref we just took would leak. Detect it and
+	// release exactly once (releaseSessionProxiedToolSet is idempotent, so a reap
+	// that instead ran AFTER our bind is handled too, with no double release). We
+	// still run/await the build below so any live waiter for the same key is
+	// served.
 	if !tm.sm.sessionRegistered(sessionID, state) {
 		defer tm.releaseSessionProxiedToolSet(state)
 	}
@@ -912,15 +957,15 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 
 	// A failed build (transient: discovery error, cancellation, or panic) was
 	// de-cached. Do NOT mark this session registered: release its reference to
-	// the failed set, clear the binding, and return so the next hook invocation
-	// for this session retries a fresh attach (which triggers a fresh build).
-	// This keeps the failure transient for the session, matching the cache's
-	// behavior for later sessions.
+	// the failed set, clear the binding, and return so the next call for this
+	// session retries a fresh attach (which triggers a fresh build). This keeps
+	// the failure transient for the session, matching the cache's behavior for
+	// later sessions.
 	//
 	// A usable build with zero tools is NOT a failure: either the instance has no
 	// MCP datasources, or its datasources exposed no tools. That is a stable,
 	// cached result, so the session keeps its reference and is marked registered
-	// (there is simply nothing to register); it must not retry, so repeated hooks
+	// (there is simply nothing to register); it must not retry, so repeated calls
 	// do not re-run discovery.
 	if !usable {
 		tm.releaseSessionProxiedToolSet(state)
@@ -928,28 +973,21 @@ func (tm *ToolManager) InitializeAndRegisterProxiedTools(ctx context.Context, se
 	}
 
 	if len(tools) > 0 {
-		// Register the shared tools on this session. AddSessionTools is
-		// per-session SDK bookkeeping; it references the shared (now immutable)
-		// mcp.Tool values directly, with no per-session deep copy, JSON decode, or
-		// client dial.
-		serverTools := make([]server.ServerTool, 0, len(tools))
-		for _, tool := range tools {
-			handler := NewProxiedToolHandler(tm.sm, tm, tool.Name)
-			serverTools = append(serverTools, server.ServerTool{
-				Tool:    tool,
-				Handler: handler.Handle,
-			})
-		}
-
-		if err := tm.server.AddSessionTools(sessionID, serverTools...); err != nil {
-			logger.WarnContext(ctx, "failed to add session tools", "session", sessionID, "error", err)
+		sessionServer, ok := tm.sessionServers.Load(sessionID)
+		if !ok {
+			logger.WarnContext(ctx, "no server registered for session; cannot add proxied tools", "session", sessionID)
 		} else {
+			s := sessionServer.(*mcp.Server)
+			for _, tool := range tools {
+				handler := NewProxiedToolHandler(tm.sm, tm, tool.Name)
+				s.AddTool(tool, handler.Handle)
+			}
 			logger.InfoContext(ctx, "registered proxied tools", "session", sessionID, "tools", len(tools))
 		}
 	}
 
 	// The attach succeeded (usable set, ref held). Mark the session registered so
-	// later hooks are no-ops; teardown will release the reference.
+	// later calls are no-ops; the reaper will release the reference.
 	state.proxiedRegistered = true
 }
 

--- a/session.go
+++ b/session.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -66,7 +65,7 @@ type SessionState struct {
 	// session's attempt, or that session would be stuck without proxied tools
 	// forever even though the cache treats the failure as transient and lets
 	// other sessions rebuild. Leaving proxiedRegistered false on failure lets the
-	// next OnBeforeListTools/OnBeforeCallTool hook for this session retry.
+	// next call's touch-or-create path retry.
 	proxiedInitMu      sync.Mutex
 	proxiedRegistered  bool
 	proxiedSet         *proxiedToolSet
@@ -100,7 +99,16 @@ func WithSessionLogger(logger *slog.Logger) SessionManagerOption {
 	}
 }
 
-// SessionManager manages client sessions and their state
+// SessionManager manages client sessions and their state.
+//
+// Unlike mark3labs, the official go-sdk exposes no session-disconnect hook
+// (ServerSessionOptions.onClose exists but is unexported, and ServerOptions
+// has no general connect/disconnect callback), so cleanup here relies
+// entirely on the idle reaper rather than an immediate on-disconnect
+// notification paired with a reaper backstop. A session's proxied tool set
+// reference (and its underlying remote MCP connections) is therefore held
+// for up to sessionTTL after a client actually disconnects, not released
+// the instant it does.
 type SessionManager struct {
 	sessions   map[string]*SessionState
 	mutex      sync.RWMutex
@@ -111,26 +119,10 @@ type SessionManager struct {
 	metrics    sessionMetrics
 	logger     *slog.Logger
 
-	// mcpServer is an optional reference to the MCP server, used to unregister
-	// sessions from the SDK's internal session map when they are reaped. This
-	// prevents a memory leak when sessions are registered via RegisterSession
-	// in horizontal scaling scenarios (where ephemeral sessions are registered
-	// so that AddSessionTools can find them).
-	mcpServer *server.MCPServer
-
 	// toolManager is an optional reference to the ToolManager, used on session
 	// teardown to release the session's reference to its shared proxied tool
 	// set (closing the underlying clients only when the last session detaches).
 	toolManager *ToolManager
-}
-
-// SetMCPServer sets the MCP server reference for session cleanup. When set,
-// the reaper will call MCPServer.UnregisterSession for reaped sessions to
-// prevent a memory leak in the SDK's internal session map.
-func (sm *SessionManager) SetMCPServer(s *server.MCPServer) {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-	sm.mcpServer = s
 }
 
 // SetToolManager sets the ToolManager reference for session cleanup. When set,
@@ -168,15 +160,24 @@ func (sm *SessionManager) recordActiveSessionCount() {
 	sm.metrics.activeSessions.Record(context.Background(), int64(len(sm.sessions)))
 }
 
-func (sm *SessionManager) CreateSession(ctx context.Context, session server.ClientSession) {
+// TouchOrCreateSession records activity for sessionID, creating its state if
+// this is the first time it's been seen. It is the equivalent of mark3labs'
+// OnRegisterSession hook, called lazily on the first call for a session
+// (typically from GrafanaContextMiddleware) rather than at connection time,
+// since the official SDK has no dedicated session-registration hook.
+func (sm *SessionManager) TouchOrCreateSession(sessionID string) *SessionState {
 	sm.mutex.Lock()
 	defer sm.mutex.Unlock()
 
-	sessionID := session.SessionID()
-	if _, exists := sm.sessions[sessionID]; !exists {
-		sm.sessions[sessionID] = newSessionState()
+	state, exists := sm.sessions[sessionID]
+	if !exists {
+		state = newSessionState()
+		sm.sessions[sessionID] = state
 		sm.recordActiveSessionCount()
+	} else {
+		state.lastActivity = time.Now()
 	}
+	return state
 }
 
 func (sm *SessionManager) GetSession(sessionID string) (*SessionState, bool) {
@@ -191,10 +192,10 @@ func (sm *SessionManager) GetSession(sessionID string) (*SessionState, bool) {
 }
 
 // sessionRegistered reports whether sessionID is still tracked and maps to the
-// exact state pointer given. It is used to detect a teardown that raced an
-// attach: if the session was removed (or replaced by a newer state) since the
-// state was obtained, the caller must release the reference it took, because no
-// future RemoveSession will fire for this untracked state.
+// exact state pointer given. It is used to detect a teardown (reap) that raced
+// an attach: if the session was removed (or replaced by a newer state) since
+// the state was obtained, the caller must release the reference it took,
+// because no future reap will fire for this untracked state.
 func (sm *SessionManager) sessionRegistered(sessionID string, state *SessionState) bool {
 	sm.mutex.RLock()
 	defer sm.mutex.RUnlock()
@@ -202,32 +203,18 @@ func (sm *SessionManager) sessionRegistered(sessionID string, state *SessionStat
 	return exists && current == state
 }
 
-func (sm *SessionManager) RemoveSession(ctx context.Context, session server.ClientSession) {
-	sm.mutex.Lock()
-	sessionID := session.SessionID()
-	state, exists := sm.sessions[sessionID]
-	delete(sm.sessions, sessionID)
-	sm.recordActiveSessionCount()
-	sm.mutex.Unlock()
-
-	if !exists {
-		return
-	}
-
-	sm.cleanupSessionState(state)
-}
-
 // cleanupSessionState releases the session's reference to its shared proxied
-// tool set. The set's clients are closed only when the last referencing session
-// is torn down; other live sessions sharing the same credentials keep them
-// open.
-func (sm *SessionManager) cleanupSessionState(state *SessionState) {
+// tool set and drops its registered *mcp.Server (if any). The set's clients
+// are closed only when the last referencing session is torn down; other live
+// sessions sharing the same credentials keep them open.
+func (sm *SessionManager) cleanupSessionState(sessionID string, state *SessionState) {
 	sm.mutex.RLock()
 	tm := sm.toolManager
 	sm.mutex.RUnlock()
 
 	if tm != nil {
 		tm.releaseSessionProxiedToolSet(state)
+		tm.UnregisterSessionServer(sessionID)
 	}
 }
 
@@ -248,8 +235,8 @@ func (sm *SessionManager) Close() {
 		sm.recordActiveSessionCount()
 		sm.mutex.Unlock()
 
-		for _, state := range sessions {
-			sm.cleanupSessionState(state)
+		for id, state := range sessions {
+			sm.cleanupSessionState(id, state)
 		}
 		sm.logger.Debug("SessionManager closed", "cleaned_sessions", len(sessions))
 	})
@@ -277,13 +264,14 @@ func (sm *SessionManager) runReaper() {
 }
 
 // reapStaleSessions removes sessions that have been idle longer than the TTL.
+// This is the SessionManager's only cleanup path (see the type doc): the
+// official SDK gives no earlier signal that a session has disconnected.
 func (sm *SessionManager) reapStaleSessions() {
 	now := time.Now()
 
 	sm.mutex.Lock()
 	var stale []*SessionState
 	var staleIDs []string
-	mcpSrv := sm.mcpServer
 	for id, state := range sm.sessions {
 		if now.Sub(state.lastActivity) > sm.sessionTTL {
 			stale = append(stale, state)
@@ -301,31 +289,19 @@ func (sm *SessionManager) reapStaleSessions() {
 		sm.logger.Info("Reaping stale sessions", "count", len(stale), "session_ids", staleIDs)
 	}
 
-	ctx := context.Background()
 	for i, state := range stale {
-		sm.cleanupSessionState(state)
-		// Also unregister from MCPServer.sessions to prevent a memory leak.
-		// Sessions may have been registered there via RegisterSession in the
-		// OnBeforeListTools/OnBeforeCallTool hooks for horizontal scaling support.
-		if mcpSrv != nil {
-			mcpSrv.UnregisterSession(ctx, staleIDs[i])
-		}
+		sm.cleanupSessionState(staleIDs[i], state)
 	}
 }
 
 // GetProxiedClient retrieves a proxied client for the given datasource and
 // registers an in-flight call against its shared set, so the client cannot be
-// Closed by a concurrent teardown (RemoveSession / reaper) while the returned
-// client is still in use. The caller MUST invoke the returned release func
-// (deferred) once the call completes; only then may the set be torn down. On
-// error the release func is nil and must not be called.
-func (sm *SessionManager) GetProxiedClient(ctx context.Context, datasourceType, datasourceUID string) (*ProxiedClient, func(), error) {
-	session := server.ClientSessionFromContext(ctx)
-	if session == nil {
-		return nil, nil, fmt.Errorf("session not found in context")
-	}
-
-	state, exists := sm.GetSession(session.SessionID())
+// Closed by a concurrent teardown (the reaper) while the returned client is
+// still in use. The caller MUST invoke the returned release func (deferred)
+// once the call completes; only then may the set be torn down. On error the
+// release func is nil and must not be called.
+func (sm *SessionManager) GetProxiedClient(sessionID, datasourceType, datasourceUID string) (*ProxiedClient, func(), error) {
+	state, exists := sm.GetSession(sessionID)
 	if !exists {
 		return nil, nil, fmt.Errorf("session not found")
 	}


### PR DESCRIPTION
Completes the mark3labs -> official SDK migration for all remaining
production code: mcpgrafana.go's context-propagation plumbing,
session.go's SessionManager, the proxied-tools MCP client/handler
(proxied_client.go, proxied_handler.go, proxied_tools.go),
observability's metrics/tracing hooks, and cmd/mcp-grafana/main.go's
server construction across all three transports.

Context propagation: collapses mark3labs' three separate transport
hook types (StdioContextFunc/SSEContextFunc/HTTPContextFunc, composed
once per connection) into GrafanaContextMiddleware, a single
mcp.Middleware that reads CallToolRequest.Extra.Header per JSON-RPC
call. This runs on every call rather than once per connection, so
auth/org-id isolation holds even when multiple calls share one
session - verified empirically against the real built binary (two
tools/call requests on the same streamable-http session, different
X-Grafana-Org-Id/token headers, correctly isolated per-call in the
proxied-tool-set cache key and request logs).

Session-scoped tools: the official SDK has no AddSessionTools
equivalent, so each HTTP session now gets its own *mcp.Server
instance (built in a getServer callback), with ToolManager tracking
sessionID -> *mcp.Server so proxied-tool discovery can add tools
directly to the right instance. Stateless mode (proxied tools
disabled) shares one server across all ephemeral per-request
sessions instead, avoiding re-registering ~35 tool categories per
call.

Session cleanup is TTL-reaper-only now: the official SDK exposes no
session-disconnect hook at all (mark3labs' OnUnregisterSession has no
equivalent), so a session's proxied-tool-set reference is held for up
to the idle TTL after a client actually disconnects rather than
released immediately. Session-duration metrics are not ported for the
same reason (no reliable "session ended" moment) - documented in
observability.go.

CORS: the official SDK sets no CORS headers at all (unlike mark3labs'
SSE/StreamableHTTP servers, which required a sentinel origin to
suppress a wildcard default). Added a small corsMiddleware in main.go
for parity - no headers by default, matching the existing
secure-by-default posture, with headers only when --allowed-origins
is configured.

Verified by running the actual built binary: stdio transport
(initialize, tools/list returning 65 tools, tools/call with correct
error surfacing) and streamable-http transport (session
establishment, tools/list, and the per-call auth isolation above).

Not yet migrated (tracked as follow-up, same as the previous layer):
session_test.go, proxied_tools_test.go, proxied_tools_lifecycle_test.go,
session_reaper_test.go, session_horizontal_scaling_test.go,
session_tool_store_leak_test.go, caller_auth_integration_test.go,
main_test.go, annotations_test.go - all still reference mark3labs
types or the old SessionManager/ToolManager API shapes. `go build
./...` is green; `go vet`/test breakage is confined to exactly these
files.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>