### PR TITLE
fix(dashboard): describe structured panel targets instead of dropping them

### DIFF
--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -697,12 +697,17 @@ type datasourceInfo struct {
 }
 
 type panelQuery struct {
-	Title             string         `json:"title"`
-	Query             string         `json:"query"`
-	ProcessedQuery    string         `json:"processedQuery,omitempty"`
-	Datasource        datasourceInfo `json:"datasource"`
-	RefID             string         `json:"refId,omitempty"`
-	RequiredVariables []VariableInfo `json:"requiredVariables,omitempty"`
+	Title string `json:"title"`
+	Query string `json:"query"`
+	// Target holds the panel's raw query target, minus the datasource and refId
+	// returned separately. It is set for a target built in a datasource's visual
+	// editor (CloudWatch metric search, InfluxDB's query builder), which has no
+	// string expression to put in Query.
+	Target            map[string]interface{} `json:"target,omitempty"`
+	ProcessedQuery    string                 `json:"processedQuery,omitempty"`
+	Datasource        datasourceInfo         `json:"datasource"`
+	RefID             string                 `json:"refId,omitempty"`
+	RequiredVariables []VariableInfo         `json:"requiredVariables,omitempty"`
 }
 
 func GetDashboardPanelQueriesTool(ctx context.Context, args DashboardPanelQueriesParams) ([]panelQuery, error) {
@@ -749,7 +754,7 @@ func GetDashboardPanelQueriesTool(ctx context.Context, args DashboardPanelQuerie
 
 var GetDashboardPanelQueries = mcpgrafana.MustTool(
 	"get_dashboard_panel_queries",
-	"Retrieve panel queries from a Grafana dashboard. Supports all datasource types (Prometheus, Loki, CloudWatch, SQL, etc.) and row-nested panels. Optionally filter to a specific panel by ID with `panelId`. Optionally provide `variables` for template variable substitution, which populates `processedQuery` and `requiredVariables` fields. Returns an array of objects with fields: title, query (raw expression), datasource (object with uid and type), and optionally processedQuery, refId, and requiredVariables.",
+	"Retrieve panel queries from a Grafana dashboard. Supports all datasource types (Prometheus, Loki, CloudWatch, SQL, etc.) and row-nested panels. Optionally filter to a specific panel by ID with `panelId`. Optionally provide `variables` for template variable substitution, which populates `processedQuery` and `requiredVariables` fields. Returns an array of objects with fields: title, query (raw expression), datasource (object with uid and type), and optionally processedQuery, refId, requiredVariables, and target. Targets built in a visual editor (CloudWatch metric search, InfluxDB query builder) have no string expression: those return an empty query plus `target`, the panel's raw query JSON. Run those with run_panel_query rather than a query tool.",
 	GetDashboardPanelQueriesTool,
 	mcp.WithTitleAnnotation("Get dashboard panel queries"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/dashboard_helpers.go
+++ b/tools/dashboard_helpers.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -229,18 +230,29 @@ func extractPanelQueries(panel map[string]interface{}, dashboardVars map[string]
 			RefID:      refID,
 		}
 
+		// Targets built in a datasource's visual editor carry no string
+		// expression at all. Hand back the target itself instead of dropping
+		// them silently.
+		if rawQuery == "" {
+			if !targetDescribesQuery(target) {
+				continue
+			}
+			pq.Target = queryTargetFields(target)
+		}
+
 		// Only do variable processing when dashboardVars is provided
 		if dashboardVars != nil {
-			pq.RequiredVariables = findVariablesInQuery(rawQuery, dashboardVars, overrides)
+			// A structured target has nothing runnable to substitute into, but it
+			// can still reference variables (a CloudWatch dimension of
+			// "$instance", say), so report those as required too.
+			pq.RequiredVariables = findVariablesInQuery(variableSearchText(pq), dashboardVars, overrides)
 			effectiveVars := buildEffectiveVariables(dashboardVars, overrides)
 			pq.ProcessedQuery = substituteVariables(rawQuery, effectiveVars)
 			dsInfo.UID = substituteVariables(dsInfo.UID, effectiveVars)
 			pq.Datasource = dsInfo
 		}
 
-		if rawQuery != "" {
-			queries = append(queries, pq)
-		}
+		queries = append(queries, pq)
 	}
 
 	return queries
@@ -257,6 +269,7 @@ func extractQueryExpression(target map[string]interface{}) string {
 		"rawSql",     // SQL databases
 		"rawSQL",     // Athena (grafana-athena-datasource)
 		"rawQuery",   // Some datasources
+		"target",     // Graphite metric path
 	}
 
 	for _, field := range queryFields {
@@ -266,6 +279,149 @@ func extractQueryExpression(target map[string]interface{}) string {
 	}
 
 	return ""
+}
+
+// structuredQueryFields are target fields we recognise as part of a query built
+// in a datasource's visual editor rather than written out as a string
+// expression: CloudWatch metric search, Pyroscope profile selection, InfluxDB's
+// query builder and so on. Recognising a field is not enough to call the target
+// a query -- see identifyingQueryFields.
+var structuredQueryFields = []string{
+	// CloudWatch metric search
+	"region", "namespace", "metricName", "statistic", "statistics", "dimensions", "accountId",
+	// Pyroscope
+	"profileTypeId", "labelSelector", "spanSelector",
+	// InfluxDB query builder
+	"policy", "measurement", "select", "tags", "groupBy",
+	// Elasticsearch aggregations
+	"metrics", "bucketAggs",
+	// Azure Monitor
+	"azureMonitor", "azureLogAnalytics", "azureTraces",
+}
+
+// structuredFieldSet indexes structuredQueryFields for lookups.
+var structuredFieldSet = func() map[string]bool {
+	set := make(map[string]bool, len(structuredQueryFields))
+	for _, field := range structuredQueryFields {
+		set[field] = true
+	}
+	return set
+}()
+
+// identifyingQueryFields is the subset of structuredQueryFields that says what a
+// query is *about*. The rest only refine one: Grafana persists them straight
+// from the query editor's defaults -- CloudWatch's "Average" statistic and
+// "default" region, InfluxDB's default retention policy -- so a query row nobody
+// filled in has them set and nothing else.
+var identifyingQueryFields = map[string]bool{
+	"metricName":        true, // CloudWatch metric search
+	"profileTypeId":     true, // Pyroscope
+	"measurement":       true, // InfluxDB query builder
+	"metrics":           true, // Elasticsearch aggregations (an empty lucene query is match-all, and still runs)
+	"azureMonitor":      true,
+	"azureLogAnalytics": true,
+	"azureTraces":       true,
+}
+
+// editorStateFields hold rendering, transport or query-editor state. Their
+// presence says nothing about whether a target asks for anything, so they don't
+// keep an otherwise-empty query row in the results. They are still returned to
+// the caller: queryType, for one, is what tells InfluxDB whether the panel is
+// influxql or flux.
+var editorStateFields = map[string]bool{
+	"datasource":       true,
+	"datasourceId":     true,
+	"refId":            true,
+	"hide":             true,
+	"hidden":           true,
+	"key":              true,
+	"id":               true,
+	"editorMode":       true,
+	"queryType":        true,
+	"queryMode":        true,
+	"metricQueryType":  true,
+	"metricEditorMode": true,
+	"matchExact":       true,
+	"format":           true,
+	"resultFormat":     true,
+	"instant":          true,
+	"range":            true,
+	"exemplar":         true,
+	"legendFormat":     true,
+	"alias":            true,
+	"interval":         true,
+	"intervalMs":       true,
+	"intervalFactor":   true,
+	"maxDataPoints":    true,
+}
+
+// targetDescribesQuery reports whether a target that carries no string
+// expression nevertheless describes a query. It distinguishes a real
+// visual-editor query from a query row somebody added in the UI and never
+// filled in, which Grafana saves with the editor's defaults in place.
+func targetDescribesQuery(target map[string]interface{}) bool {
+	for field, val := range target {
+		if isEmptyTargetValue(val) {
+			continue
+		}
+		if identifyingQueryFields[field] {
+			return true
+		}
+		// A field we don't recognise at all belongs to a datasource we have no
+		// list for. Take the target at its word rather than dropping the panel,
+		// which is the failure this whole path exists to avoid.
+		if !structuredFieldSet[field] && !editorStateFields[field] {
+			return true
+		}
+	}
+	return false
+}
+
+// queryTargetFields returns a target's fields for the caller to interpret,
+// minus the two the result already carries in their own fields. Nothing else is
+// filtered: Grafana runs a CloudWatch panel by posting the whole target back to
+// /api/ds/query, so any field may be part of what the panel asks for.
+func queryTargetFields(target map[string]interface{}) map[string]interface{} {
+	fields := make(map[string]interface{}, len(target))
+	for k, v := range target {
+		if k == "datasource" || k == "refId" {
+			continue
+		}
+		fields[k] = v
+	}
+	return fields
+}
+
+// isEmptyTargetValue reports whether a target field is set but carries no
+// information, which query editors leave behind routinely.
+func isEmptyTargetValue(val interface{}) bool {
+	switch v := val.(type) {
+	case nil:
+		return true
+	case string:
+		return v == ""
+	case []interface{}:
+		return len(v) == 0
+	case map[string]interface{}:
+		return len(v) == 0
+	default:
+		return false
+	}
+}
+
+// variableSearchText returns the text of a panel query to scan for template
+// variable references: the expression when there is one, otherwise the target's
+// JSON, which catches variables used inside structured fields such as a
+// CloudWatch dimension of "$instance".
+func variableSearchText(pq panelQuery) string {
+	if pq.Query != "" {
+		return pq.Query
+	}
+	encoded, err := json.Marshal(pq.Target)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
 }
 
 // variableRegex matches Grafana template variable patterns

--- a/tools/dashboard_helpers_test.go
+++ b/tools/dashboard_helpers_test.go
@@ -255,8 +255,24 @@ func TestExtractQueryExpression(t *testing.T) {
 			expected: "SELECT * FROM logs WHERE time > $__timeFilter",
 		},
 		{
+			name: "graphite target",
+			target: map[string]interface{}{
+				"target": "aliasByNode(stats.gauges.*.cpu, 2)",
+			},
+			expected: "aliasByNode(stats.gauges.*.cpu, 2)",
+		},
+		{
 			name:     "empty target",
 			target:   map[string]interface{}{},
+			expected: "",
+		},
+		{
+			name: "structured cloudwatch target has no string expression",
+			target: map[string]interface{}{
+				"namespace":  "AWS/EC2",
+				"metricName": "CPUUtilization",
+				"statistic":  "Average",
+			},
 			expected: "",
 		},
 	}
@@ -568,6 +584,298 @@ func TestExtractPanelQueries(t *testing.T) {
 		require.Len(t, queries, 2)
 		assert.Equal(t, "A", queries[0].RefID)
 		assert.Equal(t, "B", queries[1].RefID)
+	})
+}
+
+func TestTargetDescribesQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   map[string]interface{}
+		expected bool
+	}{
+		{
+			name: "cloudwatch metric search",
+			target: map[string]interface{}{
+				"refId":      "A",
+				"region":     "us-east-1",
+				"namespace":  "AWS/EC2",
+				"metricName": "CPUUtilization",
+				"statistic":  "Average",
+				"dimensions": map[string]interface{}{"InstanceId": "i-1234567890"},
+			},
+			expected: true,
+		},
+		{
+			name: "pyroscope profile selection",
+			target: map[string]interface{}{
+				"profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"labelSelector": `{service_name="checkout"}`,
+			},
+			expected: true,
+		},
+		{
+			name: "influxdb query builder",
+			target: map[string]interface{}{
+				"measurement": "cpu",
+				"select":      []interface{}{[]interface{}{map[string]interface{}{"type": "field", "params": []interface{}{"usage_idle"}}}},
+				"groupBy":     []interface{}{},
+			},
+			expected: true,
+		},
+		{
+			name: "elasticsearch match-all aggregation query",
+			target: map[string]interface{}{
+				"refId":      "A",
+				"query":      "",
+				"metrics":    []interface{}{map[string]interface{}{"type": "count", "id": "1"}},
+				"bucketAggs": []interface{}{map[string]interface{}{"type": "date_histogram", "id": "2", "field": "@timestamp"}},
+			},
+			expected: true,
+		},
+		{
+			name: "unrecognised datasource is taken at its word",
+			target: map[string]interface{}{
+				"refId":        "A",
+				"legendFormat": "{{host}}",
+				"entityType":   "host",
+				"counter":      "cpu.usage",
+			},
+			expected: true,
+		},
+		{
+			name: "cloudwatch row left on the editor defaults",
+			target: map[string]interface{}{
+				"refId":            "B",
+				"region":           "default",
+				"namespace":        "",
+				"metricName":       "",
+				"statistic":        "Average",
+				"dimensions":       map[string]interface{}{},
+				"matchExact":       true,
+				"metricQueryType":  float64(0),
+				"metricEditorMode": float64(0),
+				"id":               "",
+			},
+			expected: false,
+		},
+		{
+			name: "half-filled cloudwatch row with no metric chosen",
+			target: map[string]interface{}{
+				"refId":     "B",
+				"namespace": "AWS/EC2",
+				"statistic": "Average",
+			},
+			expected: false,
+		},
+		{
+			name: "influxdb row left on the editor defaults",
+			target: map[string]interface{}{
+				"refId":        "B",
+				"policy":       "default",
+				"resultFormat": "time_series",
+				"select":       []interface{}{[]interface{}{map[string]interface{}{"type": "field", "params": []interface{}{"value"}}}},
+				"groupBy":      []interface{}{map[string]interface{}{"type": "time", "params": []interface{}{"$__interval"}}},
+			},
+			expected: false,
+		},
+		{
+			name: "blank prometheus row",
+			target: map[string]interface{}{
+				"refId":        "B",
+				"expr":         "",
+				"range":        true,
+				"instant":      false,
+				"editorMode":   "builder",
+				"legendFormat": "__auto",
+			},
+			expected: false,
+		},
+		{
+			name: "blank loki row",
+			target: map[string]interface{}{
+				"refId":     "B",
+				"expr":      "",
+				"queryType": "range",
+			},
+			expected: false,
+		},
+		{
+			name: "target with nothing but presentation fields",
+			target: map[string]interface{}{
+				"refId":      "A",
+				"hide":       true,
+				"datasource": map[string]interface{}{"uid": "abc", "type": "cloudwatch"},
+				"expr":       "",
+			},
+			expected: false,
+		},
+		{
+			name:     "empty target",
+			target:   map[string]interface{}{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, targetDescribesQuery(tt.target))
+		})
+	}
+}
+
+func TestQueryTargetFields(t *testing.T) {
+	// Everything but the datasource and refId, which the result carries in its
+	// own fields: Grafana runs a CloudWatch panel by posting the whole target
+	// back, so no other field is safe to drop.
+	fields := queryTargetFields(map[string]interface{}{
+		"refId":      "A",
+		"datasource": map[string]interface{}{"uid": "cw-uid", "type": "cloudwatch"},
+		"namespace":  "AWS/EC2",
+		"metricName": "CPUUtilization",
+		"period":     "300",
+		"matchExact": true,
+		"hide":       false,
+	})
+
+	assert.Equal(t, map[string]interface{}{
+		"namespace":  "AWS/EC2",
+		"metricName": "CPUUtilization",
+		"period":     "300",
+		"matchExact": true,
+		"hide":       false,
+	}, fields)
+}
+
+func TestExtractPanelQueriesStructuredTargets(t *testing.T) {
+	t.Run("returns cloudwatch metric search panels", func(t *testing.T) {
+		panel := map[string]interface{}{
+			"title": "EC2 CPU",
+			"datasource": map[string]interface{}{
+				"uid":  "cloudwatch-uid",
+				"type": "cloudwatch",
+			},
+			"targets": []interface{}{
+				map[string]interface{}{
+					"refId":      "A",
+					"namespace":  "AWS/EC2",
+					"metricName": "CPUUtilization",
+					"statistic":  "Average",
+				},
+			},
+		}
+
+		queries := extractPanelQueries(panel, nil, nil)
+
+		require.Len(t, queries, 1)
+		assert.Equal(t, "EC2 CPU", queries[0].Title)
+		assert.Empty(t, queries[0].Query)
+		assert.Equal(t, map[string]interface{}{
+			"namespace":  "AWS/EC2",
+			"metricName": "CPUUtilization",
+			"statistic":  "Average",
+		}, queries[0].Target)
+		assert.Equal(t, "cloudwatch-uid", queries[0].Datasource.UID)
+	})
+
+	t.Run("returns both string and structured targets from a mixed panel", func(t *testing.T) {
+		panel := map[string]interface{}{
+			"title": "Mixed",
+			"targets": []interface{}{
+				map[string]interface{}{
+					"refId":      "A",
+					"expr":       "up",
+					"datasource": map[string]interface{}{"uid": "prom-uid", "type": "prometheus"},
+				},
+				map[string]interface{}{
+					"refId":      "B",
+					"namespace":  "AWS/EC2",
+					"metricName": "NetworkIn",
+					"datasource": map[string]interface{}{"uid": "cw-uid", "type": "cloudwatch"},
+				},
+			},
+		}
+
+		queries := extractPanelQueries(panel, nil, nil)
+
+		require.Len(t, queries, 2)
+		assert.Equal(t, "up", queries[0].Query)
+		assert.Nil(t, queries[0].Target)
+		assert.Empty(t, queries[1].Query)
+		assert.Equal(t, map[string]interface{}{
+			"namespace":  "AWS/EC2",
+			"metricName": "NetworkIn",
+		}, queries[1].Target)
+	})
+
+	t.Run("skips targets that describe no query", func(t *testing.T) {
+		panel := map[string]interface{}{
+			"targets": []interface{}{
+				map[string]interface{}{
+					"refId":      "A",
+					"datasource": map[string]interface{}{"uid": "prom-uid", "type": "prometheus"},
+				},
+			},
+		}
+
+		queries := extractPanelQueries(panel, nil, nil)
+
+		assert.Empty(t, queries)
+	})
+
+	t.Run("skips a query row left on the editor defaults", func(t *testing.T) {
+		panel := map[string]interface{}{
+			"title":      "EC2 CPU",
+			"datasource": map[string]interface{}{"uid": "cloudwatch-uid", "type": "cloudwatch"},
+			"targets": []interface{}{
+				map[string]interface{}{
+					"refId":      "A",
+					"namespace":  "AWS/EC2",
+					"metricName": "CPUUtilization",
+					"statistic":  "Average",
+				},
+				// Added in the UI and never filled in, so Grafana saved the
+				// editor's defaults.
+				map[string]interface{}{
+					"refId":            "B",
+					"region":           "default",
+					"namespace":        "",
+					"metricName":       "",
+					"statistic":        "Average",
+					"matchExact":       true,
+					"metricQueryType":  float64(0),
+					"metricEditorMode": float64(0),
+				},
+			},
+		}
+
+		queries := extractPanelQueries(panel, nil, nil)
+
+		require.Len(t, queries, 1)
+		assert.Equal(t, "A", queries[0].RefID)
+	})
+
+	t.Run("reports variables referenced by a structured target", func(t *testing.T) {
+		panel := map[string]interface{}{
+			"targets": []interface{}{
+				map[string]interface{}{
+					"refId":      "A",
+					"namespace":  "AWS/EC2",
+					"metricName": "CPUUtilization",
+					"dimensions": map[string]interface{}{"InstanceId": "$instance"},
+				},
+			},
+		}
+		dashboardVars := map[string]VariableInfo{
+			"instance": {Name: "instance", CurrentValue: "i-1234567890"},
+		}
+
+		queries := extractPanelQueries(panel, dashboardVars, nil)
+
+		require.Len(t, queries, 1)
+		require.Len(t, queries[0].RequiredVariables, 1)
+		assert.Equal(t, "instance", queries[0].RequiredVariables[0].Name)
+		assert.Equal(t, "i-1234567890", queries[0].RequiredVariables[0].CurrentValue)
+		assert.Empty(t, queries[0].ProcessedQuery)
 	})
 }
 

--- a/tools/dashboard_v2.go
+++ b/tools/dashboard_v2.go
@@ -155,17 +155,25 @@ func extractPanelQueriesV2(panel map[string]interface{}, dashboardVars map[strin
 			RefID:      safeString(pqSpec, "refId"),
 		}
 
+		// As in v1, a target built in a visual editor has no string expression;
+		// hand back the query body rather than dropping the panel.
+		if rawQuery == "" {
+			body := safeObject(query, "spec")
+			if body == nil || !targetDescribesQuery(body) {
+				continue
+			}
+			result.Target = queryTargetFields(body)
+		}
+
 		if dashboardVars != nil {
-			result.RequiredVariables = findVariablesInQuery(rawQuery, dashboardVars, overrides)
+			result.RequiredVariables = findVariablesInQuery(variableSearchText(result), dashboardVars, overrides)
 			effectiveVars := buildEffectiveVariables(dashboardVars, overrides)
 			result.ProcessedQuery = substituteVariables(rawQuery, effectiveVars)
 			dsInfo.UID = substituteVariables(dsInfo.UID, effectiveVars)
 			result.Datasource = dsInfo
 		}
 
-		if rawQuery != "" {
-			queries = append(queries, result)
-		}
+		queries = append(queries, result)
 	}
 
 	return queries

--- a/tools/dashboard_v2_test.go
+++ b/tools/dashboard_v2_test.go
@@ -85,6 +85,48 @@ func TestGetPanelQueriesV2_WithVariableSubstitution(t *testing.T) {
 	assert.Equal(t, "web", queries[0].RequiredVariables[0].CurrentValue)
 }
 
+func TestExtractPanelQueriesV2_StructuredTarget(t *testing.T) {
+	// A CloudWatch metric search query has no string expression in its query
+	// spec; it must still show up, described rather than dropped.
+	panel := map[string]interface{}{
+		"title": "EC2 CPU",
+		"data": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"queries": []interface{}{
+					map[string]interface{}{
+						"spec": map[string]interface{}{
+							"refId": "A",
+							"query": map[string]interface{}{
+								"group":      "cloudwatch",
+								"datasource": map[string]interface{}{"name": "cw-uid"},
+								"spec": map[string]interface{}{
+									"namespace":  "AWS/EC2",
+									"metricName": "CPUUtilization",
+									"statistic":  "Average",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	queries := extractPanelQueriesV2(panel, nil, nil)
+
+	require.Len(t, queries, 1)
+	assert.Equal(t, "EC2 CPU", queries[0].Title)
+	assert.Equal(t, "A", queries[0].RefID)
+	assert.Empty(t, queries[0].Query)
+	assert.Equal(t, map[string]interface{}{
+		"namespace":  "AWS/EC2",
+		"metricName": "CPUUtilization",
+		"statistic":  "Average",
+	}, queries[0].Target)
+	assert.Equal(t, "cw-uid", queries[0].Datasource.UID)
+	assert.Equal(t, "cloudwatch", queries[0].Datasource.Type)
+}
+
 func TestExtractDashboardVariablesV2(t *testing.T) {
 	_, spec := loadV2Dashboard(t)
 

--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -361,7 +361,7 @@ func extractPanelInfo(panel map[string]interface{}, queryIndex int) (*panelInfo,
 
 	// CloudWatch panels use structured targets rather than string expressions
 	if query == "" && normalizeDatasourceType(info.DatasourceType) != "cloudwatch" {
-		return nil, fmt.Errorf("could not extract query from panel target (checked: expr, query, expression, rawSql, rawSQL, rawQuery)")
+		return nil, fmt.Errorf("could not extract query from panel target (checked: expr, query, expression, rawSql, rawSQL, rawQuery, target)")
 	}
 	info.Query = query
 


### PR DESCRIPTION
## Summary

`get_dashboard_panel_queries` silently omits any panel target that has no string query expression.

#539 already widened the field probe beyond Prometheus's `expr` (to `query`, `expression`, `rawSql`, `rawSQL`, `rawQuery`), which covers Elasticsearch, SQL and CloudWatch Metric Math — so the original report in #585 is partly fixed. But targets built entirely in a datasource's **visual editor** have no string to find at all, and still fall through the `rawQuery != ""` guard:

- CloudWatch **metric search** mode — `namespace` / `metricName` / `statistic` / `dimensions` / `region`
- Pyroscope — `profileTypeId` / `labelSelector`
- InfluxDB's query builder — `measurement` / `select` / `groupBy`

`run_panel_query` already special-cases CloudWatch's structured targets (`tools/run_panel_query.go:362`), so the two tools disagreed about whether such a panel had a query at all.

## Changes

- When no string expression is found, the result now carries the panel's raw query JSON in a new `target` field, minus the `datasource` and `refId` it already returns separately. Nothing else is filtered — Grafana runs a CloudWatch panel by posting the whole target back to `/api/ds/query`, so any field may be part of what the panel asks for.
- `query` stays empty for these targets, so a caller can't mistake the target for a runnable expression. The tool description points at `run_panel_query` for actually executing them.
- Query rows somebody added in the UI and never filled in are still skipped (`targetDescribesQuery`). Grafana saves those with the editor's defaults in place — a blank CloudWatch row keeps `region: "default"` and `statistic: "Average"` — so a summary is only produced when the target sets a field that says what the query is *about*, or a field belonging to a datasource we have no list for.
- Template variables referenced from a structured target (a CloudWatch dimension of `$instance`) are reported in `requiredVariables`.
- The same fix is applied to the v2 dashboard path (`extractPanelQueriesV2`), which had the identical guard.
- Graphite's `target` added to the executable-string probe (`extractQueryExpression`), which is shared with `run_panel_query` and `dashboard_v2` — it stays a probe for *runnable* expressions only.

Fixes #585. Supersedes the test-only #586, which was closed as stale.

### Why the raw target rather than a rendered summary

The first cut of this PR rendered a `querySummary` string from a curated per-datasource field list. That list is a maintenance liability, and it drops anything not on it silently — `period` never reached a CloudWatch summary, and `queryType` was classed as editor noise even though `executeInfluxDBQuery` reads that exact field to choose between influxql and flux. Handing back the target itself has no such failure mode, and it is what the caller needs to understand or re-run the query. It is bounded to the query definition, not the whole panel: `fieldConfig`/`options`/`transformations` stay out, and anyone who wants those already has `get_dashboard_property` with a JSONPath.

## Testing

- `TestTargetDescribesQuery` — CloudWatch metric search, Pyroscope, InfluxDB builder, Elasticsearch match-all, unknown datasource, and the negative cases: blank CloudWatch/InfluxDB/Prometheus/Loki rows, a half-filled CloudWatch row, presentation-only and empty targets
- `TestQueryTargetFields` — only `datasource` and `refId` are stripped
- `TestExtractPanelQueriesStructuredTargets` — CloudWatch panel returned, mixed Prometheus + CloudWatch panel, empty target skipped, unfilled row skipped, variables reported from a target
- `TestExtractPanelQueriesV2_StructuredTarget` — the v2 path
- `TestExtractQueryExpression` extended with the Graphite case and a case asserting a structured CloudWatch target yields no *executable* expression
- `make lint` and `make test-unit` pass

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (tool description)
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)