### PR TITLE
chore(deps): bump mcp-go from v0.55.0 to v0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped `mcp-go` from v0.55.0 to v0.58.0, picking up fixes for tool-filter scans on the `tools/call` hot path, raw JSON preservation for tool arguments and `structuredContent`, schema tags on nested fields, multi-line SSE `data` fields, and HEAD requests returning 200. This also inherits mcp-go's new default-on DNS rebinding protection, which returns 403 when a request arrives over a loopback connection with a non-loopback `Host` header — a second check underneath `DNSRebindingProtectionMiddleware` that `--allowed-hosts` cannot loosen. Default deployments are unaffected, since `DefaultAllowedHosts` already restricts `Host` to loopback variants; operators who widen `--allowed-hosts` while a same-host reverse proxy forwards over loopback preserving a non-localhost `Host` should configure the proxy to rewrite `Host` to localhost ([#1097](https://github.com/grafana/mcp-grafana/pull/1097))
 - `tools.Stats.Bytes` is now `int64` (was `int`) so index/stats byte counts cannot overflow on 32-bit platforms; Go API consumers of the exported struct may need a cast ([#1031](https://github.com/grafana/mcp-grafana/pull/1031))
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grafana/pyroscope/api v1.3.2
 	github.com/invopop/jsonschema v0.13.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/mark3labs/mcp-go v0.55.0
+	github.com/mark3labs/mcp-go v0.58.0
 	github.com/prometheus/alertmanager v0.31.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
@@ -24,6 +24,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0
+	go.opentelemetry.io/contrib/propagators/autoprop v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
@@ -150,7 +151,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.67.0 // indirect
-	go.opentelemetry.io/contrib/propagators/autoprop v0.68.0 // indirect
 	go.opentelemetry.io/contrib/propagators/aws v1.43.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.43.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,12 +104,8 @@ github.com/go-openapi/analysis v0.24.3 h1:a1hrvMr8X0Xt69KP5uVTu5jH62DscmDifrLzNg
 github.com/go-openapi/analysis v0.24.3/go.mod h1:Nc+dWJ/FxZbhSow5Yh3ozg5CLJioB+XXT6MdLvJUsUw=
 github.com/go-openapi/errors v0.22.7 h1:JLFBGC0Apwdzw3484MmBqspjPbwa2SHvpDm0u5aGhUA=
 github.com/go-openapi/errors v0.22.7/go.mod h1://QW6SD9OsWtH6gHllUCddOXDL0tk0ZGNYHwsw4sW3w=
-github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
-github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxgL3h1H8s=
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
-github.com/go-openapi/jsonreference v0.21.5 h1:6uCGVXU/aNF13AQNggxfysJ+5ZcU4nEAe+pJyVWRdiE=
-github.com/go-openapi/jsonreference v0.21.5/go.mod h1:u25Bw85sX4E2jzFodh1FOKMTZLcfifd1Q+iKKOUxExw=
 github.com/go-openapi/jsonreference v1.0.0 h1:jlmTr6torcd1YgDQvSfNmRtKzYDO4FGBkrAdlAVWnpY=
 github.com/go-openapi/jsonreference v1.0.0/go.mod h1:jtwdyGbJk0Xhe5Y+rwtglQP6Sb1WZST4rT32LWB+sv0=
 github.com/go-openapi/loads v0.23.3 h1:g5Xap1JfwKkUnZdn+S0L3SzBDpcTIYzZ5Qaag0YDkKQ=
@@ -148,8 +144,8 @@ github.com/go-openapi/swag/yamlutils v0.25.5 h1:kASCIS+oIeoc55j28T4o8KwlV2S4ZLPT
 github.com/go-openapi/swag/yamlutils v0.25.5/go.mod h1:Gek1/SjjfbYvM+Iq4QGwa/2lEXde9n2j4a3wI3pNuOQ=
 github.com/go-openapi/testify/enable/yaml/v2 v2.4.1 h1:NZOrZmIb6PTv5LTFxr5/mKV/FjbUzGE7E6gLz7vFoOQ=
 github.com/go-openapi/testify/enable/yaml/v2 v2.4.1/go.mod h1:r7dwsujEHawapMsxA69i+XMGZrQ5tRauhLAjV/sxg3Q=
-github.com/go-openapi/testify/v2 v2.4.1 h1:zB34HDKj4tHwyUQHrUkpV0Q0iXQ6dUCOQtIqn8hE6Iw=
-github.com/go-openapi/testify/v2 v2.4.1/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
+github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
+github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
 github.com/go-openapi/validate v0.25.2 h1:12NsfLAwGegqbGWr2CnvT65X/Q2USJipmJ9b7xDJZz0=
 github.com/go-openapi/validate v0.25.2/go.mod h1:Pgl1LpPPGFnZ+ys4/hTlDiRYQdI1ocKypgE+8Q8BLfY=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
@@ -254,8 +250,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/mark3labs/mcp-go v0.55.0 h1:lJfz2aoctiwK+sI991+uIYwmKNIBciI+O7zsyDsa4U8=
-github.com/mark3labs/mcp-go v0.55.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
+github.com/mark3labs/mcp-go v0.58.0 h1:AWfBk8lgRR0KZYve7PaLbR2MIjpw1oK2eGpBApaNS+Q=
+github.com/mark3labs/mcp-go v0.58.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
 github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mattetti/filebuffer v1.0.1 h1:gG7pyfnSIZCxdoKq+cPa8T0hhYtD9NxCdI4D7PTjRLM=
@@ -371,8 +367,6 @@ go.opentelemetry.io/contrib/propagators/aws v1.43.0 h1:EwnsB3cXRLAh7/Nr/9rMuGw73
 go.opentelemetry.io/contrib/propagators/aws v1.43.0/go.mod h1:CJjTym6F87tEdm61Qvnz5xrV8vKlH4C92djiqcn62k8=
 go.opentelemetry.io/contrib/propagators/b3 v1.43.0 h1:CETqV3QLLPTy5yNrqyMr41VnAOOD4lsRved7n4QG00A=
 go.opentelemetry.io/contrib/propagators/b3 v1.43.0/go.mod h1:Q4mCiCdziYzpNR0g+6UqVotAlCDZdzz6L8jwY4knOrw=
-go.opentelemetry.io/contrib/propagators/jaeger v1.40.0 h1:aXl9uobjJs5vquMLt9ZkI/3zIuz8XQ3TqOKSWx0/xdU=
-go.opentelemetry.io/contrib/propagators/jaeger v1.40.0/go.mod h1:ioMePqe6k6c/ovXSkmkMr1mbN5qRBGJxNTVop7/2XO0=
 go.opentelemetry.io/contrib/propagators/jaeger v1.43.0 h1:peiLMz1+aqJE+3L4mOVtR9wlmv+yh/JVYXCBjqmzJJE=
 go.opentelemetry.io/contrib/propagators/jaeger v1.43.0/go.mod h1:Agvif+4A8p/3UtZzJ0MCcDEuQwgtrzM71DueU41DCs8=
 go.opentelemetry.io/contrib/propagators/ot v1.43.0 h1:Hh1HahlGc81AOE7siqi1tVOlbanY/UxMMWedpb0d5oQ=


### PR DESCRIPTION
## Summary

Bumps `github.com/mark3labs/mcp-go` from v0.55.0 to v0.58.0 (latest stable — v1.0.0-beta.1 is a prerelease and not a candidate).

No mcp-grafana code needed changing: `go build ./...`, `go vet ./...`, `make test-unit` and `make lint` all pass with only `go.mod` and `go.sum` touched.

The range is 24 commits, 22 of them `fix` or `docs`.

## Fixes picked up

- Avoid full tool-filter scans on the `tools/call` hot path ([#908](https://github.com/mark3labs/mcp-go/pull/908))
- Stop forwarding inbound request headers on outbound client calls ([#909](https://github.com/mark3labs/mcp-go/pull/909))
- Preserve raw JSON for tool arguments and `structuredContent` ([#916](https://github.com/mark3labs/mcp-go/pull/916))
- Preserve schema tags on nested fields ([#920](https://github.com/mark3labs/mcp-go/pull/920))
- Support `jsonschema_description` and `enum` struct tags ([#931](https://github.com/mark3labs/mcp-go/pull/931))
- Concatenate rather than overwrite multi-line SSE `data` fields ([#927](https://github.com/mark3labs/mcp-go/pull/927))
- Return 200 rather than 404 for HEAD requests ([#937](https://github.com/mark3labs/mcp-go/pull/937))
- Close active sessions before `Shutdown` ([#926](https://github.com/mark3labs/mcp-go/pull/926))
- Refuse unsupported `subscribe` requests ([#946](https://github.com/mark3labs/mcp-go/pull/946))

## Behavior change worth a maintainer's eye

Two commits in the range are features. Stream resumability via a pluggable `EventStore` ([#930](https://github.com/mark3labs/mcp-go/pull/930)) is purely additive and opt-in. **Automatic DNS rebinding protection for localhost ([#921](https://github.com/mark3labs/mcp-go/pull/921)) is on by default** and is worth a look, because it lands underneath our own `DNSRebindingProtectionMiddleware` as a second host check that `--allowed-hosts` cannot loosen.

It returns 403 when the accepted connection's local address is loopback but the `Host` header is not a loopback value. Because it reads the *accepted socket's* local address rather than the bind address, it applies to `0.0.0.0` binds reached over a loopback hop, not only to explicit loopback binds. Upstream provides `server.WithDisableLocalhostProtection` as the opt-out; this PR does not wire it up.

**Default deployments are unaffected.** `DefaultAllowedHosts` already restricts `Host` to loopback variants for wildcard and localhost binds, so our own middleware rejects those requests first.

The reachable case is an operator who widens `--allowed-hosts` (including to `*`) while a same-host reverse proxy forwards over loopback preserving a non-localhost `Host`. That is already the configuration `--allowed-hosts` warns against — its help text calls `*` safe only behind a proxy that *rewrites* `Host`, and a proxy that rewrites `Host` to localhost stays compatible. So I've left the new protection enabled rather than opting out, on the grounds that it enforces what our own flag documentation already recommends.

If you'd rather `--allowed-hosts` stay authoritative, the fix is to pass `server.WithDisableLocalhostProtection(true)` when the operator sets it explicitly — happy to add that here.

## Testing

- `go build ./...` and `go vet ./...` clean
- `make test-unit` — all 7 packages pass, 0 failures
- `make lint` — 0 issues (jsonschema, openapi, gofmt, golangci-lint)
- Integration/cloud/E2E suites not run locally (require docker-compose services and cloud credentials); relying on CI for those

🤖 Generated with [Claude Code](https://claude.com/claude-code)