### PR TITLE
feat(tools): add OTel counters for Loki cost guardrail decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1126,6 +1126,19 @@ When using the SSE or streamable HTTP transports, enable Prometheus metrics with
 
 **Note:** Metrics are only available when using SSE or streamable HTTP transports. They are not available with the stdio transport.
 
+When the [Loki cost guardrail](#cli-flags-reference) (`--loki-guardrail-mode`) is enabled, four more counters record its decisions:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `mcp_loki_guardrail_admitted_total` | Counter | Queries that passed every enabled check (labels: `backend`) |
+| `mcp_loki_guardrail_would_block_total` | Counter | Queries that failed a check in `shadow` mode and ran anyway (labels: `backend`, `reason`) |
+| `mcp_loki_guardrail_blocked_total` | Counter | Queries rejected in `enforce` mode (labels: `backend`, `reason`) |
+| `mcp_loki_guardrail_fail_open_total` | Counter | Queries the guardrail could not evaluate and admitted (labels: `backend`, `cause`) |
+
+`reason` is one of `selector`, `range`, `bytes`; `cause` is one of `unparseable`, `estimate_failed`; `backend` is one of `loki`, `victorialogs`, `unknown`. A query that trips several checks is counted once, labelled with the check that ran first (`selector`, then `range`, then `bytes`), so the four counters partition the guarded population. See [Observability](docs/sources/developer/observability-metrics-and-tracing.md#loki-cost-guardrail-metrics) for how to read them during a `shadow` → `enforce` rollout.
+
+Library embedders should set `GrafanaConfig.MeterProvider` (the metrics counterpart of `GrafanaConfig.Logger`): the guardrail runs inside a tool handler, so it has no constructor option, and a process that installs a noop global `MeterProvider` would otherwise drop every recording.
+
 #### Slow-request logging
 
 The `--slow-request-threshold` flag emits a structured log event whenever an MCP request (tool invocation, list, resource read, etc.) exceeds the given duration. It is useful for diagnosing slow queries and tool calls without drowning in the full debug log.

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -670,6 +670,13 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 		slog.Info("OTLP trace export configured", "endpoint", observability.OTLPTracesEndpoint())
 	}
 
+	// Instrumentation that lives inside tool handlers (the Loki cost
+	// guardrail) has no constructor to take a meter provider option, so it
+	// reads one off the GrafanaConfig instead. Set explicitly rather than
+	// relying on otel.GetMeterProvider() so the counters land on this
+	// process's provider.
+	gc.MeterProvider = o.MeterProvider()
+
 	// Create a client cache for HTTP-based transports to avoid per-request
 	// transport allocation (see https://github.com/grafana/mcp-grafana/issues/682).
 	var clientCache *mcpgrafana.ClientCache

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -121,6 +121,8 @@ When caller authentication is enabled, the `Authorization` header is reserved fo
 - `--loki-guardrail-max-bytes`: Maximum bytes a single `query_loki_logs` call may scan, estimated via Loki's index/stats API. Defaults to 100 GiB; `0` disables the byte-budget check. Falls back to `GRAFANA_LOKI_GUARDRAIL_MAX_BYTES`.
 - `--loki-guardrail-max-range`: Maximum effective time range for a single `query_loki_logs` call, including range-vector durations. Defaults to `24h`; `0` disables the range check. Falls back to `GRAFANA_LOKI_GUARDRAIL_MAX_RANGE`.
 
+The guardrail's decisions are also exported as OTel counters (`mcp_loki_guardrail_admitted_total`, `_would_block_total`, `_blocked_total`, `_fail_open_total`), which is the recommended way to size the affected population before promoting from `shadow` to `enforce`. See [Observability](../../developer/observability-metrics-and-tracing/#loki-cost-guardrail-metrics).
+
 ## Run in read-only mode
 
 `--disable-write` prevents write operations to Grafana. Use it with read-only service accounts, safer production assistants, or to avoid accidental changes.

--- a/docs/sources/developer/observability-metrics-and-tracing.md
+++ b/docs/sources/developer/observability-metrics-and-tracing.md
@@ -67,6 +67,33 @@ Arguments are raw client input, so the two argument-derived labels are allowlist
 
 The high-cardinality **target** of a call (the datasource `uid`, else `name`) is never a metric label — it is span-only as `mcp.tool.target`, and empty for calls that name no entity (see below).
 
+### Loki cost guardrail metrics
+
+When the [Loki query cost guardrail](../../configure/command-line-flags/) is enabled (`--loki-guardrail-mode` is `shadow` or `enforce`), every `query_loki_logs` call it evaluates increments exactly one of four counters:
+
+| Metric | Type | Incremented when |
+|--------|------|------------------|
+| `mcp_loki_guardrail_admitted_total` | Counter | The query passed every enabled check |
+| `mcp_loki_guardrail_would_block_total` | Counter | The query failed a check in `shadow` mode and ran anyway |
+| `mcp_loki_guardrail_blocked_total` | Counter | The query failed a check in `enforce` mode and was rejected |
+| `mcp_loki_guardrail_fail_open_total` | Counter | The guardrail could not reach a verdict and admitted the query |
+
+The four partition the guarded population, so their sum is the number of calls the guardrail evaluated, and each is a query count rather than a check count.
+
+**Labels:**
+
+| Label | On | Values |
+|-------|-----|--------|
+| `reason` | `would_block`, `blocked` | `selector` (no selective label matcher), `range` (effective time range over the cap), `bytes` (index/stats estimate over the budget) |
+| `cause` | `fail_open` | `unparseable` (no stream selector the scanner recognises), `estimate_failed` (index/stats unavailable) |
+| `backend` | all four | `loki`, `victorialogs`, `unknown` |
+
+A query can trip more than one check. It is counted **once**, labelled with the check that ran first — `selector`, then `range`, then `bytes`. That ordering is deliberate: the selectivity check is unconditional, so a query attributed to `selector` would not be admitted by raising `--loki-guardrail-max-range` or `--loki-guardrail-max-bytes`. When promoting from `shadow` to `enforce`, read `sum(rate(mcp_loki_guardrail_would_block_total[5m]))` for the size of the affected population and `sum by (reason) (...)` for whether tuning the bounds would shrink it.
+
+Watch `mcp_loki_guardrail_fail_open_total` alongside them: a quiet `would_block` rate means "nothing would be blocked" only if the fail-open rate is also low. A high `cause="unparseable"` rate on `backend="loki"` means the guardrail's LogQL scanner does not recognise the query shapes in use, which calls for improving the scanner rather than tuning the bounds. On `backend="victorialogs"` a high `unparseable` rate is expected — brace-less LogsQL is the normal shape there, and the byte-budget check never runs on that backend at all, which is why `backend` is a label rather than being folded together.
+
+Neither the stream selector nor the LogQL is exported as a label: both are unbounded, and line filters can carry sensitive literals. The extracted selectors are logged at `WARN` and the full query at `DEBUG` instead.
+
 ## Enable OpenTelemetry tracing
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) is set, the server exports traces via OTLP/gRPC.

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -315,6 +316,16 @@ type GrafanaConfig struct {
 	// to inject their own slog.Logger for consistent structured logging with
 	// per-request context such as tenant_id.
 	Logger *slog.Logger
+
+	// MeterProvider is an optional OTel metric.MeterProvider used by
+	// instrumentation that lives inside tool handlers (which have no
+	// constructor to take a WithXxxMeterProvider option), such as the Loki
+	// cost guardrail. When unset, otel.GetMeterProvider() is used.
+	//
+	// Setting this matters for embedders whose process installs a noop
+	// global provider: without it every recording is silently dropped. It
+	// mirrors Logger above — the same injection point, for the other signal.
+	MeterProvider metric.MeterProvider
 }
 
 // HTTPTransport returns the base HTTP transport for this config.
@@ -332,6 +343,15 @@ func (c GrafanaConfig) LoggerOrDefault() *slog.Logger {
 		return c.Logger
 	}
 	return slog.Default()
+}
+
+// MeterProviderOrDefault returns the configured meter provider, or the global
+// otel.GetMeterProvider() if none is set.
+func (c GrafanaConfig) MeterProviderOrDefault() metric.MeterProvider {
+	if c.MeterProvider != nil {
+		return c.MeterProvider
+	}
+	return otel.GetMeterProvider()
 }
 
 // LoggerFromContext extracts the logger from the GrafanaConfig in the context.

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -2446,4 +2447,17 @@ func TestEnvURLSpellingsResolveToOneValue(t *testing.T) {
 			assert.Equal(t, canonical, resolvedURL)
 		})
 	}
+}
+
+// TestMeterProviderOrDefault covers the injection path that tool-level
+// instrumentation (the Loki cost guardrail) relies on. An embedder whose
+// process installs a noop global provider drops every recording unless a
+// provider is passed explicitly, so the accessor must prefer the configured
+// one and only fall back to the global.
+func TestMeterProviderOrDefault(t *testing.T) {
+	provider := sdkmetric.NewMeterProvider()
+	cfg := GrafanaConfig{MeterProvider: provider}
+	assert.Same(t, provider, cfg.MeterProviderOrDefault())
+
+	assert.Equal(t, otel.GetMeterProvider(), GrafanaConfig{}.MeterProviderOrDefault())
 }

--- a/tools/loki_guardrail.go
+++ b/tools/loki_guardrail.go
@@ -31,6 +31,35 @@ var warnUnknownGuardrailModeOnce sync.Once
 // a real backend.
 type lokiStatsFunc func(ctx context.Context, query string, start, end time.Time) (*Stats, error)
 
+// guardrailReason is one failed guardrail check: the machine-readable kind
+// that becomes the `reason` metric attribute, plus the human-readable message
+// that goes into logs and the rewrite guidance returned to the caller. The
+// kind is carried alongside the message rather than derived from it, so
+// grouping by which check tripped never depends on matching prose.
+type guardrailReason struct {
+	kind    string
+	message string
+}
+
+// guardrailOutcome is the guardrail's verdict on one query. Exactly one of
+// three states holds: reasons is non-empty (the query failed a check),
+// failOpen is set (the guardrail could not reach a verdict and admits the
+// query), or both are zero (the query passed every enabled check).
+type guardrailOutcome struct {
+	reasons  []guardrailReason
+	failOpen string // "" unless the guardrail admitted without a verdict
+}
+
+// messages returns the human-readable reason strings, for logging and for
+// the error returned in enforce mode.
+func (o guardrailOutcome) messages() []string {
+	out := make([]string, len(o.reasons))
+	for i, r := range o.reasons {
+		out[i] = r.message
+	}
+	return out
+}
+
 // guardLokiQuery applies the opt-in Loki query cost guardrail to a
 // query_loki_logs call before it reaches the datasource. Loki's own
 // max_query_bytes_read limit is not enforced on log queries without a line
@@ -74,22 +103,33 @@ func guardLokiQuery(ctx context.Context, backend lokiBackend, logql, queryType s
 		statsFn = backend.QueryStats
 	}
 
-	reasons := lokiGuardrailReasons(ctx, config, native, logql, queryType, start, end, statsFn)
-	if len(reasons) == 0 {
+	metrics := lokiGuardrailInstrumentsFor(config.MeterProviderOrDefault())
+	backendLabel := guardrailBackendLabel(backend)
+
+	outcome := lokiGuardrailReasons(ctx, config, native, logql, queryType, start, end, statsFn)
+	if outcome.failOpen != "" {
+		metrics.recordFailOpen(ctx, backendLabel, outcome.failOpen)
 		return nil
 	}
+	if len(outcome.reasons) == 0 {
+		metrics.recordAdmitted(ctx, backendLabel)
+		return nil
+	}
+	enforced := mode != mcpgrafana.LokiGuardrailShadow
+	metrics.recordBlocked(ctx, enforced, backendLabel, outcome.reasons[0].kind)
 
 	// Log the extracted selectors (the basis of the decision) rather than
 	// the full LogQL, which may embed sensitive literals in line filters;
 	// the full query is available at debug level.
 	logger := config.LoggerOrDefault()
+	reasons := outcome.messages()
 	selectors := parseLogQLSelectors(logql)
 	raws := make([]string, len(selectors))
 	for i, sel := range selectors {
 		raws[i] = sel.raw
 	}
 	logger.DebugContext(ctx, "loki guardrail query detail", "logql", logql)
-	if mode == mcpgrafana.LokiGuardrailShadow {
+	if !enforced {
 		logger.WarnContext(ctx, "loki guardrail would block query", "reasons", strings.Join(reasons, "; "), "selectors", strings.Join(raws, " "))
 		return nil
 	}
@@ -104,16 +144,18 @@ func guardLokiQuery(ctx context.Context, backend lokiBackend, logql, queryType s
 		strings.Join(reasons, "; "), rangeHint)
 }
 
-// lokiGuardrailReasons returns the list of block reasons for a query, empty
-// when allowed. logql must already have # comments stripped (guardLokiQuery
-// does this once for both the checks and the logging). Queries with no
-// parseable stream selector pass through: invalid syntax is rejected by Loki
-// with a proper error, and guessing here risks blocking legitimate syntax
-// the parser doesn't know. The fail-open is logged at warn on native Loki so
-// shadow-mode rollouts can spot query shapes the parser misses; on other
-// backends (VictoriaLogs), where brace-less queries are the normal shape, it
-// logs at debug to avoid per-query noise.
-func lokiGuardrailReasons(ctx context.Context, config mcpgrafana.GrafanaConfig, native bool, logql, queryType string, start, end time.Time, statsFn lokiStatsFunc) []string {
+// lokiGuardrailReasons returns the guardrail's verdict on a query: the block
+// reasons (empty when allowed) or the fail-open cause. logql must already
+// have # comments stripped (guardLokiQuery does this once for both the checks
+// and the logging). Queries with no parseable stream selector pass through:
+// invalid syntax is rejected by Loki with a proper error, and guessing here
+// risks blocking legitimate syntax the parser doesn't know. The fail-open is
+// logged at warn on native Loki so shadow-mode rollouts can spot query shapes
+// the parser misses; on other backends (VictoriaLogs), where brace-less
+// queries are the normal shape, it logs at debug to avoid per-query noise —
+// the fail_open counter is recorded either way, since a dashboard cannot tell
+// "nothing would be blocked" from "the guardrail is not looking" without it.
+func lokiGuardrailReasons(ctx context.Context, config mcpgrafana.GrafanaConfig, native bool, logql, queryType string, start, end time.Time, statsFn lokiStatsFunc) guardrailOutcome {
 	selectors := parseLogQLSelectors(logql)
 	if len(selectors) == 0 {
 		logger := config.LoggerOrDefault()
@@ -123,13 +165,16 @@ func lokiGuardrailReasons(ctx context.Context, config mcpgrafana.GrafanaConfig, 
 			logger.DebugContext(ctx, "loki guardrail found no parseable stream selector; passing query through (fail-open)")
 		}
 		logger.DebugContext(ctx, "loki guardrail query detail", "logql", logql)
-		return nil
+		return guardrailOutcome{failOpen: guardrailCauseUnparseable}
 	}
 
-	var reasons []string
+	var reasons []guardrailReason
 	for _, sel := range selectors {
 		if !hasSelectivePositiveMatcher(sel.matchers) {
-			reasons = append(reasons, fmt.Sprintf("the stream selector %s has no selective label matcher (catch-all, empty, or negative-only selectors scan every stream)", sel.raw))
+			reasons = append(reasons, guardrailReason{
+				kind:    guardrailReasonSelector,
+				message: fmt.Sprintf("the stream selector %s has no selective label matcher (catch-all, empty, or negative-only selectors scan every stream)", sel.raw),
+			})
 		}
 	}
 
@@ -153,11 +198,11 @@ func lokiGuardrailReasons(ctx context.Context, config mcpgrafana.GrafanaConfig, 
 			effective += vecDur
 		}
 		if effective > config.LokiGuardrailMaxRange {
-			reason := fmt.Sprintf("the time range (%s) exceeds the maximum allowed (%s)", effective.Round(time.Minute), config.LokiGuardrailMaxRange)
+			message := fmt.Sprintf("the time range (%s) exceeds the maximum allowed (%s)", effective.Round(time.Minute), config.LokiGuardrailMaxRange)
 			if vecDur > 0 {
-				reason = fmt.Sprintf("the time range (%s, including the %s range vector) exceeds the maximum allowed (%s)", effective.Round(time.Minute), vecDur, config.LokiGuardrailMaxRange)
+				message = fmt.Sprintf("the time range (%s, including the %s range vector) exceeds the maximum allowed (%s)", effective.Round(time.Minute), vecDur, config.LokiGuardrailMaxRange)
 			}
-			reasons = append(reasons, reason)
+			reasons = append(reasons, guardrailReason{kind: guardrailReasonRange, message: message})
 		}
 	}
 
@@ -168,13 +213,22 @@ func lokiGuardrailReasons(ctx context.Context, config mcpgrafana.GrafanaConfig, 
 	// selector-only estimates are accurate for exactly the queries that hurt.
 	if len(reasons) == 0 && config.LokiGuardrailMaxBytes > 0 && statsFn != nil {
 		if statsStart, statsEnd, ok := guardrailStatsWindow(instant, start, end, vecDur); ok {
-			if total, ok := sumSelectorBytes(ctx, config, selectors, statsStart, statsEnd, statsFn); ok && total > config.LokiGuardrailMaxBytes {
-				reasons = append(reasons, fmt.Sprintf("Loki estimates this query would scan %s, above the %s budget",
-					humanizeBytes(total), humanizeBytes(config.LokiGuardrailMaxBytes)))
+			total, ok := sumSelectorBytes(ctx, config, selectors, statsStart, statsEnd, statsFn)
+			switch {
+			case !ok:
+				// The static checks passed but the budget check did not
+				// happen, so this query was admitted without a full verdict.
+				return guardrailOutcome{failOpen: guardrailCauseEstimateFailed}
+			case total > config.LokiGuardrailMaxBytes:
+				reasons = append(reasons, guardrailReason{
+					kind: guardrailReasonBytes,
+					message: fmt.Sprintf("Loki estimates this query would scan %s, above the %s budget",
+						humanizeBytes(total), humanizeBytes(config.LokiGuardrailMaxBytes)),
+				})
 			}
 		}
 	}
-	return reasons
+	return guardrailOutcome{reasons: reasons}
 }
 
 // guardrailStatsWindow computes the window for the index/stats estimate.

--- a/tools/loki_guardrail_metrics.go
+++ b/tools/loki_guardrail_metrics.go
@@ -1,0 +1,145 @@
+package tools
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// lokiGuardrailMeterName is the OTel meter name for the Loki cost guardrail,
+// matching the convention used by clientCacheMeterName/proxiedToolsMeterName.
+const lokiGuardrailMeterName = "mcp-grafana"
+
+// Guardrail block reason kinds, used as the `reason` attribute on the
+// would_block/blocked counters. Deliberately a closed set: these become
+// Prometheus labels downstream.
+const (
+	guardrailReasonSelector = "selector"
+	guardrailReasonRange    = "range"
+	guardrailReasonBytes    = "bytes"
+)
+
+// Guardrail fail-open causes, used as the `cause` attribute on the fail_open
+// counter. Worth distinguishing: unparseable is a gap in the hand-rolled
+// LogQL scanner (fix the scanner), estimate_failed is a Loki index/stats
+// availability blip (fix nothing, watch the rate).
+const (
+	guardrailCauseUnparseable    = "unparseable"
+	guardrailCauseEstimateFailed = "estimate_failed"
+)
+
+// Backend attribute values. The byte-budget check only runs on native Loki,
+// so lumping the backends together would make the admitted count misleading.
+const (
+	guardrailBackendLoki         = "loki"
+	guardrailBackendVictoriaLogs = "victorialogs"
+	guardrailBackendUnknown      = "unknown"
+)
+
+// lokiGuardrailMetrics holds the OTel instruments for guardrail decisions.
+// The four counters partition every guarded query exactly once, so
+// admitted + would_block + blocked + fail_open is the total number of
+// query_loki_logs calls the guardrail evaluated.
+type lokiGuardrailMetrics struct {
+	admitted   metric.Int64Counter // Passed every enabled check
+	wouldBlock metric.Int64Counter // Failed a check in shadow mode; ran anyway
+	blocked    metric.Int64Counter // Failed a check in enforce mode; rejected
+	failOpen   metric.Int64Counter // Could not be evaluated; admitted
+}
+
+var (
+	// lokiGuardrailMetricsOnce gates one-time construction of the guardrail
+	// instruments. The guardrail has no constructor — it runs inside a tool
+	// handler and reads its settings from the per-request GrafanaConfig — so
+	// the instruments are built from the first request that reaches it and
+	// reused for the life of the process. A process that hands different
+	// requests different MeterProviders would therefore record everything
+	// against the first one; no embedder does that today, and the
+	// alternative (rebuilding instruments per request) would allocate on
+	// every query. Vars rather than literals so tests can reset them.
+	lokiGuardrailMetricsOnce sync.Once
+	lokiGuardrailInstruments lokiGuardrailMetrics
+)
+
+// lokiGuardrailInstrumentsFor returns the process-wide guardrail instruments,
+// building them against mp on first use. See lokiGuardrailMetricsOnce.
+func lokiGuardrailInstrumentsFor(mp metric.MeterProvider) lokiGuardrailMetrics {
+	lokiGuardrailMetricsOnce.Do(func() {
+		lokiGuardrailInstruments = newLokiGuardrailMetrics(mp)
+	})
+	return lokiGuardrailInstruments
+}
+
+func newLokiGuardrailMetrics(mp metric.MeterProvider) lokiGuardrailMetrics {
+	meter := mp.Meter(lokiGuardrailMeterName)
+
+	admitted, _ := meter.Int64Counter("mcp.loki_guardrail.admitted",
+		metric.WithDescription("Number of Loki queries that passed every enabled guardrail check"),
+		metric.WithUnit("{query}"),
+	)
+	wouldBlock, _ := meter.Int64Counter("mcp.loki_guardrail.would_block",
+		metric.WithDescription("Number of Loki queries that failed a guardrail check in shadow mode and ran anyway"),
+		metric.WithUnit("{query}"),
+	)
+	blocked, _ := meter.Int64Counter("mcp.loki_guardrail.blocked",
+		metric.WithDescription("Number of Loki queries rejected by the guardrail in enforce mode"),
+		metric.WithUnit("{query}"),
+	)
+	failOpen, _ := meter.Int64Counter("mcp.loki_guardrail.fail_open",
+		metric.WithDescription("Number of Loki queries the guardrail could not evaluate and admitted"),
+		metric.WithUnit("{query}"),
+	)
+
+	return lokiGuardrailMetrics{
+		admitted:   admitted,
+		wouldBlock: wouldBlock,
+		blocked:    blocked,
+		failOpen:   failOpen,
+	}
+}
+
+// recordAdmitted counts a query that passed every enabled check.
+func (m lokiGuardrailMetrics) recordAdmitted(ctx context.Context, backend string) {
+	m.admitted.Add(ctx, 1, metric.WithAttributes(attribute.String("backend", backend)))
+}
+
+// recordBlocked counts a query that failed a check. reason is the first
+// check that tripped, so the counter counts queries rather than checks: a
+// query failing both the selector and range checks is attributed to
+// `selector`, which is the right answer for rollout purposes because raising
+// the range budget would not admit it.
+func (m lokiGuardrailMetrics) recordBlocked(ctx context.Context, enforced bool, backend, reason string) {
+	counter := m.wouldBlock
+	if enforced {
+		counter = m.blocked
+	}
+	counter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("backend", backend),
+		attribute.String("reason", reason),
+	))
+}
+
+// recordFailOpen counts a query the guardrail admitted without reaching a
+// verdict.
+func (m lokiGuardrailMetrics) recordFailOpen(ctx context.Context, backend, cause string) {
+	m.failOpen.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("backend", backend),
+		attribute.String("cause", cause),
+	))
+}
+
+// guardrailBackendLabel maps a backend to its bounded `backend` attribute
+// value. A nil or unrecognized backend reports "unknown" rather than
+// guessing, keeping the label set closed.
+func guardrailBackendLabel(backend lokiBackend) string {
+	switch backend.(type) {
+	case *lokiNativeBackend:
+		return guardrailBackendLoki
+	case *victoriaLogsBackend:
+		return guardrailBackendVictoriaLogs
+	default:
+		return guardrailBackendUnknown
+	}
+}

--- a/tools/loki_guardrail_metrics_test.go
+++ b/tools/loki_guardrail_metrics_test.go
@@ -1,0 +1,316 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// newGuardrailMetricsReader installs a fresh manual-reader MeterProvider as
+// the guardrail's instrument source and returns both the reader and a
+// GrafanaConfig wired to that provider.
+//
+// The instruments are built once per process (see lokiGuardrailMetricsOnce),
+// and other tests in this package will already have built them against the
+// global noop provider, so the once has to be reset — and reset again
+// afterwards, so a later test does not record into this test's reader.
+func newGuardrailMetricsReader(t *testing.T, mode string, maxBytes int64, maxRange time.Duration) (*sdkmetric.ManualReader, mcpgrafana.GrafanaConfig) {
+	t.Helper()
+	reset := func() {
+		lokiGuardrailMetricsOnce = sync.Once{}
+		lokiGuardrailInstruments = lokiGuardrailMetrics{}
+	}
+	reset()
+	t.Cleanup(reset)
+
+	reader := sdkmetric.NewManualReader()
+	config, _ := guardrailConfig(mode, maxBytes, maxRange)
+	config.MeterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return reader, config
+}
+
+// guardrailCounts collects the guardrail counters and returns, for each
+// counter name, the recorded value per attribute set (rendered as a sorted
+// "k=v,k=v" key so assertions stay readable).
+func guardrailCounts(t *testing.T, reader *sdkmetric.ManualReader) map[string]map[string]int64 {
+	t.Helper()
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+
+	out := map[string]map[string]int64{}
+	for _, sm := range data.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				parts := make([]string, 0, dp.Attributes.Len())
+				for _, kv := range dp.Attributes.ToSlice() {
+					parts = append(parts, string(kv.Key)+"="+kv.Value.Emit())
+				}
+				key := ""
+				for i, p := range parts {
+					if i > 0 {
+						key += ","
+					}
+					key += p
+				}
+				if out[m.Name] == nil {
+					out[m.Name] = map[string]int64{}
+				}
+				out[m.Name][key] += dp.Value
+			}
+		}
+	}
+	return out
+}
+
+func TestGuardrailMetricsAdmitted(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-time.Hour)
+	reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailShadow, 0, 24*time.Hour)
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+
+	var hits int
+	backend := newStatsBackend(t, 0, &hits)
+	require.NoError(t, guardLokiQuery(ctx, backend, `{namespace="foo", app="bar"}`, "", start, end))
+
+	counts := guardrailCounts(t, reader)
+	assert.Equal(t, map[string]int64{"backend=loki": 1}, counts["mcp.loki_guardrail.admitted"])
+	assert.Empty(t, counts["mcp.loki_guardrail.would_block"])
+	assert.Empty(t, counts["mcp.loki_guardrail.blocked"])
+	assert.Empty(t, counts["mcp.loki_guardrail.fail_open"])
+}
+
+// The counter that fires is what distinguishes shadow from enforce, so
+// alerts survive the promotion that renames the log line.
+func TestGuardrailMetricsShadowAndEnforce(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-time.Hour)
+
+	t.Run("shadow records would_block", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailShadow, 0, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.NoError(t, guardLokiQuery(ctx, nil, `{cluster=~".+"}`, "", start, end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=unknown,reason=selector": 1}, counts["mcp.loki_guardrail.would_block"])
+		assert.Empty(t, counts["mcp.loki_guardrail.blocked"])
+	})
+
+	t.Run("enforce records blocked", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailEnforce, 0, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.Error(t, guardLokiQuery(ctx, nil, `{cluster=~".+"}`, "", start, end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=unknown,reason=selector": 1}, counts["mcp.loki_guardrail.blocked"])
+		assert.Empty(t, counts["mcp.loki_guardrail.would_block"])
+	})
+
+	// Unknown modes fail closed, so they must count as blocked rather than
+	// as a shadow-mode would-block.
+	t.Run("unknown mode records blocked", func(t *testing.T) {
+		warnUnknownGuardrailModeOnce = sync.Once{}
+		reader, config := newGuardrailMetricsReader(t, "enfore", 0, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.Error(t, guardLokiQuery(ctx, nil, `{cluster=~".+"}`, "", start, end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=unknown,reason=selector": 1}, counts["mcp.loki_guardrail.blocked"])
+	})
+}
+
+// Each reason kind gets its own attribute value, so a would-block population
+// dominated by the (unconditional) selectivity check is distinguishable from
+// one that raising the byte or range budget would soften.
+func TestGuardrailMetricsReasonAttribute(t *testing.T) {
+	end := time.Now()
+
+	t.Run("range", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailShadow, 0, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.NoError(t, guardLokiQuery(ctx, nil, `{namespace="foo", app="bar"}`, "", end.Add(-48*time.Hour), end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=unknown,reason=range": 1}, counts["mcp.loki_guardrail.would_block"])
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailShadow, 100<<30, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		var hits int
+		backend := newStatsBackend(t, 200<<30, &hits)
+		require.NoError(t, guardLokiQuery(ctx, backend, `{namespace="foo", app="bar"}`, "", end.Add(-time.Hour), end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=loki,reason=bytes": 1}, counts["mcp.loki_guardrail.would_block"])
+	})
+
+	// A query tripping both the selector and the range check is counted once,
+	// attributed to the check that ran first. Raising the range budget would
+	// not admit it, so `selector` is the actionable answer.
+	t.Run("selector wins over range", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailShadow, 0, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.NoError(t, guardLokiQuery(ctx, nil, `{cluster=~".+"}`, "", end.Add(-48*time.Hour), end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=unknown,reason=selector": 1}, counts["mcp.loki_guardrail.would_block"])
+	})
+}
+
+// The fail-open paths are the ones that make a quiet dashboard ambiguous:
+// without these counters "nothing would be blocked" is indistinguishable
+// from "the guardrail is not looking".
+func TestGuardrailMetricsFailOpen(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-time.Hour)
+
+	t.Run("unparseable", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailEnforce, 0, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.NoError(t, guardLokiQuery(ctx, nil, `{app=="x"}`, "", start, end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=unknown,cause=unparseable": 1}, counts["mcp.loki_guardrail.fail_open"])
+		assert.Empty(t, counts["mcp.loki_guardrail.admitted"], "a fail-open is not a clean admission")
+	})
+
+	// A brace-less LogsQL query on VictoriaLogs is the normal shape, not a
+	// scanner gap — the backend attribute is what keeps the unparseable rate
+	// on native Loki readable.
+	t.Run("unparseable on victorialogs", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailEnforce, 0, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.NoError(t, guardLokiQuery(ctx, &victoriaLogsBackend{}, `_time:5m error`, "", start, end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=victorialogs,cause=unparseable": 1}, counts["mcp.loki_guardrail.fail_open"])
+	})
+
+	t.Run("estimate failed", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailEnforce, 100<<30, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		require.NoError(t, guardLokiQuery(ctx, newBrokenStatsBackend(t), `{namespace="foo", app="bar"}`, "", start, end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=loki,cause=estimate_failed": 1}, counts["mcp.loki_guardrail.fail_open"])
+		assert.Empty(t, counts["mcp.loki_guardrail.admitted"], "the budget check did not happen")
+	})
+
+	// A partial total that is already over budget is a verdict, not a
+	// fail-open, even though a later stats call errored.
+	t.Run("partial total over budget counts as a block", func(t *testing.T) {
+		reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailShadow, 100<<30, 24*time.Hour)
+		ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+		backend := newSelectiveStatsBackend(t, map[string]int64{`{namespace="a", app="x"}`: 500 << 30})
+		logql := `sum(rate({namespace="a", app="x"}[5m])) / sum(rate({namespace="a", app="y"}[5m]))`
+		require.NoError(t, guardLokiQuery(ctx, backend, logql, "", start, end))
+
+		counts := guardrailCounts(t, reader)
+		assert.Equal(t, map[string]int64{"backend=loki,reason=bytes": 1}, counts["mcp.loki_guardrail.would_block"])
+		assert.Empty(t, counts["mcp.loki_guardrail.fail_open"])
+	})
+}
+
+// Guardrail mode off short-circuits before any instrument is touched: an
+// unguarded query must not show up as admitted.
+func TestGuardrailMetricsOffRecordsNothing(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-time.Hour)
+	reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailOff, 0, 24*time.Hour)
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+
+	require.NoError(t, guardLokiQuery(ctx, nil, `{cluster=~".+"}`, "", start, end))
+	assert.Empty(t, guardrailCounts(t, reader))
+}
+
+// The counters must reach the injected provider, not the global one: an
+// embedder that installs a noop global provider (as the hosted Cloud MCP
+// server does) would otherwise drop every recording.
+func TestGuardrailMetricsUseInjectedMeterProvider(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-time.Hour)
+	reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailEnforce, 0, 24*time.Hour)
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+	require.Error(t, guardLokiQuery(ctx, nil, `{cluster=~".+"}`, "", start, end))
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+	require.Len(t, data.ScopeMetrics, 1)
+	assert.Equal(t, lokiGuardrailMeterName, data.ScopeMetrics[0].Scope.Name)
+	require.Len(t, data.ScopeMetrics[0].Metrics, 1)
+	assert.Equal(t, "mcp.loki_guardrail.blocked", data.ScopeMetrics[0].Metrics[0].Name)
+}
+
+func TestGuardrailBackendLabel(t *testing.T) {
+	assert.Equal(t, guardrailBackendLoki, guardrailBackendLabel(&lokiNativeBackend{}))
+	assert.Equal(t, guardrailBackendVictoriaLogs, guardrailBackendLabel(&victoriaLogsBackend{}))
+	assert.Equal(t, guardrailBackendUnknown, guardrailBackendLabel(nil))
+	assert.Equal(t, guardrailBackendUnknown, guardrailBackendLabel(&fakeLokiBackend{}))
+}
+
+// TestGuardrailMetricsAttributeKeys pins the attribute keys, since they
+// become Prometheus labels that downstream alerts group by.
+func TestGuardrailMetricsAttributeKeys(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-time.Hour)
+	reader, config := newGuardrailMetricsReader(t, mcpgrafana.LokiGuardrailShadow, 0, 24*time.Hour)
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), config)
+	require.NoError(t, guardLokiQuery(ctx, nil, `{cluster=~".+"}`, "", start, end))
+
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+	require.Len(t, data.ScopeMetrics, 1)
+	require.Len(t, data.ScopeMetrics[0].Metrics, 1)
+	sum, ok := data.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+
+	attrs := sum.DataPoints[0].Attributes
+	_, hasBackend := attrs.Value(attribute.Key("backend"))
+	_, hasReason := attrs.Value(attribute.Key("reason"))
+	assert.True(t, hasBackend)
+	assert.True(t, hasReason)
+	assert.Equal(t, 2, attrs.Len(), "no unbounded attributes (selector, LogQL) may be attached")
+}
+
+// newBrokenStatsBackend returns a native Loki backend whose index/stats
+// endpoint always fails, standing in for a Loki availability blip.
+func newBrokenStatsBackend(t *testing.T) *lokiNativeBackend {
+	t.Helper()
+	return newSelectiveStatsBackend(t, nil)
+}
+
+// newSelectiveStatsBackend returns a native Loki backend whose index/stats
+// endpoint answers with the byte estimate registered for the requested
+// selector, and fails for any selector not in the map.
+func newSelectiveStatsBackend(t *testing.T, estimates map[string]int64) *lokiNativeBackend {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/loki/api/v1/index/stats", func(w http.ResponseWriter, r *http.Request) {
+		bytesEstimate, ok := estimates[r.URL.Query().Get("query")]
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "unavailable"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Stats{Bytes: bytesEstimate})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &lokiNativeBackend{client: &Client{httpClient: srv.Client(), baseURL: srv.URL}}
+}

--- a/tools/loki_guardrail_unit_test.go
+++ b/tools/loki_guardrail_unit_test.go
@@ -182,25 +182,33 @@ func TestLokiGuardrailReasonsStaticChecks(t *testing.T) {
 	end := time.Now()
 	start := end.Add(-time.Hour)
 
-	reasons := lokiGuardrailReasons(context.Background(), config, true, `{cluster=~".+"} |= "error"`, "", start, end, nil)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, `{cluster=~".+"} |= "error"`, "", start, end, nil).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "selective")
-	assert.Contains(t, reasons[0], `{cluster=~".+"}`)
+	assert.Equal(t, guardrailReasonSelector, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "selective")
+	assert.Contains(t, reasons[0].message, `{cluster=~".+"}`)
 
-	reasons = lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", end.Add(-48*time.Hour), end, nil)
+	reasons = lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", end.Add(-48*time.Hour), end, nil).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "time range")
+	assert.Equal(t, guardrailReasonRange, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "time range")
 
 	// A catch-all on either side of a binary expression is flagged.
-	reasons = lokiGuardrailReasons(context.Background(), config, true, `sum(rate({app="x"}[5m])) / sum(rate({cluster=~".+"}[5m]))`, "", start, end, nil)
+	reasons = lokiGuardrailReasons(context.Background(), config, true, `sum(rate({app="x"}[5m])) / sum(rate({cluster=~".+"}[5m]))`, "", start, end, nil).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], `{cluster=~".+"}`)
+	assert.Contains(t, reasons[0].message, `{cluster=~".+"}`)
 
 	// Unparseable queries pass through: Loki rejects them with a proper error.
-	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `{app=="x"}`, "", start, end, nil))
+	// They are a fail-open, not a clean admission — the guardrail never
+	// reached a verdict.
+	outcome := lokiGuardrailReasons(context.Background(), config, true, `{app=="x"}`, "", start, end, nil)
+	assert.Empty(t, outcome.reasons)
+	assert.Equal(t, guardrailCauseUnparseable, outcome.failOpen)
 
-	// Selective selector within the range cap is allowed.
-	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", start, end, nil))
+	// Selective selector within the range cap is allowed outright.
+	outcome = lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", start, end, nil)
+	assert.Empty(t, outcome.reasons)
+	assert.Empty(t, outcome.failOpen)
 }
 
 func TestLokiGuardrailReasonsRangeVector(t *testing.T) {
@@ -208,29 +216,31 @@ func TestLokiGuardrailReasonsRangeVector(t *testing.T) {
 	end := time.Now()
 
 	// Instant metric query: no window of its own, cost set by the vector.
-	reasons := lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[30d]))`, "instant", time.Time{}, time.Time{}, nil)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[30d]))`, "instant", time.Time{}, time.Time{}, nil).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "range vector")
+	assert.Equal(t, guardrailReasonRange, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "range vector")
 
 	// The vector duration counts on top of the range query window.
-	reasons = lokiGuardrailReasons(context.Background(), config, true, `rate({namespace="foo"}[20h])`, "", end.Add(-8*time.Hour), end, nil)
+	reasons = lokiGuardrailReasons(context.Background(), config, true, `rate({namespace="foo"}[20h])`, "", end.Add(-8*time.Hour), end, nil).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "time range")
+	assert.Contains(t, reasons[0].message, "time range")
 
 	// A small vector on an instant query is fine.
-	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[1h]))`, "instant", time.Time{}, time.Time{}, nil))
+	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[1h]))`, "instant", time.Time{}, time.Time{}, nil).reasons)
 
 	// Fractional durations (Loki's time.ParseDuration fallback) count too:
 	// [720.5h] on an instant query must not fail open past the range cap.
-	reasons = lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[720.5h]))`, "instant", time.Time{}, time.Time{}, nil)
+	reasons = lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[720.5h]))`, "instant", time.Time{}, time.Time{}, nil).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "range vector")
+	assert.Equal(t, guardrailReasonRange, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "range vector")
 
 	// A multi-century span saturates end.Sub(start) at MaxInt64; adding the
 	// vector duration must saturate too, not wrap negative and fail open.
-	reasons = lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[7d]))`, "", time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC), end, nil)
+	reasons = lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[7d]))`, "", time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC), end, nil).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "time range")
+	assert.Contains(t, reasons[0].message, "time range")
 }
 
 func TestLokiGuardrailReasonsByteBudget(t *testing.T) {
@@ -243,9 +253,10 @@ func TestLokiGuardrailReasonsByteBudget(t *testing.T) {
 		gotQuery = query
 		return &Stats{Bytes: 200 << 30}, nil
 	}
-	reasons := lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"} |= "error"`, "", start, end, overBudget)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"} |= "error"`, "", start, end, overBudget).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "budget")
+	assert.Equal(t, guardrailReasonBytes, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "budget")
 	// The estimate is for the bare selector: line filters do not reduce
 	// bytes scanned.
 	assert.Equal(t, `{namespace="foo", app="bar"}`, gotQuery)
@@ -253,7 +264,7 @@ func TestLokiGuardrailReasonsByteBudget(t *testing.T) {
 	underBudget := func(ctx context.Context, query string, s, e time.Time) (*Stats, error) {
 		return &Stats{Bytes: 1 << 30}, nil
 	}
-	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", start, end, underBudget))
+	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", start, end, underBudget).reasons)
 }
 
 func TestLokiGuardrailReasonsByteBudgetInstantWindow(t *testing.T) {
@@ -267,9 +278,10 @@ func TestLokiGuardrailReasonsByteBudgetInstantWindow(t *testing.T) {
 		gotStart, gotEnd = s, e
 		return &Stats{Bytes: 200 << 30}, nil
 	}
-	reasons := lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[6h]))`, "instant", time.Time{}, end, statsFn)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, `sum(count_over_time({namespace="foo"}[6h]))`, "instant", time.Time{}, end, statsFn).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "budget")
+	assert.Equal(t, guardrailReasonBytes, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "budget")
 	assert.Equal(t, end, gotEnd)
 	assert.Equal(t, end.Add(-6*time.Hour), gotStart)
 }
@@ -287,9 +299,10 @@ func TestLokiGuardrailReasonsSumsSelectors(t *testing.T) {
 
 	// Both sides of a binary expression are scanned; their estimates sum.
 	logql := `sum(rate({namespace="a", app="x"}[5m])) / sum(rate({namespace="a", app="y"}[5m]))`
-	reasons := lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "budget")
+	assert.Equal(t, guardrailReasonBytes, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "budget")
 	assert.Equal(t, []string{`{namespace="a", app="x"}`, `{namespace="a", app="y"}`}, queries)
 
 	// Repeated selectors are fetched once but each occurrence counts: both
@@ -297,9 +310,10 @@ func TestLokiGuardrailReasonsSumsSelectors(t *testing.T) {
 	// twice is over budget — with a single stats round trip.
 	queries = nil
 	logql = `sum(rate({namespace="a", app="x"}[5m])) / sum(rate({namespace="a", app="x"}[10m]))`
-	reasons = lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn)
+	reasons = lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "budget")
+	assert.Equal(t, guardrailReasonBytes, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "budget")
 	assert.Len(t, queries, 1)
 }
 
@@ -314,9 +328,10 @@ func TestLokiGuardrailReasonsByteSumSaturates(t *testing.T) {
 		return &Stats{Bytes: math.MaxInt64 / 2}, nil
 	}
 	logql := `sum(rate({app="x"}[5m])) + sum(rate({app="x"}[5m])) + sum(rate({app="x"}[5m]))`
-	reasons := lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "budget")
+	assert.Equal(t, guardrailReasonBytes, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "budget")
 }
 
 func TestLokiGuardrailReasonsByteCheckSkippedWithoutWindow(t *testing.T) {
@@ -329,7 +344,7 @@ func TestLokiGuardrailReasonsByteCheckSkippedWithoutWindow(t *testing.T) {
 		called = true
 		return &Stats{Bytes: 200 << 30}, nil
 	}
-	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo"}`, "instant", time.Time{}, time.Time{}, statsFn))
+	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo"}`, "instant", time.Time{}, time.Time{}, statsFn).reasons)
 	assert.False(t, called)
 }
 
@@ -341,7 +356,9 @@ func TestLokiGuardrailReasonsStatsFailureFailsOpen(t *testing.T) {
 	boom := func(ctx context.Context, query string, s, e time.Time) (*Stats, error) {
 		return nil, errors.New("boom")
 	}
-	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", start, end, boom))
+	outcome := lokiGuardrailReasons(context.Background(), config, true, `{namespace="foo", app="bar"}`, "", start, end, boom)
+	assert.Empty(t, outcome.reasons)
+	assert.Equal(t, guardrailCauseEstimateFailed, outcome.failOpen)
 }
 
 func TestLokiGuardrailReasonsPartialTotalOverBudgetStillBlocks(t *testing.T) {
@@ -359,9 +376,10 @@ func TestLokiGuardrailReasonsPartialTotalOverBudgetStillBlocks(t *testing.T) {
 		return nil, errors.New("boom")
 	}
 	logql := `sum(rate({namespace="a", app="x"}[5m])) / sum(rate({namespace="a", app="y"}[5m]))`
-	reasons := lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn).reasons
 	require.Len(t, reasons, 1)
-	assert.Contains(t, reasons[0], "budget")
+	assert.Equal(t, guardrailReasonBytes, reasons[0].kind)
+	assert.Contains(t, reasons[0].message, "budget")
 
 	// Under budget when the error hits: the verdict is still undetermined, so
 	// fail open as before.
@@ -371,7 +389,9 @@ func TestLokiGuardrailReasonsPartialTotalOverBudgetStillBlocks(t *testing.T) {
 		}
 		return nil, errors.New("boom")
 	}
-	assert.Empty(t, lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn))
+	outcome := lokiGuardrailReasons(context.Background(), config, true, logql, "", start, end, statsFn)
+	assert.Empty(t, outcome.reasons)
+	assert.Equal(t, guardrailCauseEstimateFailed, outcome.failOpen)
 }
 
 func TestLokiGuardrailReasonsStatsSkippedForBlockedQuery(t *testing.T) {
@@ -384,7 +404,7 @@ func TestLokiGuardrailReasonsStatsSkippedForBlockedQuery(t *testing.T) {
 		called = true
 		return &Stats{}, nil
 	}
-	reasons := lokiGuardrailReasons(context.Background(), config, true, `{cluster=~".+"}`, "", start, end, statsFn)
+	reasons := lokiGuardrailReasons(context.Background(), config, true, `{cluster=~".+"}`, "", start, end, statsFn).reasons
 	require.NotEmpty(t, reasons)
 	assert.False(t, called, "index/stats round trip must be skipped when static checks already block")
 }


### PR DESCRIPTION
Closes #1093

## Summary

The Loki cost guardrail (#1031) reported itself only through log lines. This adds four OTel counters for the decisions it makes, so the `shadow` → `enforce` promotion can be judged from numbers instead of grepped log text.

| Counter | Incremented when |
|---|---|
| `mcp.loki_guardrail.admitted` | Query passed every enabled check |
| `mcp.loki_guardrail.would_block` | Checks failed, mode is `shadow`, query ran anyway |
| `mcp.loki_guardrail.blocked` | Checks failed, mode is `enforce`, query rejected |
| `mcp.loki_guardrail.fail_open` | Guardrail could not evaluate and admitted the query |

The four partition the guarded population exactly once, so their sum is the number of calls the guardrail evaluated.

**Attributes** (bounded — these become Prometheus labels downstream):

- `reason` on the block counters: `selector`, `range`, `bytes`
- `cause` on `fail_open`: `unparseable` (scanner gap) or `estimate_failed` (Loki index/stats blip)
- `backend` on all four: `loki`, `victorialogs`, `unknown`

Neither the selector nor the LogQL is exported — both are unbounded, and line filters can carry sensitive literals.

## Decisions taken on the issue's open questions

**Reason attribution.** A query can trip more than one check; it is counted **once**, attributed to the check that ran first (`selector` → `range` → `bytes`). This keeps the invariant `admitted + would_block + blocked + fail_open == guarded queries`, so `sum(rate(mcp_loki_guardrail_would_block_total[5m]))` is directly the size of the population a promotion would break, and `sum by (reason)` is the breakdown. First-check attribution is also the actionable answer: the selectivity check is unconditional, so a query labelled `selector` would not be admitted by raising either budget. Documented in both README and the observability page.

**MeterProvider injection.** Took the `GrafanaConfig` option from the issue, as the more consistent one: a new `MeterProvider` field with a `MeterProviderOrDefault()` accessor next to `LoggerOrDefault()`. `main.go`'s `run()` sets it from `obs.MeterProvider()`. Instruments are built once per process behind a `sync.Once` (the config is per-request); the caveat — a process handing different requests different providers records everything against the first — is documented at the `sync.Once`, and no embedder does that today. Injection rather than `otel.GetMeterProvider()` is the point: an embedder installing a noop global provider drops every recording otherwise.

## Changes

- `mcpgrafana.go`: `GrafanaConfig.MeterProvider` + `MeterProviderOrDefault()`.
- `tools/loki_guardrail_metrics.go` (new): the four instruments, the bounded attribute value sets, and `guardrailBackendLabel`.
- `tools/loki_guardrail.go`: reason kinds are now carried alongside the human-readable message (`guardrailReason`), and the evaluation returns a `guardrailOutcome` that distinguishes a clean admission from a fail-open instead of collapsing both into an empty reason list. Recording happens at the one decision point in `guardLokiQuery`.
- `cmd/mcp-grafana/main.go`: wire `obs.MeterProvider()` into the config.
- Docs: a new "Loki cost guardrail metrics" section on the observability page covering how to read the counters during a rollout, plus pointers from the README metrics table and the CLI flags reference.

## Testing

`tools/loki_guardrail_metrics_test.go` drives `guardLokiQuery` against a manual-reader `MeterProvider` and asserts the exact counter and attribute set for: clean admission; shadow vs. enforce vs. unknown-mode (fail-closed, counts as `blocked`); each `reason` value; `selector` winning over a co-occurring `range`; both fail-open causes; a partial-total-over-budget that must count as a block rather than a fail-open; mode `off` recording nothing; the injected provider actually receiving the recordings; and a pin on the attribute keys so no unbounded attribute creeps in.

The existing guardrail unit tests were updated for the new return type and strengthened to assert reason kinds and fail-open causes rather than only prose.

`make lint` and `go test -tags unit ./...` pass.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)