### PR TITLE
fix(observability): bound the mcp.tool.phase metric label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `observability.ToolMetricDimensions` now bounds the `mcp.tool.phase` metric label against the `toolMetricDims` allowlist, like `mcp.tool.operation` and `mcp.tool.resource_type`. Phase is read from a tool result's `_meta`, and results proxied from an MCP-enabled datasource come from a remote server rather than from this repo, so the label was unbounded-cardinality in the general case. A tool that does not opt into `phases` now contributes no phase, and an opted-in tool reporting an unexpected value reports `other`. Behaviour is unchanged for every in-tree tool: `create_datasource` is the only producer, with `schema` and `created` ([#1094](https://github.com/grafana/mcp-grafana/issues/1094))
 - Distributed traces are no longer broken over the HTTP transports: the server now installs a global OTel `TextMapPropagator` (via `autoprop`, honouring `OTEL_PROPAGATORS`, default `tracecontext,baggage`), so an inbound `traceparent` continues the caller's trace and outbound Grafana API requests carry one of their own. Previously every hop started a disconnected trace. Trace context forwarded via `GRAFANA_FORWARD_HEADERS` no longer overrides the propagated value, which would have cut mcp-grafana out of the middle of the trace ([#1084](https://github.com/grafana/mcp-grafana/issues/1084))
 
 ## [1.1.0] - 2026-08-10

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -416,8 +416,8 @@ func toolNameFromMessage(method mcp.MCPMethod, message any) (string, bool) {
 	return req.Params.Name, true
 }
 
-// Attribute keys for tool-argument-derived telemetry dimensions. operation and
-// resourceType become metric labels once bounded by the toolMetricDims value
+// Attribute keys for tool telemetry dimensions. operation, resourceType and
+// phase become metric labels once bounded by the toolMetricDims value
 // allowlist; target is high-cardinality and span-only. Spans carry the raw,
 // unbounded values for all of them.
 const (
@@ -430,11 +430,16 @@ const (
 // ToolPhaseMetaKey is the result _meta key a tool sets to declare which phase of
 // a multi-call flow a given call represents — e.g. create_datasource's
 // schema-guidance response vs the actual creation. When present, its string
-// value is surfaced as the bounded mcp.tool.phase metric label (and span
-// attribute). Because it is read from the result, it reflects what the tool
-// actually did (e.g. a no-schema type that creates directly) rather than what
-// the request asked for. Tools MUST keep the value set bounded/low-cardinality,
-// since it becomes a Prometheus label.
+// value is surfaced as the mcp.tool.phase metric label, bounded by the
+// toolMetricDims allowlist, and as an unbounded span attribute. Because it is
+// read from the result, it reflects what the tool actually did (e.g. a no-schema
+// type that creates directly) rather than what the request asked for.
+//
+// A tool that declares a phase must also list its value set under phases in
+// toolMetricDims, or the phase is dropped from the metric entirely. The
+// allowlist — not the tool author — is what keeps the label low-cardinality:
+// results proxied from a remote MCP server are not authored in this repo, so
+// their _meta cannot be trusted to hold a bounded value.
 //
 // Living in result _meta, it is also transmitted to the client — intentional: a
 // non-sensitive flow-control signal for telling schema guidance from an actual
@@ -445,16 +450,17 @@ const ToolPhaseMetaKey = attrKeyToolPhase
 // into.
 const metricDimValueOther = "other"
 
-// metricDimSet declares which tool-argument-derived dimensions a given tool may
-// contribute as BOUNDED metric labels, and for each one the exact set of values
-// permitted. A nil set means the tool contributes nothing for that dimension.
+// metricDimSet declares which dimensions a given tool may contribute as BOUNDED
+// metric labels, and for each one the exact set of values permitted. A nil set
+// means the tool contributes nothing for that dimension.
 type metricDimSet struct {
 	operations    map[string]struct{}
 	resourceTypes map[string]struct{}
+	phases        map[string]struct{}
 }
 
-// toolMetricDims is the opt-in allowlist of which argument-derived dimensions
-// each tool may emit as metric labels, and which values those labels may carry.
+// toolMetricDims is the opt-in allowlist of which dimensions each tool may emit
+// as metric labels, and which values those labels may carry.
 // A label is emitted only for a listed tool, only for a dimension that tool
 // opts into, and only with a value in that dimension's set - everything else becomes metricDimValueOther
 var toolMetricDims = map[string]metricDimSet{
@@ -475,7 +481,13 @@ var toolMetricDims = map[string]metricDimSet{
 		"create_suite", "update_suite", "create_draft_version", "publish_version",
 		"upsert_test_case", "delete_test_case",
 	)},
-	"create_datasource": {resourceTypes: datasourcePluginTypes},
+	"create_datasource": {
+		resourceTypes: datasourcePluginTypes,
+		// Mirrors dsPhaseSchema/dsPhaseCreated in tools/datasources.go, which
+		// sets these on the result _meta. Duplicated rather than shared because
+		// tools imports this package, so the constants cannot be imported back.
+		phases: valueSet("schema", "created"),
+	},
 }
 
 // datasourcePluginTypes bounds create_datasource's mcp.tool.resource_type label
@@ -585,13 +597,15 @@ type ToolMetricDims struct {
 }
 
 // ToolMetricDimensions returns the metric-safe label dimensions for a tools/call,
-// applying the same tool-and-value allowlist the server's own metrics use:
-// argument-derived values outside the allowed set come back as "other", so the
-// returned Operation/ResourceType are safe to use as labels for any input. It
-// lets external consumers (e.g. the hosted Cloud MCP server, which records tool
-// metrics via its own middleware) stay in lockstep with the allowlist instead of
-// re-deriving it. args is the raw argument map (request.GetArguments()); result
-// is the *mcp.CallToolResult for the phase, and may be nil on the error path.
+// applying the same tool-and-value allowlist the server's own metrics use: a
+// value outside the allowed set comes back as "other", so every field of the
+// returned struct is safe to use as a label for any input — including Phase,
+// which is read from the result and therefore remote-controlled for tools
+// proxied from another MCP server. It lets external consumers (e.g. the hosted
+// Cloud MCP server, which records tool metrics via its own middleware) stay in
+// lockstep with the allowlist instead of re-deriving it. args is the raw
+// argument map (request.GetArguments()); result is the *mcp.CallToolResult for
+// the phase, and may be nil on the error path.
 func ToolMetricDimensions(toolName string, args map[string]any, result any) ToolMetricDims {
 	allowed := toolMetricDims[toolName]
 	var d ToolMetricDims
@@ -601,7 +615,9 @@ func ToolMetricDimensions(toolName string, args map[string]any, result any) Tool
 	if allowed.resourceTypes != nil {
 		d.ResourceType = boundedMetricValue(stringArg(args, "type"), allowed.resourceTypes)
 	}
-	d.Phase = toolPhaseFromResult(result)
+	if allowed.phases != nil {
+		d.Phase = boundedMetricValue(toolPhaseFromResult(result), allowed.phases)
+	}
 	return d
 }
 
@@ -628,6 +644,10 @@ func (o *Observability) enrichSpanWithToolDims(ctx context.Context, method mcp.M
 	if dims.target != "" {
 		spanAttrs = append(spanAttrs, attribute.String(attrKeyToolTarget, dims.target))
 	}
+	// Raw, unbounded — as with operation and resourceType above, and for the
+	// same reason: span attributes are not metric-series dimensions, and a span
+	// carrying the phase a proxied server actually reported is more useful for
+	// debugging than one collapsed to "other".
 	if phase := toolPhaseFromResult(result); phase != "" {
 		spanAttrs = append(spanAttrs, attribute.String(attrKeyToolPhase, phase))
 	}

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -987,7 +987,7 @@ func TestToolMetricDimensions(t *testing.T) {
 		assert.Equal(t, ToolMetricDims{}, got)
 	})
 
-	t.Run("phase is read from result regardless of allowlist", func(t *testing.T) {
+	t.Run("allowlisted phase is read from the result", func(t *testing.T) {
 		got := ToolMetricDimensions("create_datasource",
 			map[string]any{"type": "loki"}, mkResult("created"))
 		assert.Equal(t, ToolMetricDims{ResourceType: "loki", Phase: "created"}, got)
@@ -1028,6 +1028,128 @@ func TestToolMetricDimensions(t *testing.T) {
 			facade[attrKeyToolPhase] = d.Phase
 		}
 		assert.Equal(t, fromAttrs, facade)
+	})
+}
+
+func TestToolMetricDimensionsPhaseIsBounded(t *testing.T) {
+	// Phase comes from the result's _meta, and a proxied tool's result is
+	// produced by a remote MCP server rather than by this repo — so the phase
+	// must be bounded by the allowlist exactly like the argument-derived
+	// dimensions, not trusted to be low-cardinality.
+	mkResult := func(meta map[string]any) *mcp.CallToolResult {
+		r := mcp.NewToolResultText("{}")
+		if meta != nil {
+			r.Meta = &mcp.Meta{AdditionalFields: meta}
+		}
+		return r
+	}
+
+	tests := []struct {
+		name     string
+		toolName string
+		result   any
+		want     string
+	}{
+		{
+			// The case that matters: a tool proxied from an MCP-enabled
+			// datasource can put anything in _meta, and it must not reach a label.
+			name:     "tool absent from the allowlist contributes no phase",
+			toolName: "tempo_traceql-search",
+			result:   mkResult(map[string]any{ToolPhaseMetaKey: "attacker-chosen-" + strings.Repeat("x", 32)}),
+			want:     "",
+		},
+		{
+			name:     "allowlisted tool that does not opt into phases contributes no phase",
+			toolName: "alerting_manage_rules",
+			result:   mkResult(map[string]any{ToolPhaseMetaKey: "created"}),
+			want:     "",
+		},
+		{
+			name:     "opted-in tool passes through an allowed phase (schema)",
+			toolName: "create_datasource",
+			result:   mkResult(map[string]any{ToolPhaseMetaKey: "schema"}),
+			want:     "schema",
+		},
+		{
+			name:     "opted-in tool passes through an allowed phase (created)",
+			toolName: "create_datasource",
+			result:   mkResult(map[string]any{ToolPhaseMetaKey: "created"}),
+			want:     "created",
+		},
+		{
+			name:     "opted-in tool collapses an unexpected phase to other",
+			toolName: "create_datasource",
+			result:   mkResult(map[string]any{ToolPhaseMetaKey: "not-a-real-phase-7b1e"}),
+			want:     metricDimValueOther,
+		},
+		{
+			// Absent stays absent rather than becoming "other", matching
+			// boundedMetricValue's semantics for the other dimensions.
+			name:     "meta without a phase key stays empty",
+			toolName: "create_datasource",
+			result:   mkResult(map[string]any{"other": "x"}),
+			want:     "",
+		},
+		{
+			name:     "result without meta stays empty",
+			toolName: "create_datasource",
+			result:   mkResult(nil),
+			want:     "",
+		},
+		{
+			name:     "non-string phase stays empty",
+			toolName: "create_datasource",
+			result:   mkResult(map[string]any{ToolPhaseMetaKey: 42}),
+			want:     "",
+		},
+		{
+			name:     "nil result stays empty",
+			toolName: "create_datasource",
+			result:   nil,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToolMetricDimensions(tt.toolName, nil, tt.result)
+			assert.Equal(t, tt.want, got.Phase)
+		})
+	}
+
+	t.Run("phase cardinality is bounded regardless of remote input", func(t *testing.T) {
+		seen := map[string]struct{}{}
+		for _, injected := range []string{"a", "b", "c", "schema", "created", "created'; DROP", ""} {
+			d := ToolMetricDimensions("create_datasource", nil,
+				mkResult(map[string]any{ToolPhaseMetaKey: injected}))
+			seen[d.Phase] = struct{}{}
+		}
+		// "", "schema", "created" and one shared "other" bucket — the four junk
+		// values do not each mint a series.
+		assert.Len(t, seen, 4)
+	})
+
+	t.Run("every phase create_datasource declares is allowlisted", func(t *testing.T) {
+		// Guards the duplicated literals: tools/datasources.go declares
+		// dsPhaseSchema/dsPhaseCreated, and this package cannot import them.
+		for _, phase := range []string{"schema", "created"} {
+			got := ToolMetricDimensions("create_datasource", nil,
+				mkResult(map[string]any{ToolPhaseMetaKey: phase}))
+			assert.Equal(t, phase, got.Phase)
+		}
+	})
+
+	t.Run("buildOperationAttrs drops an un-allowlisted tool's phase", func(t *testing.T) {
+		obs := &Observability{}
+		req := &mcp.CallToolRequest{}
+		req.Params.Name = "tempo_traceql-search"
+
+		attrs := obs.buildOperationAttrs(context.Background(), "tools/call", req,
+			mkResult(map[string]any{ToolPhaseMetaKey: "remote-chosen"}), nil)
+
+		for _, a := range attrs {
+			assert.NotEqual(t, attrKeyToolPhase, string(a.Key))
+		}
 	})
 }
 

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -28,7 +28,9 @@ const (
 // create_datasource telemetry phases, declared on the tool result via
 // observability.ToolPhaseMetaKey so the server's per-call metric/span can
 // distinguish a schema-guidance call from an actual creation. Keep this set
-// small — the value becomes a bounded Prometheus label (mcp_tool_phase).
+// small — the value becomes a bounded Prometheus label (mcp_tool_phase). Adding
+// a phase here means adding it to create_datasource's phases set in
+// observability.toolMetricDims too, or the metric drops it.
 const (
 	dsPhaseSchema  = "schema"  // returned field guidance (schema or no-schema); nothing created
 	dsPhaseCreated = "created" // a datasource was created


### PR DESCRIPTION
`ToolMetricDimensions` bounded `Operation` and `ResourceType` against the `toolMetricDims` allowlist but forwarded `Phase` through unbounded. Phase is read from a tool result's `_meta`, and a proxied tool's result comes back from a remote MCP server behind a datasource rather than being authored here — `ProxiedToolHandler.Handle` returns the remote `*mcp.CallToolResult` unchanged, `Meta` included — so `ToolPhaseMetaKey`'s "tools MUST keep the value set bounded" contract does not hold for it. A remote server could therefore drive an unbounded-cardinality Prometheus label in any embedder that trusts `ToolMetricDimensions`' documented label-safety promise.

## What changed

- `metricDimSet` gains a `phases` set, and `Phase` now goes through `boundedMetricValue` like the other two dimensions: a tool absent from `toolMetricDims` or not opting into `phases` contributes **no** phase, an opted-in tool reporting an unexpected value reports `other`, and an absent phase stays `""` rather than becoming `other`.
- `create_datasource` opts in with `schema` / `created`. It's the only in-tree producer, so behaviour is unchanged for every shipped tool.
- Doc comments corrected: `ToolMetricDimensions`' label-safety sentence now covers the whole struct rather than just `Operation`/`ResourceType`, and `ToolPhaseMetaKey` now says the allowlist — not the tool author — is what keeps the label bounded, since a proxied result has no author here.

## Two notes on the issue's suggested fix

**The snippet doesn't compile as written.** `phases: valueSet(dsPhaseSchema, dsPhaseCreated)` can't work: those constants are unexported in `tools/datasources.go`, and `tools` imports `observability`, so importing them back is an import cycle. This PR uses literals with comments tying the two sites together in both directions — matching how every other entry in `toolMetricDims` already duplicates its operation values as literals (`"list"`, `"create"`, …). Moving the constants into `observability` was the other option, but it would put two tool-specific values into a shared package's public API while the equivalent operation values stay as literals. A test asserts both declared phases are allowlisted, so the duplication can't silently drift.

**The span path deliberately keeps the raw value.** The issue flags `enrichSpanWithToolDims` as a nice-to-have, and I've left it unbounded on purpose: the file's existing convention is span-raw / metric-bounded for the *same* attribute keys — `mcp.tool.operation` and `mcp.tool.resource_type` are already raw on spans and bounded on metrics, and `mcp.tool.target` (uid/name) is unbounded on spans by design. Span attributes are not metric-series dimensions, and a span carrying the phase a proxied server actually reported is more useful for debugging a misbehaving remote than one collapsed to `other`. Bounding phase alone there would break the convention and lose exactly the information you'd want. There's now a comment at that line saying so. Happy to change it if you'd rather have uniformity.

## Testing

`go test -tags unit -count=1 ./observability/ ./tools/` — green.

New table-driven `TestToolMetricDimensionsPhaseIsBounded` covers: a tool absent from the allowlist reporting a phase (using a proxied-style name, `tempo_traceql-search`), an allowlisted tool that doesn't opt into `phases`, both allowed `create_datasource` values, an unexpected value collapsing to `other`, absent/no-`_meta`/non-string/nil-result staying empty, plus a cardinality-bounding check and a `buildOperationAttrs` end-to-end assertion.

I verified the tests are actually load-bearing: stashing the production change turns 5 of them red (including the proxied-tool case and the `other` collapse), and restoring it turns them green.

Fixes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)