### PR TITLE
fix(server): return structured tool errors on schema type mismatch

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -515,6 +515,13 @@ func newServer(serverName, transport string, dt disabledTools, obs *observabilit
 	serverOpts := []server.ServerOption{
 		server.WithInstructions(instructions),
 		server.WithHooks(hooks),
+		// A tool call with a JSON type mismatch (e.g. a number where the
+		// schema declares a string) is a client/agent input error, not a
+		// server fault: surface it as a structured tool result (IsError:
+		// true, with the validation message) instead of a raw JSON-RPC
+		// -32603 internal error, so the agent can see what was wrong and
+		// self-correct. See SEP-1303.
+		server.WithInputSchemaValidation(),
 	}
 	if mcpgrafana.DynamicMultiOrgEnabled {
 		// Honor an optional per-call "orgId" argument so a single connection can

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -515,13 +515,6 @@ func newServer(serverName, transport string, dt disabledTools, obs *observabilit
 	serverOpts := []server.ServerOption{
 		server.WithInstructions(instructions),
 		server.WithHooks(hooks),
-		// A tool call with a JSON type mismatch (e.g. a number where the
-		// schema declares a string) is a client/agent input error, not a
-		// server fault: surface it as a structured tool result (IsError:
-		// true, with the validation message) instead of a raw JSON-RPC
-		// -32603 internal error, so the agent can see what was wrong and
-		// self-correct. See SEP-1303.
-		server.WithInputSchemaValidation(),
 	}
 	if mcpgrafana.DynamicMultiOrgEnabled {
 		// Honor an optional per-call "orgId" argument so a single connection can

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1265,3 +1265,35 @@ func TestRegisterOps_HealthzAddressDoesNotEnableMetrics(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, getPath(side[":8080"], "/metrics").Code)
 	assert.Equal(t, http.StatusNotFound, getPath(main, "/metrics").Code)
 }
+
+// TestNewServer_InvalidArgumentTypeReturnsToolErrorNotProtocolError verifies
+// that a tool call with a JSON type mismatch (e.g. a number where the schema
+// declares a string) surfaces as a structured tool result (IsError: true)
+// that an agent can act on, rather than escaping as a raw JSON-RPC internal
+// error (-32603) with a bare Go unmarshal message. See issue #830.
+func TestNewServer_InvalidArgumentTypeReturnsToolErrorNotProtocolError(t *testing.T) {
+	obs := newTestObservability(t)
+	s, _, sm := newServer(defaultServerName, "stdio", disabledTools{enabledTools: "datasource"}, obs, 0)
+	defer sm.Close()
+
+	c, err := client.NewInProcessClient(s)
+	require.NoError(t, err)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Initialize(context.Background(), mcp.InitializeRequest{})
+	require.NoError(t, err)
+
+	result, err := c.CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "list_datasources",
+			// "type" is declared as a string in ListDatasourcesParams; send a
+			// number instead, matching issue #830's exact repro.
+			Arguments: map[string]any{"type": 42},
+		},
+	})
+
+	require.NoError(t, err, "a schema type mismatch must not surface as a JSON-RPC protocol error")
+	require.NotNil(t, result)
+	assert.True(t, result.IsError, "a schema type mismatch must surface as a structured tool error")
+}

--- a/tools.go
+++ b/tools.go
@@ -336,7 +336,13 @@ func ConvertTool[T any, R any](name, description string, toolHandler ToolHandler
 		if err := unmarshalWithIntConversion(argBytes, unmarshaledArgs); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to unmarshal arguments")
-			return nil, fmt.Errorf("unmarshal args: %s", err)
+			// A type mismatch that survives unmarshalWithIntConversion's
+			// coercion is a client/agent input error, not a server fault:
+			// return it as a structured tool result (IsError: true), same as
+			// the unknown-arguments check above, so the agent can see what
+			// was wrong and self-correct instead of the call escaping as a
+			// raw JSON-RPC -32603 internal error.
+			return mcp.NewToolResultError(fmt.Sprintf("invalid arguments: %s", err)), nil
 		}
 
 		// Need to dereference the unmarshaled arguments

--- a/tools_test.go
+++ b/tools_test.go
@@ -555,7 +555,10 @@ func TestConvertTool(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "marshal args")
 
-		// Test with type mismatch
+		// Test with type mismatch: surfaced as a structured tool error
+		// (IsError: true), not a Go error, so an agent can see what was
+		// wrong and self-correct instead of the call escaping as a raw
+		// JSON-RPC protocol error. See issue #830.
 		mismatchRequest := mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
 				Arguments: map[string]any{
@@ -565,9 +568,13 @@ func TestConvertTool(t *testing.T) {
 			},
 		}
 
-		_, err = handler(context.Background(), mismatchRequest)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "unmarshal args")
+		mismatchResult, err := handler(context.Background(), mismatchRequest)
+		require.NoError(t, err)
+		require.NotNil(t, mismatchResult)
+		assert.True(t, mismatchResult.IsError)
+		mismatchText, ok := mismatchResult.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, mismatchText.Text, "invalid arguments")
 	})
 }
 
@@ -766,4 +773,34 @@ func TestValidateNoBooleanSchemasAllowsAdditionalPropertiesFalse(t *testing.T) {
 	input := `{"type":"object","properties":{"name":{"type":"string"}},"additionalProperties":false}`
 	err := validateNoBooleanSchemas("test_tool", []byte(input))
 	assert.NoError(t, err)
+}
+
+// TestConvertTool_UnmarshalTypeMismatchReturnsToolErrorNotProtocolError
+// verifies that an argument type mismatch that survives unmarshalWithIntConversion's
+// coercion (e.g. a boolean where an int is declared) surfaces as a structured
+// tool result (IsError: true), the same way an unknown argument does just
+// above it in the handler, rather than escaping as a raw JSON-RPC protocol
+// error via a returned Go error. See issue #830.
+func TestConvertTool_UnmarshalTypeMismatchReturnsToolErrorNotProtocolError(t *testing.T) {
+	_, handler, err := ConvertTool("test_tool", "A test tool", testToolHandler)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "test_tool",
+			Arguments: map[string]any{
+				"name": "test",
+				// "value" is declared as int; a bool is not one of
+				// unmarshalWithIntConversion's coercions (string -> int,
+				// string -> []string), so this must still fail to unmarshal.
+				"value": true,
+			},
+		},
+	}
+
+	result, err := handler(ctx, request)
+	require.NoError(t, err, "an argument type mismatch must not surface as a JSON-RPC protocol error")
+	require.NotNil(t, result)
+	assert.True(t, result.IsError, "an argument type mismatch must surface as a structured tool error")
 }


### PR DESCRIPTION
## Summary

Fixes #830. A tool call with a JSON type mismatch (e.g. a number where the schema declares a string) surfaced as a raw JSON-RPC `-32603` internal error carrying a bare Go unmarshal message, instead of a structured tool result the agent could see and self-correct from — affecting all 50 registered tools, since the failure happens in `json.Unmarshal` on the arguments before any tool handler runs:

```json
// Request
{"method":"tools/call","params":{"name":"list_datasources","arguments":{"type":42}}}

// Response (before)
{"error":{"code":-32603,"message":"unmarshal args: json: cannot unmarshal number into Go struct field ... of type string"}}
```

## Fix (revised)

The first version of this PR enabled `mcp-go`'s `server.WithInputSchemaValidation()`. Cursor Bugbot correctly flagged a regression in that approach: schema validation runs *before* the tool handler, which means it also runs before `unmarshalWithIntConversion`'s existing LLM-tolerance coercions (`"42"` → `42`, a bare string → a single-element `[]string`) get a chance to apply — so a model sending a stringified int (something this codebase already deliberately tolerates) would be newly rejected.

Reverted that and fixed the actual bug at its source instead: `tools.go`'s generated handler wrapper has an `unknownArguments` check immediately above the unmarshal call that already does this correctly — on failure it returns `mcp.NewToolResultError(...)` (a structured tool result) rather than a Go error, for exactly this reason. The unmarshal-failure branch just below it didn't follow that pattern; it returned a raw Go error, which is what `-32603` comes from. This PR applies the same `mcp.NewToolResultError(...)` pattern to that branch. `unmarshalWithIntConversion` still runs first, completely unchanged, so no existing coercion behavior is lost — only a type mismatch that survives it now returns a structured tool error instead of a protocol error.

## Testing Plan

- `TestConvertTool_UnmarshalTypeMismatchReturnsToolErrorNotProtocolError` (new, in `tools_test.go`): uses a `bool` where an `int` is declared — deliberately outside `unmarshalWithIntConversion`'s coercion set (string→int, string→[]string) — so it can't pass by accident of the coercion succeeding. Asserts no Go error and `IsError: true`.
- `TestConvertTool`'s existing "type mismatch" subtest, which asserted the old raw-Go-error shape (a pre-existing test that predates this PR), updated to assert the new tool-error shape.
- `TestNewServer_InvalidArgumentTypeReturnsToolErrorNotProtocolError` (`cmd/mcp-grafana/main_test.go`): the issue's exact repro (`list_datasources` with `{"type": 42}`) via an in-process client, end to end through the real server.
- Re-ran the full existing coercion test suite (`TestConvertToolWithStringToIntConversion`, `TestUnmarshalWithAllIntegerTypes`, `TestUnmarshalWithStringToSliceCoercion`) unchanged — all still pass, confirming the regression Bugbot flagged doesn't apply to this approach.
- Verified RED→GREEN on the new test against pre-fix code.
- Full `go test ./... -tags unit` run: one pre-existing failure (`TestVersionOutput`, both subtests) reproduces identically on unmodified `main` — a Windows-sandbox `exec: ... executable file not found in %PATH%` issue unrelated to this change.
- `go vet ./...` and `gofmt` clean on all touched files.