### PR TITLE
feat(run_panel_query): support PostgreSQL datasources

### DIFF
--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -24,7 +24,7 @@ type RunPanelQueryParams struct {
 	End            string            `json:"end" jsonschema:"description=Override end time (e.g. 'now'\\, RFC3339\\, Unix ms)"`
 	Variables      map[string]string `json:"variables" jsonschema:"description=Override dashboard variables (e.g. {\"job\": \"api-server\"})"`
 	DatasourceUID  string            `json:"datasourceUid,omitempty" jsonschema:"description=Override datasource UID"`
-	DatasourceType string            `json:"datasourceType,omitempty" jsonschema:"description=Override datasource type (prometheus\\, loki\\, grafana-clickhouse-datasource\\, cloudwatch\\, influxdb\\, grafana-bigquery-datasource\\, mssql)"`
+	DatasourceType string            `json:"datasourceType,omitempty" jsonschema:"description=Override datasource type (prometheus\\, loki\\, grafana-clickhouse-datasource\\, cloudwatch\\, influxdb\\, grafana-bigquery-datasource\\, mssql\\, grafana-postgresql-datasource\\, postgres)"`
 }
 
 // QueryTimeRange represents the actual time range used for a panel query
@@ -226,6 +226,11 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, BigQueryDatasourceType)
 	case "mssql":
 		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, MSSQLDatasourceType)
+	case "postgres":
+		// PostgreSQL exposes two datasource identifiers (grafana-postgresql-datasource
+		// and the legacy postgres); pass the resolved type through so the datasource
+		// object sent to Grafana matches what the panel actually declared.
+		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, datasourceType)
 	default:
 		return nil, fmt.Errorf("datasource type '%s' is not supported by run_panel_query; use the native query tool (e.g. query_prometheus\\, query_loki_logs\\, query_clickhouse\\, query_cloudwatch\\, query_influxdb) directly", datasourceType)
 	}
@@ -558,6 +563,13 @@ const BigQueryDatasourceType = "grafana-bigquery-datasource"
 // MSSQLDatasourceType is the type identifier for Microsoft SQL Server datasources.
 const MSSQLDatasourceType = "mssql"
 
+// PostgresDatasourceType is the modern type identifier for PostgreSQL datasources.
+const PostgresDatasourceType = "grafana-postgresql-datasource"
+
+// PostgresLegacyDatasourceType is the legacy identifier that older and provisioned
+// Grafana installations still expose for the same PostgreSQL datasource.
+const PostgresLegacyDatasourceType = "postgres"
+
 // SQLFormatTable is the format value for table/tabular query results on sqlds-based
 // datasources such as BigQuery, whose query model takes a numeric format enum.
 const SQLFormatTable = 1
@@ -568,10 +580,14 @@ const MSSQLFormatTable = "table"
 
 // defaultSQLFormat returns the table format value understood by the given datasource.
 func defaultSQLFormat(datasourceType string) interface{} {
-	if datasourceType == MSSQLDatasourceType {
+	switch normalizeDatasourceType(datasourceType) {
+	case "mssql", "postgres":
+		// MSSQL and PostgreSQL both use Grafana's sqleng backend, whose query model
+		// unmarshals format into a string and errors on a number.
 		return MSSQLFormatTable
+	default:
+		return SQLFormatTable
 	}
-	return SQLFormatTable
 }
 
 // SQLQueryResult represents the tabular result of a SQL panel query.
@@ -772,6 +788,8 @@ func normalizeDatasourceType(dsType string) string {
 		return "clickhouse"
 	case lower == "mssql":
 		return "mssql"
+	case lower == "postgres" || lower == "grafana-postgresql-datasource":
+		return "postgres"
 	case strings.Contains(lower, "bigquery"):
 		return "bigquery"
 	default:
@@ -859,6 +877,13 @@ func generatePanelQueryHints(datasourceType, query string) []string {
 			"- The $__timeFilter(column) macro may reference a column whose type or timezone doesn't match the time range",
 			"- The datasource login may lack SELECT permission on the referenced tables",
 		)
+	case "postgres":
+		hints = append(hints,
+			"- Table may be empty for this time range - try a COUNT(*) without the time filter to verify",
+			"- Column names or WHERE clause may not match the schema - check the table definition in PostgreSQL",
+			"- The $__timeFilter(column) macro may reference a column whose type or timezone doesn't match the time range",
+			"- The datasource role may lack SELECT privilege on the referenced tables, or the schema may not be on the search_path",
+		)
 	}
 
 	if query != "" {
@@ -879,7 +904,7 @@ func truncateString(s string, maxLen int) string {
 // RunPanelQuery is the tool definition for running panel queries
 var RunPanelQuery = mcpgrafana.MustTool(
 	"run_panel_query",
-	"Executes one or more dashboard panel queries with optional time range and variable overrides. Accepts an array of panel IDs to query in a single call. Fetches the dashboard\\, extracts queries from the specified panels\\, substitutes template variables and Grafana macros ($__range\\, $__rate_interval\\, $__interval)\\, and routes to the appropriate datasource (Prometheus\\, Loki\\, ClickHouse\\, CloudWatch\\, InfluxDB\\, or BigQuery). Returns results keyed by panel ID - partial failures are allowed (some panels can succeed while others fail). Use get_dashboard_summary first to find panel IDs. If a panel uses a template variable datasource you cannot access\\, provide datasourceUid and datasourceType to override.",
+	"Executes one or more dashboard panel queries with optional time range and variable overrides. Accepts an array of panel IDs to query in a single call. Fetches the dashboard\\, extracts queries from the specified panels\\, substitutes template variables and Grafana macros ($__range\\, $__rate_interval\\, $__interval)\\, and routes to the appropriate datasource (Prometheus\\, Loki\\, ClickHouse\\, CloudWatch\\, InfluxDB\\, BigQuery\\, MSSQL\\, or PostgreSQL). Returns results keyed by panel ID - partial failures are allowed (some panels can succeed while others fail). Use get_dashboard_summary first to find panel IDs. If a panel uses a template variable datasource you cannot access\\, provide datasourceUid and datasourceType to override.",
 	runPanelQuery,
 	mcp.WithTitleAnnotation("Run panel query"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/run_panel_query_postgres_test.go
+++ b/tools/run_panel_query_postgres_test.go
@@ -1,0 +1,205 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	mcpgrafana "github.com/grafana/mcp-grafana"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// postgresPanelDashboard builds a minimal dashboard containing a single
+// PostgreSQL-backed panel. The rawSql exercises three concerns at once:
+//   - ${schema} is a dashboard variable, substituted before dispatch;
+//   - $__interval is a frontend macro, substituted by run_panel_query;
+//   - $__timeFilter(ts) is a SQL macro, left untouched for the backend plugin.
+//
+// The target also carries a datasource-specific field (rawQuery) and no format,
+// so the test can assert both target preservation and the format default.
+func postgresPanelDashboard(dsType string) map[string]interface{} {
+	return map[string]interface{}{
+		"templating": map[string]interface{}{
+			"list": []interface{}{
+				map[string]interface{}{
+					"name":    "schema",
+					"type":    "constant",
+					"query":   "public",
+					"current": map[string]interface{}{"value": "public"},
+				},
+			},
+		},
+		"panels": []interface{}{
+			map[string]interface{}{
+				"id":    float64(7),
+				"title": "Reconciliation counts",
+				"type":  "table",
+				"datasource": map[string]interface{}{
+					"uid":  "postgres-uid",
+					"type": dsType,
+				},
+				"targets": []interface{}{
+					map[string]interface{}{
+						"refId":    "A",
+						"rawSql":   "SELECT count(*) FROM ${schema}.checks WHERE $__timeFilter(ts) /* interval=$__interval */",
+						"rawQuery": true,
+					},
+				},
+			},
+		},
+	}
+}
+
+// capturedQuery holds the first query object from a captured /api/ds/query payload.
+type capturedQuery struct {
+	payload map[string]interface{}
+	query   map[string]interface{}
+}
+
+// newDSQueryTestServer stands in for Grafana's /api/ds/query endpoint. It records
+// the request payload and returns the supplied frames.
+func newDSQueryTestServer(t *testing.T, captured *capturedQuery, frames data.Frames) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/ds/query", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var payload map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		captured.payload = payload
+		queries, ok := payload["queries"].([]interface{})
+		require.True(t, ok, "payload.queries should be an array")
+		require.Len(t, queries, 1)
+		captured.query, ok = queries[0].(map[string]interface{})
+		require.True(t, ok, "query should be an object")
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": backend.DataResponse{Frames: frames},
+			},
+		}
+		b, err := json.Marshal(resp)
+		require.NoError(t, err)
+		_, _ = w.Write(b)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestRunSinglePanelQuery_PostgresDispatch drives the full panel-query path for a
+// PostgreSQL panel: dispatch by datasource type, variable and frontend-macro
+// substitution, SQL-macro preservation, request construction, target
+// preservation, and result parsing. Both the modern and legacy datasource
+// identifiers are covered.
+func TestRunSinglePanelQuery_PostgresDispatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		dsType string
+	}{
+		{name: "modern identifier", dsType: "grafana-postgresql-datasource"},
+		{name: "legacy identifier", dsType: "postgres"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frames := data.Frames{
+				data.NewFrame("",
+					data.NewField("region", nil, []string{"us", "eu"}),
+					data.NewField("count", nil, []int64{42, 17}),
+				),
+			}
+			var captured capturedQuery
+			ts := newDSQueryTestServer(t, &captured, frames)
+			ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: ts.URL})
+
+			result, err := runSinglePanelQuery(ctx, singlePanelQueryParams{
+				DB:         postgresPanelDashboard(tt.dsType),
+				PanelID:    7,
+				QueryIndex: 0,
+				Start:      "now-1h",
+				End:        "now",
+			})
+			require.NoError(t, err)
+
+			// Dispatch: the panel routed through the SQL path and kept its type.
+			assert.Equal(t, tt.dsType, result.DatasourceType)
+			assert.Equal(t, "postgres-uid", result.DatasourceUID)
+
+			// Result parsing: frames became a tabular SQLQueryResult.
+			sqlResult, ok := result.Results.(*SQLQueryResult)
+			require.True(t, ok, "expected *SQLQueryResult, got %T", result.Results)
+			assert.Equal(t, []string{"region", "count"}, sqlResult.Columns)
+			require.Len(t, sqlResult.Rows, 2)
+			assert.Equal(t, "us", sqlResult.Rows[0]["region"])
+			assert.Equal(t, int64(42), sqlResult.Rows[0]["count"])
+			assert.Equal(t, 2, sqlResult.RowCount)
+
+			// Macro/variable handling: the dashboard variable and the frontend
+			// $__interval macro were substituted, while the SQL macro survived
+			// for the backend plugin to expand.
+			assert.Contains(t, sqlResult.ProcessedQuery, "public.checks")
+			assert.NotContains(t, sqlResult.ProcessedQuery, "${schema}")
+			assert.Contains(t, sqlResult.ProcessedQuery, "$__timeFilter(ts)")
+			assert.NotContains(t, sqlResult.ProcessedQuery, "$__interval")
+
+			// Request construction: the query object carries the processed SQL,
+			// the resolved datasource, a refId, and the string table format.
+			assert.Equal(t, sqlResult.ProcessedQuery, captured.query["rawSql"])
+			assert.Equal(t, "A", captured.query["refId"])
+			assert.Equal(t, MSSQLFormatTable, captured.query["format"])
+			ds, ok := captured.query["datasource"].(map[string]interface{})
+			require.True(t, ok)
+			assert.Equal(t, "postgres-uid", ds["uid"])
+			assert.Equal(t, tt.dsType, ds["type"])
+
+			// Target preservation: datasource-specific fields survive untouched.
+			assert.Equal(t, true, captured.query["rawQuery"])
+
+			// The envelope carries the resolved time range.
+			assert.NotEmpty(t, captured.payload["from"])
+			assert.NotEmpty(t, captured.payload["to"])
+		})
+	}
+}
+
+// TestRunSinglePanelQuery_PostgresEmptyResultHints verifies that an empty
+// PostgreSQL result surfaces PostgreSQL-specific hints through the real path.
+func TestRunSinglePanelQuery_PostgresEmptyResultHints(t *testing.T) {
+	frames := data.Frames{
+		data.NewFrame("",
+			data.NewField("count", nil, []int64{}),
+		),
+	}
+	var captured capturedQuery
+	ts := newDSQueryTestServer(t, &captured, frames)
+	ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: ts.URL})
+
+	result, err := runSinglePanelQuery(ctx, singlePanelQueryParams{
+		DB:         postgresPanelDashboard("grafana-postgresql-datasource"),
+		PanelID:    7,
+		QueryIndex: 0,
+		Start:      "now-1h",
+		End:        "now",
+	})
+	require.NoError(t, err)
+
+	sqlResult, ok := result.Results.(*SQLQueryResult)
+	require.True(t, ok)
+	assert.Empty(t, sqlResult.Rows)
+
+	require.NotEmpty(t, result.Hints)
+	joined := ""
+	for _, h := range result.Hints {
+		joined += h + " "
+	}
+	assert.Contains(t, joined, "PostgreSQL")
+	assert.Contains(t, joined, "search_path")
+}

--- a/tools/run_panel_query_test.go
+++ b/tools/run_panel_query_test.go
@@ -1007,6 +1007,27 @@ func TestGeneratePanelQueryHints(t *testing.T) {
 				"SELECT permission",
 			},
 		},
+		{
+			name:           "postgres hints (modern identifier)",
+			datasourceType: "grafana-postgresql-datasource",
+			query:          "SELECT COUNT(*) FROM revenue WHERE $__timeFilter(ts)",
+			containsHints: []string{
+				"No data found",
+				"Time range",
+				"COUNT(*)",
+				"PostgreSQL",
+				"search_path",
+			},
+		},
+		{
+			name:           "postgres hints (legacy identifier)",
+			datasourceType: "postgres",
+			query:          "SELECT COUNT(*) FROM revenue WHERE $__timeFilter(ts)",
+			containsHints: []string{
+				"No data found",
+				"PostgreSQL",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1086,6 +1107,10 @@ func TestNormalizeDatasourceType(t *testing.T) {
 		{"MSSQL", "mssql"},
 		{"bigquery", "bigquery"},
 		{"BigQuery", "bigquery"},
+		{"postgres", "postgres"},
+		{"Postgres", "postgres"},
+		{"grafana-postgresql-datasource", "postgres"},
+		{"Grafana-PostgreSQL-Datasource", "postgres"},
 		{"some-other-type", "some-other-type"},
 		{"", ""},
 	}
@@ -1239,6 +1264,10 @@ func TestExecuteSQLPanelQuery_NilTarget(t *testing.T) {
 	_, err = executeSQLPanelQuery(t.Context(), "mssql-uid", &panelInfo{}, "SELECT 1", "now-1h", "now", nil, MSSQLDatasourceType)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "SQL panel target not available")
+
+	_, err = executeSQLPanelQuery(t.Context(), "postgres-uid", &panelInfo{}, "SELECT 1", "now-1h", "now", nil, PostgresDatasourceType)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SQL panel target not available")
 }
 
 func TestDefaultSQLFormat(t *testing.T) {
@@ -1246,6 +1275,10 @@ func TestDefaultSQLFormat(t *testing.T) {
 	// unmarshals format into a string and errors on a number.
 	assert.Equal(t, SQLFormatTable, defaultSQLFormat(BigQueryDatasourceType))
 	assert.Equal(t, MSSQLFormatTable, defaultSQLFormat(MSSQLDatasourceType))
+	// PostgreSQL is also sqleng-based, so it uses the string table format under
+	// both its modern and legacy datasource identifiers.
+	assert.Equal(t, MSSQLFormatTable, defaultSQLFormat(PostgresDatasourceType))
+	assert.Equal(t, MSSQLFormatTable, defaultSQLFormat(PostgresLegacyDatasourceType))
 }
 
 func TestExtractPanelInfoMSSQL(t *testing.T) {
@@ -1273,6 +1306,49 @@ func TestExtractPanelInfoMSSQL(t *testing.T) {
 	assert.Equal(t, "mssql", info.DatasourceType)
 	assert.Contains(t, info.Query, "$__timeFrom()")
 	assert.Equal(t, "table", info.RawTarget["format"])
+}
+
+func TestExtractPanelInfoPostgres(t *testing.T) {
+	// PostgreSQL panels carry their statement in rawSql like the other SQL
+	// datasources, and the raw target must survive so datasource-specific fields
+	// (e.g. format) and the format override are preserved.
+	tests := []struct {
+		name       string
+		dsType     string
+		wantDSType string
+	}{
+		{name: "modern identifier", dsType: "grafana-postgresql-datasource", wantDSType: "grafana-postgresql-datasource"},
+		{name: "legacy identifier", dsType: "postgres", wantDSType: "postgres"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			panel := map[string]interface{}{
+				"id":    91,
+				"title": "Reconciliation",
+				"datasource": map[string]interface{}{
+					"uid":  "postgres-uid",
+					"type": tt.dsType,
+				},
+				"targets": []interface{}{
+					map[string]interface{}{
+						"refId":  "A",
+						"rawSql": "SELECT $__timeGroup(ts, '1h') AS t, count(*) FROM checks WHERE $__timeFilter(ts) GROUP BY 1",
+						"format": "table",
+					},
+				},
+			}
+
+			info, err := extractPanelInfo(panel, 0)
+			require.NoError(t, err)
+			assert.Equal(t, "postgres-uid", info.DatasourceUID)
+			assert.Equal(t, tt.wantDSType, info.DatasourceType)
+			assert.Contains(t, info.Query, "$__timeGroup(ts, '1h')")
+			assert.Contains(t, info.Query, "$__timeFilter(ts)")
+			// The raw target survives so the panel's saved format is preserved.
+			assert.Equal(t, "table", info.RawTarget["format"])
+		})
+	}
 }
 
 func TestSubstituteTemplateVariablesInMap(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1101.

`run_panel_query` could execute panels for Prometheus, Loki, ClickHouse, CloudWatch, InfluxDB, BigQuery and MSSQL, but rejected Grafana's PostgreSQL datasource before running the query:

```text
datasource type 'grafana-postgresql-datasource' is not supported by run_panel_query
```

Older/provisioned installations expose the same datasource as the legacy identifier `postgres`, which was also unhandled. This PR routes PostgreSQL panels through the **existing** SQL panel-query path already used for BigQuery and MSSQL — no new tool, no change to the input/output shape.

## Changes

- `normalizeDatasourceType` maps both `grafana-postgresql-datasource` and `postgres` to a single internal `postgres` type.
- `runSinglePanelQuery` dispatches `postgres` to `executeSQLPanelQuery`, passing the **resolved** type through so the datasource object sent to Grafana matches the panel's declared identifier.
- `defaultSQLFormat` returns the string `"table"` for PostgreSQL, matching its `sqleng` backend (like MSSQL), whose query model rejects a numeric format enum.
- The complete saved panel target is preserved; dashboard variables and the frontend `$__interval`/`$__range` macros are substituted locally, while SQL macros (`$__timeFilter`, `$__timeFrom`, `$__timeTo`, `$__timeGroup`) are left for the backend plugin to expand.
- Empty results surface PostgreSQL-specific hints.
- The tool schema and description now list PostgreSQL (and MSSQL, which was previously missing from the description).

## Testing

- `make test-unit` — all green.
- New unit tests cover type normalization, dispatch, target preservation, variable + macro handling, request construction, result parsing, and empty-result hints — the request-construction/result-parsing tests drive the real path against a mock `/api/ds/query` server for both the modern and legacy datasource identifiers.
- `gofmt`, `golangci-lint`, and the jsonschema/openapi linters pass.

No PostgreSQL datasource exists in the integration-test environment (neither did BigQuery/MSSQL), so coverage is unit-only, matching that precedent.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (tool description; the docs tool table is generic and needs no change)
- [x] Linting passes