### PR TITLE
fix(alerting): apply search_rule_name client-side on datasource rules list

### DIFF
--- a/tools/alerting_manage_rules_datasource.go
+++ b/tools/alerting_manage_rules_datasource.go
@@ -38,6 +38,13 @@ func listDatasourceAlertRules(ctx context.Context, dsUID string, opts *GetRulesO
 		summaries = filterSummaryByRuleType(summaries, opts.RuleType)
 	}
 
+	// The upstream Prometheus/Mimir ruler API does not support the search.rule_name
+	// parameter at all, so it is silently ignored by the proxy. Filter client-side
+	// so callers get consistent behavior across both list paths.
+	if opts != nil && opts.RuleName != "" {
+		summaries = filterSummaryByRuleName(summaries, opts.RuleName)
+	}
+
 	if len(labelSelectors) > 0 {
 		summaries, err = filterSummaryByLabels(summaries, labelSelectors)
 		if err != nil {

--- a/tools/alerting_manage_rules_handlers.go
+++ b/tools/alerting_manage_rules_handlers.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -244,6 +245,20 @@ func filterSummaryByRuleType(summaries []alertRuleSummary, ruleType string) []al
 	filtered := make([]alertRuleSummary, 0, len(summaries))
 	for _, s := range summaries {
 		if s.Type == ruleType {
+			filtered = append(filtered, s)
+		}
+	}
+	return filtered
+}
+
+// filterSummaryByRuleName keeps summaries whose title contains name as a
+// case-insensitive substring, matching the partial-match semantics of the
+// search.rule_name parameter on the Grafana-managed rules API.
+func filterSummaryByRuleName(summaries []alertRuleSummary, name string) []alertRuleSummary {
+	needle := strings.ToLower(name)
+	filtered := make([]alertRuleSummary, 0, len(summaries))
+	for _, s := range summaries {
+		if strings.Contains(strings.ToLower(s.Title), needle) {
 			filtered = append(filtered, s)
 		}
 	}

--- a/tools/alerting_manage_rules_unit_test.go
+++ b/tools/alerting_manage_rules_unit_test.go
@@ -1233,6 +1233,45 @@ func TestFilterSummaryByRuleType(t *testing.T) {
 	})
 }
 
+func TestFilterSummaryByRuleName(t *testing.T) {
+	summaries := []alertRuleSummary{
+		{UID: "r1", Title: "HighNoQuotesRateForT2Chains"},
+		{UID: "r2", Title: "HighNoQuotesRateForT1Chains"},
+		{UID: "r3", Title: "GetQuoteErrorRate5Percent"},
+		{UID: "r4", Title: "GatewayAPINoHeartbeatsSent"},
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		filtered := filterSummaryByRuleName(summaries, "HighNoQuotesRateForT2Chains")
+		require.Len(t, filtered, 1)
+		require.Equal(t, "r1", filtered[0].UID)
+	})
+
+	t.Run("partial match", func(t *testing.T) {
+		filtered := filterSummaryByRuleName(summaries, "NoQuotesRate")
+		require.Len(t, filtered, 2)
+		require.Equal(t, "r1", filtered[0].UID)
+		require.Equal(t, "r2", filtered[1].UID)
+	})
+
+	t.Run("case-insensitive match", func(t *testing.T) {
+		filtered := filterSummaryByRuleName(summaries, "highnoquotes")
+		require.Len(t, filtered, 2)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		filtered := filterSummaryByRuleName(summaries, "DoesNotExist")
+		require.Empty(t, filtered)
+	})
+
+	t.Run("empty name keeps all", func(t *testing.T) {
+		// Callers guard on empty RuleName before invoking the filter,
+		// but the filter itself must not drop everything on "".
+		filtered := filterSummaryByRuleName(summaries, "")
+		require.Len(t, filtered, 4)
+	})
+}
+
 func TestFindRuleInResponse(t *testing.T) {
 	evalTime := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
 


### PR DESCRIPTION
## What this changes

The datasource-managed path of `alerting_manage_rules` (`list` with `datasource_uid`) silently ignores `search_rule_name`. `GetDatasourceRules` proxies to the upstream Prometheus/Mimir ruler API (`/api/prometheus/{uid}/api/v1/rules`), which does not support the `search.rule_name` parameter — the proxy drops it and the tool returns **every rule in the datasource**.

This PR mirrors the existing client-side `rule_type` backstop for `rule_name`: if `RuleName` is set, summaries are filtered client-side (case-insensitive substring, matching the partial-match semantics of `search.rule_name` on the Grafana-managed API).

Found while investigating a production incident-trace cost issue in an agent built on this server: a rule search intended to return one rule returned ~150 rules (~40–50k tokens) because the filter was dropped upstream and nothing errored.

## How you tested it

- New unit tests `TestFilterSummaryByRuleName` (exact, partial, case-insensitive, no-match, empty-name) in `tools/alerting_manage_rules_unit_test.go`
- `make test-unit` passes; `gofmt` clean
- `golangci-lint run` shows only 3 pre-existing `reflect.Ptr` (govet) findings in `mcpgrafana.go`/`tools.go`, unrelated to this change (CI pins an older golangci-lint)
- Reproduced the bug against a live Grafana/Mimir stack: `{"operation":"list","datasource_uid":"<prom-uid>","search_rule_name":"HighNoQuotesRateForT2Chains"}` returned all ~150 rules before the fix; label-selector filtering on the same call confirms the client-side filter pattern behaves correctly

## Checklist

- [x] `make lint` and `make test-unit` pass locally
- [x] Commits are signed (DCO)
- [x] CLA signed (required to merge)
- [x] README tool table updated — N/A (no new tool)
- [x] Any write operation respects `--disable-write` — N/A (read-only list path)
- [x] Any datasource query execution respects `--disable-query` — N/A (no query execution changed)