### PR TITLE
fix(alerting): encode rule matchers in the JSON shape Grafana expects

### DIFF
--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -103,9 +103,33 @@ type GetRulesOpts struct {
 	RuleLimit    int      // Maximum number of rules to return (max 200)
 	LimitAlerts  int      // Maximum number of alert instances per rule (max 200)
 	// Matchers filters alert instances by labels. Each matcher is JSON-encoded
-	// as a Prometheus matcher object (e.g. {"type":0,"name":"severity","value":"critical"}).
+	// in the shape Grafana expects (e.g. {"name":"severity","value":"critical","isRegex":false,"isEqual":true}).
 	// Multiple matchers are AND-ed together.
 	Matchers []*labels.Matcher
+}
+
+// ruleMatcherJSON is the JSON shape Grafana's Prometheus rules API expects for
+// each `matcher` query parameter. Grafana unmarshals it into an
+// alertmanager pkg/labels.Matcher, which reads the lowercase name/value fields
+// plus the isRegex/isEqual booleans. Prometheus' own labels.Matcher marshals
+// with capitalized field names and a numeric Type instead, which Grafana
+// silently ignores — so we cannot json.Marshal the matcher directly.
+type ruleMatcherJSON struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	IsRegex bool   `json:"isRegex"`
+	IsEqual bool   `json:"isEqual"`
+}
+
+// toRuleMatcherJSON converts a Prometheus label matcher into the shape Grafana
+// expects, mapping the match type onto the isRegex/isEqual booleans.
+func toRuleMatcherJSON(m *labels.Matcher) ruleMatcherJSON {
+	return ruleMatcherJSON{
+		Name:    m.Name,
+		Value:   m.Value,
+		IsRegex: m.Type == labels.MatchRegexp || m.Type == labels.MatchNotRegexp,
+		IsEqual: m.Type == labels.MatchEqual || m.Type == labels.MatchRegexp,
+	}
 }
 
 func (o *GetRulesOpts) queryValues() url.Values {
@@ -143,7 +167,10 @@ func (o *GetRulesOpts) queryValues() url.Values {
 		params.Set("limit_alerts", strconv.Itoa(limitAlerts))
 	}
 	for _, m := range o.Matchers {
-		b, err := json.Marshal(m)
+		if m == nil {
+			continue
+		}
+		b, err := json.Marshal(toRuleMatcherJSON(m))
 		if err != nil {
 			continue
 		}

--- a/tools/alerting_client_test.go
+++ b/tools/alerting_client_test.go
@@ -136,7 +136,7 @@ func TestGetRulesOpts_queryValues(t *testing.T) {
 				"state":            {"firing", "pending"},
 				"rule_limit":       {"10"},
 				"limit_alerts":     {"5"},
-				"matcher":          {`{"Type":0,"Name":"severity","Value":"critical"}`},
+				"matcher":          {`{"name":"severity","value":"critical","isRegex":false,"isEqual":true}`},
 			},
 		},
 		{
@@ -193,6 +193,59 @@ func TestGetRulesOpts_queryValues(t *testing.T) {
 	}
 }
 
+func TestGetRulesOpts_queryValues_matcherEncoding(t *testing.T) {
+	// Grafana unmarshals each `matcher` param into an alertmanager
+	// pkg/labels.Matcher, so the JSON must use lowercase name/value plus the
+	// isRegex/isEqual booleans. Verify every Prometheus match type maps onto the
+	// correct booleans.
+	tests := []struct {
+		name     string
+		matcher  *labels.Matcher
+		expected string
+	}{
+		{
+			name:     "equal",
+			matcher:  labels.MustNewMatcher(labels.MatchEqual, "severity", "critical"),
+			expected: `{"name":"severity","value":"critical","isRegex":false,"isEqual":true}`,
+		},
+		{
+			name:     "not equal",
+			matcher:  labels.MustNewMatcher(labels.MatchNotEqual, "severity", "critical"),
+			expected: `{"name":"severity","value":"critical","isRegex":false,"isEqual":false}`,
+		},
+		{
+			name:     "regex",
+			matcher:  labels.MustNewMatcher(labels.MatchRegexp, "pod", "api-.*"),
+			expected: `{"name":"pod","value":"api-.*","isRegex":true,"isEqual":true}`,
+		},
+		{
+			name:     "not regex",
+			matcher:  labels.MustNewMatcher(labels.MatchNotRegexp, "pod", "api-.*"),
+			expected: `{"name":"pod","value":"api-.*","isRegex":true,"isEqual":false}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := GetRulesOpts{Matchers: []*labels.Matcher{tc.matcher}}
+			require.Equal(t, tc.expected, opts.queryValues().Get("matcher"))
+		})
+	}
+}
+
+func TestGetRulesOpts_queryValues_multipleMatchers(t *testing.T) {
+	opts := GetRulesOpts{
+		Matchers: []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, "team", "backend"),
+			labels.MustNewMatcher(labels.MatchRegexp, "env", "prod.*"),
+		},
+	}
+	require.Equal(t, []string{
+		`{"name":"team","value":"backend","isRegex":false,"isEqual":true}`,
+		`{"name":"env","value":"prod.*","isRegex":true,"isEqual":true}`,
+	}, opts.queryValues()["matcher"])
+}
+
 func TestAlertingClient_GetRules_WithOpts(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -245,7 +298,7 @@ func TestAlertingClient_GetRules_WithOpts(t *testing.T) {
 				t.Helper()
 				q := r.URL.Query()
 				require.Equal(t, "cpu-alert", q.Get("search.rule_name"))
-				require.Equal(t, `{"Type":0,"Name":"severity","Value":"critical"}`, q.Get("matcher"))
+				require.Equal(t, `{"name":"severity","value":"critical","isRegex":false,"isEqual":true}`, q.Get("matcher"))
 				require.Equal(t, "5", q.Get("limit_alerts"))
 			},
 		},
@@ -273,7 +326,7 @@ func TestAlertingClient_GetRules_WithOpts(t *testing.T) {
 				require.Equal(t, []string{"firing", "pending"}, q["state"])
 				require.Equal(t, "20", q.Get("rule_limit"))
 				require.Equal(t, "3", q.Get("limit_alerts"))
-				require.Equal(t, `{"Type":0,"Name":"team","Value":"alerting"}`, q.Get("matcher"))
+				require.Equal(t, `{"name":"team","value":"alerting","isRegex":false,"isEqual":true}`, q.Get("matcher"))
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #1110. The `matchers` filter on `alerting_manage_rules` was silently ignored — passing a matcher returned every rule instead of only the matching ones, with no error.

## Root cause

Each `matcher` query parameter was built with `json.Marshal` on a Prometheus `labels.Matcher`, which has no JSON tags. That produced capitalized, numeric-typed JSON:

```json
{"Type":0,"Name":"space_name","Value":"..."}
```

Grafana's Prometheus rules API (`/api/prometheus/grafana/api/v1/rules`) unmarshals each matcher into an alertmanager `pkg/labels.Matcher`, which reads the lowercase `name`/`value` fields plus `isRegex`/`isEqual` booleans. The capitalized fields deserialize to an empty matcher, so the filter did nothing.

## Changes

- Encode matchers via a dedicated `ruleMatcherJSON` struct that emits the fields Grafana actually reads: `{"name":...,"value":...,"isRegex":...,"isEqual":...}`.
- Map the Prometheus match type onto `isRegex`/`isEqual`, covering all four operators (`=`, `!=`, `=~`, `!~`).
- Skip nil matchers defensively.
- Update existing client tests to assert the correct wire shape.

## Testing

- New unit tests cover all four match-type mappings and multiple matchers.
- Updated the two existing tests that had encoded the buggy format.
- `make lint` and `go test ./tools/...` pass locally.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (inline comments corrected)
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)