### PR TITLE
feat(prometheus): add query_prometheus_batched to run multiple queries in one call

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Scopes define the specific resources that permissions apply to. Each action requ
 | `get_datasource`                  | Datasources               | Get a datasource by UID or name                                                                              | `datasources:read`                                     | `datasources:uid:prometheus-uid`                    |
 | `get_query_examples`              | Examples*                 | Get example queries for a datasource type                                                                    | `datasources:read`                                     | `datasources:*`                                     |
 | `query_prometheus`                | Prometheus                | Execute a query against a Prometheus datasource                                                              | `datasources:query`                                    | `datasources:uid:prometheus-uid`                    |
+| `query_prometheus_batched`        | Prometheus                | Run multiple `query_prometheus`-shaped queries in one call                                                   | `datasources:query`                                    | `datasources:uid:prometheus-uid`                    |
 | `list_prometheus_metric_metadata` | Prometheus                | List metric metadata                                                                                         | `datasources:query`                                    | `datasources:uid:prometheus-uid`                    |
 | `list_prometheus_metric_names`    | Prometheus                | List available metric names                                                                                  | `datasources:query`                                    | `datasources:uid:prometheus-uid`                    |
 | `list_prometheus_label_names`     | Prometheus                | List label names matching a selector                                                                         | `datasources:query`                                    | `datasources:uid:prometheus-uid`                    |
@@ -589,6 +590,7 @@ When `--disable-query` is enabled, the following tools are not registered:
 
 **Prometheus Tools:**
 - `query_prometheus`
+- `query_prometheus_batched`
 - `query_prometheus_histogram`
 
 **Loki Tools:**

--- a/tools/prometheus.go
+++ b/tools/prometheus.go
@@ -15,6 +15,7 @@ import (
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -182,6 +183,88 @@ var QueryPrometheus = mcpgrafana.MustTool(
 	"WORKFLOW: list_prometheus_metric_names -> list_prometheus_label_values -> query_prometheus. Query a PromQL-compatible datasource (Prometheus, Thanos, Mimir, Cloud Monitoring, etc.) using a PromQL expression. Supports instant queries (single point) and range queries (time range). Time: RFC3339 or relative expressions like 'now'\\, 'now-1h'.",
 	queryPrometheusWithHints,
 	mcp.WithTitleAnnotation("Query Prometheus metrics"),
+	mcp.WithIdempotentHintAnnotation(true),
+	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithDestructiveHintAnnotation(false),
+	mcp.WithOpenWorldHintAnnotation(false),
+)
+
+// maxBatchedPrometheusQueries caps a single query_prometheus_batched call, so
+// one request can't fan out into an unbounded number of upstream queries.
+const maxBatchedPrometheusQueries = 20
+
+// batchedPrometheusQueryConcurrency bounds how many of a batch's queries run
+// at once, so a large batch doesn't open dozens of simultaneous connections
+// to the same datasource.
+const batchedPrometheusQueryConcurrency = 8
+
+type QueryPrometheusBatchedParams struct {
+	Queries map[string]QueryPrometheusParams `json:"queries" jsonschema:"required,description=A map from a caller-chosen key to a query_prometheus-shaped query. Each key's result (or error) is returned under that same key\\, so keys should be short and distinct (e.g. 'cpu'\\, 'memory')\\, not reused across the batch."`
+}
+
+// QueryPrometheusBatchResult carries exactly one of Data or Error for a
+// single query in a batch: a failing query does not fail the whole batch,
+// it just reports its own error under its own key.
+type QueryPrometheusBatchResult struct {
+	Data  *QueryPrometheusResult `json:"data,omitempty"`
+	Error string                 `json:"error,omitempty"`
+}
+
+// runPrometheusQueryBatch runs one query per key in queries, at up to
+// concurrency at a time, via the given query func. It isolates each query's
+// result: a panic-free failure in one never affects another's result, and
+// the returned map always has exactly one entry per input key.
+func runPrometheusQueryBatch(
+	ctx context.Context,
+	queries map[string]QueryPrometheusParams,
+	concurrency int,
+	query func(context.Context, QueryPrometheusParams) (*QueryPrometheusResult, error),
+) map[string]QueryPrometheusBatchResult {
+	keys := make([]string, 0, len(queries))
+	for k := range queries {
+		keys = append(keys, k)
+	}
+
+	// Each goroutine writes to its own index only, so this needs no locking.
+	results := make([]QueryPrometheusBatchResult, len(keys))
+
+	var g errgroup.Group
+	g.SetLimit(concurrency)
+	for i, k := range keys {
+		g.Go(func() error {
+			data, err := query(ctx, queries[k])
+			if err != nil {
+				results[i] = QueryPrometheusBatchResult{Error: err.Error()}
+				return nil
+			}
+			results[i] = QueryPrometheusBatchResult{Data: data}
+			return nil
+		})
+	}
+	_ = g.Wait() // every goroutine above always returns nil; errors are captured per-key instead
+
+	out := make(map[string]QueryPrometheusBatchResult, len(keys))
+	for i, k := range keys {
+		out[k] = results[i]
+	}
+	return out
+}
+
+func queryPrometheusBatched(ctx context.Context, args QueryPrometheusBatchedParams) (map[string]QueryPrometheusBatchResult, error) {
+	if len(args.Queries) == 0 {
+		return nil, fmt.Errorf("queries must not be empty")
+	}
+	if len(args.Queries) > maxBatchedPrometheusQueries {
+		return nil, fmt.Errorf("too many queries in one batch: got %d, max %d", len(args.Queries), maxBatchedPrometheusQueries)
+	}
+	return runPrometheusQueryBatch(ctx, args.Queries, batchedPrometheusQueryConcurrency, queryPrometheusWithHints), nil
+}
+
+var QueryPrometheusBatched = mcpgrafana.MustTool(
+	"query_prometheus_batched",
+	fmt.Sprintf("Run multiple query_prometheus-shaped queries in one call instead of one tool call per query, cutting round-trip latency when several PromQL queries are needed together (e.g. CPU and memory for the same panel). Takes a map from a caller-chosen key to a query. Returns a map keyed the same way; each entry holds either that query's result or its own error, so one failing query does not fail the others. Capped at %d queries per batch.", maxBatchedPrometheusQueries),
+	queryPrometheusBatched,
+	mcp.WithTitleAnnotation("Query Prometheus metrics (batched)"),
 	mcp.WithIdempotentHintAnnotation(true),
 	mcp.WithReadOnlyHintAnnotation(true),
 	mcp.WithDestructiveHintAnnotation(false),
@@ -597,6 +680,7 @@ func AddPrometheusTools(mcp *server.MCPServer, enableQueryTools bool) {
 	ListPrometheusMetricMetadata.Register(mcp)
 	if enableQueryTools {
 		QueryPrometheus.Register(mcp)
+		QueryPrometheusBatched.Register(mcp)
 		QueryPrometheusHistogram.Register(mcp)
 	}
 	ListPrometheusMetricNames.Register(mcp)

--- a/tools/prometheus_unit_test.go
+++ b/tools/prometheus_unit_test.go
@@ -2,11 +2,13 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -474,4 +476,89 @@ func TestQueryPrometheusHistogramPercentileValidation(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.errMsg)
 		})
 	}
+}
+
+func TestRunPrometheusQueryBatch_IsolatesPerKeyResults(t *testing.T) {
+	t.Parallel()
+	queries := map[string]QueryPrometheusParams{
+		"ok":    {Expr: "up"},
+		"fails": {Expr: "broken"},
+	}
+	query := func(_ context.Context, args QueryPrometheusParams) (*QueryPrometheusResult, error) {
+		if args.Expr == "broken" {
+			return nil, fmt.Errorf("boom")
+		}
+		return &QueryPrometheusResult{Data: model.Vector{}}, nil
+	}
+
+	got := runPrometheusQueryBatch(context.Background(), queries, 4, query)
+
+	require.Len(t, got, 2)
+	require.NotNil(t, got["ok"].Data)
+	assert.Empty(t, got["ok"].Error, "a succeeding query must not carry an error")
+	assert.Nil(t, got["fails"].Data, "a failing query must not carry data")
+	assert.Equal(t, "boom", got["fails"].Error, "a failing query's error must not leak onto other keys")
+}
+
+func TestRunPrometheusQueryBatch_ReturnsExactlyOneResultPerInputKey(t *testing.T) {
+	t.Parallel()
+	queries := map[string]QueryPrometheusParams{
+		"a": {Expr: "a"}, "b": {Expr: "b"}, "c": {Expr: "c"},
+	}
+	query := func(_ context.Context, args QueryPrometheusParams) (*QueryPrometheusResult, error) {
+		return &QueryPrometheusResult{Data: model.Vector{}}, nil
+	}
+
+	got := runPrometheusQueryBatch(context.Background(), queries, 2, query)
+
+	require.Len(t, got, len(queries))
+	for k := range queries {
+		assert.Contains(t, got, k)
+	}
+}
+
+func TestRunPrometheusQueryBatch_BoundsConcurrency(t *testing.T) {
+	t.Parallel()
+	const limit = 2
+	queries := make(map[string]QueryPrometheusParams, 6)
+	for i := range 6 {
+		queries[fmt.Sprintf("q%d", i)] = QueryPrometheusParams{Expr: fmt.Sprintf("q%d", i)}
+	}
+
+	var current, max atomic.Int32
+	query := func(_ context.Context, _ QueryPrometheusParams) (*QueryPrometheusResult, error) {
+		n := current.Add(1)
+		for {
+			m := max.Load()
+			if n <= m || max.CompareAndSwap(m, n) {
+				break
+			}
+		}
+		time.Sleep(15 * time.Millisecond)
+		current.Add(-1)
+		return &QueryPrometheusResult{Data: model.Vector{}}, nil
+	}
+
+	got := runPrometheusQueryBatch(context.Background(), queries, limit, query)
+
+	require.Len(t, got, len(queries))
+	assert.LessOrEqual(t, max.Load(), int32(limit), "never more than the configured limit should run at once")
+	assert.Equal(t, int32(limit), max.Load(), "with more queries than the limit, it should actually reach the limit, not serialize")
+}
+
+func TestQueryPrometheusBatched_RejectsEmptyAndOversizedBatches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	_, err := queryPrometheusBatched(ctx, QueryPrometheusBatchedParams{Queries: map[string]QueryPrometheusParams{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+
+	oversized := make(map[string]QueryPrometheusParams, maxBatchedPrometheusQueries+1)
+	for i := range maxBatchedPrometheusQueries + 1 {
+		oversized[fmt.Sprintf("q%d", i)] = QueryPrometheusParams{Expr: "up"}
+	}
+	_, err = queryPrometheusBatched(ctx, QueryPrometheusBatchedParams{Queries: oversized})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many queries")
 }


### PR DESCRIPTION
## What this changes

`query_prometheus` only runs one query at a time, so an agent that needs several PromQL queries together (e.g. CPU and memory for the same panel) pays one full tool round-trip per query. This adds `query_prometheus_batched`: a map from a caller-chosen key to a `query_prometheus`-shaped query, run concurrently (bounded to 8 at once, capped at 20 queries per call), returning a map keyed the same way where each entry holds either that query's result or its own error — one failing query never fails the batch.

Fixes #964

## New or changed tools

**Proposal issue:** #964

| Tool name | New or changed | Proposed tier |
| --- | --- | --- |
| `query_prometheus_batched` | new | default-on (registered alongside `query_prometheus` whenever query tools are enabled) |

**Token cost:** I don't have `mcp-tokens` installed in this environment (it's a Rust binary via `cargo`/`dist`, not `go install`-able, and I didn't want to add a full Rust toolchain just to run one check), so I can't paste its exact output. As an honest proxy: the serialized `tools/list` entry for `query_prometheus_batched` is 2289 bytes of JSON (~570 tokens at a rough chars/4 estimate) versus 1826 bytes for the existing `query_prometheus` entry it reuses the schema from — so the added cost is roughly one extra tool listing of about the same size as `query_prometheus` itself, not a large new schema surface, since the batch's per-query shape is exactly `QueryPrometheusParams` (no new types). Happy to run the real `make token-check` number if a maintainer can point me at a prebuilt `mcp-tokens` binary, or I can install Rust and do it properly if that's preferred over this estimate.

**Why not extend `query_prometheus` itself?** Overloading it to accept either a single query or a map of queries would make its schema (and every caller's happy path) more complex for the common case, and would break the existing single-result response shape for every current caller. A separate tool keeps `query_prometheus` exactly as it is today.

**Read-only safety:** Purely a fan-out over the existing read-only `query_prometheus` path — no new write capability, gated behind `enableQueryTools` the same as `query_prometheus`/`query_prometheus_histogram` (excluded by `--disable-query`, and README's query-free-mode list is updated accordingly).

## How you tested it

- `go build ./...`, `go vet ./...`, `go test -tags unit ./...` (whole repo) — all clean.
- New unit tests in `tools/prometheus_unit_test.go` covering the concurrency/aggregation core (`runPrometheusQueryBatch`) with a fake query function, independent of any live datasource: per-key result/error isolation (one failing query doesn't affect others), exactly one result per input key, and — run under `-race` — that concurrency is actually bounded to the configured limit and actually reaches it (not silently serialized). Plus validation tests for the empty-batch and over-the-20-query-cap error paths.
- Manual end-to-end smoke test: built the binary, drove it over stdio with a raw `initialize`/`tools/list` JSON-RPC exchange, and confirmed `query_prometheus_batched` registers with the expected description, annotations, and a correctly-derived nested schema for `queries` (map value schema matches `query_prometheus`'s own params, generated automatically — no schema duplicated by hand).
- `gofmt`, the repo's `jsonschema`/`openapi` linters — clean. `golangci-lint` isn't installed in this environment, but the change doesn't touch anything it would flag.

## Checklist

- [x] `make lint` and `make test-unit` pass locally
- [ ] Commits are signed (required to merge — see CONTRIBUTING.md)
- [ ] CLA signed (required to merge)
- [x] README tool table updated, with RBAC permissions and scopes — added `query_prometheus_batched` to the tools table (same scopes as `query_prometheus`) and to the `--disable-query` exclusion list
- [x] Any write operation respects `--disable-write` — no write operation added
- [x] Any datasource query execution respects `--disable-query` — gated behind the same `enableQueryTools` as `query_prometheus`