### PR TITLE
fix(proxied_tools): close non-published clients before signaling ready

### DIFF
--- a/proxied_tools.go
+++ b/proxied_tools.go
@@ -982,16 +982,20 @@ func (tm *ToolManager) runProxiedToolSetBuild(ctx context.Context, set *proxiedT
 	size := len(tm.proxiedSets)
 	tm.proxiedSetsMu.Unlock()
 
-	close(set.ready)
-
 	// On any non-publish outcome the freshly-built clients were NOT stored on the
 	// set, so no teardown path can observe or close them: close them here (once,
 	// outside the lock) or their remote connections leak. This covers both the
 	// abandoned case (all sessions left mid-build) and the failed case where the
 	// builder connected some clients before erroring or panicking.
+	//
+	// Closing BEFORE signaling ready ensures that by the time any waiter unblocks
+	// and observes the failure, the cleanup is already complete. The built clients
+	// are local (never published to set.clients), so no waiter accesses them.
 	if !published {
 		tm.closeProxiedClients(built.clients)
 	}
+
+	close(set.ready)
 
 	switch {
 	case abandoned:


### PR DESCRIPTION
## Summary

- Fixes a flaky `TestTeardownReleaseToZeroDuringBuild` test caused by a race between `close(set.ready)` and `closeProxiedClients(built.clients)` in `runProxiedToolSetBuild`
- Reorders the non-published client close to happen **before** `close(set.ready)`, so cleanup is complete before any waiter unblocks
- The built clients are local (never published to `set.clients`), so no waiter accesses them — this reorder is safe

## Test plan

- [x] `go test -run TestTeardownReleaseToZeroDuringBuild -count=100 -race` — 100/100 passes
- [x] `go test -run 'TestTeardown|TestFailed|TestEmpty|TestBuild|TestInFlight|TestProxiedToolSetKey' -count=10 -race` — all lifecycle tests pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.ai/code)