### PR TITLE
feat(api): allow POST to /api/ds/query in read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ When `--disable-query` is enabled, the following tools are not registered:
 
 The `elasticsearch`, `quickwit`, `influxdb`, and `runpanelquery` categories contain nothing else, so they register no tools at all when queries are disabled. The sibling tools in every other category — `list_prometheus_metric_names`, `list_loki_label_values`, `describe_clickhouse_table`, `list_cloudwatch_metrics`, and so on — remain available.
 
-Note that `--disable-query` gates the query tools; it does not police other paths to a datasource. `grafana_api_request` (in the `api` category, itself restricted to GET requests under `--disable-write`) and `get_panel_image`, which renders a panel server-side, are unaffected.
+Note that `--disable-query` gates the query tools and the `grafana_api_request` POST-to-`/api/ds/query` path, but does not police every route to a datasource. In read-only mode, `grafana_api_request` allows POST to `/api/ds/query` only when query tools are enabled (same gate as the raw-SQL tools — blocked by `--disable-write` unless `--enable-query` overrides). `get_panel_image`, which renders a panel server-side, is unaffected.
 
 **Client TLS Configuration (for Grafana connections):**
 - `--tls-cert-file`: Path to TLS certificate file for client authentication

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -353,7 +353,7 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{func(mcp *server.MCPServer) { tools.AddGraphiteTools(mcp, enableQueryTools) }, dt.graphite, "graphite"},
 		{func(mcp *server.MCPServer) { tools.AddAthenaTools(mcp, enableMutatingQueryTools) }, dt.athena, "athena"},
 		{func(mcp *server.MCPServer) { tools.AddPluginTools(mcp, enableWriteTools) }, dt.plugin, "plugin"},
-		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools) }, dt.api, "api"},
+		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools, enableQueryTools) }, dt.api, "api"},
 		{tools.AddConfigTools, dt.config, "config"},
 		{tools.AddProvisioningTools, dt.provisioning, "provisioning"},
 		{func(mcp *server.MCPServer) { tools.AddAgento11yTools(mcp, enableWriteTools) }, dt.agento11y, "agento11y"},

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -353,7 +353,7 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{func(mcp *server.MCPServer) { tools.AddGraphiteTools(mcp, enableQueryTools) }, dt.graphite, "graphite"},
 		{func(mcp *server.MCPServer) { tools.AddAthenaTools(mcp, enableMutatingQueryTools) }, dt.athena, "athena"},
 		{func(mcp *server.MCPServer) { tools.AddPluginTools(mcp, enableWriteTools) }, dt.plugin, "plugin"},
-		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools, enableQueryTools) }, dt.api, "api"},
+		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools, enableMutatingQueryTools) }, dt.api, "api"},
 		{tools.AddConfigTools, dt.config, "config"},
 		{tools.AddProvisioningTools, dt.provisioning, "provisioning"},
 		{func(mcp *server.MCPServer) { tools.AddAgento11yTools(mcp, enableWriteTools) }, dt.agento11y, "agento11y"},

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -144,7 +144,7 @@ The following tools are not registered when the flag is set:
 
 The `elasticsearch`, `quickwit`, `influxdb`, and `runpanelquery` categories contain nothing else, so they expose no tools at all when queries are disabled. Sibling tools such as `list_prometheus_metric_names`, `list_loki_label_values`, `describe_clickhouse_table`, and `list_cloudwatch_metrics` remain available.
 
-The flag gates the query tools; it doesn't police every path to a datasource. `grafana_api_request` — itself restricted to GET requests under `--disable-write` — and `get_panel_image`, which renders a panel server-side, are unaffected.
+The flag gates the query tools and the `grafana_api_request` POST-to-`/api/ds/query` path, but doesn't police every route to a datasource. In read-only mode, `grafana_api_request` allows POST to `/api/ds/query` only when query tools are enabled (same gate as the raw-SQL tools — blocked by `--disable-write` unless `--enable-query` overrides). `get_panel_image`, which renders a panel server-side, is unaffected.
 
 ### Query execution and read-only mode
 

--- a/tools/api.go
+++ b/tools/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/itchyny/gojq"
@@ -68,7 +69,11 @@ func apiRequestReadOnly(ctx context.Context, args APIRequestReadOnlyParams) (*AP
 		method = http.MethodGet
 	}
 	if method != http.MethodGet {
-		if method != http.MethodPost || !readOnlyPOSTEndpoints[args.Endpoint] {
+		endpointPath := args.Endpoint
+		if u, err := url.Parse(args.Endpoint); err == nil {
+			endpointPath = u.Path
+		}
+		if method != http.MethodPost || !readOnlyPOSTEndpoints[endpointPath] {
 			return nil, fmt.Errorf("method %s to endpoint %s is not allowed in read-only mode; only GET requests and POST to read-only query endpoints (e.g. /api/ds/query) are permitted", method, args.Endpoint)
 		}
 	}
@@ -217,9 +222,8 @@ var APIRequestReadOnly = mcpgrafana.MustTool(
 		"Only GET requests are allowed, except POST to read-only query endpoints such as /api/ds/query.",
 	apiRequestReadOnly,
 	mcp.WithTitleAnnotation("Grafana API request"),
-	mcp.WithIdempotentHintAnnotation(true),
-	mcp.WithReadOnlyHintAnnotation(true),
-	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithReadOnlyHintAnnotation(false),
+	mcp.WithDestructiveHintAnnotation(true),
 	mcp.WithOpenWorldHintAnnotation(false),
 )
 

--- a/tools/api.go
+++ b/tools/api.go
@@ -23,6 +23,12 @@ var allowedMethods = map[string]bool{
 	http.MethodDelete: true,
 }
 
+// readOnlyPOSTEndpoints lists POST endpoints that are semantically read-only
+// (e.g. query endpoints that require POST for their request body).
+var readOnlyPOSTEndpoints = map[string]bool{
+	"/api/ds/query": true,
+}
+
 type APIRequestParams struct {
 	Endpoint string            `json:"endpoint" jsonschema:"required,description=The API path relative to the Grafana base URL (e.g. '/api/org'\\, '/api/dashboards/uid/abc123'). Must start with '/'."`
 	Method   string            `json:"method,omitempty" jsonschema:"enum=GET,enum=POST,enum=PUT,enum=PATCH,enum=DELETE,description=HTTP method. Defaults to GET"`
@@ -32,6 +38,14 @@ type APIRequestParams struct {
 }
 
 type APIRequestReadOnlyParams struct {
+	Endpoint string            `json:"endpoint" jsonschema:"required,description=The API path relative to the Grafana base URL (e.g. '/api/org'\\, '/api/dashboards/uid/abc123'\\, '/api/ds/query'). Must start with '/'."`
+	Method   string            `json:"method,omitempty" jsonschema:"enum=GET,enum=POST,description=HTTP method. Defaults to GET. POST is only allowed for specific read-only query endpoints such as /api/ds/query."`
+	Body     string            `json:"body,omitempty" jsonschema:"description=Request body (JSON string). Used with POST requests to read-only query endpoints such as /api/ds/query."`
+	Headers  map[string]string `json:"headers,omitempty" jsonschema:"description=Additional HTTP headers to include in the request."`
+	JQ       string            `json:"jq,omitempty" jsonschema:"description=A jq expression to filter or transform the JSON response (e.g. '.dashboards[] | .title')."`
+}
+
+type APIRequestReadOnlyGetOnlyParams struct {
 	Endpoint string            `json:"endpoint" jsonschema:"required,description=The API path relative to the Grafana base URL (e.g. '/api/org'\\, '/api/dashboards/uid/abc123'). Must start with '/'."`
 	Method   string            `json:"method,omitempty" jsonschema:"enum=GET,description=HTTP method. Only GET is allowed in read-only mode"`
 	Headers  map[string]string `json:"headers,omitempty" jsonschema:"description=Additional HTTP headers to include in the request."`
@@ -49,6 +63,19 @@ func apiRequest(ctx context.Context, args APIRequestParams) (*APIRequestResult, 
 }
 
 func apiRequestReadOnly(ctx context.Context, args APIRequestReadOnlyParams) (*APIRequestResult, error) {
+	method := strings.ToUpper(args.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+	if method != http.MethodGet {
+		if method != http.MethodPost || !readOnlyPOSTEndpoints[args.Endpoint] {
+			return nil, fmt.Errorf("method %s to endpoint %s is not allowed in read-only mode; only GET requests and POST to read-only query endpoints (e.g. /api/ds/query) are permitted", method, args.Endpoint)
+		}
+	}
+	return doAPIRequest(ctx, args.Endpoint, method, args.Body, args.Headers, args.JQ)
+}
+
+func apiRequestReadOnlyGetOnly(ctx context.Context, args APIRequestReadOnlyGetOnlyParams) (*APIRequestResult, error) {
 	method := strings.ToUpper(args.Method)
 	if method == "" {
 		method = http.MethodGet
@@ -187,7 +214,7 @@ var APIRequestReadOnly = mcpgrafana.MustTool(
 	"Make an authenticated HTTP request to the Grafana API. Similar to 'gh api' for GitHub. "+
 		"Supports any Grafana API endpoint with optional jq-style response filtering. "+
 		"Use this for API endpoints that don't have a dedicated tool. "+
-		"Only GET requests are allowed.",
+		"Only GET requests are allowed, except POST to read-only query endpoints such as /api/ds/query.",
 	apiRequestReadOnly,
 	mcp.WithTitleAnnotation("Grafana API request"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -196,10 +223,26 @@ var APIRequestReadOnly = mcpgrafana.MustTool(
 	mcp.WithOpenWorldHintAnnotation(false),
 )
 
-func AddAPITools(mcp *server.MCPServer, enableWriteTools bool) {
+var APIRequestReadOnlyGetOnly = mcpgrafana.MustTool(
+	"grafana_api_request",
+	"Make an authenticated HTTP request to the Grafana API. Similar to 'gh api' for GitHub. "+
+		"Supports any Grafana API endpoint with optional jq-style response filtering. "+
+		"Use this for API endpoints that don't have a dedicated tool. "+
+		"Only GET requests are allowed.",
+	apiRequestReadOnlyGetOnly,
+	mcp.WithTitleAnnotation("Grafana API request"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
+)
+
+func AddAPITools(mcp *server.MCPServer, enableWriteTools bool, enableQueryTools bool) {
 	if enableWriteTools {
 		APIRequest.Register(mcp)
-	} else {
+	} else if enableQueryTools {
 		APIRequestReadOnly.Register(mcp)
+	} else {
+		APIRequestReadOnlyGetOnly.Register(mcp)
 	}
 }

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -221,7 +221,7 @@ func TestAPIRequest_AuthHeadersIncluded(t *testing.T) {
 func TestAPIRequest_ReadOnlyRejectsNonGET(t *testing.T) {
 	ctx := apiTestContext(t, "http://localhost")
 
-	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+	for _, method := range []string{"PUT", "PATCH", "DELETE"} {
 		_, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{
 			Endpoint: "/api/org",
 			Method:   method,
@@ -229,6 +229,44 @@ func TestAPIRequest_ReadOnlyRejectsNonGET(t *testing.T) {
 		require.Error(t, err, "method %s should be rejected", method)
 		assert.Contains(t, err.Error(), "not allowed in read-only mode")
 	}
+}
+
+func TestAPIRequest_ReadOnlyRejectsPOSTToNonAllowedEndpoint(t *testing.T) {
+	ctx := apiTestContext(t, "http://localhost")
+
+	_, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{
+		Endpoint: "/api/annotations",
+		Method:   "POST",
+		Body:     `{"text":"test"}`,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed in read-only mode")
+}
+
+func TestAPIRequest_ReadOnlyAllowsPOSTToDsQuery(t *testing.T) {
+	var capturedMethod string
+	var capturedBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{}}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	queryBody := `{"queries":[{"refId":"A","datasource":{"uid":"test"},"expr":"up"}]}`
+	result, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{
+		Endpoint: "/api/ds/query",
+		Method:   "POST",
+		Body:     queryBody,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Equal(t, queryBody, capturedBody)
+	assert.Equal(t, http.StatusOK, result.Status)
 }
 
 func TestAPIRequest_ReadOnlyAllowsGET(t *testing.T) {
@@ -258,18 +296,43 @@ func TestAPIRequest_ReadOnlyDefaultMethodIsGET(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAPIRequest_ReadOnlyParamsHasNoBodyField(t *testing.T) {
+func TestAPIRequest_GetOnlyRejectsAllNonGET(t *testing.T) {
+	ctx := apiTestContext(t, "http://localhost")
+
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		_, err := apiRequestReadOnlyGetOnly(ctx, APIRequestReadOnlyGetOnlyParams{
+			Endpoint: "/api/org",
+			Method:   method,
+		})
+		require.Error(t, err, "method %s should be rejected", method)
+		assert.Contains(t, err.Error(), "not allowed in read-only mode")
+	}
+}
+
+func TestAPIRequest_GetOnlyRejectsPOSTToDsQuery(t *testing.T) {
+	ctx := apiTestContext(t, "http://localhost")
+
+	_, err := apiRequestReadOnlyGetOnly(ctx, APIRequestReadOnlyGetOnlyParams{
+		Endpoint: "/api/ds/query",
+		Method:   "POST",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed in read-only mode")
+}
+
+func TestAPIRequest_GetOnlyAllowsGET(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		assert.Empty(t, body)
+		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	t.Cleanup(ts.Close)
 
 	ctx := apiTestContext(t, ts.URL)
-	_, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{Endpoint: "/api/org"})
+	result, err := apiRequestReadOnlyGetOnly(ctx, APIRequestReadOnlyGetOnlyParams{Endpoint: "/api/org"})
+
 	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, result.Status)
 }
 
 func TestAPIRequest_MethodCaseInsensitive(t *testing.T) {

--- a/tools/api_unit_test.go
+++ b/tools/api_unit_test.go
@@ -269,6 +269,24 @@ func TestAPIRequest_ReadOnlyAllowsPOSTToDsQuery(t *testing.T) {
 	assert.Equal(t, http.StatusOK, result.Status)
 }
 
+func TestAPIRequest_ReadOnlyAllowsPOSTToDsQueryWithQueryString(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":{}}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := apiTestContext(t, ts.URL)
+	result, err := apiRequestReadOnly(ctx, APIRequestReadOnlyParams{
+		Endpoint: "/api/ds/query?ds_type=prometheus",
+		Method:   "POST",
+		Body:     `{"queries":[{"refId":"A"}]}`,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, result.Status)
+}
+
 func TestAPIRequest_ReadOnlyAllowsGET(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- Adds an allowlist (`readOnlyPOSTEndpoints`) for POST endpoints that are semantically read-only
- The read-only `grafana_api_request` tool now allows `POST /api/ds/query` so datasource queries work without write mode
- Adds `Body` field to `APIRequestReadOnlyParams` for the query payload
- POST to non-allowlisted endpoints is still rejected in read-only mode

## Test plan
- [x] Unit test: POST to `/api/ds/query` succeeds in read-only mode
- [x] Unit test: POST to non-allowed endpoints (e.g. `/api/annotations`) is rejected
- [x] Unit test: PUT/PATCH/DELETE still rejected in read-only mode
- [x] Unit test: GET requests still work as before
- [x] `go vet ./tools/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)