### PR TITLE
fix(server): skip default-org warning when dynamic multi-org is enabled

### DIFF
--- a/client_cache.go
+++ b/client_cache.go
@@ -358,7 +358,9 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		config := GrafanaConfigFromContext(ctx)
 		logger := config.LoggerOrDefault()
-		if config.OrgID == 0 {
+		// Under dynamic multi-org the org is chosen per tool call, so an unset
+		// connection-level org is the expected starting point, not a misconfiguration.
+		if config.OrgID == 0 && !DynamicMultiOrgEnabled {
 			logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 		}
 

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -1545,7 +1545,9 @@ var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Conte
 var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
-	if config.OrgID == 0 {
+	// Under dynamic multi-org the org is chosen per tool call, so an unset
+	// connection-level org is the expected starting point, not a misconfiguration.
+	if config.OrgID == 0 && !DynamicMultiOrgEnabled {
 		logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
 	}
 

--- a/mcpgrafana_test.go
+++ b/mcpgrafana_test.go
@@ -2710,3 +2710,42 @@ func TestMeterProviderOrDefault(t *testing.T) {
 
 	assert.Equal(t, otel.GetMeterProvider(), GrafanaConfig{}.MeterProviderOrDefault())
 }
+
+func TestDefaultOrgWarningSuppressedWithDynamicMultiOrg(t *testing.T) {
+	newRequestCtx := func(logger *slog.Logger) (context.Context, *http.Request) {
+		ctx := WithGrafanaConfig(context.Background(), GrafanaConfig{Logger: logger})
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		return ctx, req
+	}
+
+	t.Run("warns without dynamic multi-org", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx, req := newRequestCtx(slog.New(slog.NewTextHandler(&buf, nil)))
+		ExtractGrafanaClientFromHeaders(ctx, req)
+		assert.Contains(t, buf.String(), "using default org")
+	})
+
+	t.Run("silent with dynamic multi-org", func(t *testing.T) {
+		DynamicMultiOrgEnabled = true
+		t.Cleanup(func() { DynamicMultiOrgEnabled = false })
+
+		var buf bytes.Buffer
+		ctx, req := newRequestCtx(slog.New(slog.NewTextHandler(&buf, nil)))
+		ExtractGrafanaClientFromHeaders(ctx, req)
+		assert.NotContains(t, buf.String(), "using default org")
+	})
+
+	t.Run("silent with dynamic multi-org on the cached path", func(t *testing.T) {
+		DynamicMultiOrgEnabled = true
+		t.Cleanup(func() { DynamicMultiOrgEnabled = false })
+
+		cache := NewClientCache(nil)
+		t.Cleanup(cache.Close)
+
+		var buf bytes.Buffer
+		ctx, req := newRequestCtx(slog.New(slog.NewTextHandler(&buf, nil)))
+		extractGrafanaClientCached(cache)(ctx, req)
+		assert.NotContains(t, buf.String(), "using default org")
+	})
+}


### PR DESCRIPTION
## What this changes

With `--dynamic-multi-org`, the org is picked per tool call via the `orgId` argument, so a connection that carries no `GRAFANA_ORG_ID` and no `X-Grafana-Org-Id` header is the normal setup rather than a misconfiguration. Both HTTP client-extraction paths still logged a WARN on every request in that case, drowning out warnings that are actually worth reading.

The warning is now skipped when `DynamicMultiOrgEnabled` is set. Everything else is unchanged: without the flag, a missing org still warns exactly as before.

Fixes #1162

## How you tested it

Unit tests only. `TestDefaultOrgWarningSuppressedWithDynamicMultiOrg` covers all three cases: the warning still fires with the flag off, and is silent with the flag on for both `ExtractGrafanaClientFromHeaders` and the cached `extractGrafanaClientCached` path. It fails on the current code and passes with the fix.

## Checklist

- [x] `make lint` and `make test-unit` pass locally
- [x] Commits are signed (required to merge — see CONTRIBUTING.md)
- [ ] CLA signed (required to merge)
- [x] README tool table updated, with RBAC permissions and scopes, if this adds a tool — no new tool
- [x] Any write operation respects `--disable-write` — no write path touched
- [x] Any datasource query execution respects `--disable-query` (and `--disable-write` too, if the query is passed through unfiltered) — no query path touched
