### PR TITLE
feat: add healthz listener appart with metrics for mux, close #1090

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,9 +435,9 @@ The `mcp-grafana` binary supports various command-line flags for configuration:
 
 **HTTP Transport Security (SSE / streamable-http only):**
 
-`Host`/`Origin` validation is enforced on *every* route on the listener — `/sse`, `/mcp`, `/healthz`, and `/metrics` — so a DNS-rebinding browser cannot reach any of them. Stdio transport is unaffected.
+`Host`/`Origin` validation is enforced on *every* route on the MCP listener — `/sse`, `/mcp`, and `/healthz` / `/metrics` when they share that listener — so a DNS-rebinding browser cannot reach any of them. Stdio transport is unaffected. `--healthz-address` and `--metrics-address` start a separate listener that is not wrapped.
 
-- `--allowed-hosts`: Comma-separated allowlist of `Host` header values. Defaults to loopback variants of `--address` (e.g. `localhost:8000,127.0.0.1:8000,[::1]:8000`). A value that parses to empty (unset, `,`, ` , `, etc.) also falls back to the defaults so a typo cannot silently disable the check. Requests with a `Host` header outside the allowlist are rejected with `403`. Pass `*` to disable the check — only safe when running behind a trusted reverse proxy that rewrites `Host`, or in an isolated network. K8s `httpGet` probes and external `/metrics` scrapes will need either an explicit hostname in this list, `*`, or a `tcpSocket` probe / a separate metrics port (`--metrics-address`).
+- `--allowed-hosts`: Comma-separated allowlist of `Host` header values. Defaults to loopback variants of `--address` (e.g. `localhost:8000,127.0.0.1:8000,[::1]:8000`). A value that parses to empty (unset, `,`, ` , `, etc.) also falls back to the defaults so a typo cannot silently disable the check. Requests with a `Host` header outside the allowlist are rejected with `403`. Pass `*` to disable the check — only safe when running behind a trusted reverse proxy that rewrites `Host`, or in an isolated network. K8s `httpGet` probes and external `/metrics` scrapes will need either an explicit hostname in this list, `*`, a `tcpSocket` probe, or a separate port (`--healthz-address` / `--metrics-address`).
 - `--allowed-origins`: Comma-separated allowlist of `Origin` header values. Empty by default — any request that carries an `Origin` header is rejected (browsers always send one for cross-origin requests, and no browser should be calling this server directly). Set to an explicit list to permit browser-based clients, or `*` to disable the check.
 
 **Caller Authentication (SSE / streamable-http only):**
@@ -459,6 +459,7 @@ Caller authentication is enforced only when `--server-auth-token` is set. When i
 **Observability:**
 - `--metrics`: Enable Prometheus metrics endpoint at `/metrics`
 - `--metrics-address`: Separate address for metrics server (e.g., `:9090`). If empty, metrics are served on the main server
+- `--healthz-address`: Separate address for `/healthz` (e.g., `:8080`). If empty, `/healthz` is served on the main server. Shares a listener with `--metrics-address` when the two addresses match. Side listeners skip Host/Origin validation.
 - `--slow-request-threshold`: Log an event when any MCP request (tool invocation, list, resource read, etc.) takes longer than this duration. Accepts Go duration strings (e.g., `500ms`, `5s`). Default `0` disables slow-request logging. See the [Slow-request logging](#slow-request-logging) section.
 - `--slow-request-log-level`: Log level for slow-request events (`info` or `warn`) - default: `warn`.
 
@@ -1201,8 +1202,9 @@ When using the SSE (`-t sse`) or streamable HTTP (`-t streamable-http`) transpor
 # For streamable HTTP or SSE transport on default port
 curl http://localhost:8000/healthz
 
-# With custom address
-curl http://localhost:9090/healthz
+# Probe a side listener while MCP stays on loopback (Kubernetes + sidecar)
+./mcp-grafana -t streamable-http --address 127.0.0.1:8000 --healthz-address :8080
+curl http://127.0.0.1:8080/healthz
 ```
 
 **Note:** The health check endpoint is only available when using SSE or streamable HTTP transports. It is not available when using the stdio transport (`-t stdio`), as stdio does not expose an HTTP server.

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -720,17 +720,43 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
-// runMetricsServer starts a separate HTTP server for metrics.
-func runMetricsServer(addr string, o *observability.Observability) {
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", o.MetricsHandler())
-	slog.Info("Starting metrics server", "address", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
-		slog.Error("metrics server error", "error", err)
+// registerOps mounts /healthz and /metrics. An empty address keeps the route
+// on mux; otherwise it goes on a side mux keyed by address (so matching
+// --healthz-address and --metrics-address share a listener). Callers pass the
+// result to runOpsServers. Side listeners skip Host/Origin checks.
+func registerOps(mux *http.ServeMux, o *observability.Observability, healthzAddr string, obs observability.Config) map[string]*http.ServeMux {
+	side := map[string]*http.ServeMux{}
+	target := func(addr string) *http.ServeMux {
+		if addr == "" {
+			return mux
+		}
+		if side[addr] == nil {
+			side[addr] = http.NewServeMux()
+		}
+		return side[addr]
+	}
+
+	target(healthzAddr).HandleFunc("/healthz", handleHealthz)
+	if obs.MetricsEnabled {
+		target(obs.MetricsAddress).Handle("/metrics", o.MetricsHandler())
+	}
+	return side
+}
+
+func runOpsServers(servers map[string]*http.ServeMux) {
+	for addr, h := range servers {
+		go runOpsServer(addr, h)
 	}
 }
 
-func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, hsc httpSecurityConfig, ca callerAuthConfig, obs observability.Config, sessionIdleTimeoutMinutes int) error {
+func runOpsServer(addr string, h http.Handler) {
+	slog.Info("Starting ops server", "address", addr)
+	if err := http.ListenAndServe(addr, h); err != nil {
+		slog.Error("ops server error", "error", err)
+	}
+}
+
+func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt disabledTools, gc mcpgrafana.GrafanaConfig, tls tlsConfig, hsc httpSecurityConfig, ca callerAuthConfig, obs observability.Config, sessionIdleTimeoutMinutes int, healthzAddress string) error {
 	stderrHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
 	slog.SetDefault(slog.New(stderrHandler))
 
@@ -854,15 +880,8 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			basePath,
 		)))
-		mux.HandleFunc("/healthz", handleHealthz)
-		if obs.MetricsEnabled {
-			if obs.MetricsAddress == "" {
-				mux.Handle("/metrics", o.MetricsHandler())
-			} else {
-				go runMetricsServer(obs.MetricsAddress, o)
-			}
-		}
-		// Wrap the full mux so /healthz and /metrics are validated too.
+		runOpsServers(registerOps(mux, o, healthzAddress, obs))
+		// Wrap the full mux so ops routes left on it are validated too.
 		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
 		slog.Info("Starting Grafana MCP server using SSE transport",
 			"version", mcpgrafana.Version(), "address", addr, "basePath", basePath, "metrics", obs.MetricsEnabled)
@@ -894,15 +913,8 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			endpointPath,
 		)))
-		mux.HandleFunc("/healthz", handleHealthz)
-		if obs.MetricsEnabled {
-			if obs.MetricsAddress == "" {
-				mux.Handle("/metrics", o.MetricsHandler())
-			} else {
-				go runMetricsServer(obs.MetricsAddress, o)
-			}
-		}
-		// Wrap the full mux so /healthz and /metrics are validated too.
+		runOpsServers(registerOps(mux, o, healthzAddress, obs))
+		// Wrap the full mux so ops routes left on it are validated too.
 		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
 		slog.Info("Starting Grafana MCP server using StreamableHTTP transport",
 			"version", mcpgrafana.Version(), "address", addr, "endpointPath", endpointPath, "metrics", obs.MetricsEnabled)
@@ -942,6 +954,7 @@ func main() {
 	var obs observability.Config
 	flag.BoolVar(&obs.MetricsEnabled, "metrics", false, "Enable Prometheus metrics endpoint")
 	flag.StringVar(&obs.MetricsAddress, "metrics-address", "", "Separate address for metrics server (e.g., :9090). If empty, metrics are served on the main server at /metrics")
+	healthzAddress := flag.String("healthz-address", "", "Separate address for /healthz (e.g., :8080). If empty, /healthz is served on the main HTTP server. A side listener is not wrapped by Host/Origin validation, matching --metrics-address.")
 	flag.DurationVar(&obs.SlowRequestThreshold, "slow-request-threshold", 0, "Log an event when any MCP request (tool invocation, list, resource read, etc.) takes longer than this threshold. Accepts Go duration strings, e.g. 500ms, 5s. Default 0 disables slow-request logging.")
 	var slowRequestLogLevelStr string
 	flag.StringVar(&slowRequestLogLevelStr, "slow-request-log-level", "warn", "Log level for slow-request events. One of \"info\" or \"warn\". Default \"warn\".")
@@ -1040,7 +1053,7 @@ func main() {
 		level = slog.LevelDebug
 	}
 
-	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, hsc, ca, obs, *sessionIdleTimeoutMinutes); err != nil {
+	if err := run(transport, *addr, *basePath, *endpointPath, level, dt, grafanaConfig, tls, hsc, ca, obs, *sessionIdleTimeoutMinutes, *healthzAddress); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1183,3 +1183,85 @@ func TestProcessTools_BothDisableFlags(t *testing.T) {
 		assert.True(t, names[name], "%s should survive both flags", name)
 	}
 }
+
+func getPath(h http.Handler, path string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+func TestRegisterOps_DefaultKeepsHealthzOnMainMux(t *testing.T) {
+	main := http.NewServeMux()
+	side := registerOps(main, newTestObservability(t), "", observability.Config{})
+
+	assert.Empty(t, side, "no extra listener without --healthz-address or --metrics-address")
+	rec := getPath(main, "/healthz")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
+func TestRegisterOps_MetricsOnMainMux(t *testing.T) {
+	obs, err := observability.Setup(observability.Config{MetricsEnabled: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
+
+	main := http.NewServeMux()
+	side := registerOps(main, obs, "", observability.Config{MetricsEnabled: true})
+
+	assert.Empty(t, side, "--metrics with empty --metrics-address must not start a side listener")
+	assert.Equal(t, http.StatusOK, getPath(main, "/healthz").Code)
+	assert.Equal(t, http.StatusOK, getPath(main, "/metrics").Code)
+}
+
+func TestRegisterOps_HealthzAddressMovesItOffMainMux(t *testing.T) {
+	main := http.NewServeMux()
+	side := registerOps(main, newTestObservability(t), ":8080", observability.Config{})
+
+	assert.Equal(t, http.StatusNotFound, getPath(main, "/healthz").Code,
+		"/healthz must leave the MCP listener, not be served on both")
+	require.Len(t, side, 1)
+	require.Contains(t, side, ":8080")
+	rec := getPath(side[":8080"], "/healthz")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
+func TestRegisterOps_SharedAddressUsesOneListener(t *testing.T) {
+	obs, err := observability.Setup(observability.Config{MetricsEnabled: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
+
+	main := http.NewServeMux()
+	side := registerOps(main, obs, ":9090", observability.Config{MetricsEnabled: true, MetricsAddress: ":9090"})
+
+	require.Len(t, side, 1, "one bind address must not produce two listeners")
+	assert.Equal(t, http.StatusOK, getPath(side[":9090"], "/healthz").Code)
+	assert.Equal(t, http.StatusOK, getPath(side[":9090"], "/metrics").Code)
+	assert.Equal(t, http.StatusNotFound, getPath(main, "/healthz").Code)
+	assert.Equal(t, http.StatusNotFound, getPath(main, "/metrics").Code)
+}
+
+func TestRegisterOps_DistinctAddressesStaySplit(t *testing.T) {
+	obs, err := observability.Setup(observability.Config{MetricsEnabled: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
+
+	main := http.NewServeMux()
+	side := registerOps(main, obs, ":8080", observability.Config{MetricsEnabled: true, MetricsAddress: ":9090"})
+
+	require.Len(t, side, 2)
+	assert.Equal(t, http.StatusOK, getPath(side[":8080"], "/healthz").Code)
+	assert.Equal(t, http.StatusNotFound, getPath(side[":8080"], "/metrics").Code)
+	assert.Equal(t, http.StatusOK, getPath(side[":9090"], "/metrics").Code)
+	assert.Equal(t, http.StatusNotFound, getPath(side[":9090"], "/healthz").Code)
+}
+
+// Metrics stay opt-in: --healthz-address alone must not expose /metrics.
+func TestRegisterOps_HealthzAddressDoesNotEnableMetrics(t *testing.T) {
+	main := http.NewServeMux()
+	side := registerOps(main, newTestObservability(t), ":8080", observability.Config{})
+
+	require.Len(t, side, 1)
+	assert.Equal(t, http.StatusNotFound, getPath(side[":8080"], "/metrics").Code)
+	assert.Equal(t, http.StatusNotFound, getPath(main, "/metrics").Code)
+}

--- a/docs/docs.agent/context.md
+++ b/docs/docs.agent/context.md
@@ -206,5 +206,5 @@ Order articles from most popular language or framework to least.
 ### Observability (metrics and tracing)
 
 - **Context:** README.md (Observability)
-- **Include:** --metrics, --metrics-address; Prometheus metrics (mcp_server_operation_duration_seconds, etc.). OTEL env vars and tracing.
+- **Include:** --metrics, --metrics-address, --healthz-address; Prometheus metrics (mcp_server_operation_duration_seconds, etc.). OTEL env vars and tracing.
 - **Exclude:** Grafana datasource setup for metrics (out of scope).

--- a/docs/sources/configure/command-line-flags.md
+++ b/docs/sources/configure/command-line-flags.md
@@ -34,12 +34,12 @@ You can look up defaults, choose `--disable-*` flags, or configure TLS without r
 
 ## Configure HTTP transport security
 
-The SSE and streamable-http transports validate `Host` and `Origin` headers on every route (`/sse`, `/mcp`, `/healthz`, `/metrics`) to block DNS-rebinding attacks. Stdio transport is unaffected.
+The SSE and streamable-http transports validate `Host` and `Origin` headers on every route on the MCP listener (`/sse`, `/mcp`, and `/healthz` / `/metrics` when they stay on that listener) to block DNS-rebinding attacks. Stdio transport is unaffected. Side listeners started by `--healthz-address` or `--metrics-address` are not wrapped.
 
 - `--allowed-hosts`: Comma-separated allowlist of `Host` header values. When unset (or when the parsed value is empty — for example, `,,,`), it falls back to loopback variants of `--address` (for example, `localhost:8000`, `127.0.0.1:8000`, `[::1]:8000`). Pass `*` to disable the check — only safe behind a trusted reverse proxy that rewrites `Host`.
 - `--allowed-origins`: Comma-separated allowlist of `Origin` header values. Empty by default — any request that carries an `Origin` header is rejected (browsers always send `Origin` for cross-origin requests, and no browser should be calling this server directly). Pass an explicit list to permit browser clients, or `*` to disable the check.
 
-When deploying behind an ingress or reverse proxy that forwards the original `Host`, set `--allowed-hosts` to the expected hostname (or `*` if the proxy is fully trusted). Kubernetes `httpGet` liveness/readiness probes send `Host: <pod-ip>:<port>` by default — either set `--allowed-hosts '*'`, override the probe's `host:` field, or use a `tcpSocket` probe. External `/metrics` scrapes must add the scrape source's `Host` to the allowlist (or use `--metrics-address` to bind metrics on a separate port, which is unaffected).
+When deploying behind an ingress or reverse proxy that forwards the original `Host`, set `--allowed-hosts` to the expected hostname (or `*` if the proxy is fully trusted). Kubernetes `httpGet` liveness/readiness probes send `Host: <pod-ip>:<port>` by default — either set `--allowed-hosts '*'`, override the probe's `host:` field, use a `tcpSocket` probe, or bind `/healthz` on `--healthz-address` (and `/metrics` on `--metrics-address`). Those side listeners are not wrapped by Host/Origin validation.
 
 ## Configure caller authentication
 
@@ -74,6 +74,7 @@ When caller authentication is enabled, the `Authorization` header is reserved fo
 
 - `--metrics`: Expose a Prometheus metrics endpoint at `/metrics` (SSE and streamable-http only).
 - `--metrics-address`: Optional separate listen address for metrics (for example, `:9090`). If empty, metrics are served on the main HTTP server.
+- `--healthz-address`: Optional separate listen address for `/healthz` (for example, `:8080`). If empty, `/healthz` is served on the main HTTP server. If this matches `--metrics-address`, both routes share one extra listener. The side listener is not wrapped by Host/Origin validation, so Kubernetes probes can reach it while `--address` stays on loopback.
 
 ## Configure tool categories
 

--- a/docs/sources/configure/health-check-endpoint.md
+++ b/docs/sources/configure/health-check-endpoint.md
@@ -38,9 +38,13 @@ You can probe readiness from scripts or upstream checks when the server uses an 
 # For streamable HTTP or SSE transport with default listen address (localhost:8000)
 curl http://localhost:8000/healthz
 
-# With custom address
-curl http://localhost:9090/healthz
+# Health check on a separate listen address (for example Kubernetes probes
+# while --address is bound to 127.0.0.1 behind a sidecar)
+./mcp-grafana -t streamable-http --address 127.0.0.1:8000 --healthz-address :8080
+curl http://localhost:8080/healthz
 ```
+
+The `/healthz` handler only reports that the HTTP server is up; it does not check Grafana connectivity. A `--healthz-address` listener is not wrapped by `--allowed-hosts` / `--allowed-origins` validation, matching `--metrics-address`.
 
 **Note**:  The health check endpoint is only available when using SSE or streamable HTTP transports. It is **not** available with the stdio transport (`-t stdio`), because stdio does not start an HTTP server.
 


### PR DESCRIPTION
## What this changes

Allow `/healthz` to bind separately from the MCP endpoint via `--healthz-address`, matching `--metrics-address`, so Kubernetes probes still work when MCP is loopback-only behind a sidecar.

Fixes #1090 

## How you tested it

Unit tests for route placement (`go test -tags unit ./cmd/mcp-grafana/`). Local binary: kubelet-style Host on MCP /healthz is 403; with `--healthz-address` the probe returns 200. Existing `--metrics` / `--metrics-address` paths unchanged.


## Checklist

- [x] `make lint` and `make test-unit` pass locally
- [x] Commits are signed (required to merge — see CONTRIBUTING.md)
- [x] CLA signed (required to merge)
- [x] README tool table updated, with RBAC permissions and scopes, if this adds a tool
- [x] Any write operation respects `--disable-write`
- [x] Any datasource query execution respects `--disable-query` (and `--disable-write` too, if the query is passed through unfiltered)

