### PR TITLE
Add --enable-write-tools for scoped disable-write exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ Caller authentication is enforced only when `--server-auth-token` is set. When i
 - `--disable-prometheus`: Disable prometheus tools
 - `--disable-write`: Disable write tools (create/update operations)
 - `--disable-query`: Disable query tools (tools that execute a query against a datasource); metadata and discovery tools stay available
-- `--enable-query`: Keep the raw-SQL query tools (`query_clickhouse`, `query_snowflake`, `query_athena`, `query_influxdb`) registered even under `--disable-write`
+- `--enable-query`: Keep the raw-SQL query tools (`query_clickhouse`, `query_snowflake`, `query_athena`, `query_influxdb`) registered even under `--disable-write`. Equivalent to `--enable-write-tools=query_clickhouse,query_snowflake,query_athena,query_influxdb`; kept as a shorthand for that common case.
+- `--enable-write-tools`: Comma separated list of individual tool names to keep registered even under `--disable-write`, for tools whose write behavior is scoped enough to opt back in independently (e.g. `find_error_pattern_logs,find_slow_requests`). Has no effect on a tool whose whole category is disabled, e.g. via `--disable-sift`.
 - `--disable-loki`: Disable loki tools
 - `--disable-elasticsearch`: Disable elasticsearch and opensearch tools
 - `--disable-quickwit`: Disable quickwit tools
@@ -548,6 +549,8 @@ When `--disable-write` is enabled, the following write operations are disabled:
 **Sift Tools:**
 - `find_error_pattern_logs` (creates investigations)
 - `find_slow_requests` (creates investigations)
+
+These only create ephemeral Sift investigation records via the Sift API — they never touch a Grafana dashboard, alert, or datasource. Without them, `list_sift_investigations`/`get_sift_investigation`/`get_sift_analysis` have nothing to list or get. Pass `--enable-write-tools=find_error_pattern_logs,find_slow_requests` to keep them registered under `--disable-write`.
 
 **Snapshot Tools:**
 - `create_snapshot`

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -149,6 +149,9 @@ var enableQueryToolNames = []string{"query_clickhouse", "query_snowflake", "quer
 // case.
 func (dt *disabledTools) writeToolOverridden(names ...string) bool {
 	overrides := strings.Split(dt.writeToolOverrides, ",")
+	for i, o := range overrides {
+		overrides[i] = strings.TrimSpace(o)
+	}
 	if dt.enableQuery {
 		overrides = append(overrides, enableQueryToolNames...)
 	}

--- a/cmd/mcp-grafana/main.go
+++ b/cmd/mcp-grafana/main.go
@@ -138,23 +138,74 @@ var queryOnlyCategories = []string{"elasticsearch", "quickwit", "influxdb", "run
 // whose datasource credentials are known to be read-only.
 var mutatingQueryCategories = []string{"clickhouse", "snowflake", "athena", "influxdb"}
 
+// enableQueryToolNames are the tool names --enable-query is shorthand for
+// naming in --enable-write-tools: see writeToolOverridden.
+var enableQueryToolNames = []string{"query_clickhouse", "query_snowflake", "query_athena", "query_influxdb"}
+
+// writeToolOverridden reports whether any of the given tool names should be
+// treated as named in --enable-write-tools, regardless of --disable-write.
+// --enable-query counts as naming all four raw-SQL query tools, since it
+// predates --enable-write-tools and is kept as a shorthand for that common
+// case.
+func (dt *disabledTools) writeToolOverridden(names ...string) bool {
+	overrides := strings.Split(dt.writeToolOverrides, ",")
+	if dt.enableQuery {
+		overrides = append(overrides, enableQueryToolNames...)
+	}
+	for _, name := range names {
+		if slices.Contains(overrides, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeToolEnabled reports whether a write-gated tool should be registered:
+// true when --disable-write is not set, or when the tool's name is named in
+// --enable-write-tools (or its --enable-query shorthand). Use this instead of
+// a bespoke --enable-X bool flag whenever a tool's write behavior is scoped
+// enough to opt back in independently of the rest of --disable-write (see
+// find_error_pattern_logs and find_slow_requests, gated this way because
+// they only create ephemeral Sift investigation records and never touch a
+// Grafana dashboard, alert, or datasource).
+func (dt *disabledTools) writeToolEnabled(names ...string) bool {
+	return !dt.write || dt.writeToolOverridden(names...)
+}
+
 // queryToolsEnabled reports whether a category's query tools should be
 // registered. --disable-query turns off every query tool; --disable-write
-// additionally turns off the ones that can mutate data, unless --enable-query
-// overrides it.
+// additionally turns off the ones that can mutate data, unless
+// --enable-write-tools (or its --enable-query shorthand) names that
+// category's query tool.
 func (dt *disabledTools) queryToolsEnabled(category string) bool {
 	if dt.query {
 		return false
 	}
 	if slices.Contains(mutatingQueryCategories, category) {
-		return !dt.write || dt.enableQuery
+		return dt.writeToolEnabled("query_" + category)
 	}
 	return true
+}
+
+// mutatingQueryToolsEnabled reports whether any of the four raw-SQL query
+// tools are enabled. Used to gate the query-capable variant of
+// grafana_api_request, which isn't specific to one datasource type so it
+// moves with the group rather than a single category.
+func (dt *disabledTools) mutatingQueryToolsEnabled() bool {
+	if dt.query {
+		return false
+	}
+	return dt.writeToolEnabled(enableQueryToolNames...)
 }
 
 // disabledTools indicates whether each category of tools should be disabled.
 type disabledTools struct {
 	enabledTools string
+
+	// writeToolOverrides is the raw --enable-write-tools value: a comma
+	// separated list of individual tool names to keep registered even under
+	// --disable-write. See writeToolEnabled.
+	writeToolOverrides string
 
 	search, datasource, incident,
 	prometheus, loki, elasticsearch, quickwit, influxdb, alerting,
@@ -227,7 +278,8 @@ func (dt *disabledTools) addFlags() {
 	flag.BoolVar(&dt.proxied, "disable-proxied", false, "Disable proxied tools (tools from external MCP servers)")
 	flag.BoolVar(&dt.write, "disable-write", false, "Disable write tools (create/update operations)")
 	flag.BoolVar(&dt.query, "disable-query", false, "Disable query tools (tools that execute a query against a datasource, e.g. query_prometheus, query_loki_logs, run_panel_query). Metadata and discovery tools stay available.")
-	flag.BoolVar(&dt.enableQuery, "enable-query", false, "Keep the raw-SQL query tools (query_clickhouse, query_snowflake, query_athena, query_influxdb) registered even under --disable-write. They pass the query through unfiltered, so they can mutate data if the datasource credentials permit it; use this when those credentials are known to be read-only. Has no effect if --disable-query is also set.")
+	flag.BoolVar(&dt.enableQuery, "enable-query", false, "Keep the raw-SQL query tools (query_clickhouse, query_snowflake, query_athena, query_influxdb) registered even under --disable-write. They pass the query through unfiltered, so they can mutate data if the datasource credentials permit it; use this when those credentials are known to be read-only. Has no effect if --disable-query is also set. Equivalent to --enable-write-tools=query_clickhouse,query_snowflake,query_athena,query_influxdb; kept as a shorthand for that common case.")
+	flag.StringVar(&dt.writeToolOverrides, "enable-write-tools", "", "Comma separated list of individual tool names to keep registered even under --disable-write, for tools whose write behavior is scoped enough to opt back in independently (e.g. find_error_pattern_logs,find_slow_requests, which only create ephemeral Sift investigation records and never touch a Grafana dashboard, alert, or datasource). Has no effect on a tool whose whole category is disabled, e.g. via --disable-sift.")
 	flag.BoolVar(&dt.annotations, "disable-annotations", false, "Disable annotation tools")
 	flag.BoolVar(&dt.rendering, "disable-rendering", false, "Disable rendering tools (panel/dashboard image export)")
 	flag.BoolVar(&dt.snapshot, "disable-snapshot", false, "Disable snapshot tools")
@@ -348,7 +400,6 @@ type toolEntry struct {
 func (dt *disabledTools) toolEntries() []toolEntry {
 	enableWriteTools := !dt.write
 	enableQueryTools := !dt.query
-	enableMutatingQueryTools := dt.queryToolsEnabled("clickhouse")
 	return []toolEntry{
 		{tools.AddSearchTools, dt.search, "search"},
 		{func(mcp *server.MCPServer) { tools.AddDatasourceTools(mcp, enableWriteTools) }, dt.datasource, "datasource"},
@@ -357,13 +408,15 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{func(mcp *server.MCPServer) { tools.AddLokiTools(mcp, enableQueryTools) }, dt.loki, "loki"},
 		{func(mcp *server.MCPServer) { tools.AddElasticsearchTools(mcp, enableQueryTools) }, dt.elasticsearch, "elasticsearch"},
 		{func(mcp *server.MCPServer) { tools.AddQuickwitTools(mcp, enableQueryTools) }, dt.quickwit, "quickwit"},
-		{func(mcp *server.MCPServer) { tools.AddInfluxDBTools(mcp, enableMutatingQueryTools) }, dt.influxdb, "influxdb"},
+		{func(mcp *server.MCPServer) { tools.AddInfluxDBTools(mcp, dt.queryToolsEnabled("influxdb")) }, dt.influxdb, "influxdb"},
 		{func(mcp *server.MCPServer) { tools.AddAlertingTools(mcp, enableWriteTools) }, dt.alerting, "alerting"},
 		{func(mcp *server.MCPServer) { tools.AddDashboardTools(mcp, enableWriteTools) }, dt.dashboard, "dashboard"},
 		{func(mcp *server.MCPServer) { tools.AddFolderTools(mcp, enableWriteTools) }, dt.folder, "folder"},
 		{func(mcp *server.MCPServer) { tools.AddOnCallTools(mcp, enableWriteTools) }, dt.oncall, "oncall"},
 		{tools.AddAssertsTools, dt.asserts, "asserts"},
-		{func(mcp *server.MCPServer) { tools.AddSiftTools(mcp, enableWriteTools) }, dt.sift, "sift"},
+		{func(mcp *server.MCPServer) {
+			tools.AddSiftTools(mcp, dt.writeToolEnabled("find_error_pattern_logs", "find_slow_requests"))
+		}, dt.sift, "sift"},
 		{tools.AddAdminTools, dt.admin, "admin"},
 		{func(mcp *server.MCPServer) { tools.AddPyroscopeTools(mcp, enableQueryTools) }, dt.pyroscope, "pyroscope"},
 		{func(mcp *server.MCPServer) { tools.AddNavigationTools(mcp, enableWriteTools) }, dt.navigation, "navigation"},
@@ -372,13 +425,13 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 		{func(mcp *server.MCPServer) { tools.AddSnapshotTools(mcp, enableWriteTools) }, dt.snapshot, "snapshot"},
 		{func(mcp *server.MCPServer) { tools.AddCloudWatchTools(mcp, enableQueryTools) }, dt.cloudwatch, "cloudwatch"},
 		{tools.AddExamplesTools, dt.examples, "examples"},
-		{func(mcp *server.MCPServer) { tools.AddClickHouseTools(mcp, enableMutatingQueryTools) }, dt.clickhouse, "clickhouse"},
-		{func(mcp *server.MCPServer) { tools.AddSnowflakeTools(mcp, enableMutatingQueryTools) }, dt.snowflake, "snowflake"},
+		{func(mcp *server.MCPServer) { tools.AddClickHouseTools(mcp, dt.queryToolsEnabled("clickhouse")) }, dt.clickhouse, "clickhouse"},
+		{func(mcp *server.MCPServer) { tools.AddSnowflakeTools(mcp, dt.queryToolsEnabled("snowflake")) }, dt.snowflake, "snowflake"},
 		{func(mcp *server.MCPServer) { tools.AddRunPanelQueryTools(mcp, enableQueryTools) }, dt.runpanelquery, "runpanelquery"},
 		{func(mcp *server.MCPServer) { tools.AddGraphiteTools(mcp, enableQueryTools) }, dt.graphite, "graphite"},
-		{func(mcp *server.MCPServer) { tools.AddAthenaTools(mcp, enableMutatingQueryTools) }, dt.athena, "athena"},
+		{func(mcp *server.MCPServer) { tools.AddAthenaTools(mcp, dt.queryToolsEnabled("athena")) }, dt.athena, "athena"},
 		{func(mcp *server.MCPServer) { tools.AddPluginTools(mcp, enableWriteTools) }, dt.plugin, "plugin"},
-		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools, enableMutatingQueryTools) }, dt.api, "api"},
+		{func(mcp *server.MCPServer) { tools.AddAPITools(mcp, enableWriteTools, dt.mutatingQueryToolsEnabled()) }, dt.api, "api"},
 		{tools.AddConfigTools, dt.config, "config"},
 		{tools.AddProvisioningTools, dt.provisioning, "provisioning"},
 		{func(mcp *server.MCPServer) { tools.AddAgento11yTools(mcp, enableWriteTools) }, dt.agento11y, "agento11y"},
@@ -392,6 +445,9 @@ func (dt *disabledTools) toolEntries() []toolEntry {
 func (dt *disabledTools) processTools(s *server.MCPServer) {
 	if dt.query && dt.enableQuery {
 		slog.Warn("--enable-query has no effect because --disable-query is set; no query tools will be registered")
+	}
+	if dt.sift && dt.writeToolOverridden("find_error_pattern_logs", "find_slow_requests") {
+		slog.Warn("--enable-write-tools naming find_error_pattern_logs/find_slow_requests has no effect because --disable-sift is set; no sift tools will be registered")
 	}
 	enabledTools := strings.Split(dt.enabledTools, ",")
 	for _, e := range dt.toolEntries() {

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1346,6 +1346,58 @@ func TestProcessTools_BothDisableFlags(t *testing.T) {
 	}
 }
 
+// See issue #744: --disable-write left the Sift read tools (list/get) with
+// nothing to list or get, since the investigation-creation tools were gated
+// by the same flag. --enable-write-tools restores just those two, by name.
+func TestProcessTools_DisableWriteRemovesSiftInvestigationTools(t *testing.T) {
+	names := registerAllCategories(t, disabledTools{write: true})
+	assert.False(t, names["find_error_pattern_logs"], "find_error_pattern_logs should be gone with --disable-write")
+	assert.False(t, names["find_slow_requests"], "find_slow_requests should be gone with --disable-write")
+	assert.True(t, names["list_sift_investigations"], "read-only sift tools should survive --disable-write")
+	assert.True(t, names["get_sift_investigation"], "read-only sift tools should survive --disable-write")
+	assert.True(t, names["get_sift_analysis"], "read-only sift tools should survive --disable-write")
+}
+
+func TestProcessTools_EnableWriteToolsRestoresSiftInvestigationTools(t *testing.T) {
+	names := registerAllCategories(t, disabledTools{write: true, writeToolOverrides: "find_error_pattern_logs,find_slow_requests"})
+	assert.True(t, names["find_error_pattern_logs"], "find_error_pattern_logs should be restored by --enable-write-tools")
+	assert.True(t, names["find_slow_requests"], "find_slow_requests should be restored by --enable-write-tools")
+	// The override is scoped by name: real write tools stay gone.
+	assert.False(t, names["update_dashboard"], "--enable-write-tools must not re-enable unrelated write tools")
+	assert.False(t, names["create_folder"], "--enable-write-tools must not re-enable unrelated write tools")
+}
+
+// AddSiftTools only exposes one bool for both investigation-creation tools,
+// so naming just one of them in --enable-write-tools restores both.
+func TestProcessTools_EnableWriteToolsPartialSiftListRestoresBoth(t *testing.T) {
+	names := registerAllCategories(t, disabledTools{write: true, writeToolOverrides: "find_error_pattern_logs"})
+	assert.True(t, names["find_error_pattern_logs"])
+	assert.True(t, names["find_slow_requests"])
+}
+
+func TestProcessTools_EnableWriteToolsAloneChangesNothing(t *testing.T) {
+	defaults := registerAllCategories(t, disabledTools{})
+	names := registerAllCategories(t, disabledTools{writeToolOverrides: "find_error_pattern_logs,find_slow_requests"})
+	assert.Equal(t, defaults, names, "--enable-write-tools on its own should be a no-op")
+}
+
+func TestProcessTools_DisableSiftBeatsEnableWriteTools(t *testing.T) {
+	names := registerAllCategories(t, disabledTools{sift: true, writeToolOverrides: "find_error_pattern_logs,find_slow_requests"})
+	assert.False(t, names["find_error_pattern_logs"], "sift should be gone: --disable-sift wins over --enable-write-tools")
+	assert.False(t, names["list_sift_investigations"], "sift should be gone: --disable-sift wins over --enable-write-tools")
+}
+
+// --enable-query is documented as a shorthand for naming the four raw-SQL
+// query tools in --enable-write-tools; this pins that equivalence.
+func TestProcessTools_EnableQueryIsAliasForEnableWriteTools(t *testing.T) {
+	viaEnableQuery := registerAllCategories(t, disabledTools{write: true, enableQuery: true})
+	viaWriteTools := registerAllCategories(t, disabledTools{
+		write:              true,
+		writeToolOverrides: "query_clickhouse,query_snowflake,query_athena,query_influxdb",
+	})
+	assert.Equal(t, viaEnableQuery, viaWriteTools)
+}
+
 func getPath(h http.Handler, path string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))

--- a/cmd/mcp-grafana/main_test.go
+++ b/cmd/mcp-grafana/main_test.go
@@ -1367,6 +1367,18 @@ func TestProcessTools_EnableWriteToolsRestoresSiftInvestigationTools(t *testing.
 	assert.False(t, names["create_folder"], "--enable-write-tools must not re-enable unrelated write tools")
 }
 
+// A space after the comma (a natural way to write the flag by hand) must not
+// prevent the match. Exercised directly against writeToolOverridden with a
+// single name, since AddSiftTools ORs both Sift tool names together and
+// would pass even if only one of them matched.
+func TestWriteToolOverridden_TrimsWhitespaceAroundNames(t *testing.T) {
+	dt := &disabledTools{write: true, writeToolOverrides: "find_error_pattern_logs, find_slow_requests"}
+	assert.True(t, dt.writeToolOverridden("find_slow_requests"), "trailing name after a space-separated comma should still match")
+
+	dt = &disabledTools{write: true, writeToolOverrides: " find_error_pattern_logs"}
+	assert.True(t, dt.writeToolOverridden("find_error_pattern_logs"), "leading whitespace before a name should still match")
+}
+
 // AddSiftTools only exposes one bool for both investigation-creation tools,
 // so naming just one of them in --enable-write-tools restores both.
 func TestProcessTools_EnableWriteToolsPartialSiftListRestoresBoth(t *testing.T) {


### PR DESCRIPTION
If server launched with `--disable-write`, all tools that can cause writes are disabled.
A carve-out was created for raw-SQL query tools with `--enable-query` but I want to avoid adding carve-outs for all other tools.

This adds a `--enable-write-tools=<tool1>,<tool2>,...` flag to allow more tool carve-outs.



## What this changes

`--disable-write` gates `find_error_pattern_logs`/`find_slow_requests` alongside the read-only Sift tools (`list_sift_investigations`, `get_sift_investigation`, `get_sift_analysis`), so anyone who wants read-only mode but still wants Sift ends up with list/get tools that have nothing to list or get. These two tools only create ephemeral Sift investigation records via the Sift API, never a Grafana dashboard, alert, or datasource.

`--enable-query` already solves the same kind of problem for the raw-SQL query tools, but as a single-purpose flag. Adding another single-purpose flag for every future exception does not scale, so this instead adds one generic flag:

- `--enable-write-tools=<tool1>,<tool2>,...`: a comma-separated list of individual tool names to keep registered even under `--disable-write`.

`--enable-query` stays as a flag, now implemented as shorthand for naming the four raw-SQL query tools (`query_clickhouse,query_snowflake,query_athena,query_influxdb`) in the new list, so both flags share one code path (`writeToolEnabled`/`writeToolOverridden` in `cmd/mcp-grafana/main.go`) instead of two parallel ones.
