### PR TITLE
feat(mcpgrafana): expose the target Grafana version to tools

### DIFF
--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -983,6 +983,9 @@ type frontendSettings struct {
 	// computed server-side by Grafana's namespacer (e.g. "default", "org-2",
 	// or "stacks-123" on Grafana Cloud). Empty if not reported.
 	Namespace string
+	// Version is the Grafana version reported by buildInfo.version
+	// (e.g. "12.1.0"). Empty if not reported.
+	Version string
 }
 
 // doFetchPublicURL performs the actual HTTP request to fetch the public URL.
@@ -1034,6 +1037,9 @@ func doFetchFrontendSettings(ctx context.Context, cfg *GrafanaConfig) frontendSe
 	var settings struct {
 		AppURL    string `json:"appUrl"`
 		Namespace string `json:"namespace"`
+		BuildInfo struct {
+			Version string `json:"version"`
+		} `json:"buildInfo"`
 	}
 	if err := json.Unmarshal(body, &settings); err != nil {
 		logger.Warn("Failed to parse frontend settings response", "error", err)
@@ -1044,7 +1050,11 @@ func doFetchFrontendSettings(ctx context.Context, cfg *GrafanaConfig) frontendSe
 	if publicURL != "" {
 		logger.Info("Fetched public URL from Grafana frontend settings", "public_url", publicURL)
 	}
-	return frontendSettings{AppURL: publicURL, Namespace: settings.Namespace}
+	return frontendSettings{
+		AppURL:    publicURL,
+		Namespace: settings.Namespace,
+		Version:   settings.BuildInfo.Version,
+	}
 }
 
 // namespaceCache caches the Kubernetes-style namespace per (Grafana URL, OrgID).
@@ -1117,6 +1127,62 @@ func DashboardNamespace(ctx context.Context) (namespace string, fromSettings boo
 
 	r := result.(nsResult)
 	return r.namespace, r.fromSettings
+}
+
+// versionCache caches the Grafana version per Grafana URL. Unlike the
+// namespace, the version does not depend on the org, so the URL alone is the
+// cache key. Only non-empty results are cached, so a transient settings
+// failure doesn't pin the version to "unknown" for the process lifetime.
+var versionCache sync.Map // map[string]string (grafanaURL -> version)
+
+// versionFlight deduplicates concurrent frontend-settings fetches for the same
+// Grafana URL.
+var versionFlight singleflight.Group
+
+// GrafanaVersion returns the version of the Grafana instance described by the
+// GrafanaConfig in ctx, as reported by buildInfo.version in
+// /api/frontend/settings (e.g. "12.1.0"). It is fetched lazily on first use
+// and cached per Grafana URL.
+//
+// It fails soft: if the settings endpoint is unavailable, unauthorised, or
+// omits buildInfo, it returns an empty string rather than an error. Callers
+// MUST treat the empty string as "version unknown" and behave as they would
+// without the information.
+//
+// Because unknown is indistinguishable from old here, do not use this to gate
+// anything that must fail closed — a caller lacking permission to read the
+// settings endpoint gets the same empty string as an ancient Grafana. Prefer
+// capability detection (e.g. KubernetesClient.GroupVersions) for that, and
+// keep this for advisory uses: error hints, tool descriptions, telemetry.
+func GrafanaVersion(ctx context.Context) string {
+	cfg := GrafanaConfigFromContext(ctx)
+
+	if cached, ok := versionCache.Load(cfg.URL); ok {
+		return cached.(string)
+	}
+
+	result, _, _ := versionFlight.Do(cfg.URL, func() (any, error) {
+		// Double-check cache inside singleflight.
+		if cached, ok := versionCache.Load(cfg.URL); ok {
+			return cached.(string), nil
+		}
+
+		// Detached context with timeout so a cancelled caller doesn't fail the
+		// fetch for all waiters; re-inject the GrafanaConfig so the request
+		// carries the right auth and Org-ID header.
+		fetchCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		fetchCtx = WithGrafanaConfig(fetchCtx, cfg)
+
+		version := doFetchFrontendSettings(fetchCtx, &cfg).Version
+		// Don't cache an unknown version, so a transient failure is retried.
+		if version != "" {
+			versionCache.Store(cfg.URL, version)
+		}
+		return version, nil
+	})
+
+	return result.(string)
 }
 
 // NewGrafanaClient creates a Grafana client with the provided URL and API key.

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -1620,6 +1620,14 @@ func clearNamespaceCache() {
 	})
 }
 
+// clearVersionCache removes all entries from the versionCache for test isolation.
+func clearVersionCache() {
+	versionCache.Range(func(key, _ any) bool {
+		versionCache.Delete(key)
+		return true
+	})
+}
+
 func TestDashboardNamespace(t *testing.T) {
 	t.Cleanup(clearNamespaceCache)
 
@@ -1682,6 +1690,94 @@ func TestDashboardNamespace(t *testing.T) {
 		assert.True(t, from1)
 		assert.True(t, from2)
 		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "frontend settings should be fetched once and cached")
+	})
+}
+
+func TestGrafanaVersion(t *testing.T) {
+	t.Cleanup(clearVersionCache)
+
+	t.Run("returns version from frontend settings buildInfo", func(t *testing.T) {
+		t.Cleanup(clearVersionCache)
+		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/frontend/settings" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"appUrl": "https://grafana.example.com", "buildInfo": {"version": "12.1.0", "edition": "Enterprise"}}`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		})
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: ts.URL, APIKey: "test-key"})
+		assert.Equal(t, "12.1.0", GrafanaVersion(ctx))
+	})
+
+	t.Run("returns empty when settings omit buildInfo", func(t *testing.T) {
+		t.Cleanup(clearVersionCache)
+		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"appUrl": "https://grafana.example.com"}`))
+		})
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: ts.URL})
+		assert.Empty(t, GrafanaVersion(ctx), "unknown version must fail soft, not error")
+	})
+
+	t.Run("returns empty when settings are unavailable", func(t *testing.T) {
+		t.Cleanup(clearVersionCache)
+		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: ts.URL})
+		assert.Empty(t, GrafanaVersion(ctx), "an unauthorised settings endpoint must fail soft")
+	})
+
+	t.Run("caches successful lookups", func(t *testing.T) {
+		t.Cleanup(clearVersionCache)
+		var calls int32
+		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"buildInfo": {"version": "11.6.3"}}`))
+		})
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: ts.URL})
+		assert.Equal(t, "11.6.3", GrafanaVersion(ctx))
+		assert.Equal(t, "11.6.3", GrafanaVersion(ctx))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "frontend settings should be fetched once and cached")
+	})
+
+	t.Run("does not cache failures", func(t *testing.T) {
+		t.Cleanup(clearVersionCache)
+		var calls int32
+		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"buildInfo": {"version": "12.2.0"}}`))
+		})
+
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: ts.URL})
+		assert.Empty(t, GrafanaVersion(ctx))
+		assert.Equal(t, "12.2.0", GrafanaVersion(ctx), "a transient failure should be retried, not cached")
+	})
+
+	t.Run("is keyed on url alone, not org id", func(t *testing.T) {
+		t.Cleanup(clearVersionCache)
+		var calls int32
+		ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"buildInfo": {"version": "12.1.0"}}`))
+		})
+
+		// The version of an instance doesn't vary by org, so a second org
+		// hitting the same URL should reuse the cached entry.
+		assert.Equal(t, "12.1.0", GrafanaVersion(WithGrafanaConfig(context.Background(), GrafanaConfig{URL: ts.URL, OrgID: 1})))
+		assert.Equal(t, "12.1.0", GrafanaVersion(WithGrafanaConfig(context.Background(), GrafanaConfig{URL: ts.URL, OrgID: 7})))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "version cache should not be partitioned by org")
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds `GrafanaVersion(ctx)`, so tools can find out which version of Grafana they're targeting. There was no way to do this before — the nearest thing was the dashboard capability check, which infers "new enough" from the API versions `dashboard.grafana.app` serves rather than reading a version.

The server already fetches `/api/frontend/settings` for `appUrl` and `namespace`, and that response carries `buildInfo`. So this is mostly parsing one more field out of a response we were already throwing away, plus a cache and an accessor.

## Changes

- Parse `buildInfo.version` in `doFetchFrontendSettings` and surface it as `frontendSettings.Version`.
- Add `GrafanaVersion(ctx) string`, fetched lazily on first use and cached per Grafana URL behind `singleflight`, mirroring the existing `publicURL` and `namespace` helpers.

Two deliberate choices worth a look in review:

- **Cache key is the URL alone**, not `URL|orgID` like `namespaceCache`. An instance's version doesn't vary by org, so partitioning by org would just mean redundant fetches. There's a test pinning this.
- **Only non-empty results are cached**, so a transient settings failure is retried rather than pinning the version to unknown for the process lifetime. Same reasoning as `publicURLCache`.

## A caveat on how this should be used

It fails soft: empty string when the endpoint is unavailable, unauthorised, or omits `buildInfo`. That means **unknown is indistinguishable from old** — a caller lacking permission to read the settings endpoint gets the same empty string as an ancient Grafana.

So this is not safe for gating anything that must fail closed. `fetchDashboard` is the cautionary case: silently routing to the legacy API on a v2-capable Grafana would read and write a lossy conversion. Capability detection via `KubernetesClient.GroupVersions` stays the right tool there. This is for advisory uses — error hints, tool descriptions, telemetry. The doc comment says so at the call site.

No caller is added in this PR; it's the mechanism only.

## Testing

Six subtests covering the happy path, settings without `buildInfo`, a 401, caching (asserting one HTTP call), retry-after-failure, and the org-independence of the cache key.

Locally: `go build`, `go vet`, `gofmt`, `make lint-jsonschema`, `make lint-openapi`, and `go test -race -count=2` on the new tests all pass.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (godoc; no README tool-table row needed — this adds no tool)