### PR TITLE
fix(run-panel-query): support sqlstring dashboard variables

### DIFF
--- a/tools/run_panel_query.go
+++ b/tools/run_panel_query.go
@@ -153,12 +153,16 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 		return nil, fmt.Errorf("extracting panel info: %w", err)
 	}
 
-	// Extract template variables from dashboard
-	vars := extractTemplateVariables(params.DB)
+	// Extract template variables from the dashboard. Keep both the first value
+	// (used for datasource references) and the complete value list (used for
+	// formatted query interpolation).
+	templateVariables := extractTemplateVariableValues(params.DB)
+	vars := firstTemplateVariableValues(templateVariables)
 
 	// Apply variable overrides from user
 	for name, value := range params.Variables {
 		vars[name] = value
+		templateVariables[name] = []string{value}
 	}
 
 	// Resolve datasource UID and type
@@ -206,7 +210,7 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 	}
 
 	// Substitute variables in the query
-	query := substituteTemplateVariables(panelData.Query, vars)
+	query := substituteTemplateVariableValues(panelData.Query, templateVariables)
 
 	// Route to appropriate datasource and execute query
 	var results interface{}
@@ -219,18 +223,18 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 	case "clickhouse":
 		results, err = executeClickHouseQuery(ctx, datasourceUID, query, params.Start, params.End)
 	case "cloudwatch":
-		results, err = executeCloudWatchPanelQuery(ctx, datasourceUID, panelData, params.Start, params.End, vars)
+		results, err = executeCloudWatchPanelQuery(ctx, datasourceUID, panelData, params.Start, params.End, templateVariables)
 	case "influxdb":
 		results, err = executeInfluxDBQuery(ctx, datasourceUID, panelData, query, params.Start, params.End)
 	case "bigquery":
-		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, BigQueryDatasourceType)
+		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, templateVariables, BigQueryDatasourceType)
 	case "mssql":
-		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, MSSQLDatasourceType)
+		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, templateVariables, MSSQLDatasourceType)
 	case "postgres":
 		// PostgreSQL exposes two datasource identifiers (grafana-postgresql-datasource
 		// and the legacy postgres); pass the resolved type through so the datasource
 		// object sent to Grafana matches what the panel actually declared.
-		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, vars, datasourceType)
+		results, err = executeSQLPanelQuery(ctx, datasourceUID, panelData, query, params.Start, params.End, templateVariables, datasourceType)
 	default:
 		return nil, fmt.Errorf("datasource type '%s' is not supported by run_panel_query; use the native query tool (e.g. query_prometheus\\, query_loki_logs\\, query_clickhouse\\, query_cloudwatch\\, query_influxdb) directly", datasourceType)
 	}
@@ -256,35 +260,97 @@ func runSinglePanelQuery(ctx context.Context, params singlePanelQueryParams) (*P
 	}, nil
 }
 
-// substituteTemplateVariables replaces template variables in a query string
-// Supports ${varname}, [[varname]], and $varname (with word boundary) patterns
-func substituteTemplateVariables(query string, variables map[string]string) string {
-	if variables == nil {
-		return query
-	}
-	for name, value := range variables {
-		// Replace ${varname}
-		query = strings.ReplaceAll(query, "${"+name+"}", value)
-		// Replace [[varname]]
-		query = strings.ReplaceAll(query, "[["+name+"]]", value)
-		// Replace $varname with word boundary to avoid partial matches
-		varRe := regexp.MustCompile(fmt.Sprintf(`\$%s\b`, regexp.QuoteMeta(name)))
-		query = varRe.ReplaceAllLiteralString(query, value)
+type templateVariableValues map[string][]string
+
+// substituteTemplateVariableValues interpolates variables while retaining
+// multi-select values for formatters such as sqlstring. Explicitly supported
+// formatters follow Grafana's formatting syntax; unknown formatters fall back
+// to Grafana's glob representation.
+func substituteTemplateVariableValues(query string, variables templateVariableValues) string {
+	for name, values := range variables {
+		variableRe := regexp.MustCompile(fmt.Sprintf(
+			`\$\{%s(?::[^}]*)?\}|\[\[%s(?::[^\]]*)?\]\]|\$%s\b`,
+			regexp.QuoteMeta(name), regexp.QuoteMeta(name), regexp.QuoteMeta(name),
+		))
+		query = variableRe.ReplaceAllStringFunc(query, func(match string) string {
+			format, hasFormat := templateVariableFormat(match)
+			if !hasFormat {
+				return firstTemplateVariableValue(values)
+			}
+			return formatTemplateVariable(values, format)
+		})
 	}
 	return query
 }
 
-// substituteTemplateVariablesInMap recursively substitutes variables in a map's string values
-func substituteTemplateVariablesInMap(target map[string]interface{}, variables map[string]string) map[string]interface{} {
+func templateVariableFormat(match string) (string, bool) {
+	var inner string
+	switch {
+	case strings.HasPrefix(match, "${") && strings.HasSuffix(match, "}"):
+		inner = match[2 : len(match)-1]
+	case strings.HasPrefix(match, "[[") && strings.HasSuffix(match, "]]"):
+		inner = match[2 : len(match)-2]
+	default:
+		return "", false
+	}
+
+	separator := strings.IndexByte(inner, ':')
+	if separator < 0 {
+		return "", false
+	}
+	return inner[separator+1:], true
+}
+
+func firstTemplateVariableValue(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func formatTemplateVariable(values []string, format string) string {
+	formatName := format
+	if separator := strings.IndexByte(format, ':'); separator >= 0 {
+		formatName = format[:separator]
+	}
+
+	if formatName == "sqlstring" {
+		return formatSQLStringVariable(values)
+	}
+
+	// Grafana uses glob as the fallback for unknown formatting options.
+	if len(values) > 1 {
+		return "{" + strings.Join(values, ",") + "}"
+	}
+	return firstTemplateVariableValue(values)
+}
+
+func formatSQLStringVariable(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	formatted := make([]string, len(values))
+	for i, value := range values {
+		// Match Grafana's SQLString formatter: pair single quotes and escape
+		// double quotes with a backslash before surrounding the value in quotes.
+		value = strings.ReplaceAll(value, "'", "''")
+		value = strings.ReplaceAll(value, `"`, `\"`)
+		formatted[i] = "'" + value + "'"
+	}
+	return strings.Join(formatted, ",")
+}
+
+func substituteTemplateVariablesInMapWithValues(target map[string]interface{}, variables templateVariableValues) map[string]interface{} {
 	result := make(map[string]interface{})
 	for k, v := range target {
 		switch val := v.(type) {
 		case string:
-			result[k] = substituteTemplateVariables(val, variables)
+			result[k] = substituteTemplateVariableValues(val, variables)
 		case map[string]interface{}:
-			result[k] = substituteTemplateVariablesInMap(val, variables)
+			result[k] = substituteTemplateVariablesInMapWithValues(val, variables)
 		case []interface{}:
-			result[k] = substituteTemplateVariablesInSlice(val, variables)
+			result[k] = substituteTemplateVariablesInSliceWithValues(val, variables)
 		default:
 			result[k] = v
 		}
@@ -292,17 +358,16 @@ func substituteTemplateVariablesInMap(target map[string]interface{}, variables m
 	return result
 }
 
-// substituteTemplateVariablesInSlice recursively substitutes variables in a slice
-func substituteTemplateVariablesInSlice(slice []interface{}, variables map[string]string) []interface{} {
+func substituteTemplateVariablesInSliceWithValues(slice []interface{}, variables templateVariableValues) []interface{} {
 	result := make([]interface{}, len(slice))
 	for i, v := range slice {
 		switch val := v.(type) {
 		case string:
-			result[i] = substituteTemplateVariables(val, variables)
+			result[i] = substituteTemplateVariableValues(val, variables)
 		case map[string]interface{}:
-			result[i] = substituteTemplateVariablesInMap(val, variables)
+			result[i] = substituteTemplateVariablesInMapWithValues(val, variables)
 		case []interface{}:
-			result[i] = substituteTemplateVariablesInSlice(val, variables)
+			result[i] = substituteTemplateVariablesInSliceWithValues(val, variables)
 		default:
 			result[i] = v
 		}
@@ -368,9 +433,11 @@ func extractPanelInfo(panel map[string]interface{}, queryIndex int) (*panelInfo,
 	return info, nil
 }
 
-// extractTemplateVariables extracts template variables and their current values from dashboard
-func extractTemplateVariables(db map[string]interface{}) map[string]string {
-	variables := make(map[string]string)
+// extractTemplateVariableValues extracts all selected values of each dashboard
+// template variable. Grafana stores multi-select values in current.value as an
+// array, and formatted interpolation needs to retain that array.
+func extractTemplateVariableValues(db map[string]interface{}) templateVariableValues {
+	variables := make(templateVariableValues)
 
 	templating := safeObject(db, "templating")
 	if templating == nil {
@@ -391,27 +458,43 @@ func extractTemplateVariables(db map[string]interface{}) map[string]string {
 
 		// Get current value - can be in different formats
 		current := safeObject(variable, "current")
+		currentValueSet := false
 		if current != nil {
-			// Try "value" field first (can be string or array)
+			// Try "value" field first (can be string or array).
 			if val, ok := current["value"]; ok {
+				currentValueSet = true
 				switch v := val.(type) {
 				case string:
 					if v != "$__all" {
-						variables[name] = v
+						variables[name] = []string{v}
 					}
+				case nil:
+					// Grafana formats a defined null/undefined value as an empty
+					// string. Keep the empty slice distinguishable from a missing
+					// variable so formatted expressions are still replaced.
+					variables[name] = []string{}
 				case []interface{}:
-					// Multi-value - take first value for simplicity
-					if len(v) > 0 {
-						if str, ok := v[0].(string); ok && str != "$__all" {
-							variables[name] = str
+					if len(v) == 0 {
+						variables[name] = []string{}
+					} else if first, ok := v[0].(string); ok && first != "$__all" {
+						values := make([]string, 0, len(v))
+						for _, item := range v {
+							if str, ok := item.(string); ok {
+								values = append(values, str)
+							}
 						}
+						variables[name] = values
+					}
+				case []string:
+					if len(v) == 0 || v[0] != "$__all" {
+						variables[name] = append([]string(nil), v...)
 					}
 				}
 			}
 			// Fall back to "text" field
-			if variables[name] == "" {
+			if !currentValueSet {
 				if text, ok := current["text"].(string); ok && text != "" && text != "All" {
-					variables[name] = text
+					variables[name] = []string{text}
 				}
 			}
 		}
@@ -420,16 +503,26 @@ func extractTemplateVariables(db map[string]interface{}) map[string]string {
 		// frequently saved without a "current" at all. Without this fallback
 		// the raw $name survives substitution and reaches the datasource,
 		// which for SQL datasources is a syntax error.
-		if variables[name] == "" {
+		if !currentValueSet {
 			switch safeString(variable, "type") {
 			case "constant", "textbox":
 				if q := safeString(variable, "query"); q != "" {
-					variables[name] = q
+					variables[name] = []string{q}
 				}
 			}
 		}
 	}
 
+	return variables
+}
+
+func firstTemplateVariableValues(values templateVariableValues) map[string]string {
+	variables := make(map[string]string, len(values))
+	for name, value := range values {
+		if len(value) > 0 {
+			variables[name] = value[0]
+		}
+	}
 	return variables
 }
 
@@ -501,7 +594,7 @@ func executeClickHouseQuery(ctx context.Context, datasourceUID, query, start, en
 }
 
 // executeCloudWatchPanelQuery runs a CloudWatch query using Grafana's /api/ds/query endpoint
-func executeCloudWatchPanelQuery(ctx context.Context, datasourceUID string, panelData *panelInfo, start, end string, variables map[string]string) (interface{}, error) {
+func executeCloudWatchPanelQuery(ctx context.Context, datasourceUID string, panelData *panelInfo, start, end string, variables templateVariableValues) (interface{}, error) {
 	if panelData.RawTarget == nil {
 		return nil, fmt.Errorf("CloudWatch panel target not available")
 	}
@@ -524,7 +617,7 @@ func executeCloudWatchPanelQuery(ctx context.Context, datasourceUID string, pane
 	}
 
 	// Deep copy and substitute variables in target fields
-	target := substituteTemplateVariablesInMap(panelData.RawTarget, variables)
+	target := substituteTemplateVariablesInMapWithValues(panelData.RawTarget, variables)
 
 	// Ensure datasource is set correctly
 	target["datasource"] = map[string]interface{}{"uid": datasourceUID, "type": "cloudwatch"}
@@ -605,7 +698,7 @@ type SQLQueryResult struct {
 // panel's raw target is preserved so datasource-specific fields (BigQuery's location,
 // project and dataset, for example) reach the backend; only rawSql, datasource, refId
 // and format are overridden.
-func executeSQLPanelQuery(ctx context.Context, datasourceUID string, panelData *panelInfo, query, start, end string, variables map[string]string, datasourceType string) (*SQLQueryResult, error) {
+func executeSQLPanelQuery(ctx context.Context, datasourceUID string, panelData *panelInfo, query, start, end string, variables templateVariableValues, datasourceType string) (*SQLQueryResult, error) {
 	if panelData == nil || panelData.RawTarget == nil {
 		return nil, fmt.Errorf("SQL panel target not available")
 	}
@@ -624,7 +717,7 @@ func executeSQLPanelQuery(ctx context.Context, datasourceUID string, panelData *
 	processedQuery := substituteGrafanaMacros(query, startTime, endTime)
 
 	// Deep copy the raw target and substitute variables in its fields (e.g. location).
-	target := substituteTemplateVariablesInMap(panelData.RawTarget, variables)
+	target := substituteTemplateVariablesInMapWithValues(panelData.RawTarget, variables)
 
 	// Override the SQL with the fully-processed query and ensure required fields are set.
 	target["rawSql"] = processedQuery

--- a/tools/run_panel_query_postgres_test.go
+++ b/tools/run_panel_query_postgres_test.go
@@ -170,8 +170,176 @@ func TestRunSinglePanelQuery_PostgresDispatch(t *testing.T) {
 	}
 }
 
-// TestRunSinglePanelQuery_PostgresEmptyResultHints verifies that an empty
-// PostgreSQL result surfaces PostgreSQL-specific hints through the real path.
+// postgresSQLStringPanelDashboard builds a PostgreSQL panel with an explicit
+// sqlstring variable expression. The target contains an extra string field so
+// the request test can verify recursive target interpolation and preservation.
+func postgresSQLStringPanelDashboard(currentValue interface{}, includeVariable bool) map[string]interface{} {
+	expression := "$" + "{order_intent_id:sqlstring}"
+	variableList := []interface{}{}
+	if includeVariable {
+		variableList = append(variableList, map[string]interface{}{
+			"name":    "order_intent_id",
+			"type":    "query",
+			"current": map[string]interface{}{"value": currentValue},
+		})
+	}
+
+	return map[string]interface{}{
+		"templating": map[string]interface{}{"list": variableList},
+		"panels": []interface{}{
+			map[string]interface{}{
+				"id":    float64(8),
+				"title": "Order replay",
+				"type":  "table",
+				"datasource": map[string]interface{}{
+					"uid":  "postgres-uid",
+					"type": PostgresDatasourceType,
+				},
+				"targets": []interface{}{
+					map[string]interface{}{
+						"refId":          "A",
+						"rawSql":         "SELECT * FROM orders WHERE order_intent_id IN (" + expression + ")",
+						"rawQuery":       true,
+						"preservedField": expression,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRunSinglePanelQuery_PostgresSQLStringVariable(t *testing.T) {
+	expression := "$" + "{order_intent_id:sqlstring}"
+	baseQuery := "SELECT * FROM orders WHERE order_intent_id IN ("
+	tests := []struct {
+		name            string
+		currentValue    interface{}
+		includeVariable bool
+		wantQuery       string
+		wantField       string
+	}{
+		{
+			name:            "single value",
+			currentValue:    "oi-123",
+			includeVariable: true,
+			wantQuery:       baseQuery + "'oi-123')",
+			wantField:       "'oi-123'",
+		},
+		{
+			name:            "multiple values",
+			currentValue:    []interface{}{"oi-123", "oi-456"},
+			includeVariable: true,
+			wantQuery:       baseQuery + "'oi-123','oi-456')",
+			wantField:       "'oi-123','oi-456'",
+		},
+		{
+			name:            "value with a single quote",
+			currentValue:    "oi'123",
+			includeVariable: true,
+			wantQuery:       baseQuery + "'oi''123')",
+			wantField:       "'oi''123'",
+		},
+		{
+			name:            "empty value",
+			currentValue:    "",
+			includeVariable: true,
+			wantQuery:       baseQuery + "'')",
+			wantField:       "''",
+		},
+		{
+			name:            "empty multi-select",
+			currentValue:    []interface{}{},
+			includeVariable: true,
+			wantQuery:       baseQuery + ")",
+			wantField:       "",
+		},
+		{
+			name:            "missing variable",
+			includeVariable: false,
+			wantQuery:       baseQuery + expression + ")",
+			wantField:       expression,
+		},
+		{
+			name:            "defined variable with null value",
+			currentValue:    nil,
+			includeVariable: true,
+			wantQuery:       baseQuery + ")",
+			wantField:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frames := data.Frames{
+				data.NewFrame("", data.NewField("order_intent_id", nil, []string{"oi-123"})),
+			}
+			var captured capturedQuery
+			ts := newDSQueryTestServer(t, &captured, frames)
+			ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: ts.URL})
+
+			result, err := runSinglePanelQuery(ctx, singlePanelQueryParams{
+				DB:         postgresSQLStringPanelDashboard(tt.currentValue, tt.includeVariable),
+				PanelID:    8,
+				QueryIndex: 0,
+				Start:      "now-1h",
+				End:        "now",
+			})
+			require.NoError(t, err)
+
+			sqlResult, ok := result.Results.(*SQLQueryResult)
+			require.True(t, ok, "expected *SQLQueryResult, got %T", result.Results)
+			assert.Equal(t, tt.wantQuery, sqlResult.ProcessedQuery)
+			assert.Equal(t, tt.wantQuery, captured.query["rawSql"])
+			assert.Equal(t, tt.wantField, captured.query["preservedField"])
+			assert.Equal(t, true, captured.query["rawQuery"])
+			assert.Equal(t, PostgresDatasourceType, captured.query["datasource"].(map[string]interface{})["type"])
+		})
+	}
+}
+
+func TestRunSinglePanelQuery_SQLDatasourceRegression(t *testing.T) {
+	tests := []struct {
+		name       string
+		dsType     string
+		wantFormat interface{}
+	}{
+		{name: "BigQuery", dsType: BigQueryDatasourceType, wantFormat: SQLFormatTable},
+		{name: "MSSQL", dsType: MSSQLDatasourceType, wantFormat: MSSQLFormatTable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured capturedQuery
+			ts := newDSQueryTestServer(t, &captured, data.Frames{
+				data.NewFrame("", data.NewField("count", nil, []int64{1})),
+			})
+			ctx := mcpgrafana.WithGrafanaConfig(context.Background(), mcpgrafana.GrafanaConfig{URL: ts.URL})
+
+			result, err := runSinglePanelQuery(ctx, singlePanelQueryParams{
+				DB:         postgresPanelDashboard(tt.dsType),
+				PanelID:    7,
+				QueryIndex: 0,
+				Start:      "now-1h",
+				End:        "now",
+			})
+			require.NoError(t, err)
+
+			sqlResult, ok := result.Results.(*SQLQueryResult)
+			require.True(t, ok, "expected *SQLQueryResult, got %T", result.Results)
+			assert.Contains(t, sqlResult.ProcessedQuery, "public.checks")
+			assert.Contains(t, sqlResult.ProcessedQuery, "$__timeFilter(ts)")
+			assert.NotContains(t, sqlResult.ProcessedQuery, "$__interval")
+			wantFormat := tt.wantFormat
+			if tt.dsType == BigQueryDatasourceType {
+				wantFormat = float64(SQLFormatTable)
+			}
+			assert.Equal(t, wantFormat, captured.query["format"])
+			assert.Equal(t, sqlResult.ProcessedQuery, captured.query["rawSql"])
+			assert.Equal(t, true, captured.query["rawQuery"])
+		})
+	}
+}
+
 func TestRunSinglePanelQuery_PostgresEmptyResultHints(t *testing.T) {
 	frames := data.Frames{
 		data.NewFrame("",

--- a/tools/run_panel_query_test.go
+++ b/tools/run_panel_query_test.go
@@ -10,6 +10,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// These test shims preserve the historic single-value helper signatures used
+// by the existing substitution and extraction tests. Production code uses the
+// multi-value helpers directly so formatted variables can retain all values.
+func testTemplateVariableValues(variables map[string]string) templateVariableValues {
+	if variables == nil {
+		return nil
+	}
+
+	result := make(templateVariableValues, len(variables))
+	for name, value := range variables {
+		result[name] = []string{value}
+	}
+	return result
+}
+
+func substituteTemplateVariables(query string, variables map[string]string) string {
+	return substituteTemplateVariableValues(query, testTemplateVariableValues(variables))
+}
+
+func substituteTemplateVariablesInMap(target map[string]interface{}, variables map[string]string) map[string]interface{} {
+	return substituteTemplateVariablesInMapWithValues(target, testTemplateVariableValues(variables))
+}
+
+func substituteTemplateVariablesInSlice(slice []interface{}, variables map[string]string) []interface{} {
+	return substituteTemplateVariablesInSliceWithValues(slice, testTemplateVariableValues(variables))
+}
+
+func extractTemplateVariables(db map[string]interface{}) map[string]string {
+	return firstTemplateVariableValues(extractTemplateVariableValues(db))
+}
+
 func TestFindPanelByIDForRunPanelQuery(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -582,6 +613,87 @@ func TestSubstituteTemplateVariables(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := substituteTemplateVariables(tt.query, tt.variables)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSubstituteTemplateVariablesSQLString(t *testing.T) {
+	query := "SELECT * FROM orders WHERE order_intent_id = ${order_intent_id:sqlstring}"
+	variables := map[string]string{"order_intent_id": "oi-123"}
+
+	assert.Equal(t,
+		"SELECT * FROM orders WHERE order_intent_id = 'oi-123'",
+		substituteTemplateVariables(query, variables),
+	)
+}
+
+func TestSubstituteTemplateVariableValuesSQLString(t *testing.T) {
+	expression := "$" + "{order_intent_id:sqlstring}"
+	tests := []struct {
+		name      string
+		query     string
+		variables templateVariableValues
+		want      string
+	}{
+		{
+			name:      "single value",
+			query:     "WHERE order_intent_id = " + expression,
+			variables: templateVariableValues{"order_intent_id": {"oi-123"}},
+			want:      "WHERE order_intent_id = 'oi-123'",
+		},
+		{
+			name:      "multiple values",
+			query:     "WHERE order_intent_id IN (" + expression + ")",
+			variables: templateVariableValues{"order_intent_id": {"oi-123", "oi-456"}},
+			want:      "WHERE order_intent_id IN ('oi-123','oi-456')",
+		},
+		{
+			name:      "single quote is doubled",
+			query:     "WHERE order_intent_id = " + expression,
+			variables: templateVariableValues{"order_intent_id": {"oi'123"}},
+			want:      "WHERE order_intent_id = 'oi''123'",
+		},
+		{
+			name:      "double quote is escaped",
+			query:     "WHERE order_intent_id = " + expression,
+			variables: templateVariableValues{"order_intent_id": {"oi\"123"}},
+			want:      "WHERE order_intent_id = 'oi\\\"123'",
+		},
+		{
+			name:      "empty string is quoted",
+			query:     "WHERE order_intent_id = " + expression,
+			variables: templateVariableValues{"order_intent_id": {""}},
+			want:      "WHERE order_intent_id = ''",
+		},
+		{
+			name:      "empty multi-select is empty",
+			query:     "WHERE order_intent_id IN (" + expression + ")",
+			variables: templateVariableValues{"order_intent_id": {}},
+			want:      "WHERE order_intent_id IN ()",
+		},
+		{
+			name:      "unknown format falls back to glob",
+			query:     "WHERE order_intent_id IN ($" + "{order_intent_id:unsupported})",
+			variables: templateVariableValues{"order_intent_id": {"oi-123", "oi-456"}},
+			want:      "WHERE order_intent_id IN ({oi-123,oi-456})",
+		},
+		{
+			name:      "unformatted multi-select keeps historical first value",
+			query:     "WHERE order_intent_id = $order_intent_id",
+			variables: templateVariableValues{"order_intent_id": {"oi-123", "oi-456"}},
+			want:      "WHERE order_intent_id = oi-123",
+		},
+		{
+			name:      "missing variable remains unchanged",
+			query:     "WHERE order_intent_id = " + expression,
+			variables: templateVariableValues{},
+			want:      "WHERE order_intent_id = " + expression,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, substituteTemplateVariableValues(tt.query, tt.variables))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`run_panel_query` only recognized unformatted dashboard variable references, so `${order_intent_id:sqlstring}` could reach PostgreSQL unchanged. This PR:

- retains all selected dashboard variable values internally, including multi-select arrays;
- implements Grafana-compatible `sqlstring` interpolation (quoted values, comma-separated lists, single-quote doubling, and double-quote escaping);
- preserves the existing public `run_panel_query` input/output schema, SQL macro handling, datasource routing, and raw panel target fields;
- keeps the existing first-value behavior for unformatted variables and Grafana's glob fallback for unsupported explicit formats.

Grafana semantics are documented here: https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/variable-syntax/

Relates to #1101

## Testing

- `go test -v -tags unit ./tools`
- focused `sqlstring`/PostgreSQL/BigQuery/MSSQL regression tests
- `go run ./cmd/linters/jsonschema --path .`
- `go run ./cmd/linters/openapi ./tools/... ./`
- `golangci-lint v2.11.4 run` (`0 issues`)
- `go build -buildvcs=false ./cmd/mcp-grafana`
- `git diff --check`

## Scope

Only `run_panel_query` interpolation/extraction and its regression tests are changed. No external Grafana deployment, datasource, schema, or credentials are involved.