### PR TITLE
fix(datasources): don't report frontend-only plugins as unhealthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--loki-enforced-matchers`: operator-configured LogQL label matchers AND-ed into every native-Loki query (logs, stats, patterns, and label enumeration) to restrict which streams the server can read. Fails closed on unparseable queries and refuses VictoriaLogs datasources while set. Pair with `--disable-api` so the raw datasource proxy cannot bypass it. A companion `--loki-label-enumeration-fallback` controls label-enumeration behaviour under purely-negative matchers ([#978](https://github.com/grafana/mcp-grafana/pull/978))
 - `--instructions-append` flag to append operator-supplied text to the server instructions returned to MCP clients on initialize, so every connecting agent sees it — e.g. to explain that Loki reads are restricted by `--loki-enforced-matchers` ([#978](https://github.com/grafana/mcp-grafana/pull/978))
 
+### Fixed
+
+- `check_datasources_health` no longer reports a frontend-only datasource plugin (e.g. the built-in Alertmanager datasource) as unhealthy: those plugins have no backend to serve the health endpoint, so it always failed for them. Such datasources now report `"status": "UNKNOWN"` and are counted separately in a new `unknown` field on the bulk result, rather than inflating `unhealthy` ([#1069](https://github.com/grafana/mcp-grafana/issues/1069))
+
 ## [1.3.0] - 2026-08-28
 
 ### Added

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -851,6 +851,13 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 	withoutBackend := datasourcesWithoutBackend(ctx)
 
 	results := make([]DatasourceHealthCheckResult, len(targets))
+	// noBackend tracks which results were skipped for lacking a backend
+	// component, distinct from a backend plugin's own health check
+	// legitimately returning a "UNKNOWN" status: both currently surface as
+	// Status == "UNKNOWN", but only the former belongs in the unknown tally
+	// below — folding a real inconclusive/failed backend check into it would
+	// hide it from Unhealthy.
+	noBackend := make([]bool, len(targets))
 	var wg sync.WaitGroup
 	for i, ds := range targets {
 		wg.Add(1)
@@ -861,6 +868,7 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 				r.Status = "UNKNOWN"
 				r.Message = "This datasource's plugin has no backend component, so it cannot be health-checked."
 				results[i] = r
+				noBackend[i] = true
 				return
 			}
 			health, err := checkDatasourceHealth(ctx, CheckDatasourceHealthParams{UID: ds.UID})
@@ -876,9 +884,9 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 	wg.Wait()
 
 	healthy, unhealthy, unknown := 0, 0, 0
-	for _, r := range results {
+	for i, r := range results {
 		switch {
-		case r.Status == "UNKNOWN":
+		case noBackend[i]:
 			unknown++
 		case r.Error != "" || r.Status != "OK":
 			unhealthy++

--- a/tools/datasources.go
+++ b/tools/datasources.go
@@ -769,7 +769,34 @@ type BulkDatasourceHealthResult struct {
 	Checked   int                           `json:"checked"` // Number of datasources health-checked in this page
 	Healthy   int                           `json:"healthy"`
 	Unhealthy int                           `json:"unhealthy"`
-	HasMore   bool                          `json:"hasMore"` // Whether more datasources exist beyond this page
+	// Unknown counts datasources whose plugin has no backend component (so
+	// the health endpoint can only ever fail for them, e.g. the built-in
+	// Alertmanager datasource type) and were therefore not asked at all,
+	// rather than genuinely unreachable. See issue #1069.
+	Unknown int  `json:"unknown"`
+	HasMore bool `json:"hasMore"` // Whether more datasources exist beyond this page
+}
+
+// datasourcesWithoutBackend returns the set of UIDs, among targets, whose
+// plugin declares meta.backend: false in GET /api/frontend/settings — i.e.
+// a frontend-only datasource type (the built-in Alertmanager datasource is
+// the common case) that the health endpoint can never successfully check,
+// because that endpoint always dispatches to a plugin backend. A UID absent
+// from the returned set (including every UID when frontend/settings itself
+// is unavailable to this token) must be treated as normally checkable: this
+// is a best-effort classification, not a requirement.
+func datasourcesWithoutBackend(ctx context.Context) map[string]bool {
+	settings, _, err := fetchFrontendSettingsDatasources(ctx)
+	if err != nil {
+		return nil
+	}
+	without := make(map[string]bool)
+	for _, ds := range settings {
+		if ds.Meta != nil && ds.Meta.Backend != nil && !*ds.Meta.Backend {
+			without[ds.UID] = true
+		}
+	}
+	return without
 }
 
 func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthParams) (*BulkDatasourceHealthResult, error) {
@@ -821,6 +848,8 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 		targets = all[offset:end]
 	}
 
+	withoutBackend := datasourcesWithoutBackend(ctx)
+
 	results := make([]DatasourceHealthCheckResult, len(targets))
 	var wg sync.WaitGroup
 	for i, ds := range targets {
@@ -828,6 +857,12 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 		go func() {
 			defer wg.Done()
 			r := DatasourceHealthCheckResult{UID: ds.UID, Name: ds.Name, Type: ds.Type}
+			if withoutBackend[ds.UID] {
+				r.Status = "UNKNOWN"
+				r.Message = "This datasource's plugin has no backend component, so it cannot be health-checked."
+				results[i] = r
+				return
+			}
 			health, err := checkDatasourceHealth(ctx, CheckDatasourceHealthParams{UID: ds.UID})
 			if err != nil {
 				r.Error = err.Error()
@@ -840,11 +875,14 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 	}
 	wg.Wait()
 
-	healthy, unhealthy := 0, 0
+	healthy, unhealthy, unknown := 0, 0, 0
 	for _, r := range results {
-		if r.Error != "" || r.Status != "OK" {
+		switch {
+		case r.Status == "UNKNOWN":
+			unknown++
+		case r.Error != "" || r.Status != "OK":
 			unhealthy++
-		} else {
+		default:
 			healthy++
 		}
 	}
@@ -855,6 +893,7 @@ func checkDatasourcesHealth(ctx context.Context, args BulkCheckDatasourceHealthP
 		Checked:   len(results),
 		Healthy:   healthy,
 		Unhealthy: unhealthy,
+		Unknown:   unknown,
 		HasMore:   offset+len(results) < len(all),
 	}, nil
 }

--- a/tools/datasources_fallback.go
+++ b/tools/datasources_fallback.go
@@ -131,13 +131,22 @@ func fallbackProxyBases(ctx context.Context, identifier string) (primaryBase, fa
 // frontendSettingsDatasource mirrors the datasource entries of
 // GET /api/frontend/settings.
 type frontendSettingsDatasource struct {
-	ID        int64          `json:"id"`
-	UID       string         `json:"uid"`
-	Name      string         `json:"name"`
-	Type      string         `json:"type"`
-	URL       string         `json:"url"`
-	IsDefault bool           `json:"isDefault"`
-	JSONData  map[string]any `json:"jsonData"`
+	ID        int64                           `json:"id"`
+	UID       string                          `json:"uid"`
+	Name      string                          `json:"name"`
+	Type      string                          `json:"type"`
+	URL       string                          `json:"url"`
+	IsDefault bool                            `json:"isDefault"`
+	JSONData  map[string]any                  `json:"jsonData"`
+	Meta      *frontendSettingsDatasourceMeta `json:"meta,omitempty"`
+}
+
+// frontendSettingsDatasourceMeta mirrors the subset of a datasource's plugin
+// metadata that GET /api/frontend/settings exposes. Backend is nil when the
+// server's response omits it (older Grafana, or a deployment that strips
+// plugin metadata), which callers must treat as "unknown" rather than false.
+type frontendSettingsDatasourceMeta struct {
+	Backend *bool `json:"backend,omitempty"`
 }
 
 func fetchFrontendSettingsDatasources(ctx context.Context) (map[string]frontendSettingsDatasource, string, error) {

--- a/tools/datasources_test.go
+++ b/tools/datasources_test.go
@@ -210,7 +210,7 @@ func TestCheckDatasourcesHealthTool(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Greater(t, result.Total, 0)
-		assert.Len(t, result.Results, result.Healthy+result.Unhealthy)
+		assert.Len(t, result.Results, result.Healthy+result.Unhealthy+result.Unknown)
 		assert.LessOrEqual(t, len(result.Results), result.Total)
 	})
 

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -1084,6 +1084,48 @@ func TestCheckDatasourcesHealth_FrontendOnlyPluginReportsUnknownNotUnhealthy(t *
 	assert.Empty(t, alertmanagerResult.Error, "must not surface the health endpoint's error for a plugin that was never asked")
 }
 
+// TestCheckDatasourcesHealth_BackendPluginUnknownStatusCountsAsUnhealthy
+// guards against overloading Status == "UNKNOWN" to mean two different
+// things: a plugin skipped for lacking a backend (issue #1069) versus a
+// backend plugin whose own /health endpoint legitimately reports UNKNOWN
+// (a real, inconclusive-or-failed result). Only the former belongs in the
+// Unknown tally; folding the latter in there would hide a real problem from
+// Unhealthy.
+func TestCheckDatasourcesHealth_BackendPluginUnknownStatusCountsAsUnhealthy(t *testing.T) {
+	list := []*models.DataSourceListItemDTO{
+		{ID: 1, UID: "prom-1", Name: "Prometheus", Type: "prometheus"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/datasources":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(list)
+		case r.URL.Path == "/api/frontend/settings":
+			// This plugin has a backend, so it must actually be health-checked.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"datasources": map[string]any{
+					"Prometheus": map[string]any{
+						"id": 1, "uid": "prom-1", "name": "Prometheus", "type": "prometheus",
+						"meta": map[string]any{"backend": true},
+					},
+				},
+			})
+		default:
+			// The backend plugin's own health endpoint reports UNKNOWN.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "UNKNOWN", "message": "check not implemented"})
+		}
+	}))
+	defer srv.Close()
+
+	result, err := checkDatasourcesHealth(mockDatasourcesCtx(srv), BulkCheckDatasourceHealthParams{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Healthy)
+	assert.Equal(t, 1, result.Unhealthy, "a backend plugin's own UNKNOWN health result must count as unhealthy, not be hidden in Unknown")
+	assert.Equal(t, 0, result.Unknown, "Unknown is reserved for plugins skipped for lacking a backend")
+}
+
 func TestCheckDatasourcesHealth_FrontendSettingsUnavailableFallsBackToNormalCheck(t *testing.T) {
 	// No frontend/settings handler at all: fetchFrontendSettingsDatasources
 	// fails, and the bulk check must fall back to today's behavior (call the

--- a/tools/datasources_unit_test.go
+++ b/tools/datasources_unit_test.go
@@ -1000,6 +1000,105 @@ func TestCheckDatasourcesHealth_Pagination_OffsetBeyondTotal(t *testing.T) {
 	assert.Empty(t, result.Results)
 }
 
+// newBulkHealthServerWithFrontendSettings extends newBulkHealthServer with a
+// GET /api/frontend/settings handler reporting meta.backend per UID, so
+// check_datasources_health can distinguish "genuinely unreachable" from
+// "this plugin has no backend to health-check" (issue #1069).
+func newBulkHealthServerWithFrontendSettings(
+	t *testing.T,
+	list []*models.DataSourceListItemDTO,
+	healthyUIDs map[string]bool,
+	backendByUID map[string]bool,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/datasources":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(list)
+		case r.URL.Path == "/api/frontend/settings":
+			datasources := make(map[string]any, len(list))
+			for _, ds := range list {
+				backend, known := backendByUID[ds.UID]
+				entry := map[string]any{
+					"id":   ds.ID,
+					"uid":  ds.UID,
+					"name": ds.Name,
+					"type": ds.Type,
+				}
+				if known {
+					entry["meta"] = map[string]any{"backend": backend}
+				}
+				datasources[ds.Name] = entry
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"datasources": datasources})
+		default:
+			// /api/datasources/uid/{uid}/health
+			parts := strings.Split(r.URL.Path, "/")
+			uid := parts[len(parts)-2]
+			if healthyUIDs[uid] {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "OK", "message": "Data source is working"})
+			} else {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "ERROR", "message": "connection refused"})
+			}
+		}
+	}))
+}
+
+func TestCheckDatasourcesHealth_FrontendOnlyPluginReportsUnknownNotUnhealthy(t *testing.T) {
+	list := []*models.DataSourceListItemDTO{
+		{ID: 1, UID: "alertmanager", Name: "Alertmanager", Type: "alertmanager"},
+		{ID: 2, UID: "prom-1", Name: "Prometheus", Type: "prometheus"},
+	}
+	// The health endpoint would report "alertmanager" as ERROR if asked (it
+	// has no backend to serve /health), matching issue #1069's repro; the
+	// fix must never call it for a plugin frontend/settings marks
+	// meta.backend: false.
+	srv := newBulkHealthServerWithFrontendSettings(
+		t, list,
+		map[string]bool{"alertmanager": false, "prom-1": true},
+		map[string]bool{"alertmanager": false, "prom-1": true},
+	)
+	defer srv.Close()
+
+	result, err := checkDatasourcesHealth(mockDatasourcesCtx(srv), BulkCheckDatasourceHealthParams{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Total)
+	assert.Equal(t, 2, result.Checked)
+	assert.Equal(t, 1, result.Healthy)
+	assert.Equal(t, 0, result.Unhealthy, "a frontend-only plugin must not count as unhealthy")
+	assert.Equal(t, 1, result.Unknown)
+
+	var alertmanagerResult *DatasourceHealthCheckResult
+	for i := range result.Results {
+		if result.Results[i].UID == "alertmanager" {
+			alertmanagerResult = &result.Results[i]
+		}
+	}
+	require.NotNil(t, alertmanagerResult)
+	assert.Equal(t, "UNKNOWN", alertmanagerResult.Status)
+	assert.Empty(t, alertmanagerResult.Error, "must not surface the health endpoint's error for a plugin that was never asked")
+}
+
+func TestCheckDatasourcesHealth_FrontendSettingsUnavailableFallsBackToNormalCheck(t *testing.T) {
+	// No frontend/settings handler at all: fetchFrontendSettingsDatasources
+	// fails, and the bulk check must fall back to today's behavior (call the
+	// health endpoint for every datasource) rather than erroring out.
+	list := mockDatasourceList([]string{"ds-1"}, "prometheus")
+	srv := newBulkHealthServer(t, list, map[string]bool{"ds-1": true})
+	defer srv.Close()
+
+	result, err := checkDatasourcesHealth(mockDatasourcesCtx(srv), BulkCheckDatasourceHealthParams{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Healthy)
+	assert.Equal(t, 0, result.Unhealthy)
+	assert.Equal(t, 0, result.Unknown)
+}
+
 func TestCreateDatasource_SecureFieldsNotLeakedToJSONData(t *testing.T) {
 	var capturedJSONData map[string]any
 


### PR DESCRIPTION
## Summary

Fixes #1069. `check_datasources_health` reports the built-in **Alertmanager** datasource (and any other frontend-only plugin) as unhealthy on every deployment that provisions one — including every `kube-prometheus-stack` default install — because `GET /api/datasources/uid/{uid}/health` always dispatches to a plugin **backend**, and that plugin type has none (`public/app/plugins/datasource/alertmanager/plugin.json` declares neither `backend` nor `executable`). The endpoint can only ever fail for it, regardless of whether the real service is reachable and working:

```json
{"uid":"alertmanager","name":"Alertmanager","type":"alertmanager",
 "error":"check datasource health alertmanager: HTTP 500: {\"messageId\":\"plugin.unavailable\",...}"}
```

An agent reading `unhealthy > 0` from this tool currently gets a false-positive outage report on any such deployment, with no way to tell it apart from a genuinely unreachable datasource.

grafana/grafana#83794 asked Grafana to implement a working health check for this plugin type and was closed `not planned`, so this needs handling on our side.

## Fix

`GET /api/frontend/settings` already reports `meta.backend` per datasource and is readable by a Viewer-role service account. `check_datasources_health` now fetches it once per bulk call and skips the health-endpoint request entirely for any datasource it marks `backend: false`, reporting `"status": "UNKNOWN"` for that entry instead — tallied in a new `unknown` field on the bulk result (`BulkDatasourceHealthResult`) rather than folding into `unhealthy`, so `unhealthy > 0` keeps meaning what callers already expect it to mean.

Classifying on the error body (e.g. `messageId: plugin.unavailable`) was considered and rejected, per the issue discussion: Grafana returns the same error for a registered backend plugin that's genuinely decommissioned or unavailable (a real failure), so that would silence genuine outages too. Capability-based classification (`meta.backend`) doesn't have that false-negative risk.

When `/api/frontend/settings` itself is unavailable to the token, every datasource falls back to today's unchanged behavior (nothing here is a hard dependency).

## Testing Plan

- Added `TestCheckDatasourcesHealth_FrontendOnlyPluginReportsUnknownNotUnhealthy`: a mock server where the health endpoint would report a frontend-only plugin as ERROR if asked; asserts the fix never calls it, reports `UNKNOWN`, and `unhealthy` stays 0 with `unknown` at 1.
- Added `TestCheckDatasourcesHealth_FrontendSettingsUnavailableFallsBackToNormalCheck`: no frontend/settings handler at all; asserts the bulk check still succeeds and behaves exactly as before.
- Verified RED: the two new tests fail to compile against pre-fix code (`result.Unknown` doesn't exist), confirming the behavior didn't already exist.
- Verified GREEN: all `check_datasources_health` tests pass (11/11), including every pre-existing test unchanged.
- Full `go test ./... -tags unit` run: one pre-existing failure (`TestVersionOutput`, both subtests) reproduces identically on unmodified `main` — a Windows-sandbox `exec: ... executable file not found in %PATH%` issue unrelated to this change.
- `go vet ./...` and `gofmt` clean on all touched files.
- Bug fix to an existing tool's internal classification logic — no new tool, no change to any tool's name, input shape, or purpose — so this is exempt from `CONTRIBUTING.md`'s new-tool proposal gate.