### PR TITLE
fix(server): include resultType, cacheScope, and ttlMs in tools/list response

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -543,7 +543,7 @@ func newServer(serverName, transport string, dt disabledTools, obs *observabilit
 				result.CacheScope = mcp.CacheScopePrivate
 			}
 			if result.TTLMs == nil {
-				ttl := int64(0)
+				ttl := int64(5 * 60 * 1000) // 5 minutes; the tool list rarely changes within a session
 				result.TTLMs = &ttl
 			}
 		},

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -525,6 +525,30 @@ func newServer(serverName, transport string, dt disabledTools, obs *observabilit
 		}
 	}
 
+	// Ensure ListToolsResult always includes resultType, cacheScope, and ttlMs.
+	// The mcp-go SDK only populates these fields for the "modern" protocol
+	// (2026-07-28+), but the Python MCP SDK (mcp>=2.0.0) requires them
+	// regardless of protocol version. Without this hook, tools/list responses
+	// to legacy-protocol clients omit the fields, causing validation errors in
+	// cross-SDK proxy setups (see #1140).
+	hooks.OnAfterListTools = append(hooks.OnAfterListTools,
+		func(_ context.Context, _ any, _ *mcp.ListToolsRequest, result *mcp.ListToolsResult) {
+			if result == nil {
+				return
+			}
+			if result.ResultType == "" {
+				result.ResultType = mcp.ResultTypeComplete
+			}
+			if result.CacheScope == "" {
+				result.CacheScope = mcp.CacheScopePrivate
+			}
+			if result.TTLMs == nil {
+				ttl := int64(0)
+				result.TTLMs = &ttl
+			}
+		},
+	)
+
 	// Merge observability hooks with existing hooks
 	hooks = observability.MergeHooks(hooks, obs.MCPHooks())
 

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -543,7 +543,7 @@ func newServer(serverName, transport string, dt disabledTools, obs *observabilit
 				result.CacheScope = mcp.CacheScopePrivate
 			}
 			if result.TTLMs == nil {
-				ttl := int64(5 * 60 * 1000) // 5 minutes; the tool list rarely changes within a session
+				ttl := int64(0)
 				result.TTLMs = &ttl
 			}
 		},

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1459,3 +1459,44 @@ func TestNewServer_InvalidArgumentTypeReturnsToolErrorNotProtocolError(t *testin
 	require.NotNil(t, result)
 	assert.True(t, result.IsError, "a schema type mismatch must surface as a structured tool error")
 }
+
+// TestListToolsResult_IncludesRequiredFields verifies that tools/list responses
+// always include resultType, cacheScope, and ttlMs, even when the client uses a
+// legacy protocol version (no _meta.protocolVersion). The Python MCP SDK
+// (mcp>=2.0.0) requires these fields regardless of protocol version, and their
+// absence causes a ValidationError that silently drops all tools in proxy
+// setups. See #1140.
+func TestListToolsResult_IncludesRequiredFields(t *testing.T) {
+	obs := newTestObservability(t)
+	s, _, sm := newServer(defaultServerName, "stdio", disabledTools{enabledTools: "search"}, obs, 0, "")
+	defer sm.Close()
+
+	// Send a legacy-protocol tools/list request (no _meta.protocolVersion).
+	resp := s.HandleMessage(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	// Parse the raw JSON to check for the specific fields. Using a raw map
+	// instead of mcp.ListToolsResult to verify the wire format.
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &envelope))
+	require.NotNil(t, envelope.Result)
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(envelope.Result, &result))
+
+	assert.Contains(t, result, "resultType", "resultType must be present in tools/list response")
+	assert.Contains(t, result, "cacheScope", "cacheScope must be present in tools/list response")
+	assert.Contains(t, result, "ttlMs", "ttlMs must be present in tools/list response")
+
+	// Verify the actual values.
+	assert.JSONEq(t, `"complete"`, string(result["resultType"]))
+	assert.JSONEq(t, `"private"`, string(result["cacheScope"]))
+
+	var ttl *int64
+	require.NoError(t, json.Unmarshal(result["ttlMs"], &ttl))
+	require.NotNil(t, ttl, "ttlMs must not be null")
+	assert.Equal(t, int64(0), *ttl)
+}

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1498,5 +1498,5 @@ func TestListToolsResult_IncludesRequiredFields(t *testing.T) {
 	var ttl *int64
 	require.NoError(t, json.Unmarshal(result["ttlMs"], &ttl))
 	require.NotNil(t, ttl, "ttlMs must not be null")
-	assert.Equal(t, int64(5*60*1000), *ttl, "ttlMs should be 5 minutes")
+	assert.Equal(t, int64(0), *ttl)
 }

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1498,5 +1498,5 @@ func TestListToolsResult_IncludesRequiredFields(t *testing.T) {
 	var ttl *int64
 	require.NoError(t, json.Unmarshal(result["ttlMs"], &ttl))
 	require.NotNil(t, ttl, "ttlMs must not be null")
-	assert.Equal(t, int64(0), *ttl)
+	assert.Equal(t, int64(5*60*1000), *ttl, "ttlMs should be 5 minutes")
 }

--- a/tests/list_tools_result_test.py
+++ b/tests/list_tools_result_test.py
@@ -75,7 +75,7 @@ async def test_list_tools_result_includes_required_fields(grafana_env):
         assert result["resultType"] == "complete"
         assert result["cacheScope"] == "private"
         assert isinstance(result["ttlMs"], int)
-        assert result["ttlMs"] > 0, "ttlMs should be a positive cache hint"
+        assert result["ttlMs"] == 0
     finally:
         proc.terminate()
         proc.wait(timeout=5)

--- a/tests/list_tools_result_test.py
+++ b/tests/list_tools_result_test.py
@@ -1,0 +1,81 @@
+import json
+import os
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+def send_jsonrpc(process, method, params=None, request_id=1):
+    """Send a JSON-RPC request over stdin and read the response from stdout."""
+    request = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params:
+        request["params"] = params
+    line = json.dumps(request) + "\n"
+    process.stdin.write(line.encode())
+    process.stdin.flush()
+
+    raw = process.stdout.readline()
+    return json.loads(raw)
+
+
+@pytest.fixture
+def grafana_env():
+    env = {"GRAFANA_URL": os.environ.get("GRAFANA_URL", "http://localhost:3000")}
+    if key := os.environ.get("GRAFANA_SERVICE_ACCOUNT_TOKEN"):
+        env["GRAFANA_SERVICE_ACCOUNT_TOKEN"] = key
+    elif key := os.environ.get("GRAFANA_API_KEY"):
+        env["GRAFANA_API_KEY"] = key
+    return env
+
+
+async def test_list_tools_result_includes_required_fields(grafana_env):
+    """Verify that tools/list responses include resultType, cacheScope, and ttlMs.
+
+    The Python MCP SDK (mcp>=2.0.0) and fastmcp (>=4.0.0) require these fields
+    regardless of protocol version. Their absence causes a ValidationError that
+    silently drops all tools when mcp-grafana is proxied via a Python-based
+    aggregator. See https://github.com/grafana/mcp-grafana/issues/1140.
+    """
+    binary = os.environ.get("MCP_GRAFANA_PATH", "../dist/mcp-grafana")
+    proc = subprocess.Popen(
+        [binary, "--enabled-tools", "search"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, **grafana_env},
+    )
+    try:
+        # Initialize (required before tools/list).
+        init_resp = send_jsonrpc(proc, "initialize", {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "0"},
+        })
+        assert "error" not in init_resp, f"initialize failed: {init_resp}"
+
+        # Acknowledge initialization.
+        notification = json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n"
+        proc.stdin.write(notification.encode())
+        proc.stdin.flush()
+
+        # List tools.
+        resp = send_jsonrpc(proc, "tools/list", {}, request_id=2)
+        assert "error" not in resp, f"tools/list failed: {resp}"
+
+        result = resp["result"]
+        assert "tools" in result
+
+        # These three fields are required by MCP spec 2025-11 / Python SDK 2.x.
+        assert "resultType" in result, "resultType missing from tools/list response"
+        assert "cacheScope" in result, "cacheScope missing from tools/list response"
+        assert "ttlMs" in result, "ttlMs missing from tools/list response"
+
+        assert result["resultType"] == "complete"
+        assert result["cacheScope"] == "private"
+        assert isinstance(result["ttlMs"], int)
+        assert result["ttlMs"] > 0, "ttlMs should be a positive cache hint"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)


### PR DESCRIPTION
## Summary

Fixes #1140

The `tools/list` response was missing `resultType`, `cacheScope`, and `ttlMs` fields when the client used a legacy MCP protocol version (pre-2026-07-28). The mcp-go SDK intentionally only populates these fields for the "modern" protocol, but the Python MCP SDK (`mcp>=2.0.0`) and `fastmcp` (`>=4.0.0`) require them regardless of protocol version. This caused a `ValidationError` that silently dropped all Grafana tools when `mcp-grafana` was used behind a Python-based proxy (e.g. `fastmcp.ProxyProvider`).

## Changes

- Added an `OnAfterListTools` hook in `newServer()` that ensures the three fields are always populated with sensible defaults:
  - `resultType` = `"complete"`
  - `cacheScope` = `"private"`
  - `ttlMs` = `0`
- The hook is idempotent: it only sets fields that are not already populated, so modern-protocol clients that receive decoration from the SDK are unaffected.
- Added a test that verifies these fields are present in the wire format of a legacy-protocol `tools/list` response.

## Testing

- New unit test `TestListToolsResult_IncludesRequiredFields` validates the fix against the exact scenario described in the issue (legacy-protocol `tools/list` request).
- All existing tests in `cmd/mcp-grafana` pass without changes.

## Checklist

- [x] Tests added
- [x] `go vet` passes
- [x] Conventional commit format