### PR TITLE
feat(dashboard): add semantic selectors for partial reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _The following features are currently available in MCP server. This list is for 
 - **Search for dashboards:** Find dashboards by title, folder UID, tag, or starred status
 - **Get dashboard by UID:** Retrieve full dashboard details using its unique identifier. _Warning: Large dashboards can consume significant context window space._
 - **Get dashboard summary:** Get a compact overview of a dashboard including title, panel count, panel types, variables, and metadata without the full JSON to minimize context window usage
-- **Get dashboard property:** Extract specific parts of a dashboard using JSONPath expressions (e.g., `$.title`, `$.panels[*].title`) to fetch only needed data and reduce context window consumption
+- **Get dashboard property:** Extract specific parts of a dashboard using JSONPath. Optional semantic selectors address a panel by ID, query by panel ID and ref ID, or variable by name across classic, legacy-row, and v2 dashboards without discovering physical array paths
 - **Update or create a dashboard:** Modify existing dashboards or create new ones. _Warning: Requires full dashboard JSON which can consume large amounts of context window space._
 - **Patch dashboard:** Apply specific changes to a dashboard without requiring the full JSON, significantly reducing context window usage for targeted modifications
 - **Get panel queries and datasource info:** Get the title, query string, and datasource information (including UID and type, if available) from every panel in a dashboard
@@ -60,7 +60,7 @@ _The following features are currently available in MCP server. This list is for 
 The dashboard tools now include several strategies to manage context window usage effectively ([issue #101](https://github.com/grafana/mcp-grafana/issues/101)):
 
 - **Use `get_dashboard_summary`** for dashboard overview and planning modifications
-- **Use `get_dashboard_property`** with JSONPath when you only need specific dashboard parts
+- **Use `get_dashboard_property`** with a semantic selector and relative JSONPath for stable, bounded partial reads; native-schema JSONPath remains available when needed
 - **Avoid `get_dashboard_by_uid`** unless you specifically need the complete dashboard JSON
 
 ### Datasources

--- a/tools/dashboard.go
+++ b/tools/dashboard.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -12,8 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/PaesslerAG/gval"
-	"github.com/PaesslerAG/jsonpath"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -765,8 +762,9 @@ var GetDashboardPanelQueries = mcpgrafana.MustTool(
 
 // GetDashboardPropertyParams defines parameters for getting specific dashboard properties
 type GetDashboardPropertyParams struct {
-	UID      string `json:"uid" jsonschema:"required,description=The UID of the dashboard"`
-	JSONPath string `json:"jsonPath" jsonschema:"required,description=JSONPath expression to extract specific data (e.g.\\, '$.panels[0].title' for first panel title\\, '$.panels[*].title' for all panel titles\\, '$.templating.list' for variables\\, '$.annotations.list' for saved dashboard annotation queries/definitions)"`
+	UID      string             `json:"uid" jsonschema:"required,description=The UID of the dashboard"`
+	JSONPath string             `json:"jsonPath" jsonschema:"required,description=JSONPath expression to extract specific data. Without selector it is rooted at the dashboard (e.g.\\, '$.panels[*].title'). With selector it is relative to the selected object (e.g.\\, '$.fieldConfig.defaults' for a panel or '$.rawSql' for a query)"`
+	Selector *DashboardSelector `json:"selector,omitempty" jsonschema:"description=Optional semantic selector for a dashboard\\, panel\\, query\\, or variable. Avoids schema-specific array indices and works across classic\\, legacy-row\\, and v2 dashboards"`
 }
 
 // getDashboardProperty retrieves specific parts of a dashboard using JSONPath expressions.
@@ -776,37 +774,12 @@ func getDashboardProperty(ctx context.Context, args GetDashboardPropertyParams) 
 	if err != nil {
 		return nil, fmt.Errorf("get dashboard by uid: %w", err)
 	}
-
-	// Convert dashboard to JSON for JSONPath processing. The spec is in its
-	// native schema (classic v1 or v2), so v2 paths target elements/layout.
-	dashboardJSON, err := json.Marshal(res.Spec)
-	if err != nil {
-		return nil, fmt.Errorf("marshal dashboard to JSON: %w", err)
-	}
-
-	var dashboardData interface{}
-	if err := json.Unmarshal(dashboardJSON, &dashboardData); err != nil {
-		return nil, fmt.Errorf("unmarshal dashboard JSON: %w", err)
-	}
-
-	// Apply JSONPath expression
-	builder := gval.Full(jsonpath.Language())
-	path, err := builder.NewEvaluable(args.JSONPath)
-	if err != nil {
-		return nil, fmt.Errorf("create JSONPath evaluable '%s': %w", args.JSONPath, err)
-	}
-
-	result, err := path(ctx, dashboardData)
-	if err != nil {
-		return nil, fmt.Errorf("apply JSONPath '%s': %w", args.JSONPath, err)
-	}
-
-	return result, nil
+	return readDashboardProperty(ctx, res, args)
 }
 
 var GetDashboardProperty = mcpgrafana.MustTool(
 	"get_dashboard_property",
-	"Get specific parts of a dashboard using JSONPath expressions to minimize context window usage. JSONPath targets the dashboard's native schema. Classic v1 paths: '$.title' (title)\\, '$.panels[*].title' (all panel titles)\\, '$.panels[0]' (first panel)\\, '$.templating.list' (variables)\\, '$.annotations.list' (saved dashboard annotation queries/definitions)\\, '$.tags' (tags)\\, '$.panels[*].targets[*].expr' (all queries). v2 dashboards (see isV2 from get_dashboard_by_uid) use different paths: '$.title'\\, '$.elements' (panels\\, keyed by name)\\, '$.variables' (variables)\\, '$.annotations'. Use this instead of get_dashboard_by_uid when you only need specific dashboard properties.",
+	"Get specific parts of a dashboard using JSONPath expressions to minimize context window usage. For stable addressing across classic\\, legacy-row\\, and v2 dashboards\\, provide a semantic selector: dashboard by kind; panel by panelId; query by panelId + refId; or variable by name. With a selector\\, JSONPath is relative to that object (for example '$.fieldConfig.defaults' on a panel or '$.rawSql' on a query) and the bounded response includes value\\, revision\\, isV2\\, and selector. Without a selector\\, existing native-schema JSONPath behavior and raw-value output are unchanged. Selector responses over 32 KiB are rejected; use a narrower JSONPath instead.",
 	getDashboardProperty,
 	mcp.WithTitleAnnotation("Get dashboard property"),
 	mcp.WithIdempotentHintAnnotation(true),

--- a/tools/dashboard_selector.go
+++ b/tools/dashboard_selector.go
@@ -1,0 +1,272 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/PaesslerAG/gval"
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/invopop/jsonschema"
+)
+
+const maxDashboardPropertyResponseBytes = 32 * 1024
+
+// DashboardSelector identifies a dashboard object without exposing its
+// schema-specific physical path.
+type DashboardSelector struct {
+	Kind    string `json:"kind" jsonschema:"required,enum=dashboard,enum=panel,enum=query,enum=variable,description=Object kind to select"`
+	PanelID *int   `json:"panelId,omitempty" jsonschema:"description=Exact panel ID. Required for panel and query selectors"`
+	RefID   string `json:"refId,omitempty" jsonschema:"description=Exact query ref ID. Required for query selectors"`
+	Name    string `json:"name,omitempty" jsonschema:"description=Exact variable name. Required for variable selectors"`
+}
+
+func (DashboardSelector) JSONSchemaExtend(schema *jsonschema.Schema) {
+	schema.AdditionalProperties = jsonschema.FalseSchema
+}
+
+func (selector *DashboardSelector) UnmarshalJSON(data []byte) error {
+	type selectorAlias DashboardSelector
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	for field := range fields {
+		switch field {
+		case "kind", "panelId", "refId", "name":
+		default:
+			return fmt.Errorf("unknown field %q in dashboard selector", field)
+		}
+	}
+
+	var decoded selectorAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*selector = DashboardSelector(decoded)
+	return nil
+}
+
+// DashboardPropertyResponse is returned when get_dashboard_property uses a
+// semantic selector. Calls without a selector retain their legacy raw value.
+type DashboardPropertyResponse struct {
+	Value    interface{}       `json:"value"`
+	Revision string            `json:"revision"`
+	IsV2     bool              `json:"isV2"`
+	Selector DashboardSelector `json:"selector"`
+}
+
+// readDashboardProperty applies a JSONPath either to the complete dashboard
+// (legacy behavior) or relative to a semantically selected object.
+func readDashboardProperty(ctx context.Context, res *dashboardResult, args GetDashboardPropertyParams) (interface{}, error) {
+	root := interface{}(res.Spec)
+	if args.Selector != nil {
+		selected, err := resolveDashboardSelector(res.Spec, res.IsV2, *args.Selector)
+		if err != nil {
+			return nil, err
+		}
+		root = selected
+	}
+
+	value, err := evaluateDashboardJSONPath(ctx, root, args.JSONPath)
+	if err != nil {
+		return nil, err
+	}
+	if args.Selector == nil {
+		return value, nil
+	}
+
+	response := &DashboardPropertyResponse{
+		Value:    value,
+		Revision: dashboardRevision(res),
+		IsV2:     res.IsV2,
+		Selector: *args.Selector,
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("marshal selected dashboard property: %w", err)
+	}
+	if len(encoded) > maxDashboardPropertyResponseBytes {
+		return nil, fmt.Errorf(
+			"selected dashboard property response is %d bytes and exceeds the %d-byte limit; use a narrower JSONPath",
+			len(encoded),
+			maxDashboardPropertyResponseBytes,
+		)
+	}
+	return response, nil
+}
+
+func evaluateDashboardJSONPath(ctx context.Context, root interface{}, expression string) (interface{}, error) {
+	encoded, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("marshal dashboard to JSON: %w", err)
+	}
+
+	var data interface{}
+	if err := json.Unmarshal(encoded, &data); err != nil {
+		return nil, fmt.Errorf("unmarshal dashboard JSON: %w", err)
+	}
+
+	path, err := gval.Full(jsonpath.Language()).NewEvaluable(expression)
+	if err != nil {
+		return nil, fmt.Errorf("create JSONPath evaluable '%s': %w", expression, err)
+	}
+	value, err := path(ctx, data)
+	if err != nil {
+		return nil, fmt.Errorf("apply JSONPath '%s': %w", expression, err)
+	}
+	return value, nil
+}
+
+func resolveDashboardSelector(spec map[string]interface{}, isV2 bool, selector DashboardSelector) (map[string]interface{}, error) {
+	if err := validateDashboardSelector(selector); err != nil {
+		return nil, err
+	}
+
+	switch selector.Kind {
+	case "dashboard":
+		return spec, nil
+	case "panel":
+		return resolveSelectedPanel(spec, isV2, *selector.PanelID)
+	case "query":
+		panel, err := resolveSelectedPanel(spec, isV2, *selector.PanelID)
+		if err != nil {
+			return nil, err
+		}
+		if isV2 {
+			return findQueryByRefIDV2(panel, selector.RefID)
+		}
+		return findQueryByRefID(panel, selector.RefID)
+	case "variable":
+		if isV2 {
+			return findVariableByNameV2(spec, selector.Name)
+		}
+		return findVariableByName(spec, selector.Name)
+	default:
+		panic("selector kind was validated")
+	}
+}
+
+func validateDashboardSelector(selector DashboardSelector) error {
+	switch selector.Kind {
+	case "dashboard":
+		if selector.PanelID != nil || selector.RefID != "" || selector.Name != "" {
+			return fmt.Errorf("dashboard selector does not accept panelId, refId, or name")
+		}
+	case "panel":
+		if selector.PanelID == nil {
+			return fmt.Errorf("panelId is required for panel selector")
+		}
+		if selector.RefID != "" || selector.Name != "" {
+			return fmt.Errorf("panel selector does not accept refId or name")
+		}
+	case "query":
+		if selector.PanelID == nil {
+			return fmt.Errorf("panelId is required for query selector")
+		}
+		if selector.RefID == "" {
+			return fmt.Errorf("refId is required for query selector")
+		}
+		if selector.Name != "" {
+			return fmt.Errorf("query selector does not accept name")
+		}
+	case "variable":
+		if selector.Name == "" {
+			return fmt.Errorf("name is required for variable selector")
+		}
+		if selector.PanelID != nil || selector.RefID != "" {
+			return fmt.Errorf("variable selector does not accept panelId or refId")
+		}
+	default:
+		return fmt.Errorf("unsupported selector kind %q; use dashboard, panel, query, or variable", selector.Kind)
+	}
+	return nil
+}
+
+func resolveSelectedPanel(spec map[string]interface{}, isV2 bool, panelID int) (map[string]interface{}, error) {
+	if isV2 {
+		return findSelectablePanelByIDV2(spec, panelID)
+	}
+	return findPanelByID(spec, panelID)
+}
+
+func findSelectablePanelByIDV2(spec map[string]interface{}, panelID int) (map[string]interface{}, error) {
+	for _, element := range collectElementsV2(spec) {
+		if (element.Kind == "Panel" || element.Kind == "LibraryPanel") && safeInt(element.Spec, "id") == panelID {
+			return element.Spec, nil
+		}
+	}
+	return nil, fmt.Errorf("panel with ID %d not found", panelID)
+}
+
+func findQueryByRefID(panel map[string]interface{}, refID string) (map[string]interface{}, error) {
+	for _, raw := range safeArray(panel, "targets") {
+		query, ok := raw.(map[string]interface{})
+		if ok && safeString(query, "refId") == refID {
+			return query, nil
+		}
+	}
+	return nil, fmt.Errorf("query with refId %q not found in panel", refID)
+}
+
+// findQueryByRefIDV2 returns the datasource-specific query body. This makes
+// relative paths such as $.expr and $.rawSql work for both classic and v2
+// dashboards even though v2 wraps the body in PanelQuery/DataQuery objects.
+func findQueryByRefIDV2(panel map[string]interface{}, refID string) (map[string]interface{}, error) {
+	dataSpec := safeObject(safeObject(panel, "data"), "spec")
+	for _, raw := range safeArray(dataSpec, "queries") {
+		query, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		panelQuerySpec := safeObject(query, "spec")
+		if safeString(panelQuerySpec, "refId") != refID {
+			continue
+		}
+		dataQuery := safeObject(panelQuerySpec, "query")
+		body := safeObject(dataQuery, "spec")
+		if body == nil {
+			return nil, fmt.Errorf("query with refId %q has no query body", refID)
+		}
+		return body, nil
+	}
+	return nil, fmt.Errorf("query with refId %q not found in panel", refID)
+}
+
+func findVariableByName(spec map[string]interface{}, name string) (map[string]interface{}, error) {
+	templating := safeObject(spec, "templating")
+	for _, raw := range safeArray(templating, "list") {
+		variable, ok := raw.(map[string]interface{})
+		if ok && safeString(variable, "name") == name {
+			return variable, nil
+		}
+	}
+	return nil, fmt.Errorf("variable with name %q not found", name)
+}
+
+// findVariableByNameV2 returns the variable spec rather than its kind/spec
+// wrapper so relative paths such as $.name and $.current are schema-independent.
+func findVariableByNameV2(spec map[string]interface{}, name string) (map[string]interface{}, error) {
+	for _, raw := range safeArray(spec, "variables") {
+		variable, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		variableSpec := safeObject(variable, "spec")
+		if safeString(variableSpec, "name") == name {
+			return variableSpec, nil
+		}
+	}
+	return nil, fmt.Errorf("variable with name %q not found", name)
+}
+
+func dashboardRevision(res *dashboardResult) string {
+	if revision := k8sNestedString(res.Object, "metadata", "resourceVersion"); revision != "" {
+		return revision
+	}
+	if res.Meta != nil {
+		return strconv.FormatInt(res.Meta.Version, 10)
+	}
+	return ""
+}

--- a/tools/dashboard_selector_test.go
+++ b/tools/dashboard_selector_test.go
@@ -1,0 +1,274 @@
+//go:build unit
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDashboardSelectorSchemaRejectsAdditionalProperties(t *testing.T) {
+	var schema map[string]interface{}
+	require.NoError(t, json.Unmarshal(GetDashboardProperty.Tool.RawInputSchema, &schema))
+
+	selectorSchema := findSchemaWithProperties(schema, "kind", "panelId", "refId", "name")
+	require.NotNil(t, selectorSchema, "selector schema not found")
+	assert.Equal(t, false, selectorSchema["additionalProperties"])
+}
+
+func TestDashboardSelectorRejectsUnknownFields(t *testing.T) {
+	var params GetDashboardPropertyParams
+	err := json.Unmarshal([]byte(`{
+		"uid": "service-overview",
+		"jsonPath": "$.title",
+		"selector": {"kind": "dashboard", "panelID": 17}
+	}`), &params)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+	assert.Contains(t, err.Error(), "panelID")
+}
+
+func findSchemaWithProperties(node interface{}, names ...string) map[string]interface{} {
+	switch value := node.(type) {
+	case map[string]interface{}:
+		if properties, ok := value["properties"].(map[string]interface{}); ok {
+			matches := true
+			for _, name := range names {
+				if _, ok := properties[name]; !ok {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				return value
+			}
+		}
+		for _, child := range value {
+			if found := findSchemaWithProperties(child, names...); found != nil {
+				return found
+			}
+		}
+	case []interface{}:
+		for _, child := range value {
+			if found := findSchemaWithProperties(child, names...); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+func TestResolveDashboardSelectorClassic(t *testing.T) {
+	panelID := 17
+	dashboard := map[string]interface{}{
+		"title": "Service overview",
+		"panels": []interface{}{
+			map[string]interface{}{
+				"id":    float64(panelID),
+				"title": "Requests",
+				"targets": []interface{}{
+					map[string]interface{}{"refId": "A", "rawSql": "select 1"},
+					map[string]interface{}{"refId": "B", "expr": "up"},
+				},
+			},
+		},
+		"templating": map[string]interface{}{
+			"list": []interface{}{
+				map[string]interface{}{"name": "cluster", "label": "Cluster"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		selector DashboardSelector
+		want     interface{}
+	}{
+		{
+			name:     "dashboard",
+			selector: DashboardSelector{Kind: "dashboard"},
+			want:     "Service overview",
+		},
+		{
+			name:     "panel",
+			selector: DashboardSelector{Kind: "panel", PanelID: &panelID},
+			want:     "Requests",
+		},
+		{
+			name:     "query",
+			selector: DashboardSelector{Kind: "query", PanelID: &panelID, RefID: "A"},
+			want:     "select 1",
+		},
+		{
+			name:     "variable",
+			selector: DashboardSelector{Kind: "variable", Name: "cluster"},
+			want:     "Cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected, err := resolveDashboardSelector(dashboard, false, tt.selector)
+			require.NoError(t, err)
+
+			switch tt.selector.Kind {
+			case "dashboard":
+				assert.Equal(t, tt.want, selected["title"])
+			case "panel":
+				assert.Equal(t, tt.want, selected["title"])
+			case "query":
+				assert.Equal(t, tt.want, selected["rawSql"])
+			case "variable":
+				assert.Equal(t, tt.want, selected["label"])
+			}
+		})
+	}
+}
+
+func TestResolveDashboardSelectorLegacyRows(t *testing.T) {
+	panelID := 5
+
+	selected, err := resolveDashboardSelector(
+		loadLegacyRowsDashboard(t),
+		false,
+		DashboardSelector{Kind: "panel", PanelID: &panelID},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Receive bandwidth", selected["title"])
+}
+
+func TestResolveDashboardSelectorV2(t *testing.T) {
+	_, spec := loadV2Dashboard(t)
+	panelID := 1
+
+	panel, err := resolveDashboardSelector(spec, true, DashboardSelector{Kind: "panel", PanelID: &panelID})
+	require.NoError(t, err)
+	assert.Equal(t, "CPU usage", panel["title"])
+
+	libraryPanelID := 3
+	libraryPanel, err := resolveDashboardSelector(spec, true, DashboardSelector{Kind: "panel", PanelID: &libraryPanelID})
+	require.NoError(t, err)
+	assert.Equal(t, "Shared graph", libraryPanel["title"])
+
+	query, err := resolveDashboardSelector(spec, true, DashboardSelector{Kind: "query", PanelID: &panelID, RefID: "A"})
+	require.NoError(t, err)
+	assert.Equal(t, `rate(cpu_seconds_total{job="$job"}[5m])`, query["expr"])
+
+	variable, err := resolveDashboardSelector(spec, true, DashboardSelector{Kind: "variable", Name: "job"})
+	require.NoError(t, err)
+	assert.Equal(t, "Job", variable["label"])
+}
+
+func TestResolveDashboardSelectorValidatesFields(t *testing.T) {
+	panelID := 1
+	tests := []struct {
+		name     string
+		selector DashboardSelector
+		want     string
+	}{
+		{name: "unknown kind", selector: DashboardSelector{Kind: "row"}, want: "unsupported selector kind"},
+		{name: "panel needs id", selector: DashboardSelector{Kind: "panel"}, want: "panelId is required"},
+		{name: "query needs ref id", selector: DashboardSelector{Kind: "query", PanelID: &panelID}, want: "refId is required"},
+		{name: "variable needs name", selector: DashboardSelector{Kind: "variable"}, want: "name is required"},
+		{name: "dashboard rejects panel id", selector: DashboardSelector{Kind: "dashboard", PanelID: &panelID}, want: "does not accept"},
+		{name: "panel rejects query field", selector: DashboardSelector{Kind: "panel", PanelID: &panelID, RefID: "A"}, want: "does not accept"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveDashboardSelector(map[string]interface{}{}, false, tt.selector)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestReadDashboardPropertyWithSelector(t *testing.T) {
+	panelID := 17
+	selector := &DashboardSelector{Kind: "panel", PanelID: &panelID}
+	res := &dashboardResult{
+		Spec: map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"id": float64(panelID),
+					"fieldConfig": map[string]interface{}{
+						"defaults": map[string]interface{}{"unit": "short"},
+					},
+				},
+			},
+		},
+		Meta: &models.DashboardMeta{Version: 9},
+	}
+
+	result, err := readDashboardProperty(context.Background(), res, GetDashboardPropertyParams{
+		UID:      "service-overview",
+		JSONPath: "$.fieldConfig.defaults.unit",
+		Selector: selector,
+	})
+
+	require.NoError(t, err)
+	response, ok := result.(*DashboardPropertyResponse)
+	require.True(t, ok)
+	assert.Equal(t, "short", response.Value)
+	assert.Equal(t, "9", response.Revision)
+	assert.False(t, response.IsV2)
+	assert.Equal(t, *selector, response.Selector)
+}
+
+func TestReadDashboardPropertyWithoutSelectorKeepsLegacyResponse(t *testing.T) {
+	res := &dashboardResult{Spec: map[string]interface{}{"title": "Service overview"}}
+
+	result, err := readDashboardProperty(context.Background(), res, GetDashboardPropertyParams{
+		UID:      "service-overview",
+		JSONPath: "$.title",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Service overview", result)
+}
+
+func TestReadDashboardPropertyUsesKubernetesRevision(t *testing.T) {
+	res := &dashboardResult{
+		Spec: map[string]interface{}{"title": "Service overview"},
+		IsV2: true,
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{"resourceVersion": "42"},
+		},
+	}
+
+	result, err := readDashboardProperty(context.Background(), res, GetDashboardPropertyParams{
+		UID:      "service-overview",
+		JSONPath: "$.title",
+		Selector: &DashboardSelector{Kind: "dashboard"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "42", result.(*DashboardPropertyResponse).Revision)
+	assert.True(t, result.(*DashboardPropertyResponse).IsV2)
+}
+
+func TestReadDashboardPropertyRejectsOversizedSelectorResponse(t *testing.T) {
+	res := &dashboardResult{
+		Spec: map[string]interface{}{
+			"description": strings.Repeat("x", maxDashboardPropertyResponseBytes),
+		},
+	}
+
+	_, err := readDashboardProperty(context.Background(), res, GetDashboardPropertyParams{
+		UID:      "large-dashboard",
+		JSONPath: "$.description",
+		Selector: &DashboardSelector{Kind: "dashboard"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+	assert.Contains(t, err.Error(), "narrower JSONPath")
+}


### PR DESCRIPTION
## What this changes

Extends `get_dashboard_property` with an optional semantic selector so agents can address a dashboard, panel, query, or variable without discovering schema-specific array paths. Selectors resolve across classic v1, legacy-row, and native v2 dashboards; JSONPath is evaluated relative to the selected object.

Calls without a selector keep the existing raw-value behavior. Selector calls return a compact envelope with `value`, `revision`, `isV2`, and the resolved selector, and reject responses over 32 KiB instead of truncating them. This PR intentionally contains only the read-only first phase of #1159.

## New or changed tools

**Proposal issue:** #1159

| Tool name | New or changed | Proposed tier |
| --- | --- | --- |
| `get_dashboard_property` | changed | default-on |

**Token cost:** Pending the Token Analysis workflow summary; the local analyzer and main-branch baseline are not installed in this checkout.

**Read-only safety:** This changes only `get_dashboard_property`; no write path or write-gating behavior is modified.

## How you tested it

- `GOFLAGS=-p=1 make test-unit`
- `GOFLAGS=-p=1 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run`
- JSON-schema and OpenAPI linters
- `GOFLAGS=-p=1 make build`
- Synthetic classic, legacy-row, and v2 dashboard fixtures, including LibraryPanel and oversized-response cases

## Checklist

- [x] `make lint` equivalent checks and `make test-unit` pass locally
- [x] Commit is signed
- [ ] CLA signed (pending GitHub check)
- [x] README dashboard capability and context-management guidance updated
- [x] No write operation added
- [x] No datasource query execution added
