### PR TITLE
feat(transport): support scoped SOCKS5 proxy via GRAFANA_SOCKS5_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,32 @@ You can add arbitrary HTTP headers to all Grafana API requests using the `GRAFAN
 }
 ```
 
+### SOCKS5 Proxy
+
+You can route all requests this server makes to Grafana through a SOCKS5 proxy using the `GRAFANA_SOCKS5_PROXY` environment variable. The proxy is scoped to this server's Grafana traffic: it does not modify the global `HTTP_PROXY`/`HTTPS_PROXY` variables, and when set it overrides their proxy selection for Grafana transports only, without affecting other MCP servers or your shell session. When unset, behavior is unchanged.
+
+The URL must use the `socks5://` or `socks5h://` scheme (Go treats them identically: hostname resolution is delegated to the proxy) and may include credentials, e.g. `socks5://user:pass@127.0.0.1:1080`.
+
+**Example:**
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "mcp-grafana",
+      "args": [],
+      "env": {
+        "GRAFANA_URL": "http://localhost:3000",
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "<your token>",
+        "GRAFANA_SOCKS5_PROXY": "socks5://127.0.0.1:1080"
+      }
+    }
+  }
+}
+```
+
+An invalid proxy URL is a startup error, and if building a proxied connection fails at runtime the server fails closed rather than silently sending Grafana traffic directly.
+
 ### Forwarding Headers from the Client (SSE/Streamable-HTTP Only)
 
 When the MCP server runs behind a gateway or reverse proxy that handles SSO (e.g. an AWS ALB with OIDC), each user's session cookie must reach Grafana so it can associate the request with the authenticated user. The `GRAFANA_FORWARD_HEADERS` environment variable enables this by specifying a comma-separated allowlist of header names to copy from the **incoming** HTTP request to every outbound Grafana API request.

--- a/client_cache.go
+++ b/client_cache.go
@@ -390,10 +390,15 @@ func extractIncidentClientCached(cache *ClientCache) httpContextFunc {
 
 			config.OrgID = orgID
 			transport, err := BuildTransport(&config, nil, WithoutAuth())
-			if err != nil {
-				logger.Error("Failed to create custom transport for incident client, using default", "error", err)
-			} else {
+			switch {
+			case err == nil:
 				client.HTTPClient.Transport = transport
+			case config.SOCKS5ProxyURL != "":
+				// Fail closed: a default transport would bypass the configured proxy.
+				logger.Error("Failed to create custom transport for incident client, failing closed because a SOCKS5 proxy is configured", "error", err)
+				client.HTTPClient.Transport = failClosedTransport(err)
+			default:
+				logger.Error("Failed to create custom transport for incident client, using default", "error", err)
 			}
 
 			return client

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -233,6 +233,22 @@ func (gc *grafanaConfig) applyLokiGuardrailEnv(setFlags map[string]bool) error {
 	return nil
 }
 
+// socks5ProxyFromEnv reads GRAFANA_SOCKS5_PROXY and validates it so a
+// misconfigured proxy fails at startup instead of surfacing later when the
+// first Grafana client is built. The error names the env var but never the
+// raw value, which may contain proxy credentials. Extracted from main so the
+// handling is unit-testable.
+func socks5ProxyFromEnv() (string, error) {
+	raw := os.Getenv("GRAFANA_SOCKS5_PROXY")
+	if raw == "" {
+		return "", nil
+	}
+	if err := mcpgrafana.ValidateSOCKS5ProxyURL(raw); err != nil {
+		return "", fmt.Errorf("invalid GRAFANA_SOCKS5_PROXY: %w", err)
+	}
+	return raw, nil
+}
+
 // validateLokiGuardrail rejects invalid guardrail settings (unknown mode,
 // negative limits) after flag and env processing. Extracted from main so the
 // validation is unit-testable.
@@ -897,6 +913,12 @@ func main() {
 		slog.Info("Loki guardrail enabled", "mode", gc.lokiGuardrailMode, "max_bytes", gc.lokiGuardrailMaxBytes, "max_range", gc.lokiGuardrailMaxRange)
 	}
 
+	socks5Proxy, err := socks5ProxyFromEnv()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+
 	// Convert local grafanaConfig to mcpgrafana.GrafanaConfig
 	grafanaConfig := mcpgrafana.GrafanaConfig{
 		Debug:                   gc.debug,
@@ -906,6 +928,7 @@ func main() {
 		LokiGuardrailMaxRange:   gc.lokiGuardrailMaxRange,
 		IncludeArgumentsInSpans: gc.includeArgsInSpans,
 		Timeout:                 gc.timeout,
+		SOCKS5ProxyURL:          socks5Proxy,
 	}
 	if gc.tlsCertFile != "" || gc.tlsKeyFile != "" || gc.tlsCAFile != "" || gc.tlsSkipVerify {
 		grafanaConfig.TLSConfig = &mcpgrafana.TLSConfig{

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -917,3 +917,31 @@ func TestCheckCallerAuthPolicy(t *testing.T) {
 		})
 	}
 }
+
+// TestSOCKS5ProxyFromEnv locks in GRAFANA_SOCKS5_PROXY handling: unset or
+// empty leaves the proxy disabled, a valid URL is returned verbatim, and an
+// invalid URL is a startup error that does not leak the raw value (it may
+// contain proxy credentials).
+func TestSOCKS5ProxyFromEnv(t *testing.T) {
+	t.Run("unset env leaves proxy empty", func(t *testing.T) {
+		t.Setenv("GRAFANA_SOCKS5_PROXY", "")
+		raw, err := socks5ProxyFromEnv()
+		require.NoError(t, err)
+		assert.Empty(t, raw)
+	})
+
+	t.Run("valid URL is returned verbatim", func(t *testing.T) {
+		t.Setenv("GRAFANA_SOCKS5_PROXY", "socks5://127.0.0.1:1080")
+		raw, err := socks5ProxyFromEnv()
+		require.NoError(t, err)
+		assert.Equal(t, "socks5://127.0.0.1:1080", raw)
+	})
+
+	t.Run("invalid URL is an error naming the env var but not the value", func(t *testing.T) {
+		t.Setenv("GRAFANA_SOCKS5_PROXY", "http://user:secretpw@proxy.example.com:1080")
+		_, err := socks5ProxyFromEnv()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "GRAFANA_SOCKS5_PROXY")
+		assert.NotContains(t, err.Error(), "secretpw")
+	})
+}

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -279,6 +279,16 @@ type GrafanaConfig struct {
 	// Parsed from GRAFANA_EXTRA_HEADERS environment variable as JSON object.
 	ExtraHeaders map[string]string
 
+	// SOCKS5ProxyURL is an optional SOCKS5 proxy URL (socks5:// or socks5h://,
+	// treated identically: hostname resolution is delegated to the proxy)
+	// applied to all Grafana traffic built via BuildTransport. It is scoped to
+	// this configuration and independent of the HTTP_PROXY/HTTPS_PROXY
+	// environment variables. The CLI populates it from GRAFANA_SOCKS5_PROXY.
+	// When set, BuildTransport returns an error if BaseTransport is present
+	// but is not an *http.Transport, since the proxy cannot be applied to an
+	// opaque RoundTripper.
+	SOCKS5ProxyURL string
+
 	// MaxLokiLogLimit is the maximum number of log lines that can be returned
 	// from Loki queries.
 	MaxLokiLogLimit int
@@ -794,6 +804,22 @@ func BuildTransport(cfg *GrafanaConfig, base http.RoundTripper, opts ...Transpor
 
 	if base == nil {
 		base = cfg.HTTPTransport()
+	}
+
+	// SOCKS5 proxy (applied to the innermost *http.Transport so the TLS layer
+	// below clones it with the proxy already in place).
+	if cfg.SOCKS5ProxyURL != "" {
+		proxyURL, err := parseSOCKS5ProxyURL(cfg.SOCKS5ProxyURL)
+		if err != nil {
+			return nil, err
+		}
+		t, ok := base.(*http.Transport)
+		if !ok {
+			return nil, fmt.Errorf("SOCKS5 proxy requires the base transport to be an *http.Transport, got %T", base)
+		}
+		t = t.Clone()
+		t.Proxy = http.ProxyURL(proxyURL)
+		base = t
 	}
 	transport := base
 
@@ -1320,6 +1346,7 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 	// The OpenAPI client handles APIKey/BasicAuth itself, so we skip transport-
 	// level auth and only inject OBO tokens (which the OpenAPI client doesn't
 	// know about) via the AuthRoundTripper.
+	transportInstalled := false
 	v := reflect.ValueOf(grafanaClient.Transport)
 	if v.Kind() == reflect.Ptr && !v.IsNil() {
 		v = v.Elem()
@@ -1350,39 +1377,49 @@ func NewGrafanaClient(ctx context.Context, grafanaURL, apiKey string, auth *url.
 					// transport-level injection since the OpenAPI client
 					// doesn't support them natively.
 					oboConfig := GrafanaConfig{
-						AccessToken:  config.AccessToken,
-						IDToken:      config.IDToken,
-						OrgID:        config.OrgID,
-						TLSConfig:    config.TLSConfig,
-						ExtraHeaders: config.ExtraHeaders,
-						Debug:        config.Debug,
-						Logger:       config.Logger,
+						AccessToken:    config.AccessToken,
+						IDToken:        config.IDToken,
+						OrgID:          config.OrgID,
+						TLSConfig:      config.TLSConfig,
+						ExtraHeaders:   config.ExtraHeaders,
+						SOCKS5ProxyURL: config.SOCKS5ProxyURL,
+						Debug:          config.Debug,
+						Logger:         config.Logger,
 					}
 					// Panic matches the existing TLS error handling above
-					// (line ~887). The only realistic failure is a TLS
-					// misconfiguration, which can't happen here since base
-					// is always an *http.Transport.
+					// (line ~887). The only realistic failures are a TLS or
+					// SOCKS5 proxy misconfiguration; the CLI validates the
+					// proxy URL at startup, and base is always an
+					// *http.Transport here.
 					wrapped, err := BuildTransport(&oboConfig, base)
 					if err != nil {
 						panic(fmt.Errorf("failed to build transport: %w", err))
 					}
 					transportField.Set(reflect.ValueOf(wrapped))
+					transportInstalled = true
 					logger.Debug("HTTP tracing, user agent tracking, and timeout enabled for Grafana client", "timeout", timeout)
 				}
 			}
 		}
 	}
+	if config.SOCKS5ProxyURL != "" && !transportInstalled {
+		// Fail closed: the reflection above could not replace the OpenAPI
+		// client's transport, so its default transport would bypass the
+		// configured proxy. Panic matches the transport error handling above.
+		panic(fmt.Errorf("SOCKS5 proxy is configured but the Grafana OpenAPI client's transport could not be replaced"))
+	}
 
 	// Fetch the public URL from Grafana's frontend settings.
 	fetchCfg := &GrafanaConfig{
-		URL:          grafanaURL,
-		APIKey:       apiKey,
-		BasicAuth:    auth,
-		AccessToken:  config.AccessToken,
-		IDToken:      config.IDToken,
-		TLSConfig:    config.TLSConfig,
-		ExtraHeaders: config.ExtraHeaders,
-		Logger:       config.Logger,
+		URL:            grafanaURL,
+		APIKey:         apiKey,
+		BasicAuth:      auth,
+		AccessToken:    config.AccessToken,
+		IDToken:        config.IDToken,
+		TLSConfig:      config.TLSConfig,
+		ExtraHeaders:   config.ExtraHeaders,
+		SOCKS5ProxyURL: config.SOCKS5ProxyURL,
+		Logger:         config.Logger,
 	}
 	publicURL := fetchPublicURL(ctx, fetchCfg)
 
@@ -1505,10 +1542,15 @@ var ExtractIncidentClientFromEnv server.StdioContextFunc = func(ctx context.Cont
 	client := incident.NewClient(incidentURL, apiKey)
 
 	transport, err := BuildTransport(&config, nil, WithoutAuth())
-	if err != nil {
-		logger.Error("Failed to create custom transport for incident client, using default", "error", err)
-	} else {
+	switch {
+	case err == nil:
 		client.HTTPClient.Transport = transport
+	case config.SOCKS5ProxyURL != "":
+		// Fail closed: a default transport would bypass the configured proxy.
+		logger.Error("Failed to create custom transport for incident client, failing closed because a SOCKS5 proxy is configured", "error", err)
+		client.HTTPClient.Transport = failClosedTransport(err)
+	default:
+		logger.Error("Failed to create custom transport for incident client, using default", "error", err)
 	}
 
 	return context.WithValue(ctx, incidentClientKey{}, client)
@@ -1527,10 +1569,15 @@ var ExtractIncidentClientFromHeaders httpContextFunc = func(ctx context.Context,
 	// the incident client may be created with a different org context.
 	config.OrgID = orgID
 	transport, err := BuildTransport(&config, nil, WithoutAuth())
-	if err != nil {
-		logger.Error("Failed to create custom transport for incident client, using default", "error", err)
-	} else {
+	switch {
+	case err == nil:
 		client.HTTPClient.Transport = transport
+	case config.SOCKS5ProxyURL != "":
+		// Fail closed: a default transport would bypass the configured proxy.
+		logger.Error("Failed to create custom transport for incident client, failing closed because a SOCKS5 proxy is configured", "error", err)
+		client.HTTPClient.Transport = failClosedTransport(err)
+	default:
+		logger.Error("Failed to create custom transport for incident client, using default", "error", err)
 	}
 
 	return context.WithValue(ctx, incidentClientKey{}, client)

--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -349,25 +349,28 @@ func parseProxiedToolName(toolName string) (string, string, error) {
 //     and are sent on every request; a serialized, unambiguous form is used
 //     because a map is neither comparable nor usable as a struct field of a map
 //     key.
+//   - socks5ProxyURL: the proxy is baked into the built transport, and the URL
+//     may carry proxy credentials.
 //
 // GrafanaConfig.BaseTransport is intentionally NOT part of the key: it is an
 // http.RoundTripper (an interface value that is not reliably comparable) and is
 // process-constant (set once at server construction, never per request/session),
 // so it cannot differ between two sessions and needs no differentiation.
 type proxiedToolSetKey struct {
-	url           string
-	apiKey        string
-	accessToken   string
-	idToken       string
-	orgID         int64
-	timeout       time.Duration
-	basicAuthUser string
-	basicAuthPass string
-	tlsCertFile   string
-	tlsKeyFile    string
-	tlsCAFile     string
-	tlsSkipVerify bool
-	extraHeaders  string // sorted, unambiguously-encoded ExtraHeaders
+	url            string
+	apiKey         string
+	accessToken    string
+	idToken        string
+	orgID          int64
+	timeout        time.Duration
+	basicAuthUser  string
+	basicAuthPass  string
+	tlsCertFile    string
+	tlsKeyFile     string
+	tlsCAFile      string
+	tlsSkipVerify  bool
+	extraHeaders   string // sorted, unambiguously-encoded ExtraHeaders
+	socks5ProxyURL string
 }
 
 // proxiedToolSetKeyFromContext builds a proxiedToolSetKey from the GrafanaConfig
@@ -375,13 +378,14 @@ type proxiedToolSetKey struct {
 func proxiedToolSetKeyFromContext(ctx context.Context) proxiedToolSetKey {
 	config := GrafanaConfigFromContext(ctx)
 	key := proxiedToolSetKey{
-		url:          config.URL,
-		apiKey:       config.APIKey,
-		accessToken:  config.AccessToken,
-		idToken:      config.IDToken,
-		orgID:        config.OrgID,
-		timeout:      config.Timeout,
-		extraHeaders: serializeHeaders(config.ExtraHeaders),
+		url:            config.URL,
+		apiKey:         config.APIKey,
+		accessToken:    config.AccessToken,
+		idToken:        config.IDToken,
+		orgID:          config.OrgID,
+		timeout:        config.Timeout,
+		extraHeaders:   serializeHeaders(config.ExtraHeaders),
+		socks5ProxyURL: config.SOCKS5ProxyURL,
 	}
 	if config.BasicAuth != nil {
 		key.basicAuthUser = config.BasicAuth.Username()
@@ -422,18 +426,18 @@ func serializeHeaders(headers map[string]string) string {
 }
 
 // String returns a redacted string representation for logging: secret-bearing
-// fields (apiKey, accessToken, idToken, basicAuthPass) are reduced to a present/
-// absent bool, never their value.
+// fields (apiKey, accessToken, idToken, basicAuthPass, socks5ProxyURL) are
+// reduced to a present/absent bool, never their value.
 func (k proxiedToolSetKey) String() string {
-	return fmt.Sprintf("url=%s apiKey=%t accessToken=%t idToken=%t orgID=%d timeout=%s basicAuth=%t tlsCert=%t tlsCA=%t tlsSkipVerify=%t extraHeaders=%t",
+	return fmt.Sprintf("url=%s apiKey=%t accessToken=%t idToken=%t orgID=%d timeout=%s basicAuth=%t tlsCert=%t tlsCA=%t tlsSkipVerify=%t extraHeaders=%t socks5Proxy=%t",
 		k.url, k.apiKey != "", k.accessToken != "", k.idToken != "", k.orgID, k.timeout, k.basicAuthUser != "",
-		k.tlsCertFile != "", k.tlsCAFile != "", k.tlsSkipVerify, k.extraHeaders != "")
+		k.tlsCertFile != "", k.tlsCAFile != "", k.tlsSkipVerify, k.extraHeaders != "", k.socks5ProxyURL != "")
 }
 
 // LogValue makes proxiedToolSetKey a slog.LogValuer so that logging it (e.g.
 // slog "key", set.key) emits the redacted String() form. slog does NOT honor
 // fmt.Stringer for Any values, so without this the raw struct fields (including
-// the secret apiKey/accessToken/idToken/basicAuthPass) would be reflected into
+// the secret apiKey/accessToken/idToken/basicAuthPass/socks5ProxyURL) would be reflected into
 // logs.
 func (k proxiedToolSetKey) LogValue() slog.Value {
 	return slog.StringValue(k.String())

--- a/socks5_proxy.go
+++ b/socks5_proxy.go
@@ -1,0 +1,71 @@
+package mcpgrafana
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// parseSOCKS5ProxyURL parses and validates a SOCKS5 proxy URL for use with
+// http.Transport.Proxy. Only the socks5 and socks5h schemes are accepted
+// (net/http treats them identically: hostname resolution is delegated to the
+// proxy). The URL must consist of scheme, optional userinfo, host, and
+// optional port only.
+//
+// Error messages never include the raw input: proxy URLs may embed
+// credentials, and these errors end up in logs and stderr.
+func parseSOCKS5ProxyURL(raw string) (*url.URL, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("SOCKS5 proxy URL is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("SOCKS5 proxy URL is not a valid URL")
+	}
+	if u.Scheme != "socks5" && u.Scheme != "socks5h" {
+		return nil, fmt.Errorf("SOCKS5 proxy URL must use the socks5 or socks5h scheme, got %q", u.Scheme)
+	}
+	if u.Opaque != "" {
+		return nil, fmt.Errorf("SOCKS5 proxy URL must be of the form socks5://host:port")
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("SOCKS5 proxy URL must include a host")
+	}
+	if port := u.Port(); port != "" {
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return nil, fmt.Errorf("SOCKS5 proxy URL port must be between 1 and 65535")
+		}
+	}
+	if u.Path != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return nil, fmt.Errorf("SOCKS5 proxy URL must not contain a path, query, or fragment")
+	}
+	return u, nil
+}
+
+// failClosedRoundTripper fails every request with the stored error.
+type failClosedRoundTripper struct {
+	err error
+}
+
+func (t *failClosedRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.err
+}
+
+// failClosedTransport returns an http.RoundTripper that fails every request
+// with err. Call sites that fall back to a default transport when
+// BuildTransport fails must use it instead when a SOCKS5 proxy is configured,
+// so that a misconfigured transport never silently bypasses the proxy.
+func failClosedTransport(err error) http.RoundTripper {
+	return &failClosedRoundTripper{err: err}
+}
+
+// ValidateSOCKS5ProxyURL reports whether raw is a valid SOCKS5 proxy URL as
+// accepted by GrafanaConfig.SOCKS5ProxyURL. It is intended for early
+// validation at startup so that misconfiguration fails fast instead of
+// surfacing later when the first Grafana client is built.
+func ValidateSOCKS5ProxyURL(raw string) error {
+	_, err := parseSOCKS5ProxyURL(raw)
+	return err
+}

--- a/socks5_proxy_test.go
+++ b/socks5_proxy_test.go
@@ -1,0 +1,292 @@
+package mcpgrafana
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSOCKS5ProxyURL(t *testing.T) {
+	t.Run("valid URLs", func(t *testing.T) {
+		for _, raw := range []string{
+			"socks5://proxy.example.com:1080",
+			"socks5h://proxy.example.com",
+			"socks5://user:pass@proxy.example.com:1080",
+			"socks5://[::1]:1080",
+		} {
+			u, err := parseSOCKS5ProxyURL(raw)
+			require.NoError(t, err, "expected %q to be valid", raw)
+			require.NotNil(t, u)
+		}
+	})
+
+	t.Run("invalid URLs", func(t *testing.T) {
+		for name, raw := range map[string]string{
+			"empty string":     "",
+			"http scheme":      "http://proxy.example.com:1080",
+			"https scheme":     "https://proxy.example.com:1080",
+			"empty host":       "socks5://:1080",
+			"port zero":        "socks5://proxy.example.com:0",
+			"port too large":   "socks5://proxy.example.com:65536",
+			"non-numeric port": "socks5://proxy.example.com:abc",
+			"path":             "socks5://proxy.example.com:1080/path",
+			"query":            "socks5://proxy.example.com:1080?key=value",
+			"force query":      "socks5://proxy.example.com:1080?",
+			"fragment":         "socks5://proxy.example.com:1080#frag",
+			"opaque":           "socks5:proxy.example.com",
+			"no scheme":        "proxy.example.com:1080",
+		} {
+			_, err := parseSOCKS5ProxyURL(raw)
+			assert.Error(t, err, "expected %q (%s) to be invalid", raw, name)
+		}
+	})
+
+	t.Run("errors do not leak credentials or the raw URL", func(t *testing.T) {
+		for _, raw := range []string{
+			"socks5://user:secretpw@proxy.example.com:99999",
+			"socks5://user:secretpw@proxy.example.com:bad%port",
+		} {
+			_, err := parseSOCKS5ProxyURL(raw)
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "secretpw")
+			assert.NotContains(t, err.Error(), raw)
+		}
+	})
+}
+
+// TestNewGrafanaClientUsesSOCKS5Proxy is a behavioral regression test: every
+// request made by NewGrafanaClient — the public-URL fetch during construction
+// (fetchCfg) and OpenAPI client calls (oboConfig) — must be dialed through the
+// configured SOCKS5 proxy, never directly. The fake proxy accepts TCP
+// connections and immediately closes them; a full SOCKS handshake is not
+// needed to observe the dial.
+func TestNewGrafanaClientUsesSOCKS5Proxy(t *testing.T) {
+	var directHits atomic.Int32
+	ts := newTestHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		directHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	var proxyConns atomic.Int32
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			proxyConns.Add(1)
+			_ = conn.Close()
+		}
+	}()
+
+	ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{
+		SOCKS5ProxyURL: "socks5://" + ln.Addr().String(),
+	})
+	c := NewGrafanaClient(ctx, ts.URL, "test-key", nil)
+	require.NotNil(t, c)
+
+	// The public-URL fetch inside NewGrafanaClient uses fetchCfg.
+	assert.Positive(t, proxyConns.Load(), "public URL fetch must be dialed through the proxy")
+	assert.Zero(t, directHits.Load(), "no request may bypass the proxy")
+
+	// An OpenAPI client call uses the transport built from oboConfig.
+	before := proxyConns.Load()
+	_, err = c.Search.Search(nil, nil)
+	require.Error(t, err, "the fake proxy drops connections, so the call must fail")
+	assert.Greater(t, proxyConns.Load(), before, "OpenAPI calls must be dialed through the proxy")
+	assert.Zero(t, directHits.Load(), "no request may bypass the proxy")
+}
+
+func TestProxiedToolSetKeyIncludesSOCKS5Proxy(t *testing.T) {
+	ctxA := WithGrafanaConfig(context.Background(), GrafanaConfig{SOCKS5ProxyURL: "socks5://proxy-a.example.com:1080"})
+	ctxB := WithGrafanaConfig(context.Background(), GrafanaConfig{SOCKS5ProxyURL: "socks5://user:secretpw@proxy-b.example.com:1080"})
+	keyA := proxiedToolSetKeyFromContext(ctxA)
+	keyB := proxiedToolSetKeyFromContext(ctxB)
+	keyNone := proxiedToolSetKeyFromContext(context.Background())
+
+	assert.NotEqual(t, keyA, keyB, "different proxy URLs must produce different keys")
+	assert.NotEqual(t, keyA, keyNone, "proxy vs no proxy must produce different keys")
+
+	s := keyB.String()
+	assert.NotContains(t, s, "secretpw", "String() must not leak proxy credentials")
+	assert.NotContains(t, s, "proxy-b.example.com", "String() must not leak the proxy host")
+	assert.Contains(t, s, "socks5Proxy=true")
+	assert.Contains(t, keyNone.String(), "socks5Proxy=false")
+	assert.Equal(t, s, keyB.LogValue().String())
+}
+
+// TestProxiedToolSetKeyLogRedaction logs the key through a real slog JSON
+// handler (the way production code logs it) and asserts the proxy URL and its
+// credentials never reach the log output.
+func TestProxiedToolSetKeyLogRedaction(t *testing.T) {
+	key := proxiedToolSetKeyFromContext(WithGrafanaConfig(context.Background(),
+		GrafanaConfig{SOCKS5ProxyURL: "socks5://user:secretpw@proxy-b.example.com:1080"}))
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.Info("test", "key", key)
+
+	out := buf.String()
+	assert.NotContains(t, out, "secretpw")
+	assert.NotContains(t, out, "proxy-b.example.com")
+	assert.Contains(t, out, "socks5Proxy=true")
+}
+
+// TestExtractIncidentClientFromHeadersFailsClosed mirrors the env-based
+// fail-closed test for the request-scoped incident client constructor.
+func TestExtractIncidentClientFromHeadersFailsClosed(t *testing.T) {
+	baseCalled := false
+	mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+		baseCalled = true
+		return &http.Response{StatusCode: 200}, nil
+	}}
+	cfg := GrafanaConfig{SOCKS5ProxyURL: "socks5://proxy.example.com:1080", BaseTransport: mock}
+	ctx := WithGrafanaConfig(context.Background(), cfg)
+	req, _ := http.NewRequest("GET", "http://mcp.example.com/mcp", nil)
+	ctx = ExtractIncidentClientFromHeaders(ctx, req)
+	client := IncidentClientFromContext(ctx)
+	require.NotNil(t, client)
+	require.NotNil(t, client.HTTPClient.Transport, "transport must be set to a fail-closed RoundTripper")
+
+	outReq, _ := http.NewRequest("GET", "http://grafana.example.com/api/health", nil)
+	_, err := client.HTTPClient.Transport.RoundTrip(outReq)
+	require.Error(t, err)
+	assert.False(t, baseCalled, "request must not reach the base transport")
+}
+
+func TestFailClosedTransport(t *testing.T) {
+	sentinel := errors.New("transport misconfigured")
+	rt := failClosedTransport(sentinel)
+	req, _ := http.NewRequest("GET", "http://grafana.example.com", nil)
+	resp, err := rt.RoundTrip(req)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestValidateSOCKS5ProxyURL(t *testing.T) {
+	assert.NoError(t, ValidateSOCKS5ProxyURL("socks5://proxy.example.com:1080"))
+	assert.Error(t, ValidateSOCKS5ProxyURL("http://proxy.example.com:1080"))
+}
+
+// innermostTransport builds a transport with all optional layers disabled and
+// unwraps the always-present ExtraHeaders layer, returning the innermost
+// RoundTripper that BuildTransport produced.
+func innermostTransport(t *testing.T, cfg *GrafanaConfig, base http.RoundTripper) (http.RoundTripper, error) {
+	t.Helper()
+	transport, err := BuildTransport(cfg, base, WithoutAuth(), WithoutOrgID(), WithoutUserAgent(), WithoutOtel())
+	if err != nil {
+		return nil, err
+	}
+	eh, ok := transport.(*ExtraHeadersRoundTripper)
+	require.True(t, ok, "expected outermost layer to be ExtraHeadersRoundTripper, got %T", transport)
+	return eh.underlying, nil
+}
+
+func TestBuildTransportSOCKS5Proxy(t *testing.T) {
+	const proxyRaw = "socks5://proxy.example.com:1080"
+	grafanaReq, _ := http.NewRequest("GET", "http://grafana.example.com/api/health", nil)
+
+	t.Run("proxy applied to default transport", func(t *testing.T) {
+		inner, err := innermostTransport(t, &GrafanaConfig{SOCKS5ProxyURL: proxyRaw}, nil)
+		require.NoError(t, err)
+		ht, ok := inner.(*http.Transport)
+		require.True(t, ok, "expected *http.Transport, got %T", inner)
+		proxyURL, err := ht.Proxy(grafanaReq)
+		require.NoError(t, err)
+		require.NotNil(t, proxyURL)
+		assert.Equal(t, proxyRaw, proxyURL.String())
+	})
+
+	t.Run("proxy preserved when TLS config is applied", func(t *testing.T) {
+		cfg := &GrafanaConfig{
+			SOCKS5ProxyURL: proxyRaw,
+			TLSConfig:      &TLSConfig{SkipVerify: true},
+		}
+		inner, err := innermostTransport(t, cfg, nil)
+		require.NoError(t, err)
+		ht, ok := inner.(*http.Transport)
+		require.True(t, ok, "expected *http.Transport, got %T", inner)
+		require.NotNil(t, ht.TLSClientConfig)
+		assert.True(t, ht.TLSClientConfig.InsecureSkipVerify)
+		proxyURL, err := ht.Proxy(grafanaReq)
+		require.NoError(t, err)
+		require.NotNil(t, proxyURL)
+		assert.Equal(t, proxyRaw, proxyURL.String())
+	})
+
+	t.Run("unset proxy leaves base untouched", func(t *testing.T) {
+		base := &http.Transport{MaxIdleConns: 123}
+		inner, err := innermostTransport(t, &GrafanaConfig{}, base)
+		require.NoError(t, err)
+		assert.Same(t, base, inner, "base transport must not be cloned when no proxy is set")
+		assert.Nil(t, base.Proxy)
+	})
+
+	t.Run("custom *http.Transport base is cloned, not mutated", func(t *testing.T) {
+		base := &http.Transport{MaxIdleConns: 123}
+		inner, err := innermostTransport(t, &GrafanaConfig{SOCKS5ProxyURL: proxyRaw}, base)
+		require.NoError(t, err)
+		ht, ok := inner.(*http.Transport)
+		require.True(t, ok, "expected *http.Transport, got %T", inner)
+		assert.NotSame(t, base, ht)
+		assert.Equal(t, 123, ht.MaxIdleConns, "clone must preserve base transport settings")
+		assert.Nil(t, base.Proxy, "original base transport must not be mutated")
+		proxyURL, err := ht.Proxy(grafanaReq)
+		require.NoError(t, err)
+		require.NotNil(t, proxyURL)
+		assert.Equal(t, proxyRaw, proxyURL.String())
+	})
+
+	t.Run("invalid proxy URL returns error", func(t *testing.T) {
+		_, err := BuildTransport(&GrafanaConfig{SOCKS5ProxyURL: "http://proxy.example.com:1080"}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("fail-closed incident client never sends requests when proxy is misconfigured", func(t *testing.T) {
+		baseCalled := false
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			baseCalled = true
+			return &http.Response{StatusCode: 200}, nil
+		}}
+		// A non-*http.Transport base makes BuildTransport fail when a SOCKS5
+		// proxy is configured; the incident client must then refuse to send
+		// requests instead of falling back to a direct connection.
+		cfg := GrafanaConfig{SOCKS5ProxyURL: proxyRaw, BaseTransport: mock}
+		ctx := WithGrafanaConfig(context.Background(), cfg)
+		ctx = ExtractIncidentClientFromEnv(ctx)
+		client := IncidentClientFromContext(ctx)
+		require.NotNil(t, client)
+		require.NotNil(t, client.HTTPClient.Transport, "transport must be set to a fail-closed RoundTripper")
+
+		req, _ := http.NewRequest("GET", "http://grafana.example.com/api/health", nil)
+		_, err := client.HTTPClient.Transport.RoundTrip(req)
+		require.Error(t, err)
+		assert.False(t, baseCalled, "request must not reach the base transport")
+	})
+
+	t.Run("non-Transport BaseTransport conflicts with proxy", func(t *testing.T) {
+		mock := &capturingMockRT{fn: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200}, nil
+		}}
+		cfg := &GrafanaConfig{
+			SOCKS5ProxyURL: "socks5://user:secretpw@proxy.example.com:1080",
+			BaseTransport:  mock,
+		}
+		_, err := BuildTransport(cfg, nil)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "secretpw", "error must not leak proxy credentials")
+		assert.NotContains(t, err.Error(), "proxy.example.com", "error must not leak the proxy URL")
+	})
+}

--- a/tools/oncall.go
+++ b/tools/oncall.go
@@ -80,6 +80,7 @@ func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
 	// Customize the HTTP client's transport using reflection since the
 	// OnCall client doesn't expose its HTTP client directly. Auth is
 	// handled by the OnCall library (API key passed above), so we skip it.
+	transportInstalled := false
 	clientValue := reflect.ValueOf(client)
 	if clientValue.Kind() == reflect.Ptr && !clientValue.IsNil() {
 		clientValue = clientValue.Elem()
@@ -95,13 +96,24 @@ func oncallClientFromContext(ctx context.Context) (*aapi.Client, error) {
 				if httpClient, ok := httpClientField.Interface().(*http.Client); ok {
 					transport, err := mcpgrafana.BuildTransport(&cfg, nil, mcpgrafana.WithoutAuth())
 					if err != nil {
+						if cfg.SOCKS5ProxyURL != "" {
+							// Fail closed: a default transport would bypass the configured proxy.
+							return nil, fmt.Errorf("building transport for OnCall client: %w", err)
+						}
 						mcpgrafana.LoggerFromContext(ctx).Error("Failed to build transport for OnCall client", "error", err)
 					} else {
 						httpClient.Transport = transport
+						transportInstalled = true
 					}
 				}
 			}
 		}
+	}
+	if cfg.SOCKS5ProxyURL != "" && !transportInstalled {
+		// Fail closed: the reflection above could not reach the OnCall
+		// client's HTTP client, so its default transport would bypass the
+		// configured proxy.
+		return nil, fmt.Errorf("SOCKS5 proxy is configured but the OnCall client's transport could not be replaced")
 	}
 
 	return client, nil


### PR DESCRIPTION
Closes #983.

Adds a `GRAFANA_SOCKS5_PROXY` environment variable that routes this server's Grafana traffic through a SOCKS5 proxy. The setting is scoped to mcp-grafana: it does not modify `HTTP_PROXY`/`HTTPS_PROXY`, and when it is unset nothing changes.

## How it works

- `GRAFANA_SOCKS5_PROXY` accepts `socks5://` and `socks5h://` URLs (Go's net/http treats the two schemes identically; the proxy resolves hostnames). Credentials in the URL work.
- The URL is validated at startup and the process refuses to start on an invalid value. Validation errors never include the raw value, since it may embed proxy credentials.
- `BuildTransport` applies the proxy to a clone of the innermost `*http.Transport`, below the TLS layer, so every client built through it (OpenAPI, datasource backends, rendering, proxied MCP, incident, OnCall, k8s) picks it up. No new dependencies: `http.Transport.Proxy` supports SOCKS5 natively.
- A `BaseTransport` that is not an `*http.Transport` cannot carry a proxy, so that combination is an explicit error instead of a silent replacement.

## Fail-closed behavior

A few call sites used to fall back to a default transport when building the custom transport failed (the incident clients, the cached incident client, OnCall, and the reflection path in `NewGrafanaClient`). With a proxy configured, that fallback would send traffic directly, so these paths now return an error instead of bypassing the proxy. Without a proxy their behavior is unchanged.

`proxiedToolSetKey` now includes the proxy URL, since two sessions with different proxies must not share a client. Logs only see a redacted present/absent flag.

## Testing

- Unit tests cover URL validation, `BuildTransport` clone semantics and TLS interaction, the base-transport conflict, fail-closed incident clients, the cache key, and log redaction through a real `slog` JSON handler.
- A behavioral test drives `NewGrafanaClient` against an `httptest` server plus a fake SOCKS listener and asserts every request (the public-URL fetch and OpenAPI calls) is dialed through the proxy, never directly.
- `go test -tags unit ./...`, `go build ./...`, and `golangci-lint` v2.11.4 (the CI version) pass locally.
