### PR TITLE
fix(server): apply --base-path/--endpoint-path to /healthz and /metrics

### DIFF
--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"regexp"
 	"slices"
 	"strconv"
@@ -787,11 +788,31 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
+// registerAtBasePath additionally mounts handler at base+suffix (e.g.
+// "/my-base" + "/healthz") when base is a non-root path, so that a single
+// path-routed reverse-proxy rule for base can cover /healthz and /metrics
+// alongside the MCP endpoint. The unprefixed root registration is left in
+// place by the caller, so this is purely additive and preserves existing
+// behavior for callers that don't set a base path.
+func registerAtBasePath(mux *http.ServeMux, base, suffix string, handler http.Handler) {
+	base = strings.TrimSuffix(base, "/")
+	if base == "" {
+		return
+	}
+	mux.Handle(base+suffix, handler)
+}
+
 // registerOps mounts /healthz and /metrics. An empty address keeps the route
 // on mux; otherwise it goes on a side mux keyed by address (so matching
 // --healthz-address and --metrics-address share a listener). Callers pass the
 // result to runOpsServers. Side listeners skip Host/Origin checks.
-func registerOps(mux *http.ServeMux, o *observability.Observability, healthzAddr string, obs observability.Config) map[string]*http.ServeMux {
+//
+// When basePath is a non-root path, /healthz and /metrics are additionally
+// mounted under it on mux so a single path-routed reverse-proxy rule for
+// basePath can cover the whole service. This only applies to the routes that
+// stay on mux: a dedicated --healthz-address/--metrics-address listener
+// bypasses that proxy prefix entirely, so it keeps serving at its root.
+func registerOps(mux *http.ServeMux, o *observability.Observability, healthzAddr string, obs observability.Config, basePath string) map[string]*http.ServeMux {
 	side := map[string]*http.ServeMux{}
 	target := func(addr string) *http.ServeMux {
 		if addr == "" {
@@ -804,8 +825,14 @@ func registerOps(mux *http.ServeMux, o *observability.Observability, healthzAddr
 	}
 
 	target(healthzAddr).HandleFunc("/healthz", handleHealthz)
+	if healthzAddr == "" {
+		registerAtBasePath(mux, basePath, "/healthz", http.HandlerFunc(handleHealthz))
+	}
 	if obs.MetricsEnabled {
 		target(obs.MetricsAddress).Handle("/metrics", o.MetricsHandler())
+		if obs.MetricsAddress == "" {
+			registerAtBasePath(mux, basePath, "/metrics", o.MetricsHandler())
+		}
 	}
 	return side
 }
@@ -945,6 +972,10 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			server.WithSSEDisableLocalhostProtection(disableLocalhostProtection),
 		)
 		mux := http.NewServeMux()
+		// Capture the base path before it's normalized to "/" below, so
+		// registerAtBasePath can tell "no base path configured" (root only)
+		// apart from an explicit "/" base path.
+		healthzMetricsBase := basePath
 		if basePath == "" {
 			basePath = "/"
 		}
@@ -952,7 +983,7 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			basePath,
 		)))
-		runOpsServers(registerOps(mux, o, healthzAddress, obs))
+		runOpsServers(registerOps(mux, o, healthzAddress, obs, healthzMetricsBase))
 		// Wrap the full mux so ops routes left on it are validated too.
 		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
 		slog.Info("Starting Grafana MCP server using SSE transport",
@@ -986,7 +1017,13 @@ func run(transport, addr, basePath, endpointPath string, logLevel slog.Level, dt
 			mcpgrafana.ValidateGrafanaURLMiddleware(srv), //nolint:staticcheck // Retained temporarily to reject malformed legacy headers.
 			endpointPath,
 		)))
-		runOpsServers(registerOps(mux, o, healthzAddress, obs))
+		// There's no separate --base-path flag for streamable-http, but
+		// --endpoint-path plays the same role: when it's nested under a
+		// prefix (e.g. "/my-custom-base/mcp"), that directory is the base a
+		// single reverse-proxy rule would route on. path.Dir("/mcp") is "/",
+		// so this is a no-op at the default endpoint path.
+		endpointBase := path.Dir(endpointPath)
+		runOpsServers(registerOps(mux, o, healthzAddress, obs, endpointBase))
 		// Wrap the full mux so ops routes left on it are validated too.
 		httpSrv.Handler = mcpgrafana.DNSRebindingProtectionMiddleware(hsc.policy(addr))(mux)
 		slog.Info("Starting Grafana MCP server using StreamableHTTP transport",

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -639,6 +639,42 @@ func TestSplitAndTrim(t *testing.T) {
 	}
 }
 
+func TestRegisterAtBasePath(t *testing.T) {
+	cases := []struct {
+		name        string
+		base        string
+		suffix      string
+		wantHandled bool
+	}{
+		{"empty base is a no-op (default, unset --base-path)", "", "/healthz", false},
+		{"root base is a no-op (matches unset --base-path)", "/", "/healthz", false},
+		{"non-root base registers the suffixed path", "/my-custom-base", "/healthz", true},
+		{"trailing slash on base is trimmed before joining", "/my-custom-base/", "/healthz", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			called := false
+			registerAtBasePath(mux, tc.base, tc.suffix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, strings.TrimSuffix(tc.base, "/")+tc.suffix, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if tc.wantHandled {
+				assert.True(t, called, "expected the prefixed path to be routed to the handler")
+				assert.Equal(t, http.StatusOK, rec.Code)
+			} else {
+				assert.False(t, called, "expected no route to be registered for a root/empty base")
+				assert.Equal(t, http.StatusNotFound, rec.Code)
+			}
+		})
+	}
+}
+
 func TestHTTPSecurityConfigPolicy(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -1354,7 +1390,7 @@ func getPath(h http.Handler, path string) *httptest.ResponseRecorder {
 
 func TestRegisterOps_DefaultKeepsHealthzOnMainMux(t *testing.T) {
 	main := http.NewServeMux()
-	side := registerOps(main, newTestObservability(t), "", observability.Config{})
+	side := registerOps(main, newTestObservability(t), "", observability.Config{}, "")
 
 	assert.Empty(t, side, "no extra listener without --healthz-address or --metrics-address")
 	rec := getPath(main, "/healthz")
@@ -1368,7 +1404,7 @@ func TestRegisterOps_MetricsOnMainMux(t *testing.T) {
 	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
 
 	main := http.NewServeMux()
-	side := registerOps(main, obs, "", observability.Config{MetricsEnabled: true})
+	side := registerOps(main, obs, "", observability.Config{MetricsEnabled: true}, "")
 
 	assert.Empty(t, side, "--metrics with empty --metrics-address must not start a side listener")
 	assert.Equal(t, http.StatusOK, getPath(main, "/healthz").Code)
@@ -1377,7 +1413,7 @@ func TestRegisterOps_MetricsOnMainMux(t *testing.T) {
 
 func TestRegisterOps_HealthzAddressMovesItOffMainMux(t *testing.T) {
 	main := http.NewServeMux()
-	side := registerOps(main, newTestObservability(t), ":8080", observability.Config{})
+	side := registerOps(main, newTestObservability(t), ":8080", observability.Config{}, "")
 
 	assert.Equal(t, http.StatusNotFound, getPath(main, "/healthz").Code,
 		"/healthz must leave the MCP listener, not be served on both")
@@ -1394,7 +1430,7 @@ func TestRegisterOps_SharedAddressUsesOneListener(t *testing.T) {
 	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
 
 	main := http.NewServeMux()
-	side := registerOps(main, obs, ":9090", observability.Config{MetricsEnabled: true, MetricsAddress: ":9090"})
+	side := registerOps(main, obs, ":9090", observability.Config{MetricsEnabled: true, MetricsAddress: ":9090"}, "")
 
 	require.Len(t, side, 1, "one bind address must not produce two listeners")
 	assert.Equal(t, http.StatusOK, getPath(side[":9090"], "/healthz").Code)
@@ -1409,7 +1445,7 @@ func TestRegisterOps_DistinctAddressesStaySplit(t *testing.T) {
 	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
 
 	main := http.NewServeMux()
-	side := registerOps(main, obs, ":8080", observability.Config{MetricsEnabled: true, MetricsAddress: ":9090"})
+	side := registerOps(main, obs, ":8080", observability.Config{MetricsEnabled: true, MetricsAddress: ":9090"}, "")
 
 	require.Len(t, side, 2)
 	assert.Equal(t, http.StatusOK, getPath(side[":8080"], "/healthz").Code)
@@ -1421,11 +1457,45 @@ func TestRegisterOps_DistinctAddressesStaySplit(t *testing.T) {
 // Metrics stay opt-in: --healthz-address alone must not expose /metrics.
 func TestRegisterOps_HealthzAddressDoesNotEnableMetrics(t *testing.T) {
 	main := http.NewServeMux()
-	side := registerOps(main, newTestObservability(t), ":8080", observability.Config{})
+	side := registerOps(main, newTestObservability(t), ":8080", observability.Config{}, "")
 
 	require.Len(t, side, 1)
 	assert.Equal(t, http.StatusNotFound, getPath(side[":8080"], "/metrics").Code)
 	assert.Equal(t, http.StatusNotFound, getPath(main, "/metrics").Code)
+}
+
+// A base path (--base-path / the directory of --endpoint-path) additionally
+// mounts /healthz and /metrics under it on the main mux, alongside the
+// existing root routes, so a single path-routed reverse-proxy rule covers
+// the whole service. See issue #1021.
+func TestRegisterOps_BasePathAlsoMountsUnderPrefix(t *testing.T) {
+	obs, err := observability.Setup(observability.Config{MetricsEnabled: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
+
+	main := http.NewServeMux()
+	side := registerOps(main, obs, "", observability.Config{MetricsEnabled: true}, "/my-custom-base")
+
+	assert.Empty(t, side)
+	assert.Equal(t, http.StatusOK, getPath(main, "/healthz").Code, "root /healthz must keep working")
+	assert.Equal(t, http.StatusOK, getPath(main, "/metrics").Code, "root /metrics must keep working")
+	assert.Equal(t, http.StatusOK, getPath(main, "/my-custom-base/healthz").Code)
+	assert.Equal(t, http.StatusOK, getPath(main, "/my-custom-base/metrics").Code)
+}
+
+// A dedicated --healthz-address/--metrics-address listener bypasses the
+// reverse-proxy prefix entirely, so the base path must not leak onto it.
+func TestRegisterOps_BasePathIgnoredOnDedicatedListener(t *testing.T) {
+	obs, err := observability.Setup(observability.Config{MetricsEnabled: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = obs.Shutdown(context.Background()) })
+
+	main := http.NewServeMux()
+	side := registerOps(main, obs, ":8080", observability.Config{MetricsEnabled: true, MetricsAddress: ":9090"}, "/my-custom-base")
+
+	assert.Equal(t, http.StatusNotFound, getPath(main, "/my-custom-base/healthz").Code)
+	assert.Equal(t, http.StatusNotFound, getPath(side[":8080"], "/my-custom-base/healthz").Code)
+	assert.Equal(t, http.StatusNotFound, getPath(side[":9090"], "/my-custom-base/metrics").Code)
 }
 
 // TestNewServer_InvalidArgumentTypeReturnsToolErrorNotProtocolError verifies


### PR DESCRIPTION
## What this changes

`/healthz` and `/metrics` were always mounted at the server root regardless of `--base-path` (sse) or `--endpoint-path` (streamable-http), so a single path-routed reverse-proxy rule for the configured base couldn't cover the whole service — only the MCP endpoint itself respected the prefix. This additionally mounts `/healthz` and `/metrics` under the configured base path (for streamable-http, the directory of `--endpoint-path`, e.g. `/my-base/mcp` → base `/my-base`), while keeping the existing root routes for backward compatibility, so nothing changes for anyone not using a base path.

Fixes #1021

## How you tested it

- `go build ./...` and `go test -tags unit ./cmd/mcp-grafana/...` (added `TestRegisterAtBasePath` covering the new helper: empty base, root base, a real base, and a base with a trailing slash).
- Manually ran the built binary for both transports and curled the endpoints:
  - `sse` with `--base-path /my-custom-base --metrics`: `/my-custom-base/healthz` → 200, `/my-custom-base/metrics` → 200, and `/healthz` / `/metrics` at root still 200.
  - `streamable-http` with `--endpoint-path /my-custom-base/mcp --metrics`: `/my-custom-base/healthz` → 200, root `/healthz` still 200.

## Checklist

- [x] `make lint` and `make test-unit` pass locally (ran `gofmt`, the repo's jsonschema/openapi linters, and `go test -tags unit ./cmd/mcp-grafana/...` directly; `golangci-lint` isn't installed in this environment but the change doesn't touch anything it would flag)
- [ ] Commits are signed (required to merge — see CONTRIBUTING.md)
- [ ] CLA signed (required to merge)
- [ ] README tool table updated, with RBAC permissions and scopes, if this adds a tool
- [x] Any write operation respects `--disable-write` — no write operation added
- [x] Any datasource query execution respects `--disable-query` — no query added