### PR TITLE
fix(dashboard): guard v2 layout replacements

### DIFF
--- a/docs/sources/reference/mcp-tools-table.md
+++ b/docs/sources/reference/mcp-tools-table.md
@@ -134,6 +134,8 @@ _* Categories marked with `*` are off until you add them to `--enabled-tools`._
 
 `update_dashboard` supports full JSON replacement and patch-style updates (`uid` plus `operations`). Prefer patches for small changes so you do not send large dashboard JSON to the model.
 
+For schema-v2 dashboards, a full replacement fails closed when it would change the top-level layout kind. Use targeted patches for normal edits. Set `allowLayoutChange` only when a structural conversion, such as `TabsLayout` to `RowsLayout`, is intentional.
+
 To limit context use when working with dashboards ([issue #101](https://github.com/grafana/mcp-grafana/issues/101)):
 
 - Use `get_dashboard_summary` for an overview before edits.

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -236,10 +236,11 @@ type UpdateDashboardParams struct {
 	Operations []PatchOperation `json:"operations,omitempty" jsonschema:"description=Array of patch operations for targeted updates. More efficient than full dashboard JSON for small changes. Common paths: '$.templating.list/-' to add a variable\\, '$.annotations.list/-' to add a saved dashboard annotation query/definition\\, '$.panels[0].targets[0].expr' to replace a panel query."`
 
 	// Common parameters
-	FolderUID string `json:"folderUid,omitempty" jsonschema:"description=The UID of the dashboard's folder"`
-	Message   string `json:"message,omitempty" jsonschema:"description=Set a commit message for the version history"`
-	Overwrite bool   `json:"overwrite,omitempty" jsonschema:"description=Overwrite the dashboard if it exists. Otherwise create one"`
-	UserID    int64  `json:"userId,omitempty" jsonschema:"description=ID of the user making the change"`
+	FolderUID         string `json:"folderUid,omitempty" jsonschema:"description=The UID of the dashboard's folder"`
+	Message           string `json:"message,omitempty" jsonschema:"description=Set a commit message for the version history"`
+	Overwrite         bool   `json:"overwrite,omitempty" jsonschema:"description=Overwrite the dashboard if it exists. Otherwise create one"`
+	AllowLayoutChange bool   `json:"allowLayoutChange,omitempty" jsonschema:"description=Allow a full schema-v2 replacement to change the top-level layout kind. Omit for normal updates so accidental TabsLayout-to-RowsLayout conversions fail closed."`
+	UserID            int64  `json:"userId,omitempty" jsonschema:"description=ID of the user making the change"`
 }
 
 // updateDashboard intelligently handles dashboard updates using either full JSON or patch operations.
@@ -532,6 +533,9 @@ func createOrUpdateDashboardV2(ctx context.Context, args UpdateDashboardParams) 
 			if !existing.IsV2 {
 				return nil, fmt.Errorf("dashboard %q is stored as classic v1 and cannot be replaced in place with a v2 (elements/layout) body: Grafana pins the stored schema version, so the v2 content would be silently down-converted to v1. Create a new dashboard (a different uid) for the v2 version instead", uid)
 			}
+			if err := validateV2LayoutChange(existing.Spec, spec, args.AllowLayoutChange); err != nil {
+				return nil, fmt.Errorf("dashboard %q: %w", uid, err)
+			}
 			obj := existing.Object
 			obj["spec"] = spec
 			version = existing.APIVersion // an existing v2 dashboard's stored v2 version
@@ -568,6 +572,33 @@ func createOrUpdateDashboardV2(ctx context.Context, args UpdateDashboardParams) 
 		createdUID = k8sNestedString(created, "metadata", "name")
 	}
 	return postDashboardOKBodyFromK8s(created, createdUID), nil
+}
+
+// validateV2LayoutChange prevents a full replacement from silently flattening
+// or otherwise changing a dashboard's top-level layout. Targeted patch mode can
+// still edit layout details; changing the layout kind through full replacement
+// requires an explicit opt-in because it affects the dashboard's entire shape.
+func validateV2LayoutChange(existing, replacement map[string]interface{}, allow bool) error {
+	if allow {
+		return nil
+	}
+
+	existingKind := v2LayoutKind(existing)
+	replacementKind := v2LayoutKind(replacement)
+	if existingKind == "" || replacementKind == "" || existingKind == replacementKind {
+		return nil
+	}
+
+	return fmt.Errorf("full schema-v2 replacement would change the top-level layout kind from %s to %s; use targeted patch operations, or set allowLayoutChange=true when this structural conversion is intentional", existingKind, replacementKind)
+}
+
+func v2LayoutKind(spec map[string]interface{}) string {
+	layout, ok := spec["layout"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	kind, _ := layout["kind"].(string)
+	return kind
 }
 
 // sortArrayRemovesDescending reorders remove operations on the same array

--- a/tools/dashboard_k8s_test.go
+++ b/tools/dashboard_k8s_test.go
@@ -301,3 +301,102 @@ func TestCreateOrUpdateDashboardV2_DoesNotMutateInput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "newdash", input["uid"], "caller's dashboard map must not be mutated")
 }
+
+func TestCreateOrUpdateDashboardV2_RejectsImplicitLayoutChange(t *testing.T) {
+	var wrote bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(existingV2Dashboard("TabsLayout"))
+		case http.MethodPut:
+			wrote = true
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	k8s := &mcpgrafana.KubernetesClient{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: ts.URL})
+	ctx = mcpgrafana.WithKubernetesClient(ctx, k8s)
+
+	_, err := createOrUpdateDashboardV2(ctx, UpdateDashboardParams{
+		Dashboard: replacementV2Dashboard("u1", "RowsLayout"),
+		Overwrite: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "would change the top-level layout kind from TabsLayout to RowsLayout")
+	assert.Contains(t, err.Error(), "allowLayoutChange=true")
+	assert.False(t, wrote, "must not write an implicit top-level layout conversion")
+}
+
+func TestCreateOrUpdateDashboardV2_AllowsExplicitLayoutChangeAndPreservesFolder(t *testing.T) {
+	var putBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(existingV2Dashboard("TabsLayout"))
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&putBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(putBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	k8s := &mcpgrafana.KubernetesClient{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: ts.URL})
+	ctx = mcpgrafana.WithKubernetesClient(ctx, k8s)
+
+	_, err := createOrUpdateDashboardV2(ctx, UpdateDashboardParams{
+		Dashboard:         replacementV2Dashboard("u1", "RowsLayout"),
+		Overwrite:         true,
+		AllowLayoutChange: true,
+	})
+	require.NoError(t, err)
+
+	metadata, ok := putBody["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	annotations, ok := metadata["annotations"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "folder-1", annotations["grafana.app/folder"])
+
+	spec, ok := putBody["spec"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "RowsLayout", v2LayoutKind(spec))
+}
+
+func existingV2Dashboard(layoutKind string) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "dashboard.grafana.app/v2beta1",
+		"kind":       "Dashboard",
+		"metadata": map[string]interface{}{
+			"name":            "u1",
+			"resourceVersion": "3",
+			"annotations": map[string]interface{}{
+				"grafana.app/folder": "folder-1",
+			},
+		},
+		"spec": replacementV2Dashboard("", layoutKind),
+	}
+}
+
+func replacementV2Dashboard(uid, layoutKind string) map[string]interface{} {
+	dashboard := map[string]interface{}{
+		"title":    "dashboard",
+		"elements": map[string]interface{}{},
+		"layout": map[string]interface{}{
+			"kind": layoutKind,
+			"spec": map[string]interface{}{},
+		},
+	}
+	if uid != "" {
+		dashboard["uid"] = uid
+	}
+	return dashboard
+}


### PR DESCRIPTION
[written by Codex]

## What this changes

Prevents `update_dashboard` full schema-v2 replacements from implicitly changing an existing dashboard's top-level layout kind. This fails closed on accidental conversions such as `TabsLayout` to `RowsLayout`, while an explicit `allowLayoutChange` parameter permits intentional structural conversions.

The tests also verify that an explicitly allowed conversion preserves the existing `grafana.app/folder` annotation when `folderUid` is omitted.

## How you tested it

- `go test -tags unit ./tools`
- Focused layout guard tests for rejected implicit conversion and allowed explicit conversion with folder preservation
- `make lint`: JSON schema lint, OpenAPI lint, and `gofmt` passed; the command could not run `golangci-lint` because that binary is not installed locally
- `go test -tags unit ./...`: the changed `tools` package and other packages passed; the unrelated existing `observability/TestMCPHooks_MetricsDisabled` test fails when run alone on this machine

## Checklist

- [ ] `make lint` and `make test-unit` pass locally
- [x] Commits are signed (required to merge — see CONTRIBUTING.md)
- [ ] CLA signed (required to merge)
- [ ] README tool table updated, with RBAC permissions and scopes, if this adds a tool
- [x] Any write operation respects `--disable-write`
