### PR TITLE
fix(auth): reload token file for stdio requests

### DIFF
--- a/client_cache.go
+++ b/client_cache.go
@@ -361,8 +361,8 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 		if config.OrgID == 0 {
 			logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 		}
-
 		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
+		ctx = markRequestScopedAuth(ctx, req)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)
 
 		grafanaClient := cache.GetOrCreateGrafanaClient(key, func() *GrafanaClient {

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -1325,9 +1325,6 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 							IdleConnTimeout:       90 * time.Second,
 						}
 					}
-					if tokenFile := serviceAccountTokenFileFromEnv(); tokenFile != "" {
-						base = &tokenFileRoundTripper{path: tokenFile, underlying: base}
-					}
 					// Use BuildTransport but skip APIKey/BasicAuth auth
 					// (handled by the OpenAPI client). OBO tokens still need
 					// transport-level injection since the OpenAPI client
@@ -1348,6 +1345,13 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 					wrapped, err := BuildTransport(&oboConfig, base)
 					if err != nil {
 						panic(fmt.Errorf("failed to build transport: %w", err))
+					}
+					if tokenFile := serviceAccountTokenFileFromEnv(); tokenFile != "" && tokenFileMatchesAPIKey(tokenFile, apiKey) {
+						wrapped = &tokenFileRoundTripper{
+							path:          tokenFile,
+							fallbackToken: apiKey,
+							underlying:    wrapped,
+						}
 					}
 					transportField.Set(reflect.ValueOf(wrapped))
 					logger.Debug("HTTP tracing, user agent tracking, and timeout enabled for Grafana client", "timeout", timeout)

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -206,6 +206,28 @@ func apiKeyFromHeaders(req *http.Request) string {
 	return req.Header.Get(grafanaAPIKeyHeader)
 }
 
+type requestScopedAuthContextKey struct{}
+
+func requestHasGrafanaCredentials(req *http.Request) bool {
+	if apiKeyFromHeaders(req) != "" || req.Header.Get("Authorization") != "" {
+		return true
+	}
+	username, password, _ := req.BasicAuth()
+	return username != "" || password != ""
+}
+
+func markRequestScopedAuth(ctx context.Context, req *http.Request) context.Context {
+	if !requestHasGrafanaCredentials(req) {
+		return ctx
+	}
+	return context.WithValue(ctx, requestScopedAuthContextKey{}, true)
+}
+
+func requestScopedAuthIsProtected(ctx context.Context) bool {
+	protected, _ := ctx.Value(requestScopedAuthContextKey{}).(bool)
+	return protected
+}
+
 // grafanaConfigKey is the context key for Grafana configuration.
 type grafanaConfigKey struct{}
 
@@ -572,6 +594,9 @@ func (t *ExtraHeadersRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	if len(headers) > 0 {
 		propagated := propagatedHeaderFields()
 		for k, v := range headers {
+			if tokenFileAuthIsProtected(clonedReq.Context()) && isTokenFileCredentialHeader(textproto.CanonicalMIMEHeaderKey(k)) {
+				continue
+			}
 			// Never overwrite a trace-context header the OTel propagator has
 			// already injected for this request. A traceparent forwarded from
 			// the incoming request (GRAFANA_FORWARD_HEADERS) names the caller's
@@ -647,9 +672,9 @@ func (rt *AuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	if accessToken != "" && idToken != "" {
 		clonedReq.Header.Set("X-Access-Token", accessToken)
 		clonedReq.Header.Set("X-Grafana-Id", idToken)
-	} else if apiKey != "" {
+	} else if apiKey != "" && !tokenFileAuthIsProtected(clonedReq.Context()) {
 		clonedReq.Header.Set("Authorization", "Bearer "+apiKey)
-	} else if basicAuth != nil {
+	} else if basicAuth != nil && !tokenFileAuthIsProtected(clonedReq.Context()) {
 		password, _ := basicAuth.Password()
 		clonedReq.SetBasicAuth(basicAuth.Username(), password)
 	}
@@ -779,14 +804,32 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 
 	// TLS
 	if cfg.TLSConfig != nil {
-		t, ok := base.(*http.Transport)
+		tlsBase := base
+		var restoreTokenFile func(http.RoundTripper) http.RoundTripper
+		if tokenFileTransport, ok := base.(*tokenFileRoundTripper); ok {
+			if _, ok := tokenFileTransport.underlying.(*http.Transport); !ok {
+				return nil, fmt.Errorf("cannot apply TLS configuration to token-file transport around %T", tokenFileTransport.underlying)
+			}
+			// Apply TLS to the network transport without discarding the
+			// token-file layer that reloads credentials for every request.
+			tlsBase = tokenFileTransport.underlying
+			restoreTokenFile = func(transport http.RoundTripper) http.RoundTripper {
+				wrapped := *tokenFileTransport
+				wrapped.underlying = transport
+				return &wrapped
+			}
+		}
+		t, ok := tlsBase.(*http.Transport)
 		if !ok {
-			t = http.DefaultTransport.(*http.Transport).Clone()
+			return nil, fmt.Errorf("cannot apply TLS configuration to non-*http.Transport base %T", tlsBase)
 		}
 		var err error
 		transport, err = cfg.TLSConfig.HTTPTransport(t)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create TLS transport: %w", err)
+		}
+		if restoreTokenFile != nil {
+			transport = restoreTokenFile(transport)
 		}
 	}
 
@@ -914,7 +957,7 @@ var ExtractGrafanaInfoFromHeaders httpContextFunc = func(ctx context.Context, re
 	config.OrgID = orgID
 
 	config.ExtraHeaders = mergeHeaders(extraHeadersFromEnv(logger), forwardedHeadersFromRequest(req))
-	return WithGrafanaConfig(ctx, config)
+	return WithGrafanaConfig(markRequestScopedAuth(ctx, req), config)
 }
 
 // WithOnBehalfOfAuth adds the Grafana access token and user token to the Grafana config.
@@ -1243,7 +1286,15 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 		cfg.Schemes = []string{"http"}
 	}
 
-	if apiKey != "" {
+	tokenFile := serviceAccountTokenFileFromEnv()
+	// A file configured for stdio remains authoritative even when the
+	// deprecated GRAFANA_API_KEY fallback is also present. HTTP requests that
+	// supplied credentials in their headers are explicitly request-scoped and
+	// must not be converted into file-rotation clients, even if the values
+	// happen to match the file at construction time.
+	tokenFileRotation := tokenFile != "" && !requestScopedAuthIsProtected(ctx) &&
+		(tokenFileMatchesAPIKey(tokenFile, apiKey) || os.Getenv(grafanaAPIEnvVar) != "")
+	if apiKey != "" && !tokenFileRotation {
 		cfg.APIKey = apiKey
 	}
 
@@ -1346,7 +1397,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 					if err != nil {
 						panic(fmt.Errorf("failed to build transport: %w", err))
 					}
-					if tokenFile := serviceAccountTokenFileFromEnv(); tokenFile != "" && tokenFileMatchesAPIKey(tokenFile, apiKey) {
+					if tokenFileRotation {
 						wrapped = &tokenFileRoundTripper{
 							path:          tokenFile,
 							fallbackToken: apiKey,
@@ -1407,6 +1458,7 @@ var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, 
 	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
 	logger.Debug("Creating Grafana client", "url", u, "api_key_set", apiKey != "", "basic_auth_set", basicAuth != nil)
 
+	ctx = markRequestScopedAuth(ctx, req)
 	grafanaClient := NewGrafanaClient(ctx, u, apiKey, basicAuth)
 	return WithGrafanaClient(ctx, grafanaClient)
 }

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -807,29 +807,32 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 		tlsBase := base
 		var restoreTokenFile func(http.RoundTripper) http.RoundTripper
 		if tokenFileTransport, ok := base.(*tokenFileRoundTripper); ok {
-			if _, ok := tokenFileTransport.underlying.(*http.Transport); !ok {
-				return nil, fmt.Errorf("cannot apply TLS configuration to token-file transport around %T", tokenFileTransport.underlying)
-			}
-			// Apply TLS to the network transport without discarding the
-			// token-file layer that reloads credentials for every request.
-			tlsBase = tokenFileTransport.underlying
-			restoreTokenFile = func(transport http.RoundTripper) http.RoundTripper {
-				wrapped := *tokenFileTransport
-				wrapped.underlying = transport
-				return &wrapped
+			if underlying, ok := tokenFileTransport.underlying.(*http.Transport); ok {
+				// Apply TLS to the network transport without discarding the
+				// token-file layer that reloads credentials for every request.
+				tlsBase = underlying
+				restoreTokenFile = func(transport http.RoundTripper) http.RoundTripper {
+					wrapped := *tokenFileTransport
+					wrapped.underlying = transport
+					return &wrapped
+				}
 			}
 		}
 		t, ok := tlsBase.(*http.Transport)
 		if !ok {
-			return nil, fmt.Errorf("cannot apply TLS configuration to non-*http.Transport base %T", tlsBase)
-		}
-		var err error
-		transport, err = cfg.TLSConfig.HTTPTransport(t)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create TLS transport: %w", err)
-		}
-		if restoreTokenFile != nil {
-			transport = restoreTokenFile(transport)
+			// A custom RoundTripper owns its connection and TLS behavior. Keep
+			// it intact when the TLS options cannot be applied through the
+			// *http.Transport API.
+			transport = base
+		} else {
+			var err error
+			transport, err = cfg.TLSConfig.HTTPTransport(t)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create TLS transport: %w", err)
+			}
+			if restoreTokenFile != nil {
+				transport = restoreTokenFile(transport)
+			}
 		}
 	}
 

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -1325,6 +1325,9 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 							IdleConnTimeout:       90 * time.Second,
 						}
 					}
+					if tokenFile := serviceAccountTokenFileFromEnv(); tokenFile != "" {
+						base = &tokenFileRoundTripper{path: tokenFile, underlying: base}
+					}
 					// Use BuildTransport but skip APIKey/BasicAuth auth
 					// (handled by the OpenAPI client). OBO tokens still need
 					// transport-level injection since the OpenAPI client

--- a/token_file_transport.go
+++ b/token_file_transport.go
@@ -1,0 +1,37 @@
+package mcpgrafana
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// tokenFileRoundTripper injects the current service-account token from disk into
+// each request. This keeps long-lived stdio servers compatible with rotated
+// token files without rebuilding the static stdio context.
+type tokenFileRoundTripper struct {
+	path       string
+	underlying http.RoundTripper
+}
+
+func serviceAccountTokenFileFromEnv() string {
+	if os.Getenv(grafanaServiceAccountTokenEnvVar) != "" || os.Getenv(grafanaAPIEnvVar) != "" {
+		return ""
+	}
+	return os.Getenv(grafanaServiceAccountTokenFileEnvVar)
+}
+
+func (t *tokenFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := os.ReadFile(t.path)
+	if err != nil {
+		return nil, fmt.Errorf("read Grafana service account token file: %w", err)
+	}
+
+	clonedReq := req.Clone(req.Context())
+	clonedReq.Header.Del("Authorization")
+	if token := strings.TrimSpace(string(token)); token != "" {
+		clonedReq.Header.Set("Authorization", "Bearer "+token)
+	}
+	return t.underlying.RoundTrip(clonedReq)
+}

--- a/token_file_transport.go
+++ b/token_file_transport.go
@@ -67,6 +67,9 @@ func (t *tokenFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	token, err := os.ReadFile(t.path)
 	if err != nil {
 		if t.fallbackToken != "" {
+			if authorization == "" || authorization == "Bearer "+strings.TrimSpace(t.fallbackToken) {
+				clonedReq.Header.Set("Authorization", "Bearer "+strings.TrimSpace(t.fallbackToken))
+			}
 			return t.underlying.RoundTrip(markTokenFileAuth(clonedReq))
 		}
 		return nil, fmt.Errorf("read Grafana service account token file: %w", err)

--- a/token_file_transport.go
+++ b/token_file_transport.go
@@ -1,8 +1,10 @@
 package mcpgrafana
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"os"
 	"strings"
 )
@@ -14,6 +16,26 @@ type tokenFileRoundTripper struct {
 	path          string
 	fallbackToken string
 	underlying    http.RoundTripper
+}
+
+// tokenFileAuthContextKey marks a request whose credentials must not be
+// replaced by the static auth middleware or extra headers.
+type tokenFileAuthContextKey struct{}
+
+func markTokenFileAuth(req *http.Request) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), tokenFileAuthContextKey{}, true))
+}
+
+func tokenFileAuthIsProtected(ctx context.Context) bool {
+	protected, _ := ctx.Value(tokenFileAuthContextKey{}).(bool)
+	return protected
+}
+
+func isTokenFileCredentialHeader(name string) bool {
+	canonical := textproto.CanonicalMIMEHeaderKey(name)
+	return canonical == textproto.CanonicalMIMEHeaderKey("Authorization") ||
+		canonical == textproto.CanonicalMIMEHeaderKey(grafanaServiceAccountTokenHeader) ||
+		canonical == textproto.CanonicalMIMEHeaderKey(grafanaAPIKeyHeader)
 }
 
 func serviceAccountTokenFileFromEnv() string {
@@ -33,21 +55,35 @@ func tokenFileMatchesAPIKey(path, apiKey string) bool {
 
 func (t *tokenFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	clonedReq := req.Clone(req.Context())
+	authorization := clonedReq.Header.Get("Authorization")
+	if clonedReq.Header.Get(grafanaServiceAccountTokenHeader) != "" ||
+		clonedReq.Header.Get(grafanaAPIKeyHeader) != "" {
+		if authorization == "Bearer "+strings.TrimSpace(t.fallbackToken) {
+			clonedReq.Header.Del("Authorization")
+		}
+		return t.underlying.RoundTrip(markTokenFileAuth(clonedReq))
+	}
+
 	token, err := os.ReadFile(t.path)
 	if err != nil {
 		if t.fallbackToken != "" {
-			return t.underlying.RoundTrip(clonedReq)
+			return t.underlying.RoundTrip(markTokenFileAuth(clonedReq))
 		}
 		return nil, fmt.Errorf("read Grafana service account token file: %w", err)
 	}
 
-	if authorization := clonedReq.Header.Get("Authorization"); authorization != "" &&
+	// The OpenAPI runtime adds the configured API key before invoking the
+	// transport. That value is the fallbackToken captured at client creation;
+	// replace it with the current file contents so rotation is observable. Any
+	// other Authorization value is request-scoped and must win over the file.
+	if authorization != "" &&
 		(t.fallbackToken == "" || authorization != "Bearer "+strings.TrimSpace(t.fallbackToken)) {
-		return t.underlying.RoundTrip(clonedReq)
+		return t.underlying.RoundTrip(markTokenFileAuth(clonedReq))
 	}
 	clonedReq.Header.Del("Authorization")
-	if token := strings.TrimSpace(string(token)); token != "" {
-		clonedReq.Header.Set("Authorization", "Bearer "+token)
+	tokenValue := strings.TrimSpace(string(token))
+	if tokenValue != "" {
+		clonedReq.Header.Set("Authorization", "Bearer "+tokenValue)
 	}
-	return t.underlying.RoundTrip(clonedReq)
+	return t.underlying.RoundTrip(markTokenFileAuth(clonedReq))
 }

--- a/token_file_transport.go
+++ b/token_file_transport.go
@@ -46,11 +46,14 @@ func serviceAccountTokenFileFromEnv() string {
 }
 
 func tokenFileMatchesAPIKey(path, apiKey string) bool {
+	token, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
 	if apiKey == "" {
 		return true
 	}
-	token, err := os.ReadFile(path)
-	return err == nil && strings.TrimSpace(string(token)) == strings.TrimSpace(apiKey)
+	return strings.TrimSpace(string(token)) == strings.TrimSpace(apiKey)
 }
 
 func (t *tokenFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/token_file_transport.go
+++ b/token_file_transport.go
@@ -11,24 +11,40 @@ import (
 // each request. This keeps long-lived stdio servers compatible with rotated
 // token files without rebuilding the static stdio context.
 type tokenFileRoundTripper struct {
-	path       string
-	underlying http.RoundTripper
+	path          string
+	fallbackToken string
+	underlying    http.RoundTripper
 }
 
 func serviceAccountTokenFileFromEnv() string {
-	if os.Getenv(grafanaServiceAccountTokenEnvVar) != "" || os.Getenv(grafanaAPIEnvVar) != "" {
+	if os.Getenv(grafanaServiceAccountTokenEnvVar) != "" {
 		return ""
 	}
 	return os.Getenv(grafanaServiceAccountTokenFileEnvVar)
 }
 
+func tokenFileMatchesAPIKey(path, apiKey string) bool {
+	if apiKey == "" {
+		return true
+	}
+	token, err := os.ReadFile(path)
+	return err == nil && strings.TrimSpace(string(token)) == strings.TrimSpace(apiKey)
+}
+
 func (t *tokenFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	clonedReq := req.Clone(req.Context())
 	token, err := os.ReadFile(t.path)
 	if err != nil {
+		if t.fallbackToken != "" {
+			return t.underlying.RoundTrip(clonedReq)
+		}
 		return nil, fmt.Errorf("read Grafana service account token file: %w", err)
 	}
 
-	clonedReq := req.Clone(req.Context())
+	if authorization := clonedReq.Header.Get("Authorization"); authorization != "" &&
+		(t.fallbackToken == "" || authorization != "Bearer "+strings.TrimSpace(t.fallbackToken)) {
+		return t.underlying.RoundTrip(clonedReq)
+	}
 	clonedReq.Header.Del("Authorization")
 	if token := strings.TrimSpace(string(token)); token != "" {
 		clonedReq.Header.Set("Authorization", "Bearer "+token)

--- a/token_file_transport_test.go
+++ b/token_file_transport_test.go
@@ -172,6 +172,34 @@ func TestTokenFileRoundTripperAppliesFallbackWhenFileReadFails(t *testing.T) {
 	require.Equal(t, "Bearer fallback-token", captured.Header.Get("Authorization"))
 }
 
+func TestTokenFileRotationDoesNotEnableForUnreadableFileWithoutFallback(t *testing.T) {
+	tokenFile := t.TempDir() + "/missing-token"
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, tokenFile)
+	t.Setenv(grafanaAPIEnvVar, "")
+
+	var received string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/frontend/settings" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	ctx := ExtractGrafanaInfoFromEnv(t.Context())
+	require.Empty(t, GrafanaConfigFromContext(ctx).APIKey)
+	client := NewGrafanaClient(ctx, server.URL, "", nil)
+	_, err := client.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(ctx),
+	)
+	require.NoError(t, err)
+	require.Empty(t, received)
+}
+
 func TestNewGrafanaClientUsesRotatedTokenFile(t *testing.T) {
 	tokenFile := t.TempDir() + "/token"
 	require.NoError(t, os.WriteFile(tokenFile, []byte("first-token"), 0o600))
@@ -299,16 +327,26 @@ func TestBuildTransportPreservesTokenFileRoundTripperWithCustomTLS(t *testing.T)
 	require.Equal(t, "Bearer file-token", received)
 }
 
-func TestBuildTransportDoesNotDiscardCustomTokenFileUnderlyingWithTLS(t *testing.T) {
-	base := &capturingMockRT{}
+func TestBuildTransportPreservesCustomTokenFileUnderlyingWithTLS(t *testing.T) {
+	called := false
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token"), 0o600))
+	base := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusNoContent}, nil
+	}}
 	transport := &tokenFileRoundTripper{
-		path:       t.TempDir() + "/token",
+		path:       tokenFile,
 		underlying: base,
 	}
 
-	_, err := BuildTransport(&GrafanaConfig{TLSConfig: &TLSConfig{SkipVerify: true}}, transport, WithoutOtel())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "token-file transport")
+	built, err := BuildTransport(&GrafanaConfig{TLSConfig: &TLSConfig{SkipVerify: true}}, transport, WithoutOtel())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	_, err = built.RoundTrip(req)
+	require.NoError(t, err)
+	require.True(t, called)
 }
 
 func TestServiceAccountTokenFileRemainsEnabledWithDeprecatedAPIKey(t *testing.T) {
@@ -381,4 +419,41 @@ func TestNewGrafanaClientDoesNotOverwriteRotatedTokenWithContextAPIKey(t *testin
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(received), 2)
 	require.Equal(t, "Bearer rotated-token", received[len(received)-1])
+}
+
+func TestCachedGrafanaClientPreservesRequestScopedAuthWhenFileRotates(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("request-token"), 0o600))
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, tokenFile)
+	t.Setenv(grafanaAPIEnvVar, "")
+
+	var received []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/frontend/settings" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+	t.Setenv(grafanaURLEnvVar, server.URL)
+
+	cache := NewClientCache(nil)
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set(grafanaServiceAccountTokenHeader, "request-token")
+
+	ctx := extractGrafanaClientCached(cache)(t.Context(), req)
+	client := GrafanaClientFromContext(ctx)
+	require.NotNil(t, client)
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-token"), 0o600))
+	_, err = client.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(ctx),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, received)
+	require.Equal(t, "Bearer request-token", received[len(received)-1])
 }

--- a/token_file_transport_test.go
+++ b/token_file_transport_test.go
@@ -3,7 +3,9 @@
 package mcpgrafana
 
 import (
+	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -73,4 +75,82 @@ func TestNewGrafanaClientUsesRotatedTokenFile(t *testing.T) {
 
 	require.GreaterOrEqual(t, len(received), 2)
 	require.Equal(t, "Bearer rotated-token", received[len(received)-1])
+}
+
+func TestNewGrafanaClientPreservesRequestAPIKeyWhenTokenFileIsConfigured(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token"), 0o600))
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, tokenFile)
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaAPIEnvVar, "")
+
+	var received []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/frontend/settings" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	grafanaClient := NewGrafanaClient(t.Context(), server.URL, "request-token", nil)
+	_, err := grafanaClient.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(t.Context()),
+	)
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(received), 2)
+	require.Equal(t, "Bearer request-token", received[len(received)-1])
+}
+
+func TestNewGrafanaClientReloadsTokenFileWithCustomTLS(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("first-token"), 0o600))
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, tokenFile)
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaAPIEnvVar, "deprecated-token")
+
+	var received []string
+	dialed := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/frontend/settings" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	ctx := WithGrafanaConfig(t.Context(), GrafanaConfig{
+		TLSConfig: &TLSConfig{SkipVerify: true},
+		BaseTransport: &http.Transport{
+			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+				dialed = true
+				return (&net.Dialer{}).DialContext(ctx, network, address)
+			},
+		},
+	})
+	grafanaClient := NewGrafanaClient(ctx, server.URL, "first-token", nil)
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-token"), 0o600))
+	_, err := grafanaClient.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(t.Context()),
+	)
+	require.NoError(t, err)
+	require.True(t, dialed)
+
+	require.GreaterOrEqual(t, len(received), 2)
+	require.Equal(t, "Bearer rotated-token", received[len(received)-1])
+}
+
+func TestServiceAccountTokenFileRemainsEnabledWithDeprecatedAPIKey(t *testing.T) {
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaAPIEnvVar, "deprecated-token")
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, "/path/to/token")
+
+	require.Equal(t, "/path/to/token", serviceAccountTokenFileFromEnv())
 }

--- a/token_file_transport_test.go
+++ b/token_file_transport_test.go
@@ -153,6 +153,25 @@ func TestTokenFileRoundTripperProtectsFallbackCredentialsFromAuthLayers(t *testi
 	require.Empty(t, captured.Header.Get(grafanaServiceAccountTokenHeader))
 }
 
+func TestTokenFileRoundTripperAppliesFallbackWhenFileReadFails(t *testing.T) {
+	var captured *http.Request
+	transport := &tokenFileRoundTripper{
+		path:          t.TempDir() + "/missing-token",
+		fallbackToken: "fallback-token",
+		underlying: &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			captured = req
+			return &http.Response{StatusCode: http.StatusNoContent}, nil
+		}},
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Equal(t, "Bearer fallback-token", captured.Header.Get("Authorization"))
+}
+
 func TestNewGrafanaClientUsesRotatedTokenFile(t *testing.T) {
 	tokenFile := t.TempDir() + "/token"
 	require.NoError(t, os.WriteFile(tokenFile, []byte("first-token"), 0o600))

--- a/token_file_transport_test.go
+++ b/token_file_transport_test.go
@@ -1,0 +1,76 @@
+//go:build unit
+
+package mcpgrafana
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/client/datasources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenFileRoundTripperReadsRotatedTokenPerRequest(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("first-token\n"), 0o600))
+
+	var received []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	transport := &tokenFileRoundTripper{path: tokenFile, underlying: http.DefaultTransport}
+	client := &http.Client{Transport: transport}
+
+	request, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	response, err := client.Do(request)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-token\n"), 0o600))
+	request, err = http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	response, err = client.Do(request)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+
+	require.Equal(t, []string{"Bearer first-token", "Bearer rotated-token"}, received)
+}
+
+func TestNewGrafanaClientUsesRotatedTokenFile(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("first-token"), 0o600))
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, tokenFile)
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaAPIEnvVar, "")
+
+	var received []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/frontend/settings" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	grafanaClient := NewGrafanaClient(t.Context(), server.URL, "first-token", nil)
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-token"), 0o600))
+	_, err := grafanaClient.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(t.Context()),
+	)
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(received), 2)
+	require.Equal(t, "Bearer rotated-token", received[len(received)-1])
+}

--- a/token_file_transport_test.go
+++ b/token_file_transport_test.go
@@ -47,6 +47,112 @@ func TestTokenFileRoundTripperReadsRotatedTokenPerRequest(t *testing.T) {
 	require.Equal(t, []string{"Bearer first-token", "Bearer rotated-token"}, received)
 }
 
+func TestTokenFileRoundTripperPreservesRequestScopedCredentials(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token"), 0o600))
+
+	tests := []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{name: "authorization", header: "Authorization", value: "Bearer request-token"},
+		{name: "service account token", header: grafanaServiceAccountTokenHeader, value: "request-token"},
+		{name: "deprecated api key", header: grafanaAPIKeyHeader, value: "request-token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured *http.Request
+			transport := &tokenFileRoundTripper{
+				path:          tokenFile,
+				fallbackToken: "static-token",
+				underlying: &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+					captured = req
+					return &http.Response{StatusCode: http.StatusNoContent}, nil
+				}},
+			}
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			require.NoError(t, err)
+			req.Header.Set(tt.header, tt.value)
+
+			_, err = transport.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, captured)
+			require.Equal(t, tt.value, captured.Header.Get(tt.header))
+			if tt.header == "Authorization" {
+				require.Equal(t, tt.value, captured.Header.Get("Authorization"))
+			} else {
+				require.Empty(t, captured.Header.Get("Authorization"), "request-scoped API-key headers must not be replaced by the file token")
+			}
+		})
+	}
+}
+
+func TestTokenFileRoundTripperProtectsRequestCredentialsFromAuthLayers(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token"), 0o600))
+
+	var captured *http.Request
+	base := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+		captured = req
+		return &http.Response{StatusCode: http.StatusNoContent}, nil
+	}}
+	transport := &tokenFileRoundTripper{
+		path:          tokenFile,
+		fallbackToken: "static-token",
+		underlying: NewExtraHeadersRoundTripper(
+			NewAuthRoundTripper(base, "", "", "static-token", nil),
+			map[string]string{
+				"Authorization":                  "Bearer extra-token",
+				grafanaAPIKeyHeader:              "extra-api-key",
+				grafanaServiceAccountTokenHeader: "extra-service-token",
+			},
+		),
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer request-token")
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Equal(t, "Bearer request-token", captured.Header.Get("Authorization"))
+	require.Empty(t, captured.Header.Get(grafanaAPIKeyHeader))
+	require.Empty(t, captured.Header.Get(grafanaServiceAccountTokenHeader))
+}
+
+func TestTokenFileRoundTripperProtectsFallbackCredentialsFromAuthLayers(t *testing.T) {
+	tokenFile := t.TempDir() + "/missing-token"
+
+	var captured *http.Request
+	base := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+		captured = req
+		return &http.Response{StatusCode: http.StatusNoContent}, nil
+	}}
+	transport := &tokenFileRoundTripper{
+		path:          tokenFile,
+		fallbackToken: "static-token",
+		underlying: NewExtraHeadersRoundTripper(
+			NewAuthRoundTripper(base, "", "", "auth-layer-token", nil),
+			map[string]string{
+				"Authorization":                  "Bearer extra-token",
+				grafanaAPIKeyHeader:              "extra-api-key",
+				grafanaServiceAccountTokenHeader: "extra-service-token",
+			},
+		),
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer request-token")
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Equal(t, "Bearer request-token", captured.Header.Get("Authorization"))
+	require.Empty(t, captured.Header.Get(grafanaAPIKeyHeader))
+	require.Empty(t, captured.Header.Get(grafanaServiceAccountTokenHeader))
+}
+
 func TestNewGrafanaClientUsesRotatedTokenFile(t *testing.T) {
 	tokenFile := t.TempDir() + "/token"
 	require.NoError(t, os.WriteFile(tokenFile, []byte("first-token"), 0o600))
@@ -147,10 +253,113 @@ func TestNewGrafanaClientReloadsTokenFileWithCustomTLS(t *testing.T) {
 	require.Equal(t, "Bearer rotated-token", received[len(received)-1])
 }
 
+func TestBuildTransportPreservesTokenFileRoundTripperWithCustomTLS(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token"), 0o600))
+
+	var received string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	base := &tokenFileRoundTripper{
+		path:       tokenFile,
+		underlying: http.DefaultTransport,
+	}
+	transport, err := BuildTransport(&GrafanaConfig{
+		TLSConfig: &TLSConfig{SkipVerify: true},
+	}, base, WithoutOtel())
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer file-token", received)
+}
+
+func TestBuildTransportDoesNotDiscardCustomTokenFileUnderlyingWithTLS(t *testing.T) {
+	base := &capturingMockRT{}
+	transport := &tokenFileRoundTripper{
+		path:       t.TempDir() + "/token",
+		underlying: base,
+	}
+
+	_, err := BuildTransport(&GrafanaConfig{TLSConfig: &TLSConfig{SkipVerify: true}}, transport, WithoutOtel())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token-file transport")
+}
+
 func TestServiceAccountTokenFileRemainsEnabledWithDeprecatedAPIKey(t *testing.T) {
 	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
 	t.Setenv(grafanaAPIEnvVar, "deprecated-token")
 	t.Setenv(grafanaServiceAccountTokenFileEnvVar, "/path/to/token")
 
 	require.Equal(t, "/path/to/token", serviceAccountTokenFileFromEnv())
+}
+
+func TestNewGrafanaClientUsesTokenFileWhenDeprecatedAPIKeyAlsoSet(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("file-token"), 0o600))
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, tokenFile)
+	t.Setenv(grafanaAPIEnvVar, "deprecated-token")
+
+	var received []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/frontend/settings" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client := NewGrafanaClient(t.Context(), server.URL, "deprecated-token", nil)
+	_, err := client.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(t.Context()),
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-token"), 0o600))
+	_, err = client.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(t.Context()),
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(received), 3)
+	require.Contains(t, received, "Bearer file-token")
+	require.Equal(t, "Bearer rotated-token", received[len(received)-1])
+}
+
+func TestNewGrafanaClientDoesNotOverwriteRotatedTokenWithContextAPIKey(t *testing.T) {
+	tokenFile := t.TempDir() + "/token"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("first-token"), 0o600))
+	t.Setenv(grafanaServiceAccountTokenFileEnvVar, tokenFile)
+	t.Setenv(grafanaServiceAccountTokenEnvVar, "")
+	t.Setenv(grafanaAPIEnvVar, "")
+
+	var received []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/frontend/settings" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	ctx := WithGrafanaConfig(t.Context(), GrafanaConfig{APIKey: "first-token"})
+	client := NewGrafanaClient(ctx, server.URL, "first-token", nil)
+	require.NoError(t, os.WriteFile(tokenFile, []byte("rotated-token"), 0o600))
+	_, err := client.Datasources.GetDataSourcesWithParams(
+		datasources.NewGetDataSourcesParamsWithContext(ctx),
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(received), 2)
+	require.Equal(t, "Bearer rotated-token", received[len(received)-1])
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #987.

Long-lived stdio servers currently build the Grafana API client once at startup. When `GRAFANA_SERVICE_ACCOUNT_TOKEN_FILE` is rotated, subsequent tool calls keep the old token because the OpenAPI client's static authorization header is reused.

This change adds a transport layer for file-based service-account authentication that reads the token and replaces the `Authorization` header for each outgoing Grafana request. Inline `GRAFANA_SERVICE_ACCOUNT_TOKEN` and the deprecated `GRAFANA_API_KEY` retain precedence, while token-file deployments now pick up rotated credentials without restarting the stdio process.

## Verification

- TDD RED: the focused rotation test initially failed because `tokenFileRoundTripper` did not exist.
- TDD GREEN: focused rotation tests pass.
- `make test-unit` passes.
- `go vet ./...` passes.
- JSON-schema, OpenAPI, and gofmt portions of `make lint` pass; the Go lint portion could not run locally because `golangci-lint` is not installed.

The tests cover both the transport directly and the real generated Grafana client path, including a token-file rewrite between requests.
