### PR TITLE
fix(navigation): emit Explore deeplinks in the panes format

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Queries go through Grafana's Snowflake datasource (Grafana Enterprise plugin `gr
 - **Generate deeplinks:** Create accurate deeplink URLs for Grafana resources instead of relying on LLM URL guessing.
   - **Dashboard links:** Generate direct links to dashboards using their UID (e.g., `http://localhost:3000/d/dashboard-uid`)
   - **Panel links:** Create links to specific panels within dashboards with viewPanel parameter (e.g., `http://localhost:3000/d/dashboard-uid?viewPanel=5`)
-  - **Explore links:** Generate links to Grafana Explore with pre-configured datasources (e.g., `http://localhost:3000/explore?left={"datasource":"prometheus-uid"}`)
+  - **Explore links:** Generate links to Grafana Explore with pre-configured datasources (e.g., `http://localhost:3000/explore?schemaVersion=1&panes={"a":{"datasource":"prometheus-uid"}}`). Grafana below 10.2 does not understand `panes`, so the legacy `?left={...}` format is emitted for those versions instead.
   - **Time range support:** Add time range parameters to links (`from=now-1h&to=now`)
   - **Custom parameters:** Include additional query parameters like dashboard variables or refresh intervals
 

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -379,13 +379,6 @@ func buildDashboardTargetURL(baseURL string, dashboardUID *string, preview *Deep
 	return target, nil
 }
 
-// toGrafanaTimeParam converts a time value to a format Grafana understands
-// in URL query parameters. Grafana's Scenes parseUrlParam uses hardcoded
-// string length checks and only recognizes ISO 8601 at exactly 24 chars
-// (with milliseconds, e.g. "2026-04-28T12:45:00.000Z"). Shorter ISO 8601
-// strings like "2026-04-28T12:45:00Z" (20 chars) are silently ignored.
-// This function converts RFC 3339 timestamps to epoch milliseconds, which
-// is universally supported. Relative strings and epoch values pass through.
 // supportsExplorePanes reports whether a Grafana version reads Explore state
 // from `panes`. Grafana 10.2 introduced it alongside schemaVersion; earlier
 // versions ignore both and read `left`.
@@ -458,14 +451,16 @@ func buildExplorePanesParams(args GenerateDeeplinkParams) (url.Values, error) {
 		// Queries carry their own datasource reference in the pane format.
 		// Preserve a caller-supplied one — it may include the plugin type,
 		// which some query editors need to select the right editor mode —
-		// and only fall back to the uid when absent.
+		// and only fall back to the uid when absent, null or empty. A null one
+		// must not be propagated: Grafana would resolve it to the default
+		// datasource and render the wrong data, which is worse than an empty pane.
 		queries := make([]map[string]interface{}, 0, len(args.Queries))
 		for _, q := range args.Queries {
 			enriched := make(map[string]interface{}, len(q)+1)
 			for k, v := range q {
 				enriched[k] = v
 			}
-			if _, ok := enriched["datasource"]; !ok {
+			if v, ok := enriched["datasource"]; !ok || v == nil || v == "" {
 				enriched["datasource"] = map[string]string{"uid": *args.DatasourceUID}
 			}
 			queries = append(queries, enriched)
@@ -527,6 +522,13 @@ func exploreTimeRange(tr *TimeRange) map[string]string {
 	return rangeObj
 }
 
+// toGrafanaTimeParam converts a time value to a format Grafana understands
+// in URL query parameters. Grafana's Scenes parseUrlParam uses hardcoded
+// string length checks and only recognizes ISO 8601 at exactly 24 chars
+// (with milliseconds, e.g. "2026-04-28T12:45:00.000Z"). Shorter ISO 8601
+// strings like "2026-04-28T12:45:00Z" (20 chars) are silently ignored.
+// This function converts RFC 3339 timestamps to epoch milliseconds, which
+// is universally supported. Relative strings and epoch values pass through.
 func toGrafanaTimeParam(value string) string {
 	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
 		return value

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -46,6 +46,10 @@ const (
 	// explorePaneID keys the single pane this tool generates. Grafana uses
 	// short random ids in the UI; any stable key works for a one-pane link.
 	explorePaneID = "a"
+	// explorePanesMinMajor and explorePanesMinMinor are the first Grafana
+	// version that reads Explore state from `panes`.
+	explorePanesMinMajor = 10
+	explorePanesMinMinor = 2
 )
 
 type TimeRange struct {
@@ -113,59 +117,20 @@ func generateDeeplinkWithMode(ctx context.Context, args GenerateDeeplinkParams, 
 			return "", fmt.Errorf("datasourceUid is required for explore links")
 		}
 
-		// Grafana 10.2+ reads Explore state from `panes` (keyed by pane id)
-		// alongside schemaVersion, not from the pre-10.2 `left` parameter.
-		// Links built with `left` are migrated on load, and that migration is
-		// lossy for datasource-specific query models: a Cloud Monitoring
-		// PromQL query arrives as queryType "promQL" with a sibling
-		// promQLQuery, and comes back as an empty Builder query with
-		// promQLQuery nested inside timeSeriesList, rendering nothing.
-		pane := map[string]interface{}{
-			"datasource": *args.DatasourceUID,
+		// Grafana 10.2+ reads Explore state from `panes`; older versions
+		// ignore it and read `left`.
+		buildParams := buildExploreLeftParams
+		if supportsExplorePanes(mcpgrafana.GrafanaVersion(ctx)) {
+			buildParams = buildExplorePanesParams
 		}
-		if len(args.Queries) > 0 {
-			// Queries carry their own datasource reference in the pane format.
-			// Preserve a caller-supplied one — it may include the plugin type,
-			// which some query editors need to select the right editor mode —
-			// and only fall back to the uid when absent.
-			queries := make([]map[string]interface{}, 0, len(args.Queries))
-			for _, q := range args.Queries {
-				enriched := make(map[string]interface{}, len(q)+1)
-				for k, v := range q {
-					enriched[k] = v
-				}
-				if _, ok := enriched["datasource"]; !ok {
-					enriched["datasource"] = map[string]string{"uid": *args.DatasourceUID}
-				}
-				queries = append(queries, enriched)
-			}
-			pane["queries"] = queries
-		}
-		if args.TimeRange != nil {
-			rangeObj := map[string]string{}
-			if args.TimeRange.From != "" {
-				rangeObj["from"] = toGrafanaTimeParam(args.TimeRange.From)
-			}
-			if args.TimeRange.To != "" {
-				rangeObj["to"] = toGrafanaTimeParam(args.TimeRange.To)
-			}
-			if len(rangeObj) > 0 {
-				pane["range"] = rangeObj
-			}
-		}
-
-		panesJSON, err := json.Marshal(map[string]interface{}{explorePaneID: pane})
+		params, err := buildParams(args)
 		if err != nil {
-			return "", fmt.Errorf("failed to marshal explore panes: %w", err)
+			return "", err
 		}
-
-		params := url.Values{}
-		params.Set("schemaVersion", exploreSchemaVersion)
-		params.Set("panes", string(panesJSON))
 		deeplink = fmt.Sprintf("%s/explore?%s", baseURL, params.Encode())
 
-		// For explore, the time range is embedded in the pane — skip the
-		// generic time range block below by clearing it.
+		// For explore, the time range is embedded in the state object — skip
+		// the generic time range block below by clearing it.
 		args.TimeRange = nil
 
 	default:
@@ -421,6 +386,147 @@ func buildDashboardTargetURL(baseURL string, dashboardUID *string, preview *Deep
 // strings like "2026-04-28T12:45:00Z" (20 chars) are silently ignored.
 // This function converts RFC 3339 timestamps to epoch milliseconds, which
 // is universally supported. Relative strings and epoch values pass through.
+// supportsExplorePanes reports whether a Grafana version reads Explore state
+// from `panes`. Grafana 10.2 introduced it alongside schemaVersion; earlier
+// versions ignore both and read `left`.
+//
+// An empty or unparseable version means unknown. mcpgrafana.GrafanaVersion
+// fails soft, so an unreadable settings endpoint is indistinguishable from an
+// ancient Grafana; unknown is treated as 10.2+ so that instances which cannot
+// report their version keep the format the overwhelming majority of them
+// understand.
+func supportsExplorePanes(version string) bool {
+	major, minor, ok := parseMajorMinor(version)
+	if !ok {
+		return true
+	}
+	if major != explorePanesMinMajor {
+		return major > explorePanesMinMajor
+	}
+	return minor >= explorePanesMinMinor
+}
+
+// parseMajorMinor extracts the major and minor numbers from a Grafana version
+// such as "10.2.3" or "11.0.0-64123pre". A missing minor reads as zero; a
+// pre-release or build suffix on either component is ignored.
+func parseMajorMinor(version string) (int, int, bool) {
+	parts := strings.SplitN(strings.TrimPrefix(strings.TrimSpace(version), "v"), ".", 3)
+	major, ok := leadingInt(parts[0])
+	if !ok {
+		return 0, 0, false
+	}
+	if len(parts) < 2 {
+		return major, 0, true
+	}
+	minor, ok := leadingInt(parts[1])
+	if !ok {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+// leadingInt parses the digits at the start of s, ignoring any suffix. It
+// reports false when s does not start with a digit.
+func leadingInt(s string) (int, bool) {
+	end := 0
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[:end])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// buildExplorePanesParams builds Explore URL state in the `panes` format read
+// by Grafana 10.2+.
+//
+// Links built with `left` are migrated on load, and that migration is lossy
+// for datasource-specific query models: a Cloud Monitoring PromQL query goes
+// in as queryType "promQL" with a sibling promQLQuery, and comes back as an
+// empty Builder query with promQLQuery nested inside timeSeriesList, so the
+// pane renders nothing.
+func buildExplorePanesParams(args GenerateDeeplinkParams) (url.Values, error) {
+	pane := map[string]interface{}{
+		"datasource": *args.DatasourceUID,
+	}
+	if len(args.Queries) > 0 {
+		// Queries carry their own datasource reference in the pane format.
+		// Preserve a caller-supplied one — it may include the plugin type,
+		// which some query editors need to select the right editor mode —
+		// and only fall back to the uid when absent.
+		queries := make([]map[string]interface{}, 0, len(args.Queries))
+		for _, q := range args.Queries {
+			enriched := make(map[string]interface{}, len(q)+1)
+			for k, v := range q {
+				enriched[k] = v
+			}
+			if _, ok := enriched["datasource"]; !ok {
+				enriched["datasource"] = map[string]string{"uid": *args.DatasourceUID}
+			}
+			queries = append(queries, enriched)
+		}
+		pane["queries"] = queries
+	}
+	if timeRange := exploreTimeRange(args.TimeRange); timeRange != nil {
+		pane["range"] = timeRange
+	}
+
+	panesJSON, err := json.Marshal(map[string]interface{}{explorePaneID: pane})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal explore panes: %w", err)
+	}
+
+	params := url.Values{}
+	params.Set("schemaVersion", exploreSchemaVersion)
+	params.Set("panes", string(panesJSON))
+	return params, nil
+}
+
+// buildExploreLeftParams builds Explore URL state in the pre-10.2 `left`
+// format, where datasource, queries, and range share a single JSON object.
+func buildExploreLeftParams(args GenerateDeeplinkParams) (url.Values, error) {
+	exploreState := map[string]interface{}{
+		"datasource": *args.DatasourceUID,
+	}
+	if len(args.Queries) > 0 {
+		exploreState["queries"] = args.Queries
+	}
+	if timeRange := exploreTimeRange(args.TimeRange); timeRange != nil {
+		exploreState["range"] = timeRange
+	}
+
+	leftJSON, err := json.Marshal(exploreState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal explore state: %w", err)
+	}
+
+	params := url.Values{}
+	params.Set("left", string(leftJSON))
+	return params, nil
+}
+
+func exploreTimeRange(tr *TimeRange) map[string]string {
+	if tr == nil {
+		return nil
+	}
+	rangeObj := map[string]string{}
+	if tr.From != "" {
+		rangeObj["from"] = toGrafanaTimeParam(tr.From)
+	}
+	if tr.To != "" {
+		rangeObj["to"] = toGrafanaTimeParam(tr.To)
+	}
+	if len(rangeObj) == 0 {
+		return nil
+	}
+	return rangeObj
+}
+
 func toGrafanaTimeParam(value string) string {
 	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
 		return value

--- a/tools/navigation.go
+++ b/tools/navigation.go
@@ -40,6 +40,14 @@ type DeeplinkProvisioningPreview struct {
 	PullRequestURL string `json:"pullRequestUrl,omitempty" jsonschema:"description=Upstream pull request URL to surface in Grafana's preview banner."`
 }
 
+const (
+	// exploreSchemaVersion is the Explore URL state schema used by Grafana 10.2+.
+	exploreSchemaVersion = "1"
+	// explorePaneID keys the single pane this tool generates. Grafana uses
+	// short random ids in the UI; any stable key works for a one-pane link.
+	explorePaneID = "a"
+)
+
 type TimeRange struct {
 	From string `json:"from" jsonschema:"description=Start time (e.g.\\, 'now-1h')"`
 	To   string `json:"to" jsonschema:"description=End time (e.g.\\, 'now')"`
@@ -105,13 +113,33 @@ func generateDeeplinkWithMode(ctx context.Context, args GenerateDeeplinkParams, 
 			return "", fmt.Errorf("datasourceUid is required for explore links")
 		}
 
-		// Build the full explore state inside `left` — Grafana Explore reads
-		// datasource, queries, and range all from this single JSON object.
-		exploreState := map[string]interface{}{
+		// Grafana 10.2+ reads Explore state from `panes` (keyed by pane id)
+		// alongside schemaVersion, not from the pre-10.2 `left` parameter.
+		// Links built with `left` are migrated on load, and that migration is
+		// lossy for datasource-specific query models: a Cloud Monitoring
+		// PromQL query arrives as queryType "promQL" with a sibling
+		// promQLQuery, and comes back as an empty Builder query with
+		// promQLQuery nested inside timeSeriesList, rendering nothing.
+		pane := map[string]interface{}{
 			"datasource": *args.DatasourceUID,
 		}
 		if len(args.Queries) > 0 {
-			exploreState["queries"] = args.Queries
+			// Queries carry their own datasource reference in the pane format.
+			// Preserve a caller-supplied one — it may include the plugin type,
+			// which some query editors need to select the right editor mode —
+			// and only fall back to the uid when absent.
+			queries := make([]map[string]interface{}, 0, len(args.Queries))
+			for _, q := range args.Queries {
+				enriched := make(map[string]interface{}, len(q)+1)
+				for k, v := range q {
+					enriched[k] = v
+				}
+				if _, ok := enriched["datasource"]; !ok {
+					enriched["datasource"] = map[string]string{"uid": *args.DatasourceUID}
+				}
+				queries = append(queries, enriched)
+			}
+			pane["queries"] = queries
 		}
 		if args.TimeRange != nil {
 			rangeObj := map[string]string{}
@@ -122,20 +150,21 @@ func generateDeeplinkWithMode(ctx context.Context, args GenerateDeeplinkParams, 
 				rangeObj["to"] = toGrafanaTimeParam(args.TimeRange.To)
 			}
 			if len(rangeObj) > 0 {
-				exploreState["range"] = rangeObj
+				pane["range"] = rangeObj
 			}
 		}
 
-		leftJSON, err := json.Marshal(exploreState)
+		panesJSON, err := json.Marshal(map[string]interface{}{explorePaneID: pane})
 		if err != nil {
-			return "", fmt.Errorf("failed to marshal explore state: %w", err)
+			return "", fmt.Errorf("failed to marshal explore panes: %w", err)
 		}
 
 		params := url.Values{}
-		params.Set("left", string(leftJSON))
+		params.Set("schemaVersion", exploreSchemaVersion)
+		params.Set("panes", string(panesJSON))
 		deeplink = fmt.Sprintf("%s/explore?%s", baseURL, params.Encode())
 
-		// For explore, time range is already embedded in `left` — skip the
+		// For explore, the time range is embedded in the pane — skip the
 		// generic time range block below by clearing it.
 		args.TimeRange = nil
 

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -73,11 +73,13 @@ func TestGenerateDeeplink(t *testing.T) {
 
 		result, err := generateDeeplink(ctx, params)
 		require.NoError(t, err)
-		assert.Contains(t, result, "http://localhost:3000/explore?left=")
+		assert.Contains(t, result, "http://localhost:3000/explore?")
+		assert.Contains(t, result, "schemaVersion=1")
+		assert.Contains(t, result, "panes=")
 		assert.Contains(t, result, "prometheus-uid")
 	})
 
-	t.Run("Explore deeplink with time range inside left JSON", func(t *testing.T) {
+	t.Run("Explore deeplink with time range inside the pane", func(t *testing.T) {
 		params := GenerateDeeplinkParams{
 			ResourceType:  "explore",
 			DatasourceUID: stringPtr("prometheus-uid"),
@@ -93,18 +95,24 @@ func TestGenerateDeeplink(t *testing.T) {
 		u, err := url.Parse(result)
 		require.NoError(t, err)
 
-		leftRaw := u.Query().Get("left")
-		require.NotEmpty(t, leftRaw)
+		panesRaw := u.Query().Get("panes")
+		require.NotEmpty(t, panesRaw)
+		assert.Equal(t, "1", u.Query().Get("schemaVersion"))
+		assert.Empty(t, u.Query().Get("left"), "the pre-10.2 left param must not be emitted")
 
-		// Range must be inside `left`, not as top-level URL params.
-		assert.Contains(t, leftRaw, `"range"`)
-		assert.Contains(t, leftRaw, "now-1h")
-		assert.Contains(t, leftRaw, "now")
+		// Range must be inside the pane, not as top-level URL params.
+		var panes map[string]map[string]any
+		require.NoError(t, json.Unmarshal([]byte(panesRaw), &panes))
+		require.Len(t, panes, 1)
+		pane := panes["a"]
+		require.NotNil(t, pane)
+		assert.Equal(t, "prometheus-uid", pane["datasource"])
+		assert.Equal(t, map[string]any{"from": "now-1h", "to": "now"}, pane["range"])
 		assert.Empty(t, u.Query().Get("from"), "from should not be a top-level URL param for explore")
 		assert.Empty(t, u.Query().Get("to"), "to should not be a top-level URL param for explore")
 
-		// There must be exactly one `left` param.
-		assert.Len(t, u.Query()["left"], 1)
+		// There must be exactly one `panes` param.
+		assert.Len(t, u.Query()["panes"], 1)
 	})
 
 	t.Run("Explore deeplink with queries", func(t *testing.T) {
@@ -123,10 +131,43 @@ func TestGenerateDeeplink(t *testing.T) {
 		u, err := url.Parse(result)
 		require.NoError(t, err)
 
-		leftRaw := u.Query().Get("left")
-		assert.Contains(t, leftRaw, `"queries"`)
-		assert.Contains(t, leftRaw, `"expr"`)
-		assert.Contains(t, leftRaw, "up")
+		var panes map[string]map[string]any
+		require.NoError(t, json.Unmarshal([]byte(u.Query().Get("panes")), &panes))
+		queries, ok := panes["a"]["queries"].([]any)
+		require.True(t, ok)
+		require.Len(t, queries, 1)
+		q := queries[0].(map[string]any)
+		assert.Equal(t, "A", q["refId"])
+		assert.Equal(t, "up", q["expr"])
+		// A query with no explicit datasource inherits the pane's uid, which
+		// the pane query format expects.
+		assert.Equal(t, map[string]any{"uid": "prometheus-uid"}, q["datasource"])
+	})
+
+	t.Run("Explore deeplink preserves a datasource-specific query model", func(t *testing.T) {
+		params := GenerateDeeplinkParams{
+			ResourceType:  "explore",
+			DatasourceUID: stringPtr("gcp-uid"),
+			Queries: []map[string]interface{}{
+				{
+					"refId":      "A",
+					"queryType":  "promQL",
+					"datasource": map[string]string{"type": "stackdriver", "uid": "gcp-uid"},
+				},
+			},
+		}
+
+		result, err := generateDeeplink(ctx, params)
+		require.NoError(t, err)
+		u, err := url.Parse(result)
+		require.NoError(t, err)
+
+		var panes map[string]map[string]any
+		require.NoError(t, json.Unmarshal([]byte(u.Query().Get("panes")), &panes))
+		q := panes["a"]["queries"].([]any)[0].(map[string]any)
+		assert.Equal(t, "promQL", q["queryType"], "queryType must survive into the URL")
+		assert.Equal(t, map[string]any{"type": "stackdriver", "uid": "gcp-uid"}, q["datasource"],
+			"a caller-supplied datasource, including its plugin type, must be preserved")
 	})
 
 	t.Run("With time range on dashboard", func(t *testing.T) {

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -739,3 +739,99 @@ func TestGenerateDeeplink_ExploreISO8601TimeRange(t *testing.T) {
 	assert.Contains(t, result, "1777382100000")
 	assert.NotContains(t, result, "2026-04-28")
 }
+
+func TestSupportsExplorePanes(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		want    bool
+	}{
+		{"10.2.0", true},
+		{"10.2.3", true},
+		{"10.3.0", true},
+		{"11.0.0", true},
+		{"12.1.0", true},
+		{"10.1.9", false},
+		{"10.0.0", false},
+		{"9.5.21", false},
+		{"9.0.0", false},
+		{"10.2.0-64123pre", true},
+		{"10.1.0-64123pre", false},
+		{"v11.0.0", true},
+		{"10", false},
+		{"11", true},
+		// Unknown versions keep the pane format: GrafanaVersion fails soft, so
+		// an unreadable settings endpoint must not downgrade every link.
+		{"", true},
+		{"unknown", true},
+		{"10.x", true},
+	} {
+		t.Run(tc.version, func(t *testing.T) {
+			assert.Equal(t, tc.want, supportsExplorePanes(tc.version))
+		})
+	}
+}
+
+// newVersionedGrafanaContext returns a context pointing at a Grafana whose
+// frontend settings report the given version. Each call gets its own server
+// URL, which is also the version cache key, so subtests stay isolated.
+func newVersionedGrafanaContext(t *testing.T, version string) context.Context {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/frontend/settings" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"buildInfo": {"version": "` + version + `"}}`))
+	}))
+	t.Cleanup(ts.Close)
+	return mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: ts.URL})
+}
+
+func TestGenerateDeeplink_ExploreFormatByGrafanaVersion(t *testing.T) {
+	params := GenerateDeeplinkParams{
+		ResourceType:  "explore",
+		DatasourceUID: stringPtr("prometheus-uid"),
+		Queries: []map[string]interface{}{
+			{"refId": "A", "expr": "up"},
+		},
+		TimeRange: &TimeRange{From: "now-1h", To: "now"},
+	}
+
+	t.Run("10.2 and later use panes", func(t *testing.T) {
+		result, err := generateDeeplink(newVersionedGrafanaContext(t, "12.1.0"), params)
+		require.NoError(t, err)
+
+		u, err := url.Parse(result)
+		require.NoError(t, err)
+		assert.Empty(t, u.Query().Get("left"))
+		assert.Equal(t, "1", u.Query().Get("schemaVersion"))
+
+		var panes map[string]map[string]any
+		require.NoError(t, json.Unmarshal([]byte(u.Query().Get("panes")), &panes))
+		assert.Equal(t, "prometheus-uid", panes["a"]["datasource"])
+		assert.Equal(t, map[string]any{"from": "now-1h", "to": "now"}, panes["a"]["range"])
+	})
+
+	t.Run("before 10.2 falls back to left", func(t *testing.T) {
+		result, err := generateDeeplink(newVersionedGrafanaContext(t, "9.5.21"), params)
+		require.NoError(t, err)
+
+		u, err := url.Parse(result)
+		require.NoError(t, err)
+		assert.Empty(t, u.Query().Get("panes"))
+		assert.Empty(t, u.Query().Get("schemaVersion"))
+
+		var left map[string]any
+		require.NoError(t, json.Unmarshal([]byte(u.Query().Get("left")), &left))
+		assert.Equal(t, "prometheus-uid", left["datasource"])
+		assert.Equal(t, map[string]any{"from": "now-1h", "to": "now"}, left["range"])
+
+		queries, ok := left["queries"].([]any)
+		require.True(t, ok)
+		require.Len(t, queries, 1)
+		// The legacy format takes queries verbatim: Grafana 9 resolves them
+		// against the top-level datasource.
+		assert.Equal(t, map[string]any{"refId": "A", "expr": "up"}, queries[0])
+	})
+}

--- a/tools/navigation_test.go
+++ b/tools/navigation_test.go
@@ -170,6 +170,32 @@ func TestGenerateDeeplink(t *testing.T) {
 			"a caller-supplied datasource, including its plugin type, must be preserved")
 	})
 
+	t.Run("Explore deeplink replaces a null or empty query datasource", func(t *testing.T) {
+		for name, ds := range map[string]interface{}{"null": nil, "empty": ""} {
+			t.Run(name, func(t *testing.T) {
+				params := GenerateDeeplinkParams{
+					ResourceType:  "explore",
+					DatasourceUID: stringPtr("prometheus-uid"),
+					Queries: []map[string]interface{}{
+						{"refId": "A", "datasource": ds},
+					},
+				}
+
+				result, err := generateDeeplink(ctx, params)
+				require.NoError(t, err)
+				u, err := url.Parse(result)
+				require.NoError(t, err)
+
+				var panes map[string]map[string]any
+				require.NoError(t, json.Unmarshal([]byte(u.Query().Get("panes")), &panes))
+				q := panes["a"]["queries"].([]any)[0].(map[string]any)
+				assert.Equal(t, map[string]any{"uid": "prometheus-uid"}, q["datasource"],
+					"a null or empty datasource must be replaced, not propagated: Grafana would "+
+						"resolve it to the default datasource and show the wrong data")
+			})
+		}
+	})
+
 	t.Run("With time range on dashboard", func(t *testing.T) {
 		params := GenerateDeeplinkParams{
 			ResourceType: "dashboard",


### PR DESCRIPTION
Fixes #300.

## Problem

`generate_deeplink` builds Explore links with the pre-10.2 `left` parameter:

```go
params.Set("left", string(leftJSON))
```

Grafana 10.2 moved Explore URL state to `panes` (keyed by pane id) plus `schemaVersion`. Links using `left` still load, but they go through a migration that is lossy for datasource-specific query models, so the pane opens with the query silently dropped.

A Cloud Monitoring (`stackdriver`) PromQL query shows it plainly. This goes in:

```json
{"refId":"A","queryType":"promQL","promQLQuery":{"expr":"...","projectName":"...","step":"300s"}}
```

and Grafana rewrites it to:

```json
{"refId":"A","queryType":"timeSeriesList","timeSeriesList":{"promQLQuery":{"expr":"..."},"projectName":"","filters":[],"view":"FULL"}}
```

`queryType` is reset to the default and `promQLQuery` ends up nested inside `timeSeriesList`, where nothing reads it — the editor opens in Builder mode with every field empty and "No data". #300 also reports Loki links failing outright with `TypeError: Cannot read properties of undefined (reading 'datasourceInstance')`.

## Change

Emit the current format:

```
/explore?schemaVersion=1&panes={"a":{"datasource":"<uid>","queries":[...],"range":{...}}}
```

Each query also gets a `datasource` reference, as the pane format expects. A caller-supplied one is preserved rather than overwritten, because it carries the plugin `type` that some query editors need to select the right editor mode — that is what makes the Cloud Monitoring case above work.

Verified against Grafana 12.x: the same PromQL query that previously opened an empty Builder pane now round-trips and executes.

## Notes for reviewers

- The pane id is a fixed `"a"`. Grafana uses short random ids in the UI; a stable key is fine for a single-pane link, but say the word if you would rather it be randomised.
- Resolving the datasource *type* from the uid (via the client already in context) would be a better default than the uid-only fallback, and would remove the need for callers to pass `datasource` themselves. Left out to keep this focused — happy to add it here or separately.
- `shortenURL`'s test still uses a `left=` URL as its input fixture. That is unrelated to the format this tool emits, so I left it alone.

## Tests

`tools/navigation_test.go` updated for the new shape, plus two additions: one asserting `left` is never emitted, and one asserting a datasource-specific query model (`queryType: "promQL"` with a `stackdriver` datasource) survives into the URL intact. `go test ./tools/` passes.