### PR TITLE
fix(sift): add --enable-sift-investigations to keep Sift usable under --disable-write

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Caller authentication is enforced only when `--server-auth-token` is set. When i
 - `--disable-write`: Disable write tools (create/update operations)
 - `--disable-query`: Disable query tools (tools that execute a query against a datasource); metadata and discovery tools stay available
 - `--enable-query`: Keep the raw-SQL query tools (`query_clickhouse`, `query_snowflake`, `query_athena`, `query_influxdb`) registered even under `--disable-write`
+- `--enable-sift-investigations`: Keep the Sift investigation-creation tools (`find_error_pattern_logs`, `find_slow_requests`) registered even under `--disable-write`
 - `--disable-loki`: Disable loki tools
 - `--disable-elasticsearch`: Disable elasticsearch and opensearch tools
 - `--disable-quickwit`: Disable quickwit tools
@@ -548,6 +549,8 @@ When `--disable-write` is enabled, the following write operations are disabled:
 **Sift Tools:**
 - `find_error_pattern_logs` (creates investigations)
 - `find_slow_requests` (creates investigations)
+
+These only create ephemeral Sift investigation records via the Sift API — they never touch a Grafana dashboard, alert, or datasource. Without them, `list_sift_investigations`/`get_sift_investigation`/`get_sift_analysis` have nothing to list or get. Pass `--enable-sift-investigations` to keep them registered under `--disable-write`.
 
 **Snapshot Tools:**
 - `create_snapshot`

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -159,7 +159,7 @@ type disabledTools struct {
 	search, datasource, incident,
 	prometheus, loki, elasticsearch, quickwit, influxdb, alerting,
 	dashboard, folder, oncall, asserts, sift, admin,
-	pyroscope, navigation, proxied, annotations, rendering, cloudwatch, write, query, enableQuery,
+	pyroscope, navigation, proxied, annotations, rendering, cloudwatch, write, query, enableQuery, enableSiftInvestigations,
 	snapshot, examples, clickhouse, snowflake, graphite,
 	runpanelquery, athena, plugin, api, config, provisioning,
 	agento11y, assistant, docs, user bool
@@ -228,6 +228,7 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.write, "disable-write", false, "Disable write tools (create/update operations)")
 	flag.BoolVar(&dt.query, "disable-query", false, "Disable query tools (tools that execute a query against a datasource, e.g. query_prometheus, query_loki_logs, run_panel_query). Metadata and discovery tools stay available.")
 	flag.BoolVar(&dt.enableQuery, "enable-query", false, "Keep the raw-SQL query tools (query_clickhouse, query_snowflake, query_athena, query_influxdb) registered even under --disable-write. They pass the query through unfiltered, so they can mutate data if the datasource credentials permit it; use this when those credentials are known to be read-only. Has no effect if --disable-query is also set.")
+	flag.BoolVar(&dt.enableSiftInvestigations, "enable-sift-investigations", false, "Keep the Sift investigation-creation tools (find_error_pattern_logs, find_slow_requests) registered even under --disable-write. They only create ephemeral Sift investigation records via the Sift API, never Grafana dashboards/alerts/datasources, so this is safe to set even when write access to Grafana itself is not wanted. Without it, --disable-write leaves the other Sift tools (list_sift_investigations, get_sift_investigation, get_sift_analysis) with nothing to list or get.")
 	flag.BoolVar(&dt.annotations, "disable-annotations", false, "Disable annotation tools")
 	flag.BoolVar(&dt.rendering, "disable-rendering", false, "Disable rendering tools (panel/dashboard image export)")
 	flag.BoolVar(&dt.snapshot, "disable-snapshot", false, "Disable snapshot tools")
@@ -363,7 +364,7 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{func(mcp *server.MCPServer) { tools.AddFolderTools(mcp, enableWriteTools) }, dt.folder, "folder"},
 		{func(mcp *server.MCPServer) { tools.AddOnCallTools(mcp, enableWriteTools) }, dt.oncall, "oncall"},
 		{tools.AddAssertsTools, dt.asserts, "asserts"},
-		{func(mcp *server.MCPServer) { tools.AddSiftTools(mcp, enableWriteTools) }, dt.sift, "sift"},
+		{func(mcp *server.MCPServer) { tools.AddSiftTools(mcp, enableWriteTools || dt.enableSiftInvestigations) }, dt.sift, "sift"},
 		{tools.AddAdminTools, dt.admin, "admin"},
 		{func(mcp *server.MCPServer) { tools.AddPyroscopeTools(mcp, enableQueryTools) }, dt.pyroscope, "pyroscope"},
 		{func(mcp *server.MCPServer) { tools.AddNavigationTools(mcp, enableWriteTools) }, dt.navigation, "navigation"},
@@ -392,6 +393,9 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 func (dt *disabledTools) processTools(s *server.MCPServer) {
 	if dt.query && dt.enableQuery {
 		slog.Warn("--enable-query has no effect because --disable-query is set; no query tools will be registered")
+	}
+	if dt.sift && dt.enableSiftInvestigations {
+		slog.Warn("--enable-sift-investigations has no effect because --disable-sift is set; no sift tools will be registered")
 	}
 	enabledTools := strings.Split(dt.enabledTools, ",")
 	for _, e := range dt.toolEntries() {

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1346,6 +1346,39 @@ func TestProcessTools_BothDisableFlags(t *testing.T) {
 	}
 }
 
+// See issue #744: --disable-write left the Sift read tools (list/get) with
+// nothing to list or get, since the investigation-creation tools were gated
+// by the same flag. --enable-sift-investigations restores just those two.
+func TestProcessTools_DisableWriteRemovesSiftInvestigationTools(t *testing.T) {
+	names := registerAllCategories(t, disabledTools{write: true})
+	assert.False(t, names["find_error_pattern_logs"], "find_error_pattern_logs should be gone with --disable-write")
+	assert.False(t, names["find_slow_requests"], "find_slow_requests should be gone with --disable-write")
+	assert.True(t, names["list_sift_investigations"], "read-only sift tools should survive --disable-write")
+	assert.True(t, names["get_sift_investigation"], "read-only sift tools should survive --disable-write")
+	assert.True(t, names["get_sift_analysis"], "read-only sift tools should survive --disable-write")
+}
+
+func TestProcessTools_EnableSiftInvestigationsOverridesDisableWrite(t *testing.T) {
+	names := registerAllCategories(t, disabledTools{write: true, enableSiftInvestigations: true})
+	assert.True(t, names["find_error_pattern_logs"], "find_error_pattern_logs should be restored by --enable-sift-investigations")
+	assert.True(t, names["find_slow_requests"], "find_slow_requests should be restored by --enable-sift-investigations")
+	// The override is scoped to Sift investigation creation: real write tools stay gone.
+	assert.False(t, names["update_dashboard"], "--enable-sift-investigations must not re-enable write tools")
+	assert.False(t, names["create_folder"], "--enable-sift-investigations must not re-enable write tools")
+}
+
+func TestProcessTools_EnableSiftInvestigationsAloneChangesNothing(t *testing.T) {
+	defaults := registerAllCategories(t, disabledTools{})
+	names := registerAllCategories(t, disabledTools{enableSiftInvestigations: true})
+	assert.Equal(t, defaults, names, "--enable-sift-investigations on its own should be a no-op")
+}
+
+func TestProcessTools_DisableSiftBeatsEnableSiftInvestigations(t *testing.T) {
+	names := registerAllCategories(t, disabledTools{sift: true, enableSiftInvestigations: true})
+	assert.False(t, names["find_error_pattern_logs"], "sift should be gone: --disable-sift wins over --enable-sift-investigations")
+	assert.False(t, names["list_sift_investigations"], "sift should be gone: --disable-sift wins over --enable-sift-investigations")
+}
+
 func getPath(h http.Handler, path string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))


### PR DESCRIPTION
## What this changes

`--disable-write` gates `find_error_pattern_logs`/`find_slow_requests` alongside the read-only Sift tools (`list_sift_investigations`, `get_sift_investigation`, `get_sift_analysis`), so anyone who opts into Sift but also wants read-only mode ends up with list/get tools that have nothing to list or get — a broken half-set.

These two tools only create ephemeral Sift investigation records via the Sift API (`siftClient.createSiftInvestigation`) — they never touch a Grafana dashboard, alert, or datasource, which is a materially different risk profile than the write operations `--disable-write` actually protects against. This adds `--enable-sift-investigations`, mirroring the existing `--enable-query` override for the raw-SQL query tools: purely additive, opt-in, and the default behavior for existing `--disable-write` users is unchanged.

Fixes #744

## How you tested it

- `go build ./...` and `go test -tags unit ./cmd/mcp-grafana/...`.
- Added 4 tests mirroring the existing `--enable-query` coverage: `--disable-write` removes the investigation tools but not the read tools, `--enable-sift-investigations` restores just those two without re-enabling real write tools, the flag alone is a no-op, and `--disable-sift` wins over it.
- Confirmed via the existing `registerAllCategories` test helper, which exercises the same `processTools`/`toolEntries` registration path the running server uses.

## Checklist

- [x] `make lint` and `make test-unit` pass locally (gofmt, the repo's jsonschema/openapi linters, `go vet`, and `go test -tags unit ./cmd/mcp-grafana/...`; `golangci-lint` isn't installed in this environment but the change doesn't touch anything it would flag)
- [ ] Commits are signed (required to merge — see CONTRIBUTING.md)
- [ ] CLA signed (required to merge)
- [ ] README tool table updated, with RBAC permissions and scopes, if this adds a tool
- [x] Any write operation respects `--disable-write` — `find_error_pattern_logs`/`find_slow_requests` still default to gated by `--disable-write`; the new flag is an explicit opt-in override, same pattern as `--enable-query`
- [x] Any datasource query execution respects `--disable-query` — no query added