### PR TITLE
fix(oncall): handle user objects in on_call_now from IRM proxy API

### DIFF
--- a/tools/oncall_proxy.go
+++ b/tools/oncall_proxy.go
@@ -499,7 +499,8 @@ func proxyGetCurrentOnCallUsers(ctx context.Context, scheduleID string) (*Curren
 }
 
 // extractUserIDs extracts user ID strings from the on_call_now field,
-// which can be []string or []any depending on the API.
+// which can be []string or []any depending on the API. Each []any entry may
+// itself be a plain ID string or a user object with a "pk" field.
 func extractUserIDs(onCallNow any) []string {
 	switch v := onCallNow.(type) {
 	case []string:
@@ -507,8 +508,13 @@ func extractUserIDs(onCallNow any) []string {
 	case []any:
 		ids := make([]string, 0, len(v))
 		for _, item := range v {
-			if s, ok := item.(string); ok {
-				ids = append(ids, s)
+			switch t := item.(type) {
+			case string:
+				ids = append(ids, t)
+			case map[string]any:
+				if pk, ok := t["pk"].(string); ok {
+					ids = append(ids, pk)
+				}
 			}
 		}
 		return ids

--- a/tools/oncall_proxy_test.go
+++ b/tools/oncall_proxy_test.go
@@ -218,6 +218,11 @@ func TestExtractUserIDs(t *testing.T) {
 			input: []any{},
 			want:  []string{},
 		},
+		{
+			name:  "any slice of user objects",
+			input: []any{map[string]any{"username": "jdoe", "pk": "U1A2B3C4D5E6F"}},
+			want:  []string{"U1A2B3C4D5E6F"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `get_current_oncall_users` could return an empty user list even when someone was on call, when routed through the IRM plugin proxy (OBO auth path).
- Root cause: the internal OnCall API returns `on_call_now` entries as user objects (e.g. `{"pk": "U1A2B3C4D5E6F", "username": "..."}`), not plain ID strings. `extractUserIDs` only handled `[]string`/`[]any` of strings, so every object entry was silently dropped.
- `extractUserIDs` now also extracts the `pk` field from object entries.

## Test plan
- [x] `go test ./tools/... -run TestExtractUserIDs -v` — added a case covering the object-entry shape
- [x] `go build ./...`
- [x] `go test ./tools/... -run "OnCall|OncallProxy|Proxy" -v`
- [x] Manually verified against a real schedule on irmplayground.grafana.net where a user was on call but the tool previously returned an empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)