### PR TITLE
feat(loki): add optional matcher to list_loki_label_names/values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Optional `matcher` parameter on `list_loki_label_names` and `list_loki_label_values` to narrow label discovery to a subset of streams (a LogQL stream selector on Loki, LogsQL on VictoriaLogs) ([#382](https://github.com/grafana/mcp-grafana/issues/382))
+
 ## [1.3.0] - 2026-08-28
 
 ### Added

--- a/tools/loki.go
+++ b/tools/loki.go
@@ -158,9 +158,15 @@ func (c *Client) makeRequest(ctx context.Context, method, urlPath string, params
 	return bytes.TrimSpace(bodyBytes), nil
 }
 
-// fetchData is a generic method to fetch data from Loki API
-func (c *Client) fetchData(ctx context.Context, urlPath string, startRFC3339, endRFC3339 string) ([]string, error) {
+// fetchData is a generic method to fetch data from Loki API. matcher, when
+// non-empty, is forwarded as the "query" parameter to narrow the label
+// search to streams selected by a LogQL stream selector (e.g. `{app="foo"}`),
+// per Loki's /labels and /label/<name>/values API.
+func (c *Client) fetchData(ctx context.Context, urlPath, matcher, startRFC3339, endRFC3339 string) ([]string, error) {
 	params := url.Values{}
+	if matcher != "" {
+		params.Add("query", matcher)
+	}
 	if startRFC3339 != "" {
 		params.Add("start", startRFC3339)
 	}
@@ -199,6 +205,7 @@ func (c *Client) fetchData(ctx context.Context, urlPath string, startRFC3339, en
 // ListLokiLabelNamesParams defines the parameters for listing Loki label names
 type ListLokiLabelNamesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
+	Matcher       string `json:"matcher,omitempty" jsonschema:"description=Optionally\\, a stream selector to narrow the search to matching streams (Loki: LogQL\\, e.g. '{namespace=\"prod\"}'; VictoriaLogs: LogsQL). Defaults to searching across all streams."`
 	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
 	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 }
@@ -219,7 +226,7 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
-	result, err := backend.ListLabelNames(ctx, start, end)
+	result, err := backend.ListLabelNames(ctx, args.Matcher, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +241,7 @@ func listLokiLabelNames(ctx context.Context, args ListLokiLabelNamesParams) ([]s
 // ListLokiLabelNames is a tool for listing Loki label names
 var ListLokiLabelNames = mcpgrafana.MustTool(
 	"list_loki_label_names",
-	"Lists all available label/field names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour.",
+	"Lists all available label/field names (keys) found in logs within a specified Loki or VictoriaLogs datasource and time range. Returns a list of unique label strings (e.g., `[\"app\", \"env\", \"pod\"]`). If the time range is not provided, it defaults to the last hour. Optionally narrow the search to a subset of streams with `matcher` (e.g. `{namespace=\"prod\"}`).",
 	listLokiLabelNames,
 	mcp.WithTitleAnnotation("List Loki label names"),
 	mcp.WithIdempotentHintAnnotation(true),
@@ -247,6 +254,7 @@ var ListLokiLabelNames = mcpgrafana.MustTool(
 type ListLokiLabelValuesParams struct {
 	DatasourceUID string `json:"datasourceUid" jsonschema:"required,description=The UID of the datasource to query"`
 	LabelName     string `json:"labelName" jsonschema:"required,description=The name of the label to retrieve values for (e.g. 'app'\\, 'env'\\, 'pod')"`
+	Matcher       string `json:"matcher,omitempty" jsonschema:"description=Optionally\\, a stream selector to narrow the search to matching streams (Loki: LogQL\\, e.g. '{namespace=\"prod\"}'; VictoriaLogs: LogsQL). Defaults to searching across all streams."`
 	StartRFC3339  string `json:"startRfc3339,omitempty" jsonschema:"description=Optionally\\, the start time of the query in RFC3339 format or relative time (e.g. 'now-1h') (defaults to 1 hour ago)"`
 	EndRFC3339    string `json:"endRfc3339,omitempty" jsonschema:"description=Optionally\\, the end time of the query in RFC3339 format or relative time (e.g. 'now') (defaults to now)"`
 }
@@ -267,7 +275,7 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 		return nil, fmt.Errorf("parsing end time: %w", err)
 	}
 
-	result, err := backend.ListLabelValues(ctx, args.LabelName, start, end)
+	result, err := backend.ListLabelValues(ctx, args.LabelName, args.Matcher, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +291,7 @@ func listLokiLabelValues(ctx context.Context, args ListLokiLabelValuesParams) ([
 // ListLokiLabelValues is a tool for listing Loki label values
 var ListLokiLabelValues = mcpgrafana.MustTool(
 	"list_loki_label_values",
-	"Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.",
+	"Retrieves all unique values associated with a specific `labelName` within a Loki or VictoriaLogs datasource and time range. Returns a list of string values (e.g., for `labelName=\"env\"`, might return `[\"prod\", \"staging\", \"dev\"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted. Optionally narrow the search to a subset of streams with `matcher` (e.g. `{namespace=\"prod\"}`) — for example, to list `service` values seen only within a specific namespace.",
 	listLokiLabelValues,
 	mcp.WithTitleAnnotation("List Loki label values"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/loki_backend.go
+++ b/tools/loki_backend.go
@@ -18,12 +18,16 @@ import (
 // into the shared LogEntry shape.
 type lokiBackend interface {
 	// ListLabelNames returns the available label/field names within the
-	// given time range. Empty start/end means "use server defaults".
-	ListLabelNames(ctx context.Context, start, end time.Time) ([]string, error)
+	// given time range. Empty start/end means "use server defaults". An
+	// empty matcher means "no filter"; a non-empty matcher narrows the
+	// search to streams selected by it (Loki: a LogQL stream selector,
+	// e.g. `{namespace="prod"}`; VictoriaLogs: a LogsQL filter).
+	ListLabelNames(ctx context.Context, matcher string, start, end time.Time) ([]string, error)
 
 	// ListLabelValues returns the values for a single label/field within
-	// the given time range.
-	ListLabelValues(ctx context.Context, labelName string, start, end time.Time) ([]string, error)
+	// the given time range, optionally narrowed to streams selected by
+	// matcher (see ListLabelNames).
+	ListLabelValues(ctx context.Context, labelName, matcher string, start, end time.Time) ([]string, error)
 
 	// QueryLogs runs a log/metric query and returns the raw entries plus
 	// the result type ("streams" | "vector" | "matrix") and (when known)
@@ -98,13 +102,13 @@ func formatRFC3339OrEmpty(t time.Time) string {
 	return t.Format(time.RFC3339)
 }
 
-func (b *lokiNativeBackend) ListLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
-	return b.client.fetchData(ctx, "/loki/api/v1/labels", formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end))
+func (b *lokiNativeBackend) ListLabelNames(ctx context.Context, matcher string, start, end time.Time) ([]string, error) {
+	return b.client.fetchData(ctx, "/loki/api/v1/labels", matcher, formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end))
 }
 
-func (b *lokiNativeBackend) ListLabelValues(ctx context.Context, labelName string, start, end time.Time) ([]string, error) {
+func (b *lokiNativeBackend) ListLabelValues(ctx context.Context, labelName, matcher string, start, end time.Time) ([]string, error) {
 	urlPath := fmt.Sprintf("/loki/api/v1/label/%s/values", labelName)
-	return b.client.fetchData(ctx, urlPath, formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end))
+	return b.client.fetchData(ctx, urlPath, matcher, formatRFC3339OrEmpty(start), formatRFC3339OrEmpty(end))
 }
 
 func (b *lokiNativeBackend) QueryLogs(ctx context.Context, p lokiQueryParams) (*lokiQueryResult, error) {

--- a/tools/loki_backend_victorialogs.go
+++ b/tools/loki_backend_victorialogs.go
@@ -171,19 +171,28 @@ func (b *victoriaLogsBackend) listValueHits(ctx context.Context, urlPath string,
 	return out, nil
 }
 
-func (b *victoriaLogsBackend) ListLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
+func (b *victoriaLogsBackend) ListLabelNames(ctx context.Context, matcher string, start, end time.Time) ([]string, error) {
 	params := url.Values{}
-	params.Set("query", victoriaLogsAllQuery)
+	params.Set("query", logsQLOrAll(matcher))
 	addVLTimeRange(params, start, end)
 	return b.listValueHits(ctx, "/select/logsql/field_names", params)
 }
 
-func (b *victoriaLogsBackend) ListLabelValues(ctx context.Context, labelName string, start, end time.Time) ([]string, error) {
+func (b *victoriaLogsBackend) ListLabelValues(ctx context.Context, labelName, matcher string, start, end time.Time) ([]string, error) {
 	params := url.Values{}
-	params.Set("query", victoriaLogsAllQuery)
+	params.Set("query", logsQLOrAll(matcher))
 	params.Set("field", labelName)
 	addVLTimeRange(params, start, end)
 	return b.listValueHits(ctx, "/select/logsql/field_values", params)
+}
+
+// logsQLOrAll returns matcher if non-empty, otherwise the "match everything"
+// expression, so an empty matcher still searches across all streams.
+func logsQLOrAll(matcher string) string {
+	if matcher == "" {
+		return victoriaLogsAllQuery
+	}
+	return matcher
 }
 
 // QueryLogs runs a LogsQL query. Range and instant requests both go through

--- a/tools/loki_backend_victorialogs_test.go
+++ b/tools/loki_backend_victorialogs_test.go
@@ -62,12 +62,24 @@ func TestVictoriaLogsBackend_ListLabelNames(t *testing.T) {
 	})
 	b := newTestVLBackend(t, fake.server)
 
-	names, err := b.ListLabelNames(context.Background(), time.Time{}, time.Time{})
+	names, err := b.ListLabelNames(context.Background(), "", time.Time{}, time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"app", "pod"}, names)
 	assert.Equal(t, "/select/logsql/field_names", fake.lastPath)
 	assert.Equal(t, http.MethodGet, fake.lastMethod)
 	assert.Equal(t, victoriaLogsAllQuery, fake.lastQuery.Get("query"))
+}
+
+func TestVictoriaLogsBackend_ListLabelNames_PassesMatcher(t *testing.T) {
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"values":[{"value":"service","hits":3}]}`)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	names, err := b.ListLabelNames(context.Background(), `{namespace="prod"}`, time.Time{}, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"service"}, names)
+	assert.Equal(t, `{namespace="prod"}`, fake.lastQuery.Get("query"))
 }
 
 func TestVictoriaLogsBackend_ListLabelValues_PassesField(t *testing.T) {
@@ -78,12 +90,26 @@ func TestVictoriaLogsBackend_ListLabelValues_PassesField(t *testing.T) {
 
 	start := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
-	values, err := b.ListLabelValues(context.Background(), "app", start, end)
+	values, err := b.ListLabelValues(context.Background(), "app", "", start, end)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"acme-app"}, values)
 	assert.Equal(t, "app", fake.lastQuery.Get("field"))
+	assert.Equal(t, victoriaLogsAllQuery, fake.lastQuery.Get("query"))
 	assert.Equal(t, start.Format(time.RFC3339), fake.lastQuery.Get("start"))
 	assert.Equal(t, end.Format(time.RFC3339), fake.lastQuery.Get("end"))
+}
+
+func TestVictoriaLogsBackend_ListLabelValues_PassesMatcher(t *testing.T) {
+	fake := newFakeVLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"values":[{"value":"acme-app","hits":5}]}`)
+	})
+	b := newTestVLBackend(t, fake.server)
+
+	values, err := b.ListLabelValues(context.Background(), "app", `{namespace="prod"}`, time.Time{}, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"acme-app"}, values)
+	assert.Equal(t, "app", fake.lastQuery.Get("field"))
+	assert.Equal(t, `{namespace="prod"}`, fake.lastQuery.Get("query"))
 }
 
 func TestVictoriaLogsBackend_QueryLogs_ParsesNDJSON(t *testing.T) {

--- a/tools/loki_client_unit_test.go
+++ b/tools/loki_client_unit_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLokiClient_FetchData_PassesMatcherAsQueryParam(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("query")
+		_, _ = w.Write([]byte(`{"status":"success","data":["service"]}`))
+	}))
+	defer server.Close()
+
+	c := &Client{httpClient: server.Client(), baseURL: server.URL}
+
+	result, err := c.fetchData(context.Background(), "/loki/api/v1/label/service/values", `{namespace="prod"}`, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"service"}, result)
+	assert.Equal(t, `{namespace="prod"}`, gotQuery)
+}
+
+func TestLokiClient_FetchData_OmitsQueryParamWhenMatcherEmpty(t *testing.T) {
+	var sawQuery bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawQuery = r.URL.Query()["query"]
+		_, _ = w.Write([]byte(`{"status":"success","data":["app","pod"]}`))
+	}))
+	defer server.Close()
+
+	c := &Client{httpClient: server.Client(), baseURL: server.URL}
+
+	result, err := c.fetchData(context.Background(), "/loki/api/v1/labels", "", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app", "pod"}, result)
+	assert.False(t, sawQuery, "query param should be omitted when matcher is empty")
+}

--- a/tools/loki_guardrail_unit_test.go
+++ b/tools/loki_guardrail_unit_test.go
@@ -528,11 +528,11 @@ type fakeLokiBackend struct {
 	statsCalled bool
 }
 
-func (f *fakeLokiBackend) ListLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
+func (f *fakeLokiBackend) ListLabelNames(ctx context.Context, matcher string, start, end time.Time) ([]string, error) {
 	return nil, nil
 }
 
-func (f *fakeLokiBackend) ListLabelValues(ctx context.Context, labelName string, start, end time.Time) ([]string, error) {
+func (f *fakeLokiBackend) ListLabelValues(ctx context.Context, labelName, matcher string, start, end time.Time) ([]string, error) {
 	return nil, nil
 }
 

--- a/tools/loki_label_analyzer.go
+++ b/tools/loki_label_analyzer.go
@@ -159,7 +159,7 @@ func getLokiLabelCardinality(ctx context.Context, args GetLokiLabelCardinalityPa
 
 	labels := args.LabelNames
 	if len(labels) == 0 {
-		all, err := backend.ListLabelNames(ctx, start, end)
+		all, err := backend.ListLabelNames(ctx, "", start, end)
 		if err != nil {
 			return nil, fmt.Errorf("listing label names: %w", err)
 		}
@@ -183,7 +183,7 @@ func getLokiLabelCardinality(ctx context.Context, args GetLokiLabelCardinalityPa
 
 	out := make([]LokiLabelCardinality, 0, len(labels))
 	for _, name := range labels {
-		values, err := backend.ListLabelValues(ctx, name, start, end)
+		values, err := backend.ListLabelValues(ctx, name, "", start, end)
 		if err != nil {
 			return nil, fmt.Errorf("listing values for %q: %w", name, err)
 		}

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -42,10 +42,14 @@ func TestLokiTools(t *testing.T) {
 
 	t.Run("get loki label values narrowed by matcher", func(t *testing.T) {
 		ctx := newTestContext()
+		// A regex, not an exact match: promtail's docker_sd_configs derives
+		// the "container" label from the running container's actual name
+		// (testdata/promtail-config.yml), which Docker Compose generates as
+		// "<project>-grafana-<n>" rather than the bare service name "grafana".
 		result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
 			DatasourceUID: "loki",
 			LabelName:     "container",
-			Matcher:       `{container="grafana"}`,
+			Matcher:       `{container=~".*grafana.*"}`,
 		})
 		require.NoError(t, err)
 		assert.NotEmpty(t, result, "Should have at least one container label value matching the selector")

--- a/tools/loki_test.go
+++ b/tools/loki_test.go
@@ -40,6 +40,17 @@ func TestLokiTools(t *testing.T) {
 		assert.NotEmpty(t, result, "Should have at least one container label value")
 	})
 
+	t.Run("get loki label values narrowed by matcher", func(t *testing.T) {
+		ctx := newTestContext()
+		result, err := listLokiLabelValues(ctx, ListLokiLabelValuesParams{
+			DatasourceUID: "loki",
+			LabelName:     "container",
+			Matcher:       `{container="grafana"}`,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result, "Should have at least one container label value matching the selector")
+	})
+
 	t.Run("query loki stats", func(t *testing.T) {
 		ctx := newTestContext()
 		result, err := queryLokiStats(ctx, QueryLokiStatsParams{


### PR DESCRIPTION
## Summary

Fixes #382

`list_loki_label_names` and `list_loki_label_values` previously listed labels/values across an entire Loki (or VictoriaLogs) datasource with no way to scope the search — e.g. there was no way to ask "what `service` values exist within a given `namespace`" without listing every value and filtering client-side.

Adds an optional `matcher` parameter, forwarded to the underlying API on both backends:
- **Loki**: the `query` parameter on `/labels` and `/label/<name>/values` (a LogQL stream selector, e.g. `{namespace="prod"}`)
- **VictoriaLogs**: the `query` parameter on `/select/logsql/field_names` and `/select/logsql/field_values` (a LogsQL filter), falling back to the existing "match everything" expression when `matcher` is empty so behavior is unchanged by default

This is a parameter addition to two existing tools (their purpose/shape is unchanged), so per CONTRIBUTING.md it doesn't require a new-tool proposal.

## Context

There's a stale PR (#380) that attempted the same thing against an earlier version of this file; a maintainer closed it for staleness in March and explicitly invited a redo ("feel free to pick this up again though, we'd be happy to review!"). This PR is a fresh implementation against the current codebase — the Loki tools have since moved to a `lokiBackend` interface (native Loki + VictoriaLogs), so the change threads `matcher` through both backend implementations rather than the old single `Client.fetchData` method #380 touched.

## Test plan

- [x] Added unit tests for both backends: `TestLokiClient_FetchData_PassesMatcherAsQueryParam` / `_OmitsQueryParamWhenMatcherEmpty` (native), `TestVictoriaLogsBackend_ListLabelNames_PassesMatcher` / `TestVictoriaLogsBackend_ListLabelValues_PassesMatcher` (VictoriaLogs), plus updated the two existing VictoriaLogs tests to assert the "match everything" fallback when `matcher` is empty.
- [x] Verified RED→GREEN: `git stash` on the source-only changes fails the build with unmatched call sites, confirming the tests exercise the new parameter; restoring the fix goes green.
- [x] Full unit suite (`go test -tags unit ./tools/...`) passes.
- [x] `go build ./...` and `go vet ./...` clean under both `unit` and `integration` build tags.
- [x] `gofmt -l` clean on all changed files.
- [x] Added an integration-tagged test case (`get loki label values narrowed by matcher` in `loki_test.go`) alongside the existing ones — **not run locally**, since it requires a real Loki instance; flagging this explicitly rather than claiming it passed.
- [x] CHANGELOG.md updated under `[Unreleased]`.