### PR TITLE
fix(logging): demote missing-org-ID warning to Debug under dynamic multi-org

### DIFF
--- a/client_cache.go
+++ b/client_cache.go
@@ -358,9 +358,7 @@ func extractGrafanaClientCached(cache *ClientCache) httpContextFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		config := GrafanaConfigFromContext(ctx)
 		logger := config.LoggerOrDefault()
-		if config.OrgID == 0 {
-			logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
-		}
+		warnOnMissingOrgID(logger, config.OrgID)
 
 		u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)
 		key := cacheKeyFromRequest(u, apiKey, basicAuth, config.OrgID, req)

--- a/mcpgrafana.go
+++ b/mcpgrafana.go
@@ -1545,9 +1545,7 @@ var ExtractGrafanaClientFromEnv server.StdioContextFunc = func(ctx context.Conte
 var ExtractGrafanaClientFromHeaders httpContextFunc = func(ctx context.Context, req *http.Request) context.Context {
 	config := GrafanaConfigFromContext(ctx)
 	logger := config.LoggerOrDefault()
-	if config.OrgID == 0 {
-		logger.Warn("No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.")
-	}
+	warnOnMissingOrgID(logger, config.OrgID)
 
 	// Extract transport config from request headers, and set it on the context.
 	u, apiKey, basicAuth, _ := extractKeyGrafanaInfoFromReq(req, logger)

--- a/orgid.go
+++ b/orgid.go
@@ -23,6 +23,24 @@ import (
 // connection) works regardless of this flag.
 var DynamicMultiOrgEnabled bool
 
+// warnOnMissingOrgID logs that a request fell back to the default Grafana org
+// because no org ID was found in request headers or environment variables.
+// With dynamic multi-org enabled, omitting orgId is the expected way to target
+// the default org on a per-call basis, so this is logged at Debug rather than
+// Warn to avoid spamming every such call; without it, a missing org ID may
+// indicate a misconfigured connection, so it stays a Warn.
+func warnOnMissingOrgID(logger *slog.Logger, orgID int64) {
+	if orgID != 0 {
+		return
+	}
+	const msg = "No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org."
+	if DynamicMultiOrgEnabled {
+		logger.Debug(msg)
+	} else {
+		logger.Warn(msg)
+	}
+}
+
 // OrgIDArgument is the name of the optional per-call tool argument that selects
 // which Grafana organization a tool call targets. When dynamic multi-org is
 // enabled it is advertised on every native tool's input schema (see

--- a/orgid_test.go
+++ b/orgid_test.go
@@ -1,9 +1,11 @@
 package mcpgrafana
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -227,5 +229,49 @@ func TestCurrentUserInfoOrgIsRequestScoped(t *testing.T) {
 		got, err := UserPersistedOrgID(server(t, 1, 2))
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), got)
+	})
+}
+
+func TestWarnOnMissingOrgID(t *testing.T) {
+	// DynamicMultiOrgEnabled is a package-level flag set from the
+	// --dynamic-multi-org CLI flag; restore it so this test doesn't leak into
+	// others that run in the same binary.
+	original := DynamicMultiOrgEnabled
+	t.Cleanup(func() { DynamicMultiOrgEnabled = original })
+
+	t.Run("a resolved org ID never logs anything, in either mode", func(t *testing.T) {
+		for _, DynamicMultiOrgEnabled = range []bool{false, true} {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			warnOnMissingOrgID(logger, 42)
+
+			assert.Empty(t, buf.String())
+		}
+	})
+
+	t.Run("a missing org ID logs at Warn when dynamic multi-org is off", func(t *testing.T) {
+		DynamicMultiOrgEnabled = false
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		warnOnMissingOrgID(logger, 0)
+
+		logOutput := buf.String()
+		assert.Contains(t, logOutput, "level=WARN")
+		assert.Contains(t, logOutput, "No org ID found")
+	})
+
+	t.Run("a missing org ID logs at Debug when dynamic multi-org is on, not Warn", func(t *testing.T) {
+		DynamicMultiOrgEnabled = true
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		warnOnMissingOrgID(logger, 0)
+
+		logOutput := buf.String()
+		assert.Contains(t, logOutput, "level=DEBUG")
+		assert.Contains(t, logOutput, "No org ID found")
+		assert.NotContains(t, logOutput, "level=WARN")
 	})
 }


### PR DESCRIPTION
Fixes #1162.

## Problem

`ExtractGrafanaClientFromHeaders` and `extractGrafanaClientCached` (both in the HTTP context-func chain, so they run per request) log:

```
No org ID found in request headers or environment variables, using default org. Set GRAFANA_ORG_ID or pass X-Grafana-Org-Id header to target a specific org.
```

at `Warn` whenever `config.OrgID == 0`. With `--dynamic-multi-org` enabled, omitting the per-call `orgId` argument is the normal, expected way to target the connection's default org — it's not a misconfiguration — so this fires on essentially every call and drowns out genuinely actionable warnings, exactly as reported.

## Fix

Factored both call sites into a shared `warnOnMissingOrgID(logger, orgID)` helper in `orgid.go` (next to the `DynamicMultiOrgEnabled` flag it reads):

- `DynamicMultiOrgEnabled == false` (the default): unchanged — still logs at `Warn`, since a missing org ID in that mode may still indicate a misconfigured connection.
- `DynamicMultiOrgEnabled == true`: logs the same message at `Debug` instead, so it's still available for troubleshooting but doesn't spam normal operation.

## Tests

- `orgid_test.go`: new `TestWarnOnMissingOrgID` — a resolved org ID logs nothing in either mode; a missing org ID logs at `Warn` with the flag off and at `Debug` (never `Warn`) with it on.
- `go test .` — full package passes. `TestExtractGrafanaClientFromHeaders` (unchanged) continues to see the `Warn` in its default (non-dynamic) scenarios, confirming existing behavior is preserved.
- `go build ./...` clean.
- `go test ./cmd/mcp-grafana/...` has a pre-existing, unrelated failure (`TestHTTPAllowedHostsLoopbackProxy` needs a pre-built `mcp-grafana` binary on `PATH`) — confirmed present on unmodified `upstream/main` via `git stash`, not caused by this change.
