### PR TITLE
fix: alert list matcher format

### DIFF
--- a/tools/alerting_client.go
+++ b/tools/alerting_client.go
@@ -143,13 +143,24 @@ func (o *GetRulesOpts) queryValues() url.Values {
 		params.Set("limit_alerts", strconv.Itoa(limitAlerts))
 	}
 	for _, m := range o.Matchers {
-		b, err := json.Marshal(m)
+		b, err := json.Marshal(apiMatcher{
+			Name:    m.Name,
+			Value:   m.Value,
+			IsRegex: m.Type == labels.MatchRegexp || m.Type == labels.MatchNotRegexp,
+		})
 		if err != nil {
 			continue
 		}
 		params.Add("matcher", string(b))
 	}
 	return params
+}
+
+// apiMatcher is the JSON shape the "matcher" query parameter expects.
+type apiMatcher struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	IsRegex bool   `json:"isRegex"`
 }
 
 func (c *alertingClient) GetRules(ctx context.Context, opts *GetRulesOpts) (*rulesResponse, error) {

--- a/tools/alerting_client_test.go
+++ b/tools/alerting_client_test.go
@@ -136,7 +136,7 @@ func TestGetRulesOpts_queryValues(t *testing.T) {
 				"state":            {"firing", "pending"},
 				"rule_limit":       {"10"},
 				"limit_alerts":     {"5"},
-				"matcher":          {`{"Type":0,"Name":"severity","Value":"critical"}`},
+				"matcher":          {`{"name":"severity","value":"critical","isRegex":false}`},
 			},
 		},
 		{
@@ -172,6 +172,15 @@ func TestGetRulesOpts_queryValues(t *testing.T) {
 			},
 			expected: url.Values{
 				"rule_limit": {"200"},
+			},
+		},
+		{
+			name: "regex matcher sets isRegex true",
+			opts: GetRulesOpts{
+				Matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "team", "backend.*")},
+			},
+			expected: url.Values{
+				"matcher": {`{"name":"team","value":"backend.*","isRegex":true}`},
 			},
 		},
 		{
@@ -245,7 +254,7 @@ func TestAlertingClient_GetRules_WithOpts(t *testing.T) {
 				t.Helper()
 				q := r.URL.Query()
 				require.Equal(t, "cpu-alert", q.Get("search.rule_name"))
-				require.Equal(t, `{"Type":0,"Name":"severity","Value":"critical"}`, q.Get("matcher"))
+				require.Equal(t, `{"name":"severity","value":"critical","isRegex":false}`, q.Get("matcher"))
 				require.Equal(t, "5", q.Get("limit_alerts"))
 			},
 		},
@@ -273,7 +282,7 @@ func TestAlertingClient_GetRules_WithOpts(t *testing.T) {
 				require.Equal(t, []string{"firing", "pending"}, q["state"])
 				require.Equal(t, "20", q.Get("rule_limit"))
 				require.Equal(t, "3", q.Get("limit_alerts"))
-				require.Equal(t, `{"Type":0,"Name":"team","Value":"alerting"}`, q.Get("matcher"))
+				require.Equal(t, `{"name":"team","value":"alerting","isRegex":false}`, q.Get("matcher"))
 			},
 		},
 	}


### PR DESCRIPTION
## What this changes

Changes the `matchers` filter in `alerting_manage_rules` to use lowercase keys (`name` instead of `Name`) to match what the API expects.  Before, the incorrect filter was silently ignored.

Fixes # 1110

## How you tested it

Tested against Grafana Cloud.

## Checklist

- [ ] `make lint` and `make test-unit` pass locally
- [ ] Commits are signed (required to merge — see CONTRIBUTING.md)
- [x] CLA signed (required to merge)

<!--
Note on CI: workflow runs on fork PRs need manual maintainer approval, on every
push. If your checks look stuck, they're waiting on us, not on you.
`Test Cloud` and the Python E2E suites are informational and cannot pass from a
fork — a red mark there is expected and won't block your merge.
-->
