### PR TITLE
fix(proxied-tools): auto-wire SetToolManager and clarify the nil-tm error

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -437,12 +437,9 @@ func newServer(serverName, transport string, dt disabledTools, obs *observabilit
 
 	// Give the SessionManager a reference to the MCPServer so the reaper can
 	// unregister sessions from the SDK's internal session map.
+	// (NewToolManager above already wires the SessionManager's ToolManager
+	// reference back onto sm, so no separate SetToolManager call is needed here.)
 	sm.SetMCPServer(s)
-
-	// Give the SessionManager a reference to the ToolManager so tearing down a
-	// session releases its reference to the shared proxied tool set (closing the
-	// underlying clients only when the last session using them is gone).
-	sm.SetToolManager(stm)
 
 	dt.processTools(s)
 	mcpgrafana.RegisterAppResources(s)

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -573,6 +573,15 @@ func NewToolManager(sm *SessionManager, mcpServer *server.MCPServer, opts ...too
 	if tm.proxiedSets == nil {
 		tm.proxiedSets = make(map[proxiedToolSetKey]*proxiedToolSet)
 	}
+	// Every session-mode call path (SessionManager.GetProxiedClient) needs
+	// sm.toolManager to look up a session's shared proxied client set; without
+	// it, every proxied tool call fails as if no datasources were discovered,
+	// no matter how well discovery/registration went. Wiring it here, rather
+	// than leaving it to the caller, means a caller that only calls
+	// NewToolManager can't forget this step.
+	if sm != nil {
+		sm.SetToolManager(tm)
+	}
 	return tm
 }
 

--- a/proxied_tools_test.go
+++ b/proxied_tools_test.go
@@ -472,7 +472,6 @@ func newTestToolManager(t *testing.T, ttl time.Duration, build testBuildFunc) (*
 	t.Cleanup(sm.Close)
 	tm := NewToolManager(sm, nil, WithProxiedTools(true))
 	tm.buildSet = build
-	sm.SetToolManager(tm)
 	return tm, sm
 }
 
@@ -487,7 +486,6 @@ func newToolManagerWithServer(t *testing.T, build testBuildFunc) (*ToolManager, 
 	srv := server.NewMCPServer("test", "1.0")
 	tm := NewToolManager(sm, srv, WithProxiedTools(true))
 	tm.buildSet = build
-	sm.SetToolManager(tm)
 	return tm, sm, srv
 }
 

--- a/session.go
+++ b/session.go
@@ -355,7 +355,17 @@ func (sm *SessionManager) GetProxiedClient(ctx context.Context, datasourceType, 
 	tm := sm.toolManager
 	sm.mutex.RUnlock()
 
-	if set == nil || tm == nil {
+	if tm == nil {
+		// Distinct from the "no datasources discovered" case below: this means
+		// the SessionManager was never given a ToolManager reference (a caller
+		// wiring bug — see SetToolManager), not that discovery came up empty.
+		// Every proxied tool call would fail with this until the wiring is
+		// fixed, regardless of how well discovery/registration went, so it's
+		// worth its own message rather than looking like a permissions or
+		// discovery problem.
+		return nil, nil, fmt.Errorf("session manager has no tool manager configured (internal wiring error: SessionManager.SetToolManager was never called)")
+	}
+	if set == nil {
 		return nil, nil, fmt.Errorf("datasource '%s' not found. No %s datasources with MCP support are configured", datasourceUID, datasourceType)
 	}
 

--- a/session_get_proxied_client_test.go
+++ b/session_get_proxied_client_test.go
@@ -1,0 +1,64 @@
+package mcpgrafana
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewToolManager_WiresSetToolManager is the regression guard for a caller
+// wiring bug: NewToolManager did not back-wire itself onto the SessionManager
+// it was given, so SessionManager.GetProxiedClient (the path every
+// session-mode proxied tool call goes through) always saw a nil toolManager
+// and failed as if no datasources had been discovered, no matter how well
+// discovery/build/registration went. This reproduced live in
+// grafana-assistant-app: its NewMCPServer called sm.SetMCPServer(s) but never
+// sm.SetToolManager(tm), so every proxied tool call failed identically
+// regardless of session, replica, or credentials, while tools/list kept
+// listing the tools fine (a different code path that never needed
+// sm.toolManager). NewToolManager now wires this itself so a caller that only
+// calls NewToolManager can't forget the step.
+func TestNewToolManager_WiresSetToolManager(t *testing.T) {
+	tm, sm, srv := newToolManagerWithServer(t, setWith("tempo", "uid-1"))
+
+	ctx := ctxWithCreds("http://grafana", "secret", nil, 1)
+	sess := newToolsCapableSession("sess-1")
+	sm.CreateSession(ctx, sess)
+	require.NoError(t, srv.RegisterSession(ctx, sess))
+
+	tm.InitializeAndRegisterProxiedTools(ctx, sess)
+
+	callCtx := srv.WithContext(ctx, sess)
+	client, release, err := sm.GetProxiedClient(callCtx, "tempo", "uid-1")
+	require.NoError(t, err, "GetProxiedClient must succeed once NewToolManager has wired itself onto sm")
+	require.NotNil(t, client)
+	assert.Equal(t, "uid-1", client.DatasourceUID)
+	if release != nil {
+		release()
+	}
+}
+
+// TestSessionManager_GetProxiedClient_NoToolManagerWired covers the other side
+// of the same bug: a SessionManager that was never given a ToolManager at all
+// must fail with a distinct, diagnosable error rather than the generic "no
+// datasources configured" message, which looks identical to a legitimate
+// empty discovery result and is what made the wiring bug so hard to spot from
+// logs/error text alone.
+func TestSessionManager_GetProxiedClient_NoToolManagerWired(t *testing.T) {
+	sm := NewSessionManager()
+	t.Cleanup(sm.Close)
+
+	srv := server.NewMCPServer("test", "1.0")
+
+	ctx := context.Background()
+	sess := newToolsCapableSession("sess-1")
+	sm.CreateSession(ctx, sess)
+
+	callCtx := srv.WithContext(ctx, sess)
+	_, _, err := sm.GetProxiedClient(callCtx, "tempo", "uid-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wiring error", "the error must call out the missing ToolManager wiring, not look like a discovery/permissions problem")
+}

--- a/session_reaper_test.go
+++ b/session_reaper_test.go
@@ -81,7 +81,6 @@ func TestSessionManager_ReaperCleansUpProxiedClients(t *testing.T) {
 			toolToDatasources: map[string][]string{},
 		}, nil
 	}
-	sm.SetToolManager(tm)
 
 	session := &testClientSession{id: "cleanup-session"}
 	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{URL: "http://grafana", APIKey: "secret"})


### PR DESCRIPTION
## Summary

Follow-up to #1071/#1087, prompted by finding that grafana-assistant-app's hosted cloud-mcp server has every proxied tool *call* failing in production right now, for an entirely different reason than either of those PRs touch.

`NewToolManager(sm, mcpServer, ...)` never called `sm.SetToolManager(tm)` itself — it's a caller responsibility (mcp-grafana's own `cmd/mcp-grafana/main.go` remembered to do it). Without it, `SessionManager.GetProxiedClient` — the path every session-mode (HTTP/SSE) proxied tool call goes through — always saw a nil `toolManager` and failed exactly as if no datasources had been discovered, no matter how well discovery/build/registration went. `tools/list` stayed unaffected because tool schemas are registered once via `AddSessionTools`, which only needs `tm.sm`, not `sm.toolManager` — so tools kept listing fine while every actual invocation failed identically, which is what made this look like a permissions or discovery problem rather than a wiring bug.

Confirmed live: attached delve to a running instance mid-incident and inspected the exact point `GetProxiedClient` decides "not found" — the session's `proxiedSet` held a fully built set with the target datasource's client present (`built: true`, `refs: 1`, right datasource in `clients`), but `sm.toolManager` was `nil`, so the call failed before the client map was ever consulted.

## Changes

- `NewToolManager` now calls `sm.SetToolManager(tm)` itself (nil-safe), so a caller that only calls `NewToolManager` can no longer forget this step. Removed the now-redundant explicit calls from `cmd/mcp-grafana/main.go` and the shared test helpers in `proxied_tools_test.go`/`session_reaper_test.go`.
- `session.go`: give the nil-`toolManager` branch its own error message, distinct from `"no datasources with MCP support are configured"`. The two were previously indistinguishable from the error text alone — exactly what let this wiring bug hide behind what looked like a discovery/permissions issue.

## Test plan
- [x] New `TestNewToolManager_WiresSetToolManager`: a full attach→build→register→`GetProxiedClient` call succeeds once `NewToolManager` has wired itself onto `sm`, without any test-side `SetToolManager` call.
- [x] New `TestSessionManager_GetProxiedClient_NoToolManagerWired`: a `SessionManager` that never got a `ToolManager` at all returns the new distinct wiring-error message.
- [x] Removed the redundant explicit `SetToolManager` calls from the shared test helpers, which turns the pre-existing `TestSessionManager_ReaperCleansUpProxiedClients` into an additional regression guard.
- [x] Verified regression coverage directly: reverted just the `NewToolManager` change and confirmed both the new test and `TestSessionManager_ReaperCleansUpProxiedClients` fail; restored it and confirmed the full suite passes again.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `make lint`, and `go test ./... -race` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)